### PR TITLE
[sBTC DR] Logging after effects, improve error codes, change order of functions, change guard

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -65,6 +65,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ env.BRANCH }}
+          
       - name: Publish
         uses: katyo/publish-crates@v2
         with:

--- a/romeo/asset-contract/contracts/asset.clar
+++ b/romeo/asset-contract/contracts/asset.clar
@@ -24,7 +24,9 @@
 
 ;; public functions
 ;;
-(define-public (set-new-owner (new-owner principal))
+
+;; #[allow(unchecked_data)]
+(define-public (set-contract-owner (new-owner principal))
   (begin
     (asserts! (is-contract-owner) err-forbidden)
     (var-set contract-owner new-owner)
@@ -36,14 +38,6 @@
     (begin
     (asserts! (is-contract-owner) err-forbidden)
         (ok (var-set bitcoin-wallet-public-key (some public-key)))
-    )
-)
-
-;; #[allow(unchecked_data)]
-(define-public (set-contract-owner (new-owner principal))
-    (begin
-        (asserts! (is-contract-owner) err-forbidden)
-        (ok (var-set contract-owner new-owner))
     )
 )
 
@@ -87,7 +81,7 @@
 ;; #[allow(unchecked_data)]
 (define-public (transfer (amount uint) (sender principal) (recipient principal) (memo (optional (buff 34))))
 	(begin
-        (asserts! (is-eq sender contract-caller) err-forbidden)
+        (asserts! (is-eq sender tx-sender) err-forbidden)
 		(asserts! (> amount u0) err-bad-request)
 		(try! (ft-transfer? sbtc amount sender recipient))
 		(match memo to-print (print to-print) 0x)

--- a/romeo/asset-contract/contracts/asset.clar
+++ b/romeo/asset-contract/contracts/asset.clar
@@ -14,7 +14,8 @@
 
 ;; constants
 ;;
-(define-constant err-invalid-caller (err u403))
+(define-constant err-invalid-caller (err u4))
+(define-constant err-forbidden (err u403))
 
 ;; data vars
 ;;
@@ -35,7 +36,7 @@
 ;; #[allow(unchecked_data)]
 (define-public (set-bitcoin-wallet-public-key (public-key (buff 33)))
     (begin
-    (try! (is-contract-owner))
+        (try! (is-contract-owner))
         (ok (var-set bitcoin-wallet-public-key (some public-key)))
     )
 )
@@ -72,7 +73,7 @@
         (try! (verify-txid-exists-on-burn-chain withdraw-txid burn-chain-height merkle-proof tx-index tree-depth block-header))
         (try! (ft-burn? sbtc amount owner))
         (print {notification: "burn", payload: withdraw-txid})
-    		(ok true)
+    	(ok true)
     )
 )
 
@@ -123,7 +124,7 @@
 ;; private functions
 ;;
 (define-private (is-contract-owner)
-    (ok (asserts! (is-eq (var-get contract-owner) contract-caller) err-invalid-caller))
+    (ok (asserts! (is-eq (var-get contract-owner) contract-caller) err-forbidden))
 )
 
 (define-read-only (verify-txid-exists-on-burn-chain (txid (buff 32)) (burn-chain-height uint) (merkle-proof (list 14 (buff 32))) (tx-index uint) (tree-depth uint) (block-header (buff 80)))

--- a/romeo/asset-contract/contracts/asset.clar
+++ b/romeo/asset-contract/contracts/asset.clar
@@ -76,6 +76,10 @@
     (var-get bitcoin-wallet-public-key)
 )
 
+(define-read-only (get-contract-owner)
+    (var-get contract-owner)
+)
+
 (define-read-only (get-name)
 	(ok "sBTC")
 )

--- a/romeo/asset-contract/contracts/asset.clar
+++ b/romeo/asset-contract/contracts/asset.clar
@@ -15,7 +15,7 @@
 ;; constants
 ;;
 (define-constant err-forbidden (err u403))
-(define-constant err-amount-zero (err u404))
+(define-constant err-bad-request (err u400))
 
 ;; data vars
 ;;
@@ -41,7 +41,7 @@
 (define-public (mint (amount uint) (dst principal) (deposit-txid (string-ascii 72)))
     (begin
         (asserts! (is-contract-owner) err-forbidden)
-        (asserts! (> amount u0) err-amount-zero)
+        (asserts! (> amount u0) err-bad-request)
         ;; TODO #79: Assert deposit-txid exists on chain
         (try! (ft-mint? sbtc amount dst))
         (print {notification: "mint", payload: deposit-txid})
@@ -52,7 +52,7 @@
 (define-public (burn (amount uint) (src principal) (withdraw-txid (string-ascii 72)))
     (begin
         (asserts! (is-contract-owner) err-forbidden)
-        (asserts! (> amount u0) err-amount-zero)
+        (asserts! (> amount u0) err-bad-request)
         ;; TODO #79: Assert withdraw-txid exists on chain
         (try! (ft-burn? sbtc amount src))
         (print {notification: "burn", payload: withdraw-txid})
@@ -63,7 +63,7 @@
 (define-public (transfer (amount uint) (sender principal) (recipient principal) (memo (optional (buff 34))))
 	(begin
 		(asserts! (is-eq contract-caller sender) err-forbidden)
-        (asserts! (> amount u0) err-amount-zero)
+        (asserts! (> amount u0) err-bad-request)
 		(try! (ft-transfer? sbtc amount sender recipient))
 		(match memo to-print (print to-print) 0x)
 		(ok true)

--- a/romeo/asset-contract/contracts/asset.clar
+++ b/romeo/asset-contract/contracts/asset.clar
@@ -87,8 +87,7 @@
 ;; #[allow(unchecked_data)]
 (define-public (transfer (amount uint) (sender principal) (recipient principal) (memo (optional (buff 34))))
 	(begin
-		(asserts! (is-contract-owner) err-forbidden)
-    (asserts! (> amount u0) err-bad-request)
+		(asserts! (> amount u0) err-bad-request)
 		(try! (ft-transfer? sbtc amount sender recipient))
 		(match memo to-print (print to-print) 0x)
 		(ok true)

--- a/romeo/asset-contract/contracts/asset.clar
+++ b/romeo/asset-contract/contracts/asset.clar
@@ -70,7 +70,6 @@
     (block-header (buff 80)))
     (begin
         (asserts! (is-contract-owner) err-forbidden)
-        (asserts! (> amount u0) err-bad-request)
         (try! (verify-txid-exists-on-burn-chain withdraw-txid burn-chain-height merkle-proof tx-index tree-depth block-header))
         (try! (ft-burn? sbtc amount owner))
         (print {notification: "burn", payload: withdraw-txid})
@@ -81,8 +80,7 @@
 ;; #[allow(unchecked_data)]
 (define-public (transfer (amount uint) (sender principal) (recipient principal) (memo (optional (buff 34))))
 	(begin
-        (asserts! (is-eq sender tx-sender) err-forbidden)
-		(asserts! (> amount u0) err-bad-request)
+        (asserts! (or (is-eq tx-sender sender) (is-eq contract-caller sender)) err-forbidden)
 		(try! (ft-transfer? sbtc amount sender recipient))
 		(match memo to-print (print to-print) 0x)
 		(ok true)

--- a/romeo/asset-contract/contracts/asset.clar
+++ b/romeo/asset-contract/contracts/asset.clar
@@ -87,6 +87,7 @@
 ;; #[allow(unchecked_data)]
 (define-public (transfer (amount uint) (sender principal) (recipient principal) (memo (optional (buff 34))))
 	(begin
+        (asserts! (is-eq sender contract-caller) err-forbidden)
 		(asserts! (> amount u0) err-bad-request)
 		(try! (ft-transfer? sbtc amount sender recipient))
 		(match memo to-print (print to-print) 0x)

--- a/romeo/asset-contract/contracts/asset.clar
+++ b/romeo/asset-contract/contracts/asset.clar
@@ -34,7 +34,7 @@
 ;; #[allow(unchecked_data)]
 (define-public (set-bitcoin-wallet-public-key (public-key (buff 33)))
     (begin
-        (try! (is-contract-owner))
+    (asserts! (is-contract-owner) err-forbidden)
         (ok (var-set bitcoin-wallet-public-key (some public-key)))
     )
 )
@@ -43,7 +43,6 @@
 (define-public (set-contract-owner (new-owner principal))
     (begin
         (asserts! (is-contract-owner) err-forbidden)
-        (asserts! (> amount u0) err-bad-request)
         (ok (var-set contract-owner new-owner))
     )
 )
@@ -60,7 +59,7 @@
     (begin
         (asserts! (is-contract-owner) err-forbidden)
         (try! (verify-txid-exists-on-burn-chain deposit-txid burn-chain-height merkle-proof tx-index tree-depth block-header))
-        (ft-mint? sbtc amount destination)
+        (try! (ft-mint? sbtc amount destination))
         (print {notification: "mint", payload: deposit-txid})
         (ok true)
     )
@@ -79,7 +78,7 @@
         (asserts! (is-contract-owner) err-forbidden)
         (asserts! (> amount u0) err-bad-request)
         (try! (verify-txid-exists-on-burn-chain withdraw-txid burn-chain-height merkle-proof tx-index tree-depth block-header))
-        (ft-burn? sbtc amount owner)
+        (try! (ft-burn? sbtc amount owner))
         (print {notification: "burn", payload: withdraw-txid})
     		(ok true)
     )

--- a/romeo/asset-contract/tests/asset_test.clar
+++ b/romeo/asset-contract/tests/asset_test.clar
@@ -8,6 +8,7 @@
 (define-constant expected-decimals u8)
 
 (define-constant err-forbidden (err u403))
+(define-constant err-amount-zero (err u404))
 
 (define-private (assert-eq (result (response bool uint)) (compare (response bool uint)) (message (string-ascii 100)))
 	(ok (asserts! (is-eq result compare) (err message)))
@@ -116,4 +117,21 @@
 ;; @name Can get token URI
 (define-public (test-get-token-uri)
 	(ok (asserts! (is-eq (contract-call? .asset get-token-uri) (ok expected-token-uri)) (err "Token uri does not match")))
+)
+
+;; @name Set valid new owner
+;; @caller deployer
+(define-public (test-set-valid-owner)
+(begin
+    (try! (contract-call? .asset set-new-owner 'ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y))
+    ;; Check new owner set
+    (asserts! (is-eq (contract-call? .asset get-contract-owner) 'ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y) (err u100))
+	(ok true)
+	)
+)
+
+;; @name Try to set owner without being current owner
+;; @caller wallet_1 
+(define-public (test-set-invalid-owner)
+	(assert-eq (contract-call? .asset set-new-owner 'ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y) err-forbidden "Should have failed")
 )

--- a/romeo/asset-contract/tests/asset_test.clar
+++ b/romeo/asset-contract/tests/asset_test.clar
@@ -169,3 +169,9 @@
 	(ok true)
 	)
 )
+
+;; @name Try to set owner without being current owner
+;; @caller wallet_1
+(define-public (test-set-invalid-owner)
+	(assert-eq (contract-call? .asset set-contract-owner wallet-2) err-forbidden "Should have failed")
+)

--- a/romeo/asset-contract/tests/asset_test.clar
+++ b/romeo/asset-contract/tests/asset_test.clar
@@ -7,8 +7,8 @@
 (define-constant expected-symbol "sBTC")
 (define-constant expected-decimals u8)
 
-(define-constant err-invalid-caller (err u403))
-(define-constant err-bad-request (err u400))
+(define-constant err-invalid-caller (err u4))
+(define-constant err-forbidden (err u403))
 
 (define-constant test-burn-height u1)
 (define-constant test-block-header 0x02000000000000000000000000000000000000000000000000000000000000000000000075b8bf903d0153e1463862811283ffbec83f55411c9fa5bd24e4207dee0dc1f1000000000000000000000000)
@@ -75,7 +75,7 @@
 ;; @prepare prepare-revoke-contract-owner
 ;; @caller wallet_1
 (define-public (test-protocol-mint-external)
-	(assert-eq (contract-call? .asset mint u10000000 wallet-1 test-txid u1 test-merkle-proof test-tx-index test-tree-depth test-block-header) err-invalid-caller "Should have failed")
+	(assert-eq (contract-call? .asset mint u10000000 wallet-1 test-txid u1 test-merkle-proof test-tx-index test-tree-depth test-block-header) err-forbidden "Should have failed")
 )
 
 ;; @name Protocol can burn tokens
@@ -88,7 +88,7 @@
 ;; @prepare prepare-revoke-contract-owner
 ;; @caller wallet_1
 (define-public (test-protocol-burn-external)
-	(assert-eq (contract-call? .asset burn u10000000 wallet-2 test-txid u1 test-merkle-proof test-tx-index test-tree-depth test-block-header) err-invalid-caller "Should have failed")
+	(assert-eq (contract-call? .asset burn u10000000 wallet-2 test-txid u1 test-merkle-proof test-tx-index test-tree-depth test-block-header) err-forbidden "Should have failed")
 )
 
 ;; @name Protocol can set wallet address
@@ -102,7 +102,7 @@
 ;; @prepare prepare-revoke-contract-owner
 ;; @caller wallet_1
 (define-public (test-protocol-set-wallet-public-key-external)
-	(assert-eq (contract-call? .asset set-bitcoin-wallet-public-key 0x1234) err-invalid-caller "Should have returned err forbidden")
+	(assert-eq (contract-call? .asset set-bitcoin-wallet-public-key 0x1234) err-forbidden "Should have returned err forbidden")
 )
 
 ;; --- SIP010 tests
@@ -162,11 +162,11 @@
 ;; @name Set valid new owner
 ;; @caller deployer
 (define-public (test-set-valid-owner)
-(begin
-    (try! (contract-call? .asset set-contract-owner 'ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y))
-    ;; Check new owner set
-    (asserts! (is-eq (contract-call? .asset get-contract-owner) 'ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y) (err u100))
-	(ok true)
+	(begin
+		(try! (contract-call? .asset set-contract-owner 'ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y))
+		;; Check new owner set
+		(asserts! (is-eq (contract-call? .asset get-contract-owner) 'ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y) (err u100))
+		(ok true)
 	)
 )
 
@@ -174,5 +174,5 @@
 ;; @prepare prepare-revoke-contract-owner
 ;; @caller wallet_1
 (define-public (test-set-invalid-owner)
-	(assert-eq (contract-call? .asset set-contract-owner wallet-2) err-invalid-caller "Should have failed")
+	(assert-eq (contract-call? .asset set-contract-owner wallet-2) err-forbidden "Should have failed")
 )

--- a/romeo/asset-contract/tests/asset_test.clar
+++ b/romeo/asset-contract/tests/asset_test.clar
@@ -169,9 +169,3 @@
 	(ok true)
 	)
 )
-
-;; @name Try to set owner without being current owner
-;; @caller wallet_1
-(define-public (test-set-invalid-owner)
-	(assert-eq (contract-call? .asset set-contract-owner wallet-2) err-forbidden "Should have failed")
-)

--- a/romeo/asset-contract/tests/asset_test.clar
+++ b/romeo/asset-contract/tests/asset_test.clar
@@ -110,7 +110,7 @@
 ;; @name Token owner can transfer their tokens
 ;; @caller wallet_1
 (define-public (test-transfer)
-	(contract-call? .asset transfer u100 tx-sender wallet-2 none)
+	(contract-call? .asset transfer u100 contract-caller wallet-2 none)
 )
 
 ;; @name User can transfer tokens owned by contract
@@ -124,9 +124,9 @@
 )
 
 ;; @name Cannot transfer someone else's tokens
-;; @caller wallet_1
+;; @caller deployer
 (define-public (test-transfer-external)
-	(assert-eq (contract-call? .asset transfer u100 wallet-2 tx-sender none) err-forbidden "Should have failed")
+	(assert-eq (contract-call? .asset transfer u100 wallet-2 wallet-1 none) err-forbidden "Should have failed")
 )
 
 ;; @name Can get name
@@ -171,7 +171,7 @@
 )
 
 ;; @name Try to set owner without being current owner
-;; @caller wallet_1 
+;; @caller wallet_1
 (define-public (test-set-invalid-owner)
-	(assert-eq (contract-call? .asset set-new-owner 'ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y) err-forbidden "Should have failed")
+	(assert-eq (contract-call? .asset set-new-owner wallet-2) err-forbidden "Should have failed")
 )

--- a/romeo/asset-contract/tests/asset_test.clar
+++ b/romeo/asset-contract/tests/asset_test.clar
@@ -75,7 +75,7 @@
 ;; @prepare prepare-revoke-contract-owner
 ;; @caller wallet_1
 (define-public (test-protocol-mint-external)
-	(assert-eq (contract-call? .asset mint u10000000 wallet-1 test-txid u1 test-merkle-proof test-tx-index test-tree-depth test-block-header) err-invalid-caller "Should have failed")
+	(assert-eq (contract-call? .asset mint u10000000 wallet-1 test-txid u1 test-merkle-proof test-tx-index test-tree-depth test-block-header) err-forbidden "Should have failed")
 )
 
 ;; @name Protocol can burn tokens
@@ -88,7 +88,7 @@
 ;; @prepare prepare-revoke-contract-owner
 ;; @caller wallet_1
 (define-public (test-protocol-burn-external)
-	(assert-eq (contract-call? .asset burn u10000000 wallet-2 test-txid u1 test-merkle-proof test-tx-index test-tree-depth test-block-header) err-invalid-caller "Should have failed")
+	(assert-eq (contract-call? .asset burn u10000000 wallet-2 test-txid u1 test-merkle-proof test-tx-index test-tree-depth test-block-header) err-forbidden "Should have failed")
 )
 
 ;; @name Protocol can set wallet address
@@ -102,7 +102,7 @@
 ;; @prepare prepare-revoke-contract-owner
 ;; @caller wallet_1
 (define-public (test-protocol-set-wallet-public-key-external)
-	(assert-eq (contract-call? .asset set-bitcoin-wallet-public-key 0x1234) err-invalid-caller "Should have returned err forbidden")
+	(assert-eq (contract-call? .asset set-bitcoin-wallet-public-key 0x1234) err-forbidden "Should have returned err forbidden")
 )
 
 ;; --- SIP010 tests
@@ -126,7 +126,7 @@
 ;; @name Cannot transfer someone else's tokens
 ;; @caller wallet_1
 (define-public (test-transfer-external)
-	(assert-eq (contract-call? .asset transfer u100 wallet-2 tx-sender none) err-not-token-owner "Should have failed")
+	(assert-eq (contract-call? .asset transfer u100 wallet-2 tx-sender none) err-forbidden "Should have failed")
 )
 
 ;; @name Can get name

--- a/romeo/asset-contract/tests/asset_test.clar
+++ b/romeo/asset-contract/tests/asset_test.clar
@@ -171,6 +171,7 @@
 )
 
 ;; @name Try to set owner without being current owner
+;; @prepare prepare-revoke-contract-owner
 ;; @caller wallet_1
 (define-public (test-set-invalid-owner)
 	(assert-eq (contract-call? .asset set-contract-owner wallet-2) err-forbidden "Should have failed")

--- a/romeo/asset-contract/tests/asset_test.clar
+++ b/romeo/asset-contract/tests/asset_test.clar
@@ -7,7 +7,7 @@
 (define-constant expected-symbol "sBTC")
 (define-constant expected-decimals u8)
 
-(define-constant err-forbidden (err u403))
+(define-constant err-invalid-caller (err u403))
 (define-constant err-bad-request (err u400))
 
 (define-constant test-burn-height u1)
@@ -75,7 +75,7 @@
 ;; @prepare prepare-revoke-contract-owner
 ;; @caller wallet_1
 (define-public (test-protocol-mint-external)
-	(assert-eq (contract-call? .asset mint u10000000 wallet-1 test-txid u1 test-merkle-proof test-tx-index test-tree-depth test-block-header) err-forbidden "Should have failed")
+	(assert-eq (contract-call? .asset mint u10000000 wallet-1 test-txid u1 test-merkle-proof test-tx-index test-tree-depth test-block-header) err-invalid-caller "Should have failed")
 )
 
 ;; @name Protocol can burn tokens
@@ -88,7 +88,7 @@
 ;; @prepare prepare-revoke-contract-owner
 ;; @caller wallet_1
 (define-public (test-protocol-burn-external)
-	(assert-eq (contract-call? .asset burn u10000000 wallet-2 test-txid u1 test-merkle-proof test-tx-index test-tree-depth test-block-header) err-forbidden "Should have failed")
+	(assert-eq (contract-call? .asset burn u10000000 wallet-2 test-txid u1 test-merkle-proof test-tx-index test-tree-depth test-block-header) err-invalid-caller "Should have failed")
 )
 
 ;; @name Protocol can set wallet address
@@ -102,7 +102,7 @@
 ;; @prepare prepare-revoke-contract-owner
 ;; @caller wallet_1
 (define-public (test-protocol-set-wallet-public-key-external)
-	(assert-eq (contract-call? .asset set-bitcoin-wallet-public-key 0x1234) err-forbidden "Should have returned err forbidden")
+	(assert-eq (contract-call? .asset set-bitcoin-wallet-public-key 0x1234) err-invalid-caller "Should have returned err forbidden")
 )
 
 ;; --- SIP010 tests
@@ -126,7 +126,7 @@
 ;; @name Cannot transfer someone else's tokens
 ;; @caller deployer
 (define-public (test-transfer-external)
-	(assert-eq (contract-call? .asset transfer u100 wallet-2 wallet-1 none) err-forbidden "Should have failed")
+	(assert-eq (contract-call? .asset transfer u100 wallet-2 wallet-1 none) err-invalid-caller "Should have failed")
 )
 
 ;; @name Can get name
@@ -174,5 +174,5 @@
 ;; @prepare prepare-revoke-contract-owner
 ;; @caller wallet_1
 (define-public (test-set-invalid-owner)
-	(assert-eq (contract-call? .asset set-contract-owner wallet-2) err-forbidden "Should have failed")
+	(assert-eq (contract-call? .asset set-contract-owner wallet-2) err-invalid-caller "Should have failed")
 )

--- a/romeo/asset-contract/tests/asset_test.clar
+++ b/romeo/asset-contract/tests/asset_test.clar
@@ -116,7 +116,7 @@
 ;; @name User can transfer tokens owned by contract
 ;; @caller wallet_1
 (define-public (test-transfer-contract)
-	(distribute-tokens u100 (as-contract tx-sender) wallet-2)
+	(as-contract (distribute-tokens u100 tx-sender wallet-2))
 )
 
 (define-public (distribute-tokens (amount uint) (from principal) (to principal))
@@ -163,7 +163,7 @@
 ;; @caller deployer
 (define-public (test-set-valid-owner)
 (begin
-    (try! (contract-call? .asset set-new-owner 'ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y))
+    (try! (contract-call? .asset set-contract-owner 'ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y))
     ;; Check new owner set
     (asserts! (is-eq (contract-call? .asset get-contract-owner) 'ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y) (err u100))
 	(ok true)
@@ -173,5 +173,5 @@
 ;; @name Try to set owner without being current owner
 ;; @caller wallet_1
 (define-public (test-set-invalid-owner)
-	(assert-eq (contract-call? .asset set-new-owner wallet-2) err-forbidden "Should have failed")
+	(assert-eq (contract-call? .asset set-contract-owner wallet-2) err-forbidden "Should have failed")
 )


### PR DESCRIPTION
## Description

Will close #118 

- No tx-sender for Access Control (breaks composability and can be used for phishing).
- Owner can assign a new owner, the owner can `mint` and use `set-bitcoin-wallet-public-key`.
- Only log with `print` after the changes effected on token are ok.

## Checklist
- [x] Additions and modifications are documented
- [x] Additions and modifications are tested
