### PR TITLE
Add length prefixing to contract names in deposits

### DIFF
--- a/sbtc-core/Cargo.toml
+++ b/sbtc-core/Cargo.toml
@@ -23,3 +23,6 @@ stacks-core.path = "../stacks-core"
 thiserror.workspace = true
 url.workspace = true
 wsts.workspace = true
+
+[dev-dependencies]
+rand.workspace = true

--- a/sbtc-core/Cargo.toml
+++ b/sbtc-core/Cargo.toml
@@ -25,4 +25,4 @@ url.workspace = true
 wsts.workspace = true
 
 [dev-dependencies]
-rand.workspace = true
+rand = { workspace = true, features = ["std_rng"] }

--- a/sbtc-core/src/lib.rs
+++ b/sbtc-core/src/lib.rs
@@ -4,7 +4,7 @@
 */
 
 use bdk::electrum_client::Error as ElectrumError;
-use stacks_core::{utils::ContractNameError, StacksError};
+use stacks_core::{contract_name::ContractNameError, StacksError};
 use thiserror::Error;
 
 /// Module for sBTC operations

--- a/sbtc-core/src/lib.rs
+++ b/sbtc-core/src/lib.rs
@@ -4,6 +4,7 @@
 */
 
 use bdk::electrum_client::Error as ElectrumError;
+use stacks_core::{utils::ContractNameError, StacksError};
 use thiserror::Error;
 
 /// Module for sBTC operations
