### PR TITLE
[sbtc-cli] Generate bitcoin p2wpkh address with the credentials

### DIFF
--- a/sbtc-cli/src/commands/generate.rs
+++ b/sbtc-cli/src/commands/generate.rs
@@ -45,6 +45,7 @@ struct Credentials {
     bitcoin_taproot_address_tweaked: String,
     bitcoin_taproot_address_untweaked: String,
     bitcoin_p2pkh_address: String,
+    bitcoin_p2wpkh_address: String,
 }
 
 pub fn generate(generate_args: &GenerateArgs) -> anyhow::Result<()> {
@@ -136,5 +137,7 @@ fn generate_credentials(
         bitcoin_taproot_address_tweaked,
         bitcoin_taproot_address_untweaked,
         bitcoin_p2pkh_address: BitcoinAddress::p2pkh(&public_key, private_key.network).to_string(),
+        bitcoin_p2wpkh_address: BitcoinAddress::p2wpkh(&public_key, private_key.network)?
+            .to_string(),
     })
 }


### PR DESCRIPTION
We use this type of address to pay for the sbtc btc transactions.

Sample output (random credentials don't use):
```json
{
  "mnemonic": "negative aspect salad kitchen banner enlist cram deputy describe exit jar anger market flip orient age maze ocean ranch hungry flavor disease high nothing",
  "wif": "cNidUqiKvU3K6sypaRPNhPsXL1dcW8sdzP2JJJaCjUdK39t6F5rS",
  "private_key": "0x21ea7a9532dd379130430220baba1686dbae7f5364157f2e2827a96aa1ae3f2f",
  "public_key": "0x029a19ac8fb93a7b9416b5be603fa19d53eca8f6e33ac89667abc7e777afd3b816",
  "stacks_address": "ST17Z635X9KRCAVHNRX3HX4XAWBJ0KM4VEHZZ2KBW",
  "bitcoin_taproot_address_tweaked": "tb1p90dyzzyuqdzc9lmfss8qmds3m8cur2jyf4et99pu87t583s35xzqdltv60",
  "bitcoin_taproot_address_untweaked": "tb1pngv6erae8faeg944hesrlgva20k23ahr8tyfveatclnh0t7nhqtqufj023",
  "bitcoin_p2pkh_address": "mnogqbtDSktLEfz3G5wpZUPq61AVZTjPYC",
  "bitcoin_p2wpkh_address": "tb1qflese02v7rzkudw8gu0f82hzusyapxm567p469"
}
```