### PR TITLE
fix: Remove top-level clone from romeo State struct

### DIFF
--- a/romeo/src/state.rs
+++ b/romeo/src/state.rs
@@ -12,7 +12,7 @@ use crate::event::TransactionStatus;
 use crate::task::Task;
 
 /// The whole state of the application
-#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
 pub struct State {
     contract: Option<Contract>,
     deposits: Vec<Deposit>,


### PR DESCRIPTION
closes #75 