### PR TITLE
Bitcoin client for Romeo

### DIFF
--- a/romeo/Cargo.toml
+++ b/romeo/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 anyhow.workspace = true
-bdk.workspace = true
+bdk = { workspace = true, features = ["esplora", "use-esplora-async"]}
 blockstack-core = { git = "https://github.com/stacks-network/stacks-blockchain/", branch = "master" }
 clap = { workspace = true, features = ["derive"] }
 futures.workspace = true

--- a/romeo/src/bitcoin_client.rs
+++ b/romeo/src/bitcoin_client.rs
@@ -6,6 +6,7 @@ use bdk::bitcoin::secp256k1;
 use bdk::esplora_client;
 
 /// Facilitates communication with a Bitcoin esplora server
+#[derive(Debug, Clone)]
 pub struct BitcoinClient {
     client: esplora_client::AsyncClient,
     private_key: bitcoin::PrivateKey,

--- a/romeo/src/bitcoin_client.rs
+++ b/romeo/src/bitcoin_client.rs
@@ -27,19 +27,9 @@ impl BitcoinClient {
         Ok(self.client.broadcast(tx).await?)
     }
 
-    /// Sign relevant inputs of a bitcoin transaction
-    pub async fn sign(&self, _tx: bitcoin::Transaction) -> anyhow::Result<bitcoin::Transaction> {
-        // TODO #68
-        todo!()
-    }
-
-    /// Bitcoin taproot address associated with the private key
-    pub async fn taproot_address(&self) -> bitcoin::Address {
-        let secp = secp256k1::Secp256k1::new();
-        let internal_key: schnorr::UntweakedPublicKey =
-            self.private_key.public_key(&secp).inner.into();
-
-        bitcoin::Address::p2tr(&secp, internal_key, None, self.private_key.network)
+    /// Get the status of a transaction
+    pub async fn get_tx_status(&self, txid: &bitcoin::Txid) -> anyhow::Result<Option<esplora_client::TxStatus>> {
+        Ok(self.client.get_tx_status(txid).await?)
     }
 
     /// Fetch a block at the given block height.
@@ -73,6 +63,21 @@ impl BitcoinClient {
     /// Get the current height of the Bitcoin chain
     pub async fn get_height(&self) -> anyhow::Result<u32> {
         Ok(self.client.get_height().await?)
+    }
+
+    /// Sign relevant inputs of a bitcoin transaction
+    pub async fn sign(&self, _tx: bitcoin::Transaction) -> anyhow::Result<bitcoin::Transaction> {
+        // TODO #68
+        todo!()
+    }
+
+    /// Bitcoin taproot address associated with the private key
+    pub async fn taproot_address(&self) -> bitcoin::Address {
+        let secp = secp256k1::Secp256k1::new();
+        let internal_key: schnorr::UntweakedPublicKey =
+            self.private_key.public_key(&secp).inner.into();
+
+        bitcoin::Address::p2tr(&secp, internal_key, None, self.private_key.network)
     }
 }
 

--- a/romeo/src/bitcoin_client.rs
+++ b/romeo/src/bitcoin_client.rs
@@ -1,8 +1,70 @@
 //! Bitcoin client
 
-//use bdk::esplora_client::r#async::AsyncClient;
+use bdk::bitcoin;
+use bdk::bitcoin::schnorr;
+use bdk::bitcoin::secp256k1;
+use bdk::esplora_client;
 
-/// Stateless wrapper around a bdk esplora client
+/// Facilitates communication with a Bitcoin esplora server
 pub struct BitcoinClient {
-    client: bdk::esplora_client::AsyncClient,
+    client: esplora_client::AsyncClient,
+    private_key: bitcoin::PrivateKey,
+}
+
+impl BitcoinClient {
+    /// Construct a new bitcoin client
+    pub fn new(esplora_url: &str, private_key: bitcoin::PrivateKey) -> anyhow::Result<Self> {
+        let client = esplora_client::Builder::new(esplora_url).build_async()?;
+
+        Ok(Self {
+            client,
+            private_key,
+        })
+    }
+
+    /// Broadcast a bitcoin transaction
+    pub async fn broadcast(&self, tx: &bitcoin::Transaction) -> anyhow::Result<()> {
+        Ok(self.client.broadcast(tx).await?)
+    }
+
+    /// Sign relevant inputs of a bitcoin transaction
+    pub async fn sign(&self, _tx: bitcoin::Transaction) -> anyhow::Result<bitcoin::Transaction> {
+        // TODO #68
+        todo!()
+    }
+
+    /// Bitcoin taproot address associated with the private key
+    pub async fn taproot_address(&self) -> bitcoin::Address {
+        let secp = secp256k1::Secp256k1::new();
+        let internal_key: schnorr::UntweakedPublicKey =
+            self.private_key.public_key(&secp).inner.into();
+
+        bitcoin::Address::p2tr(&secp, internal_key, None, self.private_key.network)
+    }
+
+    /// Fetch a block at the given block height.
+    /// If the current block height is lower than the requested block height
+    /// this function will poll the blockchain until that height is reached.
+    #[tracing::instrument(skip(self))]
+    pub async fn fetch_block(&self, block_height: u32) -> anyhow::Result<bitcoin::Block> {
+        let mut current_height = self.client.get_height().await?;
+
+        while current_height < block_height {
+            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+            current_height = self.client.get_height().await?;
+        }
+
+        let block_summaries = self.client.get_blocks(Some(block_height as u32)).await?;
+        let block_summary = block_summaries
+            .first()
+            .ok_or_else(|| anyhow::anyhow!("Could not find block at given block height"))?;
+
+        let block = self
+            .client
+            .get_block_by_hash(&block_summary.id)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("Found no block for the given block hash"))?;
+
+        Ok(block)
+    }
 }

--- a/romeo/src/bitcoin_client.rs
+++ b/romeo/src/bitcoin_client.rs
@@ -1,0 +1,8 @@
+//! Bitcoin client
+
+//use bdk::esplora_client::r#async::AsyncClient;
+
+/// Stateless wrapper around a bdk esplora client
+pub struct BitcoinClient {
+    client: bdk::esplora_client::AsyncClient,
+}

--- a/romeo/src/lib.rs
+++ b/romeo/src/lib.rs
@@ -6,6 +6,7 @@
 //! and respond the same way the final sBTC system is intended to.
 #![forbid(missing_docs)]
 
+pub mod bitcoin_client;
 pub mod config;
 pub mod event;
 pub mod stacks_client;


### PR DESCRIPTION
closes #61 

This PR provides a simple wrapper around a Bitcoin Esplora client to facilitate communication between Romeo and an Esplora node. This should support all Bitcoin interaction points we need for Romeo, and can easily be extended for future needs.