@@ -30,6 +31,12 @@ pub enum SBTCError {
     #[error("Deposit amount {0} should be greater than dust amount {1}")]
     /// Insufficient amount
     AmountInsufficient(u64, u64),
+    /// Contract name error
+    #[error("Contract name error: {0}")]
+    ContractNameError(#[from] ContractNameError),
+    /// Stacks error
+    #[error("Stacks error: {0}")]
+    StacksError(#[from] StacksError),
 }
 
 /// A helper type for sBTC results

--- a/sbtc-core/src/operations/parsing/deposit.rs
+++ b/sbtc-core/src/operations/parsing/deposit.rs
@@ -6,29 +6,26 @@ Deposit is a transaction with the output structure as below:
 
 The data output should contain data in the following format:
 
-0      2  3                  24                            64       80
+0      2  3                  24                            65       80
 |------|--|------------------|-----------------------------|--------|
- magic  op   Stacks address      Contract name (optional)     memo
+ magic  op   Stacks address    Size prefixed contract name    memo
+                                   (optional, see note)
+
+Contract name is prefixed by a single byte size followed by the contract name
+bytes.
 ```
 */
-use std::str::from_utf8;
+use std::io::Cursor;
 
 use stacks_core::{
     address::{AddressVersion, StacksAddress},
-    crypto::{hash160::Hash160Hasher, Hashing},
+    codec::Codec,
     utils::{ContractName, PrincipalData, StandardPrincipalData},
 };
 
 use crate::{SBTCError, SBTCResult};
 
-fn find_leading_non_zero_bytes(data: &[u8]) -> Option<&[u8]> {
-    match data.iter().rev().position(|&b| b != 0) {
-        Some(end) if end != 0 => Some(&data[0..=end]),
-        Some(_) | None => None,
-    }
-}
-
-/// Parsed data output from a deposit transaction
+/// Contains the parsed data from a deposit transaction
 pub struct ParsedDepositData {
     /// The recipient of the deposit
     pub recipient: PrincipalData,
@@ -43,38 +40,221 @@ pub fn parse(data: &[u8]) -> SBTCResult<ParsedDepositData> {
     }
 
     let standard_principal_data = {
-        let version = AddressVersion::from_repr(*data.first().expect("No version byte in data"))
+        let version = AddressVersion::from_repr(data[0])
             .ok_or(SBTCError::MalformedData("Address version is invalid"))?;
-        let address_data: [u8; 20] = data
-            .get(1..21)
-            .ok_or(SBTCError::MalformedData("Could not get address data"))?
-            .try_into()
-            .map_err(|_| {
-                SBTCError::MalformedData("Byte data is larger than 20 bytes for the address")
-            })?;
+        let addr = StacksAddress::deserialize(&mut Cursor::new(&data[0..21]))?;
 
-        StandardPrincipalData::new(
-            version,
-            StacksAddress::new(version, Hash160Hasher::new(address_data)),
-        )
+        StandardPrincipalData::new(version, addr)
     };
 
-    let recipient = find_leading_non_zero_bytes(&data[21..=61])
-        .map(|contract_bytes| {
-            let contract_name_string: String = from_utf8(contract_bytes)
-                .map_err(|_| SBTCError::MalformedData("Could not parse contract name bytes"))?
-                .to_owned();
-            let contract_name = ContractName::new(&contract_name_string)
-                .map_err(|_| SBTCError::MalformedData("Could not parse contract name"))?;
+    let contract_name_size = data[21] as usize;
 
-            Result::<_, SBTCError>::Ok(PrincipalData::Contract(
-                standard_principal_data.clone(),
-                contract_name,
-            ))
-        })
-        .unwrap_or(Ok(PrincipalData::Standard(standard_principal_data)))?;
+    let recipient: PrincipalData = if contract_name_size == 0 {
+        PrincipalData::Standard(standard_principal_data)
+    } else {
+        let contract_name_bytes = &data[22..(22 + contract_name_size)];
 
-    let memo = data.get(61..).unwrap_or(&[]).to_vec();
+        let contract_name = std::str::from_utf8(contract_name_bytes)
+            .map_err(|_| SBTCError::MalformedData("Contract name bytes are not valid UTF-8"))
+            .and_then(|contract_name_string| {
+                ContractName::new(contract_name_string).map_err(SBTCError::ContractNameError)
+            })?;
+
+        PrincipalData::Contract(standard_principal_data, contract_name)
+    };
+
+    let memo = data.get(62..).unwrap_or(&[]).to_vec();
 
     Ok(ParsedDepositData { recipient, memo })
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::{distributions::Alphanumeric, thread_rng, Rng};
+    use stacks_core::{codec::Codec, crypto::generate_keypair};
+
+    use super::*;
+
+    fn generate_address() -> StacksAddress {
+        let pk = generate_keypair(&mut thread_rng()).1;
+
+        StacksAddress::p2pkh(AddressVersion::TestnetSingleSig, &pk)
+    }
+
+    fn generate_contract_name() -> Option<ContractName> {
+        let should_have_contract_name: bool = thread_rng().gen();
+
+        if should_have_contract_name {
+            let contract_name_length: u8 = thread_rng().gen_range(1..40);
+            let contract_name = {
+                let mut contract_name_char_iter =
+                    thread_rng().sample_iter(&Alphanumeric).map(char::from);
+
+                let first_letter = loop {
+                    let letter = contract_name_char_iter.next().unwrap();
+
+                    if letter.is_digit(10) {
+                        continue;
+                    } else {
+                        break letter;
+                    };
+                };
+
+                let other_letters = contract_name_char_iter.take(contract_name_length as usize - 1);
+
+                let contract_name_string = [first_letter]
+                    .into_iter()
+                    .chain(other_letters)
+                    .collect::<String>();
+
+                ContractName::new(&contract_name_string).unwrap()
+            };
+
+            Some(contract_name)
+        } else {
+            None
+        }
+    }
+
+    fn build_deposit_data(
+        addr: &StacksAddress,
+        contract_name: Option<&ContractName>,
+        memo: &[u8; 15],
+    ) -> [u8; 77] {
+        let mut data = [0u8; 77];
+
+        data[0..21].copy_from_slice(&addr.serialize_to_vec());
+
+        if let Some(contract_name) = contract_name {
+            let contract_name_length = contract_name.len();
+
+            data[21] = contract_name_length as u8;
+            data[22..22 + contract_name_length].copy_from_slice(contract_name.as_bytes());
+        }
+
+        data[62..].copy_from_slice(memo);
+
+        data
+    }
+
+    fn generate_deposit_data() -> (StacksAddress, Option<ContractName>, [u8; 15], [u8; 77]) {
+        let addr = generate_address();
+        let maybe_contract_name = generate_contract_name();
+        let memo: [u8; 15] = thread_rng().gen();
+
+        let data = build_deposit_data(&addr, maybe_contract_name.as_ref(), &memo);
+
+        (addr, maybe_contract_name, memo, data)
+    }
+
+    #[test]
+    fn should_parse_deposit_data() {
+        for _ in 0..1000 {
+            let (expected_addr, expected_contract_name, expected_memo, data) =
+                generate_deposit_data();
+
+            let parsed_data = parse(&data).unwrap();
+
+            match parsed_data.recipient {
+                PrincipalData::Standard(StandardPrincipalData(_, addr)) => {
+                    assert!(expected_contract_name.is_none());
+                    assert_eq!(addr, expected_addr);
+                }
+                PrincipalData::Contract(StandardPrincipalData(_, addr), contract_name) => {
+                    assert!(expected_contract_name.is_some());
+                    assert_eq!(addr, expected_addr);
+                    assert_eq!(contract_name, expected_contract_name.unwrap());
+                }
+            }
+
+            assert_eq!(parsed_data.memo, expected_memo);
+        }
+    }
+
+    #[test]
+    fn should_fail_on_missing_contract_name_bytes() {
+        let addr = generate_address();
+        let contract_name = loop {
+            let contract_name = generate_contract_name();
+
+            if contract_name.is_some() {
+                break contract_name.unwrap();
+            }
+        };
+        let memo: [u8; 15] = thread_rng().gen();
+
+        let mut data = build_deposit_data(&addr, Some(&contract_name), &memo);
+        data[22..62].iter_mut().for_each(|byte| *byte = 0);
+
+        assert!(parse(&data).is_err());
+    }
+
+    #[test]
+    fn should_fail_on_incomplete_contract_name_bytes() {
+        let addr = generate_address();
+        let contract_name = loop {
+            let contract_name = generate_contract_name();
+
+            if contract_name.is_some() {
+                break contract_name.unwrap();
+            }
+        };
+        let memo: [u8; 15] = thread_rng().gen();
+
+        let mut data = build_deposit_data(&addr, Some(&contract_name), &memo);
+        data[22 + contract_name.len() - 1..62]
+            .iter_mut()
+            .for_each(|byte| *byte = 0);
+
+        assert!(parse(&data).is_err());
+    }
+
+    #[test]
+    fn should_truncate_on_extra_contract_name_bytes() {
+        let addr = generate_address();
+        let expected_contract_name = loop {
+            let maybe_contract_name = generate_contract_name();
+
+            if let Some(contract_name) = maybe_contract_name {
+                if contract_name.len() < 40 {
+                    break contract_name;
+                }
+            }
+        };
+        let memo: [u8; 15] = thread_rng().gen();
+
+        let mut data = build_deposit_data(&addr, Some(&expected_contract_name), &memo);
+        data[22 + expected_contract_name.len() + 1] = b'X';
+
+        let parsed_data = parse(&data).unwrap();
+
+        match parsed_data.recipient {
+            PrincipalData::Contract(_, contract_name) => {
+                assert_eq!(contract_name, expected_contract_name)
+            }
+            PrincipalData::Standard(_) => panic!("Should be a contract principal"),
+        }
+    }
+
+    #[test]
+    fn should_ignore_contract_name_bytes_if_size_zero() {
+        let expected_addr = generate_address();
+        let expected_memo: [u8; 15] = thread_rng().gen();
+        let mut data = build_deposit_data(&expected_addr, None, &expected_memo);
+
+        data[22..62]
+            .iter_mut()
+            .for_each(|byte| *byte = thread_rng().gen());
+
+        let parsed_data = parse(&data).unwrap();
+
+        match parsed_data.recipient {
+            PrincipalData::Standard(StandardPrincipalData(_, addr)) => {
+                assert_eq!(addr, expected_addr);
+            }
+            PrincipalData::Contract(_, _) => panic!("Should be a standard principal"),
+        }
+
+        assert_eq!(parsed_data.memo, expected_memo);
+    }
 }

--- a/sbtc-core/src/operations/parsing/mod.rs
+++ b/sbtc-core/src/operations/parsing/mod.rs
@@ -1,6 +1,3 @@
-/// Module for parsing deposit transactions
 pub mod deposit;
-/// Module for parsing withdrawal fulfillment transactions
 pub mod withdrawal_fulfillment;
-/// Module for parsing withdrawal request transactions
 pub mod withdrawal_request;

--- a/stacks-core/Cargo.toml
+++ b/stacks-core/Cargo.toml
@@ -17,7 +17,7 @@ hex.workspace = true
 once_cell.workspace = true
 regex.workspace = true
 ripemd.workspace = true
-secp256k1.workspace = true
+secp256k1 = { workspace = true, features = ["global-context", "rand"] }
 serde = { workspace = true, features = ["derive"] }
 sha2.workspace = true
 strum = { workspace = true, features = ["derive"] }

--- a/stacks-core/src/address.rs
+++ b/stacks-core/src/address.rs
@@ -93,7 +93,7 @@ impl StacksAddress {
 
 impl Codec for StacksAddress {
     fn codec_serialize<W: Write>(&self, dest: &mut W) -> io::Result<()> {
-        dest.write(&[self.version() as u8])?;
+        assert_eq!(dest.write(&[self.version() as u8])?, 1);
         dest.write_all(self.hash().as_ref())
     }
 

--- a/stacks-core/src/address.rs
+++ b/stacks-core/src/address.rs
@@ -1,10 +1,14 @@
-use std::fmt;
+use std::{
+    fmt,
+    io::{self, Read, Write},
+};
 
 use bitcoin::blockdata::{opcodes::all::OP_CHECKMULTISIG, script::Builder};
 use strum::{EnumIter, FromRepr};
 
 use crate::{
     c32::{decode_address, encode_address},
+    codec::Codec,
     crypto::{
         hash160::{Hash160Hasher, HASH160_LENGTH},
         sha256::Sha256Hasher,
@@ -35,8 +39,8 @@ impl TryFrom<u8> for AddressVersion {
     }
 }
 
-#[derive(Debug, Clone)]
 /// A Stacks address
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StacksAddress {
     version: AddressVersion,
     hash: Hash160Hasher,
@@ -84,6 +88,27 @@ impl StacksAddress {
         signature_threshold: usize,
     ) -> Self {
         Self::new(version, hash_p2wsh(keys, signature_threshold))
+    }
+}
+
+impl Codec for StacksAddress {
+    fn codec_serialize<W: Write>(&self, dest: &mut W) -> io::Result<()> {
+        dest.write(&[self.version() as u8])?;
+        dest.write_all(self.hash().as_ref())
+    }
+
+    fn codec_deserialize<R: Read>(data: &mut R) -> io::Result<Self> {
+        let mut version_buffer = [0; 1];
+        data.read_exact(&mut version_buffer)?;
+
+        let version = AddressVersion::from_repr(version_buffer[0]).unwrap();
+
+        let mut hash_buffer = [0; HASH160_LENGTH];
+        data.read_exact(&mut hash_buffer)?;
+
+        let hash = Hash160Hasher::from_bytes(&hash_buffer).unwrap();
+
+        Ok(Self { version, hash })
     }
 }
 

--- a/stacks-core/src/codec.rs
+++ b/stacks-core/src/codec.rs
@@ -1,0 +1,43 @@
+/**
+Module for contract name parsing
+*/
+use std::io;
+
+use thiserror::Error;
+
+use crate::StacksResult;
+
+#[derive(Error, Debug)]
+pub enum CodecError {
+    #[error("Could not serialize or deserialize: {0}")]
+    IoError(#[from] io::Error),
+}
+
+pub type CodecResult<T> = Result<T, CodecError>;
+
+pub trait Codec {
+    fn codec_serialize<W: io::Write>(&self, dest: &mut W) -> io::Result<()>;
+    fn codec_deserialize<R: io::Read>(data: &mut R) -> io::Result<Self>
+    where
+        Self: Sized;
+
+    fn serialize<W: io::Write>(&self, dest: &mut W) -> StacksResult<()> {
+        self.codec_serialize(dest)
+            .map_err(|err| CodecError::IoError(err).into())
+    }
+
+    fn deserialize<R: io::Read>(data: &mut R) -> StacksResult<Self>
+    where
+        Self: Sized,
+    {
+        Self::codec_deserialize(data).map_err(|err| CodecError::IoError(err).into())
+    }
+
+    fn serialize_to_vec(&self) -> Vec<u8> {
+        let mut buffer = Vec::with_capacity(21);
+
+        self.serialize(&mut buffer).unwrap();
+
+        buffer
+    }
+}

--- a/stacks-core/src/codec.rs
+++ b/stacks-core/src/codec.rs
@@ -34,7 +34,7 @@ pub trait Codec {
     }
 
     fn serialize_to_vec(&self) -> Vec<u8> {
-        let mut buffer = Vec::with_capacity(21);
+        let mut buffer = vec![];
 
         self.serialize(&mut buffer).unwrap();
 

--- a/stacks-core/src/codec.rs
+++ b/stacks-core/src/codec.rs
@@ -1,5 +1,5 @@
 /*!
-Module for contract name parsing
+Module for serializing and deserializing Stacks data types
 */
 use std::io;
 

--- a/stacks-core/src/codec.rs
+++ b/stacks-core/src/codec.rs
@@ -1,4 +1,4 @@
-/**
+/*!
 Module for contract name parsing
 */
 use std::io;
@@ -8,24 +8,32 @@ use thiserror::Error;
 use crate::StacksResult;
 
 #[derive(Error, Debug)]
+/// Codec error
 pub enum CodecError {
     #[error("Could not serialize or deserialize: {0}")]
+    /// Io error
     IoError(#[from] io::Error),
 }
 
+/// Codec result
 pub type CodecResult<T> = Result<T, CodecError>;
 
+/// Serializing and deserializing Stacks data types
 pub trait Codec {
+    /// Serialize to a writer
     fn codec_serialize<W: io::Write>(&self, dest: &mut W) -> io::Result<()>;
+    /// Deserialize from a reader
     fn codec_deserialize<R: io::Read>(data: &mut R) -> io::Result<Self>
     where
         Self: Sized;
 
+    /// Serialize to a writer and return a StacksResult
     fn serialize<W: io::Write>(&self, dest: &mut W) -> StacksResult<()> {
         self.codec_serialize(dest)
             .map_err(|err| CodecError::IoError(err).into())
     }
 
+    /// Deserialize from a reader and return a StacksResult
     fn deserialize<R: io::Read>(data: &mut R) -> StacksResult<Self>
     where
         Self: Sized,
@@ -33,6 +41,7 @@ pub trait Codec {
         Self::codec_deserialize(data).map_err(|err| CodecError::IoError(err).into())
     }
 
+    /// Serialize to a vector
     fn serialize_to_vec(&self) -> Vec<u8> {
         let mut buffer = vec![];
 

--- a/stacks-core/src/contract_name.rs
+++ b/stacks-core/src/contract_name.rs
@@ -44,6 +44,7 @@ pub enum ContractNameError {
 }
 
 /// Contract name type
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContractName(String);
 
 impl ContractName {

--- a/stacks-core/src/contract_name.rs
+++ b/stacks-core/src/contract_name.rs
@@ -1,3 +1,6 @@
+/*!
+Contract name type and parsing
+*/
 use std::{
     borrow::Borrow,
     fmt::{Display, Formatter},

--- a/stacks-core/src/lib.rs
+++ b/stacks-core/src/lib.rs
@@ -44,6 +44,8 @@ pub enum StacksError {
     InvalidUintBytes(usize),
     #[error("Codec error: {0}")]
     CodecError(#[from] CodecError),
+    #[error("Invalid data: {0}")]
+    InvalidData(&'static str),
 }
 
 /// Result type for the stacks-core library

--- a/stacks-core/src/lib.rs
+++ b/stacks-core/src/lib.rs
@@ -43,8 +43,10 @@ pub enum StacksError {
     /// Invalid Uint bytes
     InvalidUintBytes(usize),
     #[error("Codec error: {0}")]
+    /// Codec error
     CodecError(#[from] CodecError),
     #[error("Invalid data: {0}")]
+    /// Invalid data
     InvalidData(&'static str),
 }
 

--- a/stacks-core/src/lib.rs
+++ b/stacks-core/src/lib.rs
@@ -5,13 +5,14 @@
 
 use std::array::TryFromSliceError;
 
+use codec::CodecError;
 use thiserror::Error;
 
 /// Module for interacting with stacks addresses
 pub mod address;
 /// Module for c32 encoding and decoding
 pub mod c32;
-/// Module for contract name parsing
+pub mod codec;
 pub mod contract_name;
 /// Module for crypto functions
 pub mod crypto;
@@ -21,7 +22,7 @@ pub mod uint;
 pub mod utils;
 
 /// Error type for the stacks-core library
-#[derive(Error, Debug, Clone)]
+#[derive(Error, Debug)]
 pub enum StacksError {
     #[error("Invalid arguments: {0}")]
     /// Invalid arguments
@@ -41,6 +42,8 @@ pub enum StacksError {
     #[error("Could not create Uint from {0} bytes")]
     /// Invalid Uint bytes
     InvalidUintBytes(usize),
+    #[error("Codec error: {0}")]
+    CodecError(#[from] CodecError),
 }
 
 /// Result type for the stacks-core library

--- a/stacks-core/src/utils.rs
+++ b/stacks-core/src/utils.rs
@@ -1,9 +1,14 @@
+use std::io;
+
+use strum::FromRepr;
+
 use crate::{
     address::{AddressVersion, StacksAddress},
+    codec::Codec,
     contract_name::ContractName,
 };
 
-#[derive(Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 /// Standard principal data type
 pub struct StandardPrincipalData(pub AddressVersion, pub StacksAddress);
 
@@ -14,11 +19,164 @@ impl StandardPrincipalData {
     }
 }
 
-#[derive(Debug, Clone)]
+impl Codec for StandardPrincipalData {
+    fn codec_serialize<W: io::Write>(&self, dest: &mut W) -> io::Result<()> {
+        self.1.codec_serialize(dest)
+    }
+
+    fn codec_deserialize<R: io::Read>(data: &mut R) -> io::Result<Self>
+    where
+        Self: Sized,
+    {
+        let addr = StacksAddress::codec_deserialize(data)?;
+
+        Ok(Self(addr.version(), addr))
+    }
+}
+
+#[derive(PartialEq, Eq, Debug, Clone)]
 /// Principal Data type
 pub enum PrincipalData {
     /// Standard principal data type
     Standard(StandardPrincipalData),
     /// Contract principal data type
     Contract(StandardPrincipalData, ContractName),
+}
+
+#[repr(u8)]
+#[derive(FromRepr, Debug, Clone, Copy)]
+enum PrincipalTypeByte {
+    Standard = 0x05,
+    Contract = 0x06,
+}
+
+impl Codec for PrincipalData {
+    fn codec_serialize<W: io::Write>(&self, dest: &mut W) -> io::Result<()> {
+        match self {
+            Self::Standard(data) => {
+                dest.write_all(&[PrincipalTypeByte::Standard as u8])?;
+                data.codec_serialize(dest)
+            }
+            Self::Contract(data, contract_name) => {
+                dest.write_all(&[PrincipalTypeByte::Contract as u8])?;
+                data.codec_serialize(dest)?;
+                contract_name.codec_serialize(dest)
+            }
+        }
+    }
+
+    fn codec_deserialize<R: io::Read>(data: &mut R) -> io::Result<Self>
+    where
+        Self: Sized,
+    {
+        let mut type_buffer = [0u8; 1];
+        data.read_exact(&mut type_buffer)?;
+
+        let principal_type = PrincipalTypeByte::from_repr(type_buffer[0]).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("Invalid principal type: {}", type_buffer[0]),
+            )
+        })?;
+
+        match principal_type {
+            PrincipalTypeByte::Standard => {
+                let standard_data = StandardPrincipalData::codec_deserialize(data)?;
+
+                Ok(Self::Standard(standard_data))
+            }
+            PrincipalTypeByte::Contract => {
+                let standard_data = StandardPrincipalData::codec_deserialize(data)?;
+                let contract_name = ContractName::codec_deserialize(data)?;
+
+                Ok(Self::Contract(standard_data, contract_name))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::crypto::hash160::Hash160Hasher;
+
+    use super::*;
+
+    #[test]
+    fn should_serialize_standard_principal_data() {
+        let addr = StacksAddress::new(AddressVersion::TestnetSingleSig, Hash160Hasher::default());
+        let data = PrincipalData::Standard(StandardPrincipalData(addr.version(), addr.clone()));
+
+        let mut expected_bytes = vec![];
+
+        expected_bytes.push(PrincipalTypeByte::Standard as u8);
+        expected_bytes.push(addr.version() as u8);
+        expected_bytes.extend(addr.hash().as_ref());
+
+        let serialized = data.serialize_to_vec();
+
+        assert_eq!(serialized, expected_bytes);
+    }
+
+    #[test]
+    fn should_deserialize_standard_principal_data() {
+        let addr = StacksAddress::new(AddressVersion::TestnetSingleSig, Hash160Hasher::default());
+        let expected_principal_data =
+            PrincipalData::Standard(StandardPrincipalData(addr.version(), addr.clone()));
+
+        let mut expected_bytes = vec![];
+
+        expected_bytes.push(PrincipalTypeByte::Standard as u8);
+        expected_bytes.push(addr.version() as u8);
+        expected_bytes.extend(addr.hash().as_ref());
+
+        let serialized = expected_principal_data.serialize_to_vec();
+        let deserialized = PrincipalData::deserialize(&mut &serialized[..]).unwrap();
+
+        assert_eq!(deserialized, expected_principal_data);
+    }
+
+    #[test]
+    fn should_serialize_contract_principal_data() {
+        let addr = StacksAddress::new(AddressVersion::TestnetSingleSig, Hash160Hasher::default());
+        let contract = ContractName::new("helloworld").unwrap();
+        let data = PrincipalData::Contract(
+            StandardPrincipalData(addr.version(), addr.clone()),
+            contract.clone(),
+        );
+
+        let mut expected_bytes = vec![];
+
+        expected_bytes.push(PrincipalTypeByte::Contract as u8);
+        expected_bytes.push(addr.version() as u8);
+        expected_bytes.extend(addr.hash().as_ref());
+        expected_bytes.push(contract.len() as u8);
+        expected_bytes.extend(contract.as_bytes());
+
+        let serialized = data.serialize_to_vec();
+
+        assert_eq!(serialized, expected_bytes);
+    }
+
+    #[test]
+    fn should_deserialize_contract_principal_data() {
+        let addr = StacksAddress::new(AddressVersion::TestnetSingleSig, Hash160Hasher::default());
+        let contract = ContractName::new("helloworld").unwrap();
+        let expected_principal_data = PrincipalData::Contract(
+            StandardPrincipalData(addr.version(), addr.clone()),
+            contract.clone(),
+        );
+
+        let mut expected_bytes = vec![];
+
+        expected_bytes.push(PrincipalTypeByte::Contract as u8);
+        expected_bytes.push(addr.version() as u8);
+        expected_bytes.extend(addr.hash().as_ref());
+        expected_bytes.push(contract.len() as u8);
+        expected_bytes.extend(contract.as_bytes());
+
+        let serialized = expected_principal_data.serialize_to_vec();
+        let deserialized = PrincipalData::deserialize(&mut &serialized[..]).unwrap();
+
+        assert_eq!(deserialized, expected_principal_data);
+    }
 }

--- a/stacks-core/src/utils.rs
+++ b/stacks-core/src/utils.rs
@@ -1,112 +1,11 @@
-use std::{
-    borrow::Borrow,
-    fmt::{Display, Formatter},
-    ops::Deref,
+use crate::{
+    address::{AddressVersion, StacksAddress},
+    contract_name::ContractName,
 };
-
-use once_cell::sync::Lazy;
-use regex::Regex;
-use thiserror::Error;
-
-use crate::address::{AddressVersion, StacksAddress};
-
-/// Minimum length of a contract name
-pub const CONTRACT_MIN_NAME_LENGTH: usize = 1;
-/// Maximum length of a contract name
-pub const CONTRACT_MAX_NAME_LENGTH: usize = 40;
-
-/// Regex string for contract name validation
-pub static CONTRACT_NAME_REGEX_STRING: Lazy<String> = Lazy::new(|| {
-    format!(
-        r#"([a-zA-Z](([a-zA-Z0-9]|[-_])){{{},{}}})"#,
-        CONTRACT_MIN_NAME_LENGTH - 1,
-        CONTRACT_MAX_NAME_LENGTH - 1
-    )
-});
-
-/// Regex for contract name validation
-pub static CONTRACT_NAME_REGEX: Lazy<Regex> = Lazy::new(|| {
-    regex::Regex::new(format!("^{}$|^__transient$", CONTRACT_NAME_REGEX_STRING.as_str()).as_str())
-        .unwrap()
-});
-
-#[derive(Error, Debug)]
-/// Error type for contract name validation
-pub enum ContractNameError {
-    #[error(
-        "Length should be between {} and {}",
-        CONTRACT_MIN_NAME_LENGTH,
-        CONTRACT_MAX_NAME_LENGTH
-    )]
-    /// Invalid contract name length
-    InvalidLength,
-    #[error("Format should follow the contract name specification")]
-    /// Invalid contract name format
-    InvalidFormat,
-}
-
-/// Contract name type
-pub struct ContractName(String);
-
-impl ContractName {
-    /// Create a new contract name from the provided string
-    pub fn new(contract_name: &str) -> Result<Self, ContractNameError> {
-        if contract_name.len() < CONTRACT_MIN_NAME_LENGTH
-            && contract_name.len() > CONTRACT_MAX_NAME_LENGTH
-        {
-            Err(ContractNameError::InvalidLength)
-        } else if CONTRACT_NAME_REGEX.is_match(contract_name) {
-            Ok(Self(contract_name.to_string()))
-        } else {
-            Err(ContractNameError::InvalidFormat)
-        }
-    }
-}
-
-impl TryFrom<&str> for ContractName {
-    type Error = ContractNameError;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
-        ContractName::new(value)
-    }
-}
-
-impl AsRef<str> for ContractName {
-    fn as_ref(&self) -> &str {
-        self.0.as_ref()
-    }
-}
-
-impl Deref for ContractName {
-    type Target = str;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl Borrow<str> for ContractName {
-    fn borrow(&self) -> &str {
-        self.as_ref()
-    }
-}
-
-// From conversion is fallible for this type
-#[allow(clippy::from_over_into)]
-impl Into<String> for ContractName {
-    fn into(self) -> String {
-        self.0
-    }
-}
-
-impl Display for ContractName {
-    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-        self.0.fmt(f)
-    }
-}
 
 #[derive(Debug, Clone)]
 /// Standard principal data type
-pub struct StandardPrincipalData(AddressVersion, StacksAddress);
+pub struct StandardPrincipalData(pub AddressVersion, pub StacksAddress);
 
 impl StandardPrincipalData {
     /// Create a new standard principal data type from the provided address version and stacks address
@@ -114,6 +13,8 @@ impl StandardPrincipalData {
         Self(version, address)
     }
 }
+
+#[derive(Debug, Clone)]
 /// Principal Data type
 pub enum PrincipalData {
     /// Standard principal data type


### PR DESCRIPTION
Adds length prefixed contract names in deposit data.

Addresses all issues from the original PR:

- https://github.com/stacks-network/stacks-blockchain/pull/3718/files#r1258665342
- https://github.com/stacks-network/stacks-blockchain/pull/3718/files#r1258666082
- https://github.com/stacks-network/stacks-blockchain/pull/3718/files#r1258668073

There are a few more things I'd like to check before considering this ready:

- [x] Do we need reproducible tests considering they generate random data? (a bit of extra work but nothing major)
- [x] Now with the contract names being length prefixed do we want to reserve all remaining bytes for memo or keep it restricted to the current range?
- [x] Using correct principal encoding? https://github.com/stacks-network/sbtc/issues/18

Another thing I've done in this PR is changed the parsing logic to include full 80 bytes from the Bitcoin transaction output. I think it makes slicing of the data clearer. Let me know what you think.