### PR TITLE
Fix audit step in daily workflow and speed up testing

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -31,7 +31,7 @@ jobs:
           version: "0.36.13"
 
       - name: Audit
-        run: cargo make audit
+        run: cargo make --profile github-actions audit
 
       - uses: actions/upload-artifact@v3
         with:
@@ -55,8 +55,8 @@ jobs:
           with:
             ref: ${{ env.BRANCH }}
 
-        - name: Nextest with release
-          run: cargo make test
+        - name: Test with release
+          run: cargo make --profile github-actions test
 
     publish:
       needs: intense-tests

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -36,7 +36,7 @@ install_crate = { crate_name = "cargo-llvm-cov", version = "0.5.25", binary = "c
 
 [tasks._install-audit]
 private = true
-install_crate = { crate_name = "cargo-audit", version = "0.17.6", binary = "cargo", "test_arg" = ["audit" , "--help"]}
+install_crate = { crate_name = "cargo-audit", version = "0.18.1", binary = "cargo", "test_arg" = ["audit" , "--help"]}
 
 [tasks.install]
 dependencies = [
@@ -149,6 +149,7 @@ command = "cargo"
 args = ["build", "--release"]
 
 [tasks.test]
+workspace = false
 dependencies = ["_install-test-framework"]
 command = "cargo"
 args = ["${TEST_FRAMEWORK}", "run", "--release"]
@@ -161,6 +162,7 @@ args = ["doc"]
 # ------
 
 [tasks.audit]
+workspace = false # Audit must run in workspace root.
 dependencies = ["_install-audit"]
 command = "cargo"
 args = ["audit", "-D", "warnings"]


### PR DESCRIPTION
## Summary
This PR fixes an error in the daily workflow where the `cargo audit` command would result in the following ([Example](https://github.com/stacks-network/sbtc/actions/runs/6024576233/job/16343562063)):

```
error: not found: Couldn't load Cargo.lock: I/O operation failed: I/O operation failed: entity not found
[cargo-make][1] ERROR - Error while executing command, exit code: 2
[cargo-make][1] WARN - Build Failed.
[cargo-make] ERROR - Error while running duckscript: Source: Unknown Line: 5 - Error while executing command, exit code: 1
[cargo-make] WARN - Build Failed.
Error: Process completed with exit code 1.
```

## Details

### Root Cause

This issue occurred because `cargo make audit` task would actually run the `cargo audit` command in each workspace member directory as opposed to the root directory. This fails because the command `cargo generate lockfile` does not make a separate `Cargo.lock` in each workspace member root.

### Bonus changes

- GitHub Ubuntu-latest ships with `cargo audit` version `1.18.1` - switching to this version means it won't be re-downloaded when `cargo make audit` runs. *[Tools shipped with github runner ubuntu-latest](https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md)*
- Specifying the `make` profile within the daily workflow github action will switch the `test` command from the default `nextest` to `test`, which skips an absurdly long download and compile phase for `cargo nextest` within the github workflow.