### PR TITLE
Change default branch references from master to main

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 env:
-  BRANCH: "master" # TODO: Change main branch to main
+  BRANCH: "main"
   CARGO_TERM_COLOR: always
 
 jobs:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,10 +2,10 @@ name: Pull Request
 
 on:
   pull_request:
-    branches: "master"
+    branches: "main"
     paths-ignore: ['**.md']
   push:
-    branches: "master"
+    branches: "main"
     paths-ignore: ['**.md']
 
 env:

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ cargo install --version 0.36.13 cargo-make
 
 Also verify that openssl is install on your machine.
 
-[coverage-badge]: https://codecov.io/github/stacks-network/sbtc/branch/master/graph/badge.svg?token=2sbE9YLwT6
+[coverage-badge]: https://codecov.io/github/stacks-network/sbtc/branch/main/graph/badge.svg?token=2sbE9YLwT6
 [coverage-link]: https://codecov.io/github/stacks-network/sbtc
 [discord-badge]: https://img.shields.io/static/v1?logo=discord&label=discord&message=Join&color=blue
 [discord-link]: https://discord.gg/WPWZPppr


### PR DESCRIPTION
# Summary

Change the default branch name from `master` to `main` within:
1. GitHub workflows
2. README.md GitHub workflow badge

---

Open PRs to `master` have been automatically redirected to merge to `main`, but developers' local environments will need to manually switch from branch `master` to `main`.