### PR TITLE
Add nightly cargo fmt rules

### DIFF
--- a/romeo/src/bitcoin_client/esplora.rs
+++ b/romeo/src/bitcoin_client/esplora.rs
@@ -3,16 +3,15 @@
 use std::time::Duration;
 
 use async_trait::async_trait;
-use bdk::bitcoin::Transaction;
-use bdk::bitcoin::{self, Txid};
-use bdk::esplora_client::AsyncClient;
-use bdk::esplora_client::{self, Builder};
+use bdk::{
+	bitcoin::{self, Transaction, Txid},
+	esplora_client::{self, AsyncClient, Builder},
+};
 use futures::Future;
 use tracing::trace;
 
-use crate::event::{self, TransactionStatus};
-
 use super::BitcoinClient;
+use crate::event::{self, TransactionStatus};
 
 const BLOCK_POLLING_INTERVAL: Duration = Duration::from_secs(5);
 
@@ -21,76 +20,92 @@ const BLOCK_POLLING_INTERVAL: Duration = Duration::from_secs(5);
 pub struct EsploraClient(AsyncClient);
 
 impl EsploraClient {
-    /// Create Esplora Bitcoin client
-    pub fn new(url: impl AsRef<str>) -> anyhow::Result<Self> {
-        Ok(Self(Builder::new(url.as_ref()).build_async()?))
-    }
+	/// Create Esplora Bitcoin client
+	pub fn new(url: impl AsRef<str>) -> anyhow::Result<Self> {
+		Ok(Self(Builder::new(url.as_ref()).build_async()?))
+	}
 }
 
 #[async_trait]
 impl BitcoinClient for EsploraClient {
-    async fn broadcast(&self, tx: Transaction) -> anyhow::Result<()> {
-        retry(|| self.0.broadcast(&tx)).await
-    }
+	async fn broadcast(&self, tx: Transaction) -> anyhow::Result<()> {
+		retry(|| self.0.broadcast(&tx)).await
+	}
 
-    async fn get_tx_status(&self, txid: Txid) -> anyhow::Result<TransactionStatus> {
-        let status = retry(|| self.0.get_tx_status(&txid)).await?;
+	async fn get_tx_status(
+		&self,
+		txid: Txid,
+	) -> anyhow::Result<TransactionStatus> {
+		let status = retry(|| self.0.get_tx_status(&txid)).await?;
 
-        Ok(match status {
-            Some(esplora_client::TxStatus {
-                confirmed: true, ..
-            }) => event::TransactionStatus::Confirmed,
-            Some(esplora_client::TxStatus {
-                confirmed: false, ..
-            }) => event::TransactionStatus::Broadcasted,
-            None => event::TransactionStatus::Rejected,
-        })
-    }
+		Ok(match status {
+			Some(esplora_client::TxStatus {
+				confirmed: true, ..
+			}) => event::TransactionStatus::Confirmed,
+			Some(esplora_client::TxStatus {
+				confirmed: false, ..
+			}) => event::TransactionStatus::Broadcasted,
+			None => event::TransactionStatus::Rejected,
+		})
+	}
 
-    #[tracing::instrument(skip(self))]
-    async fn fetch_block(&self, block_height: u32) -> anyhow::Result<(u32, bitcoin::Block)> {
-        let mut current_height = retry(|| self.0.get_height()).await?;
+	#[tracing::instrument(skip(self))]
+	async fn fetch_block(
+		&self,
+		block_height: u32,
+	) -> anyhow::Result<(u32, bitcoin::Block)> {
+		let mut current_height = retry(|| self.0.get_height()).await?;
 
-        trace!("Looking for block height: {}", current_height + 1);
-        while current_height < block_height {
-            tokio::time::sleep(BLOCK_POLLING_INTERVAL).await;
-            current_height = retry(|| self.0.get_height()).await?;
-        }
+		trace!("Looking for block height: {}", current_height + 1);
+		while current_height < block_height {
+			tokio::time::sleep(BLOCK_POLLING_INTERVAL).await;
+			current_height = retry(|| self.0.get_height()).await?;
+		}
 
-        let block_summaries = retry(|| self.0.get_blocks(Some(block_height))).await?;
-        let block_summary = block_summaries
-            .first()
-            .ok_or_else(|| anyhow::anyhow!("Could not find block at given block height"))?;
+		let block_summaries =
+			retry(|| self.0.get_blocks(Some(block_height))).await?;
+		let block_summary = block_summaries.first().ok_or_else(|| {
+			anyhow::anyhow!("Could not find block at given block height")
+		})?;
 
-        let block = retry(|| self.0.get_block_by_hash(&block_summary.id))
-            .await?
-            .ok_or_else(|| anyhow::anyhow!("Found no block for the given block hash"))?;
+		let block = retry(|| self.0.get_block_by_hash(&block_summary.id))
+			.await?
+			.ok_or_else(|| {
+				anyhow::anyhow!("Found no block for the given block hash")
+			})?;
 
-        trace!("Fetched block");
+		trace!("Fetched block");
 
-        Ok((block_height, block))
-    }
+		Ok((block_height, block))
+	}
 
-    async fn get_height(&self) -> anyhow::Result<u32> {
-        retry(|| self.0.get_height()).await
-    }
+	async fn get_height(&self) -> anyhow::Result<u32> {
+		retry(|| self.0.get_height()).await
+	}
 }
 
 async fn retry<T, O, Fut>(operation: O) -> anyhow::Result<T>
 where
-    O: Clone + Fn() -> Fut,
-    Fut: Future<Output = Result<T, bdk::esplora_client::Error>>,
+	O: Clone + Fn() -> Fut,
+	Fut: Future<Output = Result<T, bdk::esplora_client::Error>>,
 {
-    let operation = || async {
-        operation.clone()().await.map_err(|err| match err {
-            esplora_client::Error::Reqwest(_) => backoff::Error::transient(anyhow::anyhow!(err)),
-            err => backoff::Error::permanent(anyhow::anyhow!(err)),
-        })
-    };
+	let operation = || async {
+		operation.clone()().await.map_err(|err| match err {
+			esplora_client::Error::Reqwest(_) => {
+				backoff::Error::transient(anyhow::anyhow!(err))
+			}
+			err => backoff::Error::permanent(anyhow::anyhow!(err)),
+		})
+	};
 
-    let notify = |err, duration| {
-        trace!("Retrying in {:?} after error: {:?}", duration, err);
-    };
+	let notify = |err, duration| {
+		trace!("Retrying in {:?} after error: {:?}", duration, err);
+	};
 
-    backoff::future::retry_notify(backoff::ExponentialBackoff::default(), operation, notify).await
+	backoff::future::retry_notify(
+		backoff::ExponentialBackoff::default(),
+		operation,
+		notify,
+	)
+	.await
 }

--- a/romeo/src/bitcoin_client/mod.rs
+++ b/romeo/src/bitcoin_client/mod.rs
@@ -13,21 +13,27 @@ pub mod rpc;
 /// Bitcoin client
 #[async_trait]
 pub trait BitcoinClient: Send + Sync + Debug {
-    /// Broadcast a bitcoin transaction
-    async fn broadcast(&self, tx: Transaction) -> anyhow::Result<()>;
+	/// Broadcast a bitcoin transaction
+	async fn broadcast(&self, tx: Transaction) -> anyhow::Result<()>;
 
-    /// Get the status of a transaction
-    async fn get_tx_status(&self, txid: Txid) -> anyhow::Result<TransactionStatus>;
+	/// Get the status of a transaction
+	async fn get_tx_status(
+		&self,
+		txid: Txid,
+	) -> anyhow::Result<TransactionStatus>;
 
-    /// Fetch a block at the given block height, waiting if needed
-    async fn fetch_block(&self, block_height: u32) -> anyhow::Result<(u32, Block)>;
+	/// Fetch a block at the given block height, waiting if needed
+	async fn fetch_block(
+		&self,
+		block_height: u32,
+	) -> anyhow::Result<(u32, Block)>;
 
-    /// Get the current block height
-    async fn get_height(&self) -> anyhow::Result<u32>;
+	/// Get the current block height
+	async fn get_height(&self) -> anyhow::Result<u32>;
 
-    /// Sign relevant inputs of a bitcoin transaction
-    async fn sign(&self, _tx: Transaction) -> anyhow::Result<Transaction> {
-        // TODO #68
-        todo!()
-    }
+	/// Sign relevant inputs of a bitcoin transaction
+	async fn sign(&self, _tx: Transaction) -> anyhow::Result<Transaction> {
+		// TODO #68
+		todo!()
+	}
 }

--- a/romeo/src/bitcoin_client/rpc.rs
+++ b/romeo/src/bitcoin_client/rpc.rs
@@ -5,8 +5,8 @@ use std::time::Duration;
 use anyhow::anyhow;
 use async_trait::async_trait;
 use bdk::{
-    bitcoin::{Block, Transaction, Txid},
-    bitcoincore_rpc::{self, Auth, Client, RpcApi},
+	bitcoin::{Block, Transaction, Txid},
+	bitcoincore_rpc::{self, Auth, Client, RpcApi},
 };
 use tokio::{task::spawn_blocking, time::sleep};
 use tracing::trace;
@@ -21,98 +21,112 @@ const BLOCK_POLLING_INTERVAL: Duration = Duration::from_secs(5);
 pub struct RPCClient(Url);
 
 impl RPCClient {
-    /// Create a new RPC client
-    pub fn new(url: Url) -> anyhow::Result<Self> {
-        let username = url.username().to_string();
-        let password = url.password().unwrap_or_default().to_string();
+	/// Create a new RPC client
+	pub fn new(url: Url) -> anyhow::Result<Self> {
+		let username = url.username().to_string();
+		let password = url.password().unwrap_or_default().to_string();
 
-        if username.is_empty() {
-            return Err(anyhow::anyhow!("Username is empty"));
-        }
+		if username.is_empty() {
+			return Err(anyhow::anyhow!("Username is empty"));
+		}
 
-        if password.is_empty() {
-            return Err(anyhow::anyhow!("Password is empty"));
-        }
+		if password.is_empty() {
+			return Err(anyhow::anyhow!("Password is empty"));
+		}
 
-        Ok(Self(url))
-    }
+		Ok(Self(url))
+	}
 
-    async fn execute<F, T>(&self, f: F) -> anyhow::Result<bitcoincore_rpc::Result<T>>
-    where
-        F: FnOnce(Client) -> bitcoincore_rpc::Result<T> + Send + 'static,
-        T: Send + 'static,
-    {
-        let mut url = self.0.clone();
+	async fn execute<F, T>(
+		&self,
+		f: F,
+	) -> anyhow::Result<bitcoincore_rpc::Result<T>>
+	where
+		F: FnOnce(Client) -> bitcoincore_rpc::Result<T> + Send + 'static,
+		T: Send + 'static,
+	{
+		let mut url = self.0.clone();
 
-        let username = url.username().to_string();
-        let password = url.password().unwrap_or_default().to_string();
+		let username = url.username().to_string();
+		let password = url.password().unwrap_or_default().to_string();
 
-        url.set_username("").unwrap();
-        url.set_password(None).unwrap();
+		url.set_username("").unwrap();
+		url.set_password(None).unwrap();
 
-        let client = Client::new(url.as_ref(), Auth::UserPass(username, password))?;
+		let client =
+			Client::new(url.as_ref(), Auth::UserPass(username, password))?;
 
-        Ok(spawn_blocking(move || f(client)).await?)
-    }
+		Ok(spawn_blocking(move || f(client)).await?)
+	}
 }
 
 #[async_trait]
 impl BitcoinClient for RPCClient {
-    async fn broadcast(&self, tx: Transaction) -> anyhow::Result<()> {
-        self.execute(move |client| client.send_raw_transaction(&tx))
-            .await??;
+	async fn broadcast(&self, tx: Transaction) -> anyhow::Result<()> {
+		self.execute(move |client| client.send_raw_transaction(&tx))
+			.await??;
 
-        Ok(())
-    }
+		Ok(())
+	}
 
-    async fn get_tx_status(&self, txid: Txid) -> anyhow::Result<TransactionStatus> {
-        let tx = self
-            .execute(move |client| client.get_raw_transaction_info(&txid, None))
-            .await??;
+	async fn get_tx_status(
+		&self,
+		txid: Txid,
+	) -> anyhow::Result<TransactionStatus> {
+		let tx = self
+			.execute(move |client| client.get_raw_transaction_info(&txid, None))
+			.await??;
 
-        if tx.blockhash.is_some() {
-            Ok(TransactionStatus::Confirmed)
-        } else {
-            Ok(TransactionStatus::Broadcasted)
-        }
-    }
+		if tx.blockhash.is_some() {
+			Ok(TransactionStatus::Confirmed)
+		} else {
+			Ok(TransactionStatus::Broadcasted)
+		}
+	}
 
-    async fn fetch_block(&self, block_height: u32) -> anyhow::Result<(u32, Block)> {
-        let block_hash = loop {
-            let res = self
-                .execute(move |client| client.get_block_hash(block_height as u64))
-                .await?;
+	async fn fetch_block(
+		&self,
+		block_height: u32,
+	) -> anyhow::Result<(u32, Block)> {
+		let block_hash = loop {
+			let res = self
+				.execute(move |client| {
+					client.get_block_hash(block_height as u64)
+				})
+				.await?;
 
-            match res {
-                Ok(hash) => {
-                    trace!("Got block hash: {}", hash);
-                    break hash;
-                }
-                Err(bitcoincore_rpc::Error::JsonRpc(bitcoincore_rpc::jsonrpc::Error::Rpc(err))) => {
-                    if err.code == -8 {
-                        trace!("Block not found, retrying...");
-                    } else {
-                        Err(anyhow!("Error fetching block: {:?}", err))?;
-                    }
-                }
-                Err(err) => Err(anyhow!("Error fetching block: {:?}", err))?,
-            };
+			match res {
+				Ok(hash) => {
+					trace!("Got block hash: {}", hash);
+					break hash;
+				}
+				Err(bitcoincore_rpc::Error::JsonRpc(
+					bitcoincore_rpc::jsonrpc::Error::Rpc(err),
+				)) => {
+					if err.code == -8 {
+						trace!("Block not found, retrying...");
+					} else {
+						Err(anyhow!("Error fetching block: {:?}", err))?;
+					}
+				}
+				Err(err) => Err(anyhow!("Error fetching block: {:?}", err))?,
+			};
 
-            sleep(BLOCK_POLLING_INTERVAL).await;
-        };
+			sleep(BLOCK_POLLING_INTERVAL).await;
+		};
 
-        let block = self
-            .execute(move |client| client.get_block(&block_hash))
-            .await??;
+		let block = self
+			.execute(move |client| client.get_block(&block_hash))
+			.await??;
 
-        Ok((block_height, block))
-    }
+		Ok((block_height, block))
+	}
 
-    async fn get_height(&self) -> anyhow::Result<u32> {
-        let info = self
-            .execute(|client| client.get_blockchain_info())
-            .await??;
+	async fn get_height(&self) -> anyhow::Result<u32> {
+		let info = self
+			.execute(|client| client.get_blockchain_info())
+			.await??;
 
-        Ok(info.blocks as u32)
-    }
+		Ok(info.blocks as u32)
+	}
 }

--- a/romeo/src/config.rs
+++ b/romeo/src/config.rs
@@ -1,16 +1,16 @@
 //! Config
 
 use std::{
-    fs::File,
-    path::{Path, PathBuf},
+	fs::File,
+	path::{Path, PathBuf},
 };
 
 use bdk::bitcoin::Network as BitcoinNetwork;
 use blockstack_lib::vm::ContractName;
 use clap::Parser;
 use stacks_core::{
-    wallet::{BitcoinCredentials, Credentials, Wallet},
-    Network as StacksNetwork,
+	wallet::{BitcoinCredentials, Credentials, Wallet},
+	Network as StacksNetwork,
 };
 use url::Url;
 
@@ -18,99 +18,105 @@ use url::Url;
 #[derive(Debug, Parser)]
 #[command(author, version, about)]
 pub struct Cli {
-    /// Where the config file is located
-    #[arg(short, long, value_name = "FILE")]
-    pub config_file: PathBuf,
+	/// Where the config file is located
+	#[arg(short, long, value_name = "FILE")]
+	pub config_file: PathBuf,
 }
 
-/// System configuration. This is typically constructed once and never mutated throughout the systems lifetime.
+/// System configuration. This is typically constructed once and never mutated
+/// throughout the systems lifetime.
 #[derive(Debug, Clone)]
 pub struct Config {
-    /// Directory to persist the state of the system to
-    pub state_directory: PathBuf,
+	/// Directory to persist the state of the system to
+	pub state_directory: PathBuf,
 
-    /// Credentials used to interact with the Stacks network
-    pub stacks_credentials: Credentials,
+	/// Credentials used to interact with the Stacks network
+	pub stacks_credentials: Credentials,
 
-    /// Credentials used to interact with the Bitcoin network
-    pub bitcoin_credentials: BitcoinCredentials,
+	/// Credentials used to interact with the Bitcoin network
+	pub bitcoin_credentials: BitcoinCredentials,
 
-    /// Address of a stacks node
-    pub stacks_node_url: Url,
+	/// Address of a stacks node
+	pub stacks_node_url: Url,
 
-    /// Address of a bitcoin node
-    pub bitcoin_node_url: Url,
+	/// Address of a bitcoin node
+	pub bitcoin_node_url: Url,
 
-    /// sBTC asset contract name
-    pub contract_name: ContractName,
+	/// sBTC asset contract name
+	pub contract_name: ContractName,
 }
 
 impl Config {
-    /// Read the config file in the path
-    pub fn from_path(path: impl AsRef<Path>) -> anyhow::Result<Self> {
-        let config_root = normalize(
-            std::env::current_dir().unwrap(),
-            path.as_ref().parent().unwrap(),
-        );
+	/// Read the config file in the path
+	pub fn from_path(path: impl AsRef<Path>) -> anyhow::Result<Self> {
+		let config_root = normalize(
+			std::env::current_dir().unwrap(),
+			path.as_ref().parent().unwrap(),
+		);
 
-        let config_file = ConfigFile::from_path(&path)?;
-        let state_directory = normalize(config_root.clone(), config_file.state_directory);
+		let config_file = ConfigFile::from_path(&path)?;
+		let state_directory =
+			normalize(config_root.clone(), config_file.state_directory);
 
-        let stacks_node_url = Url::parse(&config_file.stacks_node_url)?;
-        let bitcoin_node_url = Url::parse(&config_file.bitcoin_node_url)?;
+		let stacks_node_url = Url::parse(&config_file.stacks_node_url)?;
+		let bitcoin_node_url = Url::parse(&config_file.bitcoin_node_url)?;
 
-        let wallet = Wallet::new(&config_file.mnemonic)?;
+		let wallet = Wallet::new(&config_file.mnemonic)?;
 
-        let stacks_credentials = wallet.credentials(config_file.stacks_network, 0)?;
-        let bitcoin_credentials = wallet.bitcoin_credentials(config_file.bitcoin_network, 0)?;
+		let stacks_credentials =
+			wallet.credentials(config_file.stacks_network, 0)?;
+		let bitcoin_credentials =
+			wallet.bitcoin_credentials(config_file.bitcoin_network, 0)?;
 
-        Ok(Self {
-            state_directory,
-            stacks_credentials,
-            bitcoin_credentials,
-            stacks_node_url,
-            bitcoin_node_url,
-            contract_name: ContractName::from(config_file.contract_name.as_str()),
-        })
-    }
+		Ok(Self {
+			state_directory,
+			stacks_credentials,
+			bitcoin_credentials,
+			stacks_node_url,
+			bitcoin_node_url,
+			contract_name: ContractName::from(
+				config_file.contract_name.as_str(),
+			),
+		})
+	}
 }
 
 fn normalize(root_dir: PathBuf, path: impl AsRef<Path>) -> PathBuf {
-    if path.as_ref().is_relative() {
-        root_dir.join(path)
-    } else {
-        path.as_ref().into()
-    }
+	if path.as_ref().is_relative() {
+		root_dir.join(path)
+	} else {
+		path.as_ref().into()
+	}
 }
 
 #[derive(Debug, Clone, serde::Deserialize)]
 struct ConfigFile {
-    /// Directory to persist the state of the system to
-    pub state_directory: PathBuf,
+	/// Directory to persist the state of the system to
+	pub state_directory: PathBuf,
 
-    /// Seed mnemonic
-    pub mnemonic: String,
+	/// Seed mnemonic
+	pub mnemonic: String,
 
-    /// Stacks network
-    pub stacks_network: StacksNetwork,
+	/// Stacks network
+	pub stacks_network: StacksNetwork,
 
-    /// Bitcoin network
-    pub bitcoin_network: BitcoinNetwork,
+	/// Bitcoin network
+	pub bitcoin_network: BitcoinNetwork,
 
-    /// Address of a stacks node
-    pub stacks_node_url: String,
+	/// Address of a stacks node
+	pub stacks_node_url: String,
 
-    /// Address of a bitcoin node
-    pub bitcoin_node_url: String,
+	/// Address of a bitcoin node
+	pub bitcoin_node_url: String,
 
-    /// sBTC asset contract name
-    pub contract_name: String,
+	/// sBTC asset contract name
+	pub contract_name: String,
 }
 
 impl ConfigFile {
-    pub fn from_path(path: impl AsRef<Path>) -> anyhow::Result<Self> {
-        let config_file = File::open(&path)?;
+	pub fn from_path(path: impl AsRef<Path>) -> anyhow::Result<Self> {
+		let config_file = File::open(&path)?;
 
-        Ok(serde_json::from_reader(config_file)?)
-    }
+		Ok(serde_json::from_reader(config_file)?)
+	}
 }

--- a/romeo/src/event.rs
+++ b/romeo/src/event.rs
@@ -3,43 +3,45 @@
 use bdk::bitcoin::{Block, Txid as BitcoinTxId};
 use blockstack_lib::burnchains::Txid as StacksTxId;
 
-use crate::state::DepositInfo;
-use crate::state::WithdrawalInfo;
+use crate::state::{DepositInfo, WithdrawalInfo};
 
 /// Events are spawned from tasks and used
 /// to update the system state.
-#[derive(Clone, serde::Serialize, serde::Deserialize, derivative::Derivative)]
+#[derive(
+	Clone, serde::Serialize, serde::Deserialize, derivative::Derivative,
+)]
 #[derivative(Debug)]
 pub enum Event {
-    /// Block height of the contract deployment transaction
-    ContractBlockHeight(u32),
+	/// Block height of the contract deployment transaction
+	ContractBlockHeight(u32),
 
-    /// A mint transaction has been created and broadcasted
-    MintBroadcasted(DepositInfo, StacksTxId),
+	/// A mint transaction has been created and broadcasted
+	MintBroadcasted(DepositInfo, StacksTxId),
 
-    /// A burn transaction has been created and broadcasted
-    BurnBroadcasted(WithdrawalInfo, StacksTxId),
+	/// A burn transaction has been created and broadcasted
+	BurnBroadcasted(WithdrawalInfo, StacksTxId),
 
-    /// A fulfill transaction has been created and broadcasted
-    FulfillBroadcasted(WithdrawalInfo, BitcoinTxId),
+	/// A fulfill transaction has been created and broadcasted
+	FulfillBroadcasted(WithdrawalInfo, BitcoinTxId),
 
-    /// A stacks node has responded with an updated status regarding this txid
-    StacksTransactionUpdate(StacksTxId, TransactionStatus),
+	/// A stacks node has responded with an updated status regarding this txid
+	StacksTransactionUpdate(StacksTxId, TransactionStatus),
 
-    /// A bitcoin node has responded with an updated status regarding this txid
-    BitcoinTransactionUpdate(BitcoinTxId, TransactionStatus),
+	/// A bitcoin node has responded with an updated status regarding this txid
+	BitcoinTransactionUpdate(BitcoinTxId, TransactionStatus),
 
-    /// A wild bitcoin block has appeared
-    BitcoinBlock(u32, #[derivative(Debug = "ignore")] Block),
+	/// A wild bitcoin block has appeared
+	BitcoinBlock(u32, #[derivative(Debug = "ignore")] Block),
 }
 
 /// Status of a broadcasted transaction, useful for implementing retry logic
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 pub enum TransactionStatus {
-    /// Broadcasted to a node
-    Broadcasted,
-    /// This transaction has received `Config::number_of_required_confirmations` confirmations
-    Confirmed,
-    /// There are indications that this transaction will never be mined
-    Rejected,
+	/// Broadcasted to a node
+	Broadcasted,
+	/// This transaction has received
+	/// `Config::number_of_required_confirmations` confirmations
+	Confirmed,
+	/// There are indications that this transaction will never be mined
+	Rejected,
 }

--- a/romeo/src/main.rs
+++ b/romeo/src/main.rs
@@ -1,18 +1,17 @@
 use clap::Parser;
-use tracing_subscriber::layer::SubscriberExt;
-use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    tracing_subscriber::registry()
-        .with(tracing_subscriber::fmt::layer())
-        .with(tracing_subscriber::EnvFilter::from_default_env())
-        .init();
+	tracing_subscriber::registry()
+		.with(tracing_subscriber::fmt::layer())
+		.with(tracing_subscriber::EnvFilter::from_default_env())
+		.init();
 
-    let args = romeo::config::Cli::parse();
-    let config = romeo::config::Config::from_path(args.config_file)?;
+	let args = romeo::config::Cli::parse();
+	let config = romeo::config::Config::from_path(args.config_file)?;
 
-    romeo::system::run(config).await;
+	romeo::system::run(config).await;
 
-    Ok(())
+	Ok(())
 }

--- a/romeo/src/proof_data.rs
+++ b/romeo/src/proof_data.rs
@@ -1,220 +1,233 @@
 //! Proof Data used in Clarity Contracts
 use bdk::bitcoin::{Block, BlockHeader, Transaction, Txid as BitcoinTxId};
-use blockstack_lib::vm::types::{ListData, ListTypeData, SequenceData, Value, BUFF_32};
+use blockstack_lib::vm::types::{
+	ListData, ListTypeData, SequenceData, Value, BUFF_32,
+};
 use rs_merkle::{Hasher, MerkleTree};
-use stacks_core::crypto::sha256::DoubleSha256Hasher;
-use stacks_core::crypto::Hashing;
+use stacks_core::crypto::{sha256::DoubleSha256Hasher, Hashing};
 /// The double sha256 algorithm used for bitcoin
 #[derive(Clone)]
 pub struct DoubleSha256Algorithm {}
 
 impl Hasher for DoubleSha256Algorithm {
-    type Hash = [u8; 32];
+	type Hash = [u8; 32];
 
-    fn hash(data: &[u8]) -> [u8; 32] {
-        DoubleSha256Hasher::hash(data)
-            .as_bytes()
-            .try_into()
-            .unwrap()
-    }
+	fn hash(data: &[u8]) -> [u8; 32] {
+		DoubleSha256Hasher::hash(data)
+			.as_bytes()
+			.try_into()
+			.unwrap()
+	}
 }
 
 /// Data needed to prove that a bitcoin transaction was mined on the bitcoin
 /// network. This data is used by clarity contracts.
 #[derive(Debug, Clone)]
 pub struct ProofData {
-    /// The reversed transaction id of the bitcoin transaction
-    /// in little endian format
-    /// as it is produced by bdk crate.
-    /// It is the reversed txid of the one seen in explorers.
-    pub reversed_txid: BitcoinTxId,
-    /// The index of the bitcoin transaction in the block
-    pub tx_index: u32,
-    /// The block height of the bitcoin transaction
-    pub block_height: u64,
-    /// The block hash of the bitcoin transaction
-    pub block_header: BlockHeader,
-    /// The path of the bitcoin transaction in the merkle tree
-    pub merkle_path: Vec<Vec<u8>>,
-    /// The depth of the merkle tree
-    pub merkle_tree_depth: u32,
-    /// merkle root
-    pub merkle_root: String,
+	/// The reversed transaction id of the bitcoin transaction
+	/// in little endian format
+	/// as it is produced by bdk crate.
+	/// It is the reversed txid of the one seen in explorers.
+	pub reversed_txid: BitcoinTxId,
+	/// The index of the bitcoin transaction in the block
+	pub tx_index: u32,
+	/// The block height of the bitcoin transaction
+	pub block_height: u64,
+	/// The block hash of the bitcoin transaction
+	pub block_header: BlockHeader,
+	/// The path of the bitcoin transaction in the merkle tree
+	pub merkle_path: Vec<Vec<u8>>,
+	/// The depth of the merkle tree
+	pub merkle_tree_depth: u32,
+	/// merkle root
+	pub merkle_root: String,
 }
 
 /// Clarity values for the proof data
 pub struct ProofDataClarityValues {
-    /// The transaction id of the bitcoin transaction
-    pub txid: Value,
-    /// The index of the bitcoin transaction in the block
-    pub tx_index: Value,
-    /// The block height of the bitcoin transaction
-    pub block_height: Value,
-    /// The block hash of the bitcoin transaction
-    pub block_header: Value,
-    /// The path of the bitcoin transaction in the merkle tree
-    pub merkle_path: Value,
-    /// The depth of the merkle tree
-    pub merkle_tree_depth: Value,
+	/// The transaction id of the bitcoin transaction
+	pub txid: Value,
+	/// The index of the bitcoin transaction in the block
+	pub tx_index: Value,
+	/// The block height of the bitcoin transaction
+	pub block_height: Value,
+	/// The block hash of the bitcoin transaction
+	pub block_header: Value,
+	/// The path of the bitcoin transaction in the merkle tree
+	pub merkle_path: Value,
+	/// The depth of the merkle tree
+	pub merkle_tree_depth: Value,
 }
 
 impl ProofData {
-    /// Create a new proof from a bitcoin transaction and a block
-    pub fn from_block_and_index(block: &Block, index: usize) -> Self {
-        let tx: &Transaction = block.txdata.get(index).expect("Invalid tx index");
-        let mut merkle_tree = MerkleTree::<DoubleSha256Algorithm>::new();
-        for tx in &block.txdata {
-            merkle_tree.insert(tx.txid().to_vec().try_into().unwrap());
-        }
-        // append last tx id if number of leaves is odd
-        if block.txdata.len() % 2 == 1 {
-            merkle_tree.insert(
-                block
-                    .txdata
-                    .last()
-                    .unwrap()
-                    .txid()
-                    .to_vec()
-                    .try_into()
-                    .unwrap(),
-            );
-        }
-        merkle_tree.commit();
-        let merkle_path = merkle_tree.proof(&[index]);
+	/// Create a new proof from a bitcoin transaction and a block
+	pub fn from_block_and_index(block: &Block, index: usize) -> Self {
+		let tx: &Transaction =
+			block.txdata.get(index).expect("Invalid tx index");
+		let mut merkle_tree = MerkleTree::<DoubleSha256Algorithm>::new();
+		for tx in &block.txdata {
+			merkle_tree.insert(tx.txid().to_vec().try_into().unwrap());
+		}
+		// append last tx id if number of leaves is odd
+		if block.txdata.len() % 2 == 1 {
+			merkle_tree.insert(
+				block
+					.txdata
+					.last()
+					.unwrap()
+					.txid()
+					.to_vec()
+					.try_into()
+					.unwrap(),
+			);
+		}
+		merkle_tree.commit();
+		let merkle_path = merkle_tree.proof(&[index]);
 
-        // rs_merkle tree depth counts leaves as well
-        // we only care about the layers above
-        // therefore minus 1.
-        let merkle_tree_depth = merkle_tree.depth() - 1;
+		// rs_merkle tree depth counts leaves as well
+		// we only care about the layers above
+		// therefore minus 1.
+		let merkle_tree_depth = merkle_tree.depth() - 1;
 
-        Self {
-            reversed_txid: tx.txid(),
-            tx_index: index as u32,
-            block_height: block
-                .bip34_block_height()
-                .expect("Failed to get block height"),
-            block_header: block.header,
-            merkle_path: merkle_path
-                .proof_hashes()
-                .iter()
-                .map(|h| h.to_vec())
-                .collect(),
-            merkle_tree_depth: merkle_tree_depth as u32,
-            merkle_root: hex::encode(merkle_tree.root().unwrap()),
-        }
-    }
+		Self {
+			reversed_txid: tx.txid(),
+			tx_index: index as u32,
+			block_height: block
+				.bip34_block_height()
+				.expect("Failed to get block height"),
+			block_header: block.header,
+			merkle_path: merkle_path
+				.proof_hashes()
+				.iter()
+				.map(|h| h.to_vec())
+				.collect(),
+			merkle_tree_depth: merkle_tree_depth as u32,
+			merkle_root: hex::encode(merkle_tree.root().unwrap()),
+		}
+	}
 
-    /// converts the proof data to a tuple of clarity values
-    pub fn to_values(&self) -> ProofDataClarityValues {
-        let mut header = self.block_header.version.to_le_bytes().to_vec();
-        header.append(&mut self.block_header.prev_blockhash.to_vec());
-        header.append(&mut self.block_header.merkle_root.to_vec());
-        header.append(&mut self.block_header.time.to_le_bytes().to_vec());
-        header.append(&mut self.block_header.bits.to_le_bytes().to_vec());
-        header.append(&mut self.block_header.nonce.to_le_bytes().to_vec());
+	/// converts the proof data to a tuple of clarity values
+	pub fn to_values(&self) -> ProofDataClarityValues {
+		let mut header = self.block_header.version.to_le_bytes().to_vec();
+		header.append(&mut self.block_header.prev_blockhash.to_vec());
+		header.append(&mut self.block_header.merkle_root.to_vec());
+		header.append(&mut self.block_header.time.to_le_bytes().to_vec());
+		header.append(&mut self.block_header.bits.to_le_bytes().to_vec());
+		header.append(&mut self.block_header.nonce.to_le_bytes().to_vec());
 
-        // use txid in big endian for clarity call
-        let mut txid = self.reversed_txid.to_vec();
-        txid.reverse();
-        ProofDataClarityValues {
-            txid: Value::buff_from(txid).expect("Failed to convert txid to buffer"),
-            tx_index: Value::UInt(self.tx_index as u128),
-            block_height: Value::UInt(self.block_height as u128),
-            block_header: Value::buff_from(header)
-                .expect("Failed to convert block header to buffer"),
-            merkle_path: Value::Sequence(SequenceData::List(ListData {
-                data: self
-                    .merkle_path
-                    .iter()
-                    .map(|v| Value::buff_from(v.clone()).unwrap())
-                    .collect(),
-                type_signature: ListTypeData::new_list(BUFF_32.clone(), 14).unwrap(),
-            })),
-            merkle_tree_depth: Value::UInt(self.merkle_tree_depth as u128),
-        }
-    }
+		// use txid in big endian for clarity call
+		let mut txid = self.reversed_txid.to_vec();
+		txid.reverse();
+		ProofDataClarityValues {
+			txid: Value::buff_from(txid)
+				.expect("Failed to convert txid to buffer"),
+			tx_index: Value::UInt(self.tx_index as u128),
+			block_height: Value::UInt(self.block_height as u128),
+			block_header: Value::buff_from(header)
+				.expect("Failed to convert block header to buffer"),
+			merkle_path: Value::Sequence(SequenceData::List(ListData {
+				data: self
+					.merkle_path
+					.iter()
+					.map(|v| Value::buff_from(v.clone()).unwrap())
+					.collect(),
+				type_signature: ListTypeData::new_list(BUFF_32.clone(), 14)
+					.unwrap(),
+			})),
+			merkle_tree_depth: Value::UInt(self.merkle_tree_depth as u128),
+		}
+	}
 }
 
 // test module
 #[cfg(test)]
 // test from_block returns correct Proof
 mod tests {
-    use super::*;
-    use bdk::bitcoin::{consensus::deserialize, hashes::hex::FromHex, Block};
+	use bdk::bitcoin::{consensus::deserialize, hashes::hex::FromHex, Block};
 
-    #[test]
-    fn should_create_correct_proof_data() {
-        // testnet block 100,000
-        let block_hex = "0200000035ab154183570282ce9afc0b494c9fc6a3cfea05aa8c1add2ecc56490000000038ba3d78e4500a5a7570dbe61960398add4410d278b21cd9708e6d9743f374d544fc055227f1001c29c1ea3b0101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff3703a08601000427f1001c046a510100522cfabe6d6d0000000000000000000068692066726f6d20706f6f6c7365727665726aac1eeeed88ffffffff0100f2052a010000001976a914912e2b234f941f30b18afbb4fa46171214bf66c888ac00000000";
-        let block: Block = deserialize(&Vec::<u8>::from_hex(block_hex).unwrap()).unwrap();
-        let block_height = 100000;
-        let hash = "00000000009e2958c15ff9290d571bf9459e93b19765c6801ddeccadbb160a1e";
-        let txindex: usize = 0;
-        let txid = "d574f343976d8e70d91cb278d21044dd8a396019e6db70755a0a50e4783dba38";
+	use super::*;
 
-        let proof_data = ProofData::from_block_and_index(&block, txindex);
+	#[test]
+	fn should_create_correct_proof_data() {
+		// testnet block 100,000
+		let block_hex = "0200000035ab154183570282ce9afc0b494c9fc6a3cfea05aa8c1add2ecc56490000000038ba3d78e4500a5a7570dbe61960398add4410d278b21cd9708e6d9743f374d544fc055227f1001c29c1ea3b0101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff3703a08601000427f1001c046a510100522cfabe6d6d0000000000000000000068692066726f6d20706f6f6c7365727665726aac1eeeed88ffffffff0100f2052a010000001976a914912e2b234f941f30b18afbb4fa46171214bf66c888ac00000000";
+		let block: Block =
+			deserialize(&Vec::<u8>::from_hex(block_hex).unwrap()).unwrap();
+		let block_height = 100000;
+		let hash =
+			"00000000009e2958c15ff9290d571bf9459e93b19765c6801ddeccadbb160a1e";
+		let txindex: usize = 0;
+		let txid =
+			"d574f343976d8e70d91cb278d21044dd8a396019e6db70755a0a50e4783dba38";
 
-        assert_eq!(proof_data.block_height, block_height);
-        assert_eq!(proof_data.reversed_txid.to_string(), txid);
-        assert_eq!(proof_data.block_header.block_hash().to_string(), hash);
-    }
+		let proof_data = ProofData::from_block_and_index(&block, txindex);
 
-    #[test]
-    #[should_panic(expected = "Invalid tx index")]
-    fn should_throw_for_invalid_txindex() {
-        // testnet block 100,000
-        let block_hex = "0200000035ab154183570282ce9afc0b494c9fc6a3cfea05aa8c1add2ecc56490000000038ba3d78e4500a5a7570dbe61960398add4410d278b21cd9708e6d9743f374d544fc055227f1001c29c1ea3b0101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff3703a08601000427f1001c046a510100522cfabe6d6d0000000000000000000068692066726f6d20706f6f6c7365727665726aac1eeeed88ffffffff0100f2052a010000001976a914912e2b234f941f30b18afbb4fa46171214bf66c888ac00000000";
-        let block: Block = deserialize(&Vec::<u8>::from_hex(block_hex).unwrap()).unwrap();
-        let txindex: usize = 1;
+		assert_eq!(proof_data.block_height, block_height);
+		assert_eq!(proof_data.reversed_txid.to_string(), txid);
+		assert_eq!(proof_data.block_header.block_hash().to_string(), hash);
+	}
 
-        ProofData::from_block_and_index(&block, txindex);
-    }
+	#[test]
+	#[should_panic(expected = "Invalid tx index")]
+	fn should_throw_for_invalid_txindex() {
+		// testnet block 100,000
+		let block_hex = "0200000035ab154183570282ce9afc0b494c9fc6a3cfea05aa8c1add2ecc56490000000038ba3d78e4500a5a7570dbe61960398add4410d278b21cd9708e6d9743f374d544fc055227f1001c29c1ea3b0101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff3703a08601000427f1001c046a510100522cfabe6d6d0000000000000000000068692066726f6d20706f6f6c7365727665726aac1eeeed88ffffffff0100f2052a010000001976a914912e2b234f941f30b18afbb4fa46171214bf66c888ac00000000";
+		let block: Block =
+			deserialize(&Vec::<u8>::from_hex(block_hex).unwrap()).unwrap();
+		let txindex: usize = 1;
 
-    #[test]
-    #[should_panic(
-        expected = "called `Result::unwrap()` on an `Err` value: Io(Error { kind: UnexpectedEof, message: \"failed to fill whole buffer\" })"
-    )]
-    fn should_throw_for_bad_tx() {
-        let block_hex = "02000000010000000000ffffffff0100000000000000000000000000";
-        let block: Block = deserialize(&Vec::<u8>::from_hex(block_hex).unwrap()).unwrap();
-        let txindex: usize = 0;
+		ProofData::from_block_and_index(&block, txindex);
+	}
 
-        ProofData::from_block_and_index(&block, txindex);
-    }
+	#[test]
+	#[should_panic(
+		expected = "called `Result::unwrap()` on an `Err` value: Io(Error { kind: UnexpectedEof, message: \"failed to fill whole buffer\" })"
+	)]
+	fn should_throw_for_bad_tx() {
+		let block_hex =
+			"02000000010000000000ffffffff0100000000000000000000000000";
+		let block: Block =
+			deserialize(&Vec::<u8>::from_hex(block_hex).unwrap()).unwrap();
+		let txindex: usize = 0;
 
-    #[test]
-    fn should_convert_to_clarity_values() {
-        // testnet block 100,000
-        let block_hex = "0200000035ab154183570282ce9afc0b494c9fc6a3cfea05aa8c1add2ecc56490000000038ba3d78e4500a5a7570dbe61960398add4410d278b21cd9708e6d9743f374d544fc055227f1001c29c1ea3b0101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff3703a08601000427f1001c046a510100522cfabe6d6d0000000000000000000068692066726f6d20706f6f6c7365727665726aac1eeeed88ffffffff0100f2052a010000001976a914912e2b234f941f30b18afbb4fa46171214bf66c888ac00000000";
-        let block: Block = deserialize(&Vec::<u8>::from_hex(block_hex).unwrap()).unwrap();
-        let txindex: usize = 0;
-        let proof_data = ProofData::from_block_and_index(&block, txindex);
-        let values = proof_data.to_values();
-        assert_eq!(values.block_header.to_string(), "0x0200000035ab154183570282ce9afc0b494c9fc6a3cfea05aa8c1add2ecc56490000000038ba3d78e4500a5a7570dbe61960398add4410d278b21cd9708e6d9743f374d544fc055227f1001c29c1ea3b");
-        assert_eq!(values.block_height.to_string(), "u100000");
-        assert_eq!(values.merkle_tree_depth.to_string(), "u1");
-        assert_eq!(
+		ProofData::from_block_and_index(&block, txindex);
+	}
+
+	#[test]
+	fn should_convert_to_clarity_values() {
+		// testnet block 100,000
+		let block_hex = "0200000035ab154183570282ce9afc0b494c9fc6a3cfea05aa8c1add2ecc56490000000038ba3d78e4500a5a7570dbe61960398add4410d278b21cd9708e6d9743f374d544fc055227f1001c29c1ea3b0101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff3703a08601000427f1001c046a510100522cfabe6d6d0000000000000000000068692066726f6d20706f6f6c7365727665726aac1eeeed88ffffffff0100f2052a010000001976a914912e2b234f941f30b18afbb4fa46171214bf66c888ac00000000";
+		let block: Block =
+			deserialize(&Vec::<u8>::from_hex(block_hex).unwrap()).unwrap();
+		let txindex: usize = 0;
+		let proof_data = ProofData::from_block_and_index(&block, txindex);
+		let values = proof_data.to_values();
+		assert_eq!(values.block_header.to_string(), "0x0200000035ab154183570282ce9afc0b494c9fc6a3cfea05aa8c1add2ecc56490000000038ba3d78e4500a5a7570dbe61960398add4410d278b21cd9708e6d9743f374d544fc055227f1001c29c1ea3b");
+		assert_eq!(values.block_height.to_string(), "u100000");
+		assert_eq!(values.merkle_tree_depth.to_string(), "u1");
+		assert_eq!(
             values.merkle_path.to_string(),
             "(0x38ba3d78e4500a5a7570dbe61960398add4410d278b21cd9708e6d9743f374d5)"
         );
-    }
+	}
 
-    // test from_block_and_index returns correct proof
-    // block taken from local regtest node
-    #[test]
-    fn should_create_correct_merkle_root() {
-        let block_hex = "000000205214e3b1be1007826f4537f7d86d8f890104587beae37af2fb17e31195a62325bb8940196d4479391e3460fcc904963da6726ecbb99cb9dfc3705ad9ba748f2182270865ffff7f200000000003020000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff0402d20d00ffffffff029f470000000000001976a914ee9369fb719c0ba43ddf4d94638a970b84775f4788ac0000000000000000266a24aa21a9ed2bec0280b5488f0dd3cca56932fdc3eb7b7fba766f6819a0de1cfeaf74c61ecb0120000000000000000000000000000000000000000000000000000000000000000000000000010000000131bde99ad6d1edb8a0f25b7f8458e605e6c1725217346757e7c9a4c4365ef634030000006b483045022100af3c5c67e972b3c744309e79476d71b8c408ce1e45891b3f4d0a9b8bb76c3a8f0220132e8850d7573747a83ccd0b969f12056b8e960a7e6556f389a87b9be218fc2301210239810ebf35e6f6c26062c99f3e183708d377720617c90a986859ec9c95d00be9fdffffff040000000000000000536a4c5069645b76f4413c41080e57ba4b01a485dc7d2465051bfbd2c97f419ddace3e993f88be7b621278694299a79abc623dd56d071f01245e8648e141bfec88d9ba3b1deef100000dd1000100000ab900014a10270000000000001976a914000000000000000000000000000000000000000088ac10270000000000001976a914000000000000000000000000000000000000000088ac82b0c524010000001976a914ee9369fb719c0ba43ddf4d94638a970b84775f4788ac0000000001000000000101010da73321be48f30562e44ff379ea981e204a4fa4bc859c6cd99418e705c7390000000000feffffff0300000000000000001b6a1969643c051a6d78de7b0625dfbfc16c3a8a5735f6dc3dc3f2cee8030000000000002251205e682db7c014ab76f2b4fdcbbdb76f9b8111468174cdb159df6e88fe9d078ce6ab040000000000001600148ae4a48cb0c3b7874460a6f5287d9dd512a182460247304402206387c555478eb821311ef4d3b125a8b4beb698be624e186ff6234f6cd1deb75702207cf063c9cd57dcd7c34b9477129a3a70403856a46be7b9e8942d79482b246379012103ab37f5b606931d7828855affe75199d952bc6174b4a23861b7ac94132210508cc10d0000";
-        let block: Block = deserialize(&Vec::<u8>::from_hex(block_hex).unwrap()).unwrap();
-        let txindex: usize = 0;
-        let proof_data = ProofData::from_block_and_index(&block, txindex);
-        let values = proof_data.to_values();
-        assert_eq!(values.block_header.to_string(), "0x000000205214e3b1be1007826f4537f7d86d8f890104587beae37af2fb17e31195a62325bb8940196d4479391e3460fcc904963da6726ecbb99cb9dfc3705ad9ba748f2182270865ffff7f2000000000");
-        assert_eq!(values.block_height.to_string(), "u3538");
-        assert_eq!(values.merkle_tree_depth.to_string(), "u2");
-        assert_eq!(values.merkle_path.to_string(), "(0x30955a1f27461b4ca06d68147a377a585d05499d186853a2e05e21cf4f9bf55f 0xb4a7cc817198247161027ab3584b0c6a1bd2f7319d6468d2c6e128ec3acb2a47)");
-        assert_eq!(
+	// test from_block_and_index returns correct proof
+	// block taken from local regtest node
+	#[test]
+	fn should_create_correct_merkle_root() {
+		let block_hex = "000000205214e3b1be1007826f4537f7d86d8f890104587beae37af2fb17e31195a62325bb8940196d4479391e3460fcc904963da6726ecbb99cb9dfc3705ad9ba748f2182270865ffff7f200000000003020000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff0402d20d00ffffffff029f470000000000001976a914ee9369fb719c0ba43ddf4d94638a970b84775f4788ac0000000000000000266a24aa21a9ed2bec0280b5488f0dd3cca56932fdc3eb7b7fba766f6819a0de1cfeaf74c61ecb0120000000000000000000000000000000000000000000000000000000000000000000000000010000000131bde99ad6d1edb8a0f25b7f8458e605e6c1725217346757e7c9a4c4365ef634030000006b483045022100af3c5c67e972b3c744309e79476d71b8c408ce1e45891b3f4d0a9b8bb76c3a8f0220132e8850d7573747a83ccd0b969f12056b8e960a7e6556f389a87b9be218fc2301210239810ebf35e6f6c26062c99f3e183708d377720617c90a986859ec9c95d00be9fdffffff040000000000000000536a4c5069645b76f4413c41080e57ba4b01a485dc7d2465051bfbd2c97f419ddace3e993f88be7b621278694299a79abc623dd56d071f01245e8648e141bfec88d9ba3b1deef100000dd1000100000ab900014a10270000000000001976a914000000000000000000000000000000000000000088ac10270000000000001976a914000000000000000000000000000000000000000088ac82b0c524010000001976a914ee9369fb719c0ba43ddf4d94638a970b84775f4788ac0000000001000000000101010da73321be48f30562e44ff379ea981e204a4fa4bc859c6cd99418e705c7390000000000feffffff0300000000000000001b6a1969643c051a6d78de7b0625dfbfc16c3a8a5735f6dc3dc3f2cee8030000000000002251205e682db7c014ab76f2b4fdcbbdb76f9b8111468174cdb159df6e88fe9d078ce6ab040000000000001600148ae4a48cb0c3b7874460a6f5287d9dd512a182460247304402206387c555478eb821311ef4d3b125a8b4beb698be624e186ff6234f6cd1deb75702207cf063c9cd57dcd7c34b9477129a3a70403856a46be7b9e8942d79482b246379012103ab37f5b606931d7828855affe75199d952bc6174b4a23861b7ac94132210508cc10d0000";
+		let block: Block =
+			deserialize(&Vec::<u8>::from_hex(block_hex).unwrap()).unwrap();
+		let txindex: usize = 0;
+		let proof_data = ProofData::from_block_and_index(&block, txindex);
+		let values = proof_data.to_values();
+		assert_eq!(values.block_header.to_string(), "0x000000205214e3b1be1007826f4537f7d86d8f890104587beae37af2fb17e31195a62325bb8940196d4479391e3460fcc904963da6726ecbb99cb9dfc3705ad9ba748f2182270865ffff7f2000000000");
+		assert_eq!(values.block_height.to_string(), "u3538");
+		assert_eq!(values.merkle_tree_depth.to_string(), "u2");
+		assert_eq!(values.merkle_path.to_string(), "(0x30955a1f27461b4ca06d68147a377a585d05499d186853a2e05e21cf4f9bf55f 0xb4a7cc817198247161027ab3584b0c6a1bd2f7319d6468d2c6e128ec3acb2a47)");
+		assert_eq!(
             values.txid.to_string(),
             "0xd564f1a4e53e7bad92f67c9a05b748e504ac1b8155db4c2d9b4ed12afd32139f"
         )
-    }
+	}
 }

--- a/romeo/src/stacks_client.rs
+++ b/romeo/src/stacks_client.rs
@@ -3,43 +3,44 @@
 use std::sync::Arc;
 
 use anyhow::anyhow;
-use blockstack_lib::codec::StacksMessageCodec;
-use blockstack_lib::core::CHAIN_ID_TESTNET;
-use blockstack_lib::types::chainstate::StacksPrivateKey;
-use blockstack_lib::vm::types::{QualifiedContractIdentifier, StandardPrincipalData};
-use blockstack_lib::vm::ContractName;
-use rand::distributions::Alphanumeric;
-use rand::{thread_rng, Rng};
+use blockstack_lib::{
+	burnchains::Txid as StacksTxId,
+	chainstate::stacks::{
+		StacksTransaction, StacksTransactionSigner, TransactionAnchorMode,
+		TransactionPostConditionMode,
+	},
+	codec::StacksMessageCodec,
+	core::CHAIN_ID_TESTNET,
+	types::chainstate::StacksPrivateKey,
+	vm::{
+		types::{QualifiedContractIdentifier, StandardPrincipalData},
+		ContractName,
+	},
+};
+use rand::{distributions::Alphanumeric, thread_rng, Rng};
 use reqwest::Request;
+use serde::de::DeserializeOwned;
 use serde_json::Value;
 use tokio::sync::{Mutex, MutexGuard};
-
-use serde::de::DeserializeOwned;
-
-use blockstack_lib::burnchains::Txid as StacksTxId;
-use blockstack_lib::chainstate::stacks::{
-    StacksTransaction, StacksTransactionSigner, TransactionAnchorMode, TransactionPostConditionMode,
-};
 use tracing::debug;
 
-use crate::config::Config;
-use crate::event::TransactionStatus;
+use crate::{config::Config, event::TransactionStatus};
 
 /// Wrapped Stacks Client which can be shared safely between threads.
 #[derive(Clone, Debug)]
 pub struct LockedClient(Arc<Mutex<StacksClient>>);
 
 impl LockedClient {
-    /// Lock and obtain a handle to the inner stacks client
-    pub async fn lock(&self) -> MutexGuard<StacksClient> {
-        self.0.lock().await
-    }
+	/// Lock and obtain a handle to the inner stacks client
+	pub async fn lock(&self) -> MutexGuard<StacksClient> {
+		self.0.lock().await
+	}
 }
 
 impl From<StacksClient> for LockedClient {
-    fn from(client: StacksClient) -> Self {
-        Self(Arc::new(Mutex::new(client)))
-    }
+	fn from(client: StacksClient) -> Self {
+		Self(Arc::new(Mutex::new(client)))
+	}
 }
 
 /// Stateful client for creating and broadcasting Stacks transactions
@@ -48,30 +49,30 @@ impl From<StacksClient> for LockedClient {
 /// key.
 #[derive(Debug)]
 pub struct StacksClient {
-    config: Config,
-    http_client: reqwest::Client,
+	config: Config,
+	http_client: reqwest::Client,
 }
 
 impl StacksClient {
-    /// Create a new StacksClient
-    pub fn new(config: Config, http_client: reqwest::Client) -> Self {
-        Self {
-            config,
-            http_client,
-        }
-    }
+	/// Create a new StacksClient
+	pub fn new(config: Config, http_client: reqwest::Client) -> Self {
+		Self {
+			config,
+			http_client,
+		}
+	}
 
-    async fn send_request<T>(&mut self, req: Request) -> anyhow::Result<T>
-    where
-        T: DeserializeOwned,
-    {
-        let request_url = req.url().to_string();
+	async fn send_request<T>(&mut self, req: Request) -> anyhow::Result<T>
+	where
+		T: DeserializeOwned,
+	{
+		let request_url = req.url().to_string();
 
-        let res = self.http_client.execute(req).await?;
-        let status = res.status();
-        let body = res.text().await?;
+		let res = self.http_client.execute(req).await?;
+		let status = res.status();
+		let body = res.text().await?;
 
-        serde_json::from_str(&body).map_err(|err| {
+		serde_json::from_str(&body).map_err(|err| {
             let error_details = serde_json::from_str::<Value>(&body).ok().map(|details| {
                 let error = details["error"].as_str();
 
@@ -96,213 +97,221 @@ impl StacksClient {
                 error_details.unwrap_or_default()
             )
         })
-    }
+	}
 
-    /// Sign and broadcast an unsigned stacks transaction
-    pub async fn sign_and_broadcast(
-        &mut self,
-        mut tx: StacksTransaction,
-    ) -> anyhow::Result<StacksTxId> {
-        tx.set_origin_nonce(self.get_nonce_info().await?.possible_next_nonce);
-        tx.set_tx_fee(self.calculate_fee(tx.tx_len()).await?);
+	/// Sign and broadcast an unsigned stacks transaction
+	pub async fn sign_and_broadcast(
+		&mut self,
+		mut tx: StacksTransaction,
+	) -> anyhow::Result<StacksTxId> {
+		tx.set_origin_nonce(self.get_nonce_info().await?.possible_next_nonce);
+		tx.set_tx_fee(self.calculate_fee(tx.tx_len()).await?);
 
-        tx.anchor_mode = TransactionAnchorMode::Any;
-        tx.post_condition_mode = TransactionPostConditionMode::Allow;
-        tx.chain_id = CHAIN_ID_TESTNET;
+		tx.anchor_mode = TransactionAnchorMode::Any;
+		tx.post_condition_mode = TransactionPostConditionMode::Allow;
+		tx.chain_id = CHAIN_ID_TESTNET;
 
-        let mut signer = StacksTransactionSigner::new(&tx);
+		let mut signer = StacksTransactionSigner::new(&tx);
 
-        signer
-            .sign_origin(
-                &StacksPrivateKey::from_slice(
-                    &self.config.stacks_credentials.private_key().secret_bytes(),
-                )
-                .unwrap(),
-            )
-            .unwrap();
+		signer
+			.sign_origin(
+				&StacksPrivateKey::from_slice(
+					&self
+						.config
+						.stacks_credentials
+						.private_key()
+						.secret_bytes(),
+				)
+				.unwrap(),
+			)
+			.unwrap();
 
-        tx = signer.get_tx().unwrap();
+		tx = signer.get_tx().unwrap();
 
-        let mut tx_bytes = vec![];
-        tx.consensus_serialize(&mut tx_bytes).unwrap();
+		let mut tx_bytes = vec![];
+		tx.consensus_serialize(&mut tx_bytes).unwrap();
 
-        let res = self
-            .send_request(
-                self.http_client
-                    .post(self.transaction_url())
-                    .header("Content-type", "application/octet-stream")
-                    .body(tx_bytes)
-                    .build()?,
-            )
-            .await?;
+		let res = self
+			.send_request(
+				self.http_client
+					.post(self.transaction_url())
+					.header("Content-type", "application/octet-stream")
+					.body(tx_bytes)
+					.build()?,
+			)
+			.await?;
 
-        Ok(res)
-    }
+		Ok(res)
+	}
 
-    /// Get transaction status for a given txid
-    pub async fn get_transation_status(
-        &mut self,
-        txid: StacksTxId,
-    ) -> anyhow::Result<TransactionStatus> {
-        let res: Value = self
-            .send_request(
-                self.http_client
-                    .get(self.cachebust(self.get_transation_details_url(txid)))
-                    .header("Accept", "application/json")
-                    .build()?,
-            )
-            .await?;
+	/// Get transaction status for a given txid
+	pub async fn get_transation_status(
+		&mut self,
+		txid: StacksTxId,
+	) -> anyhow::Result<TransactionStatus> {
+		let res: Value = self
+			.send_request(
+				self.http_client
+					.get(self.cachebust(self.get_transation_details_url(txid)))
+					.header("Accept", "application/json")
+					.build()?,
+			)
+			.await?;
 
-        let tx_status_str = res["tx_status"]
-            .as_str()
-            .expect("Could not get raw transaction from response");
+		let tx_status_str = res["tx_status"]
+			.as_str()
+			.expect("Could not get raw transaction from response");
 
-        Ok(match tx_status_str {
-            "pending" => TransactionStatus::Broadcasted,
-            "success" => TransactionStatus::Confirmed,
-            "abort_by_response" => TransactionStatus::Rejected,
-            status => panic!("Unknown transation status: {}", status),
-        })
-    }
+		Ok(match tx_status_str {
+			"pending" => TransactionStatus::Broadcasted,
+			"success" => TransactionStatus::Confirmed,
+			"abort_by_response" => TransactionStatus::Rejected,
+			status => panic!("Unknown transation status: {}", status),
+		})
+	}
 
-    async fn get_nonce_info(&mut self) -> anyhow::Result<NonceInfo> {
-        Ok(self
-            .http_client
-            .get(self.cachebust(self.nonce_url()))
-            .send()
-            .await?
-            .json()
-            .await?)
-    }
+	async fn get_nonce_info(&mut self) -> anyhow::Result<NonceInfo> {
+		Ok(self
+			.http_client
+			.get(self.cachebust(self.nonce_url()))
+			.send()
+			.await?
+			.json()
+			.await?)
+	}
 
-    /// Get the block height of the contract
-    pub async fn get_contract_block_height(&mut self, name: ContractName) -> anyhow::Result<u32> {
-        let addr = self.config.stacks_credentials.address();
-        let id = QualifiedContractIdentifier::new(
-            StandardPrincipalData(
-                addr.version() as u8,
-                addr.hash().as_ref().try_into().unwrap(),
-            ),
-            name,
-        );
+	/// Get the block height of the contract
+	pub async fn get_contract_block_height(
+		&mut self,
+		name: ContractName,
+	) -> anyhow::Result<u32> {
+		let addr = self.config.stacks_credentials.address();
+		let id = QualifiedContractIdentifier::new(
+			StandardPrincipalData(
+				addr.version() as u8,
+				addr.hash().as_ref().try_into().unwrap(),
+			),
+			name,
+		);
 
-        let res: Value = self
-            .http_client
-            .get(self.contract_info_url(id.to_string()))
-            .send()
-            .await?
-            .json()
-            .await?;
+		let res: Value = self
+			.http_client
+			.get(self.contract_info_url(id.to_string()))
+			.send()
+			.await?
+			.json()
+			.await?;
 
-        Ok(res["block_height"].as_u64().unwrap() as u32)
-    }
+		Ok(res["block_height"].as_u64().unwrap() as u32)
+	}
 
-    async fn calculate_fee(&self, tx_len: u64) -> anyhow::Result<u64> {
-        let fee_rate: u64 = self
-            .http_client
-            .get(self.fee_url())
-            .send()
-            .await?
-            .json()
-            .await?;
+	async fn calculate_fee(&self, tx_len: u64) -> anyhow::Result<u64> {
+		let fee_rate: u64 = self
+			.http_client
+			.get(self.fee_url())
+			.send()
+			.await?
+			.json()
+			.await?;
 
-        // TODO: Figure out what's the right multiplier #98
-        Ok(fee_rate * tx_len * 100)
-    }
+		// TODO: Figure out what's the right multiplier #98
+		Ok(fee_rate * tx_len * 100)
+	}
 
-    fn transaction_url(&self) -> reqwest::Url {
-        self.config
-            .stacks_node_url
-            .join("/v2/transactions")
-            .unwrap()
-    }
+	fn transaction_url(&self) -> reqwest::Url {
+		self.config
+			.stacks_node_url
+			.join("/v2/transactions")
+			.unwrap()
+	}
 
-    fn contract_info_url(&self, id: impl AsRef<str>) -> reqwest::Url {
-        self.config
-            .stacks_node_url
-            .join(&format!("/extended/v1/contract/{}", id.as_ref()))
-            .unwrap()
-    }
+	fn contract_info_url(&self, id: impl AsRef<str>) -> reqwest::Url {
+		self.config
+			.stacks_node_url
+			.join(&format!("/extended/v1/contract/{}", id.as_ref()))
+			.unwrap()
+	}
 
-    fn get_transation_details_url(&self, txid: StacksTxId) -> reqwest::Url {
-        self.config
-            .stacks_node_url
-            .join(&format!("/extended/v1/tx/{}", txid))
-            .unwrap()
-    }
+	fn get_transation_details_url(&self, txid: StacksTxId) -> reqwest::Url {
+		self.config
+			.stacks_node_url
+			.join(&format!("/extended/v1/tx/{}", txid))
+			.unwrap()
+	}
 
-    fn cachebust(&self, mut url: reqwest::Url) -> reqwest::Url {
-        let mut rng = thread_rng();
-        let random_string: String = (0..16).map(|_| rng.sample(Alphanumeric) as char).collect();
+	fn cachebust(&self, mut url: reqwest::Url) -> reqwest::Url {
+		let mut rng = thread_rng();
+		let random_string: String =
+			(0..16).map(|_| rng.sample(Alphanumeric) as char).collect();
 
-        let mut query = url
-            .query()
-            .map(|query| query.to_string())
-            .unwrap_or_default();
+		let mut query = url
+			.query()
+			.map(|query| query.to_string())
+			.unwrap_or_default();
 
-        query = match query.is_empty() {
-            true => format!("cachebuster={}", random_string),
-            false => format!("{}&cachebuster={}", query, random_string),
-        };
+		query = match query.is_empty() {
+			true => format!("cachebuster={}", random_string),
+			false => format!("{}&cachebuster={}", query, random_string),
+		};
 
-        url.set_query(Some(&query));
+		url.set_query(Some(&query));
 
-        url
-    }
+		url
+	}
 
-    fn nonce_url(&self) -> reqwest::Url {
-        let path = format!(
-            "/extended/v1/address/{}/nonces",
-            self.config.stacks_credentials.address(),
-        );
+	fn nonce_url(&self) -> reqwest::Url {
+		let path = format!(
+			"/extended/v1/address/{}/nonces",
+			self.config.stacks_credentials.address(),
+		);
 
-        self.config.stacks_node_url.join(&path).unwrap()
-    }
+		self.config.stacks_node_url.join(&path).unwrap()
+	}
 
-    fn fee_url(&self) -> reqwest::Url {
-        self.config
-            .stacks_node_url
-            .join("/v2/fees/transfer")
-            .unwrap()
-    }
+	fn fee_url(&self) -> reqwest::Url {
+		self.config
+			.stacks_node_url
+			.join("/v2/fees/transfer")
+			.unwrap()
+	}
 }
 
 #[derive(serde::Deserialize)]
 struct NonceInfo {
-    possible_next_nonce: u64,
+	possible_next_nonce: u64,
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::config::Config;
+	use super::*;
+	use crate::config::Config;
 
-    use super::*;
+	// These integration tests are for exploration/experimentation but should be
+	// removed once we have more decent tests
+	#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+	#[ignore]
+	async fn get_nonce_info() {
+		let config = Config::from_path("./testing/config.json")
+			.expect("Failed to find config file");
+		let http_client = reqwest::Client::new();
 
-    // These integration tests are for exploration/experimentation but should be removed once we have more decent tests
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    #[ignore]
-    async fn get_nonce_info() {
-        let config =
-            Config::from_path("./testing/config.json").expect("Failed to find config file");
-        let http_client = reqwest::Client::new();
+		let mut stacks_client = StacksClient::new(config, http_client);
 
-        let mut stacks_client = StacksClient::new(config, http_client);
+		let nonce_info = stacks_client.get_nonce_info().await.unwrap();
+		assert_eq!(nonce_info.possible_next_nonce, 122);
 
-        let nonce_info = stacks_client.get_nonce_info().await.unwrap();
-        assert_eq!(nonce_info.possible_next_nonce, 122);
+		assert!(true);
+	}
 
-        assert!(true);
-    }
+	#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+	#[ignore]
+	async fn get_fee_rate() {
+		let config = Config::from_path("./testing/config.json")
+			.expect("Failed to find config file");
+		let http_client = reqwest::Client::new();
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    #[ignore]
-    async fn get_fee_rate() {
-        let config =
-            Config::from_path("./testing/config.json").expect("Failed to find config file");
-        let http_client = reqwest::Client::new();
+		let stacks_client = StacksClient::new(config, http_client);
 
-        let stacks_client = StacksClient::new(config, http_client);
-
-        stacks_client.calculate_fee(123).await.unwrap();
-    }
+		stacks_client.calculate_fee(123).await.unwrap();
+	}
 }

--- a/romeo/src/state.rs
+++ b/romeo/src/state.rs
@@ -3,305 +3,323 @@
 use std::io::Cursor;
 
 use bdk::bitcoin::{Address as BitcoinAddress, Block, Txid as BitcoinTxId};
-use blockstack_lib::burnchains::Txid as StacksTxId;
-use blockstack_lib::codec::StacksMessageCodec;
-use blockstack_lib::types::chainstate::StacksAddress;
-use blockstack_lib::vm::types::PrincipalData;
+use blockstack_lib::{
+	burnchains::Txid as StacksTxId, codec::StacksMessageCodec,
+	types::chainstate::StacksAddress, vm::types::PrincipalData,
+};
 use sbtc_core::operations::op_return;
 use stacks_core::codec::Codec;
 use tracing::debug;
 
-use crate::config::Config;
-use crate::event::Event;
-use crate::event::TransactionStatus;
-use crate::task::Task;
+use crate::{
+	config::Config,
+	event::{Event, TransactionStatus},
+	task::Task,
+};
 
 /// The whole state of the application
 #[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
 pub struct State {
-    deposits: Vec<Deposit>,
-    withdrawals: Vec<Withdrawal>,
-    current_block_height: Option<u32>,
+	deposits: Vec<Deposit>,
+	withdrawals: Vec<Withdrawal>,
+	current_block_height: Option<u32>,
 }
 
 /// A parsed deposit
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Deposit {
-    info: DepositInfo,
-    mint: Option<TransactionRequest<StacksTxId>>,
+	info: DepositInfo,
+	mint: Option<TransactionRequest<StacksTxId>>,
 }
 
 /// A transaction request
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub enum TransactionRequest<T> {
-    /// Created and passed on to a task
-    Created,
-    /// Acknowledged by a task with the status update
-    Acknowledged {
-        /// The transaction ID
-        txid: T,
-        /// The status of the transaction
-        status: TransactionStatus,
-        /// Whether the task has a pending request
-        has_pending_task: bool,
-    },
+	/// Created and passed on to a task
+	Created,
+	/// Acknowledged by a task with the status update
+	Acknowledged {
+		/// The transaction ID
+		txid: T,
+		/// The status of the transaction
+		status: TransactionStatus,
+		/// Whether the task has a pending request
+		has_pending_task: bool,
+	},
 }
 
 /// Relevant information for processing deposits
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 pub struct DepositInfo {
-    /// ID of the bitcoin deposit transaction
-    pub txid: BitcoinTxId,
+	/// ID of the bitcoin deposit transaction
+	pub txid: BitcoinTxId,
 
-    /// Amount to deposit
-    pub amount: u64,
+	/// Amount to deposit
+	pub amount: u64,
 
-    /// Recipient of the sBTC
-    pub recipient: PrincipalData,
+	/// Recipient of the sBTC
+	pub recipient: PrincipalData,
 
-    /// Height of the Bitcoin blockchain where this deposit transaction exists
-    pub block_height: u32,
+	/// Height of the Bitcoin blockchain where this deposit transaction exists
+	pub block_height: u32,
 }
 
 impl Deposit {
-    fn request_work(&mut self) -> Option<Task> {
-        match self.mint.as_mut() {
-            None => {
-                self.mint = Some(TransactionRequest::Created);
-                Some(Task::CreateMint(self.info.clone()))
-            }
-            Some(TransactionRequest::Created)
-            | Some(TransactionRequest::Acknowledged {
-                status: TransactionStatus::Confirmed,
-                ..
-            }) => None,
-            Some(TransactionRequest::Acknowledged {
-                txid,
-                status: TransactionStatus::Broadcasted,
-                has_pending_task,
-            }) => {
-                if !*has_pending_task {
-                    *has_pending_task = true;
-                    Some(Task::CheckStacksTransactionStatus(*txid))
-                } else {
-                    None
-                }
-            }
-            Some(TransactionRequest::Acknowledged {
-                txid,
-                status: TransactionStatus::Rejected,
-                ..
-            }) => {
-                panic!("Mint transaction rejected: {}", txid)
-            }
-        }
-    }
+	fn request_work(&mut self) -> Option<Task> {
+		match self.mint.as_mut() {
+			None => {
+				self.mint = Some(TransactionRequest::Created);
+				Some(Task::CreateMint(self.info.clone()))
+			}
+			Some(TransactionRequest::Created)
+			| Some(TransactionRequest::Acknowledged {
+				status: TransactionStatus::Confirmed,
+				..
+			}) => None,
+			Some(TransactionRequest::Acknowledged {
+				txid,
+				status: TransactionStatus::Broadcasted,
+				has_pending_task,
+			}) => {
+				if !*has_pending_task {
+					*has_pending_task = true;
+					Some(Task::CheckStacksTransactionStatus(*txid))
+				} else {
+					None
+				}
+			}
+			Some(TransactionRequest::Acknowledged {
+				txid,
+				status: TransactionStatus::Rejected,
+				..
+			}) => {
+				panic!("Mint transaction rejected: {}", txid)
+			}
+		}
+	}
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 struct Withdrawal {
-    info: WithdrawalInfo,
-    burn: Option<TransactionRequest<StacksTxId>>,
-    fulfillment: Option<TransactionRequest<BitcoinTxId>>,
+	info: WithdrawalInfo,
+	burn: Option<TransactionRequest<StacksTxId>>,
+	fulfillment: Option<TransactionRequest<BitcoinTxId>>,
 }
 
 /// Relevant information for processing withdrawals
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct WithdrawalInfo {
-    /// ID of the bitcoin withdrawal request transaction
-    txid: BitcoinTxId,
+	/// ID of the bitcoin withdrawal request transaction
+	txid: BitcoinTxId,
 
-    /// Amount to withdraw
-    amount: u64,
+	/// Amount to withdraw
+	amount: u64,
 
-    /// Where to withdraw sBTC from
-    source: StacksAddress,
+	/// Where to withdraw sBTC from
+	source: StacksAddress,
 
-    /// Recipient of the BTC
-    recipient: BitcoinAddress,
+	/// Recipient of the BTC
+	recipient: BitcoinAddress,
 
-    /// Height of the Bitcoin blockchain where this withdrawal request
-    /// transaction exists
-    block_height: u32,
+	/// Height of the Bitcoin blockchain where this withdrawal request
+	/// transaction exists
+	block_height: u32,
 }
 
 impl Withdrawal {
-    fn burn(&mut self) -> Option<Task> {
-        todo!();
-    }
+	fn burn(&mut self) -> Option<Task> {
+		todo!();
+	}
 
-    fn fulfill(&mut self) -> Option<Task> {
-        todo!();
-    }
+	fn fulfill(&mut self) -> Option<Task> {
+		todo!();
+	}
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 struct Response<T> {
-    txid: T,
-    status: TransactionStatus,
+	txid: T,
+	status: TransactionStatus,
 }
 
 /// Spawn initial tasks given a recovered state
 pub fn bootstrap(mut state: State) -> (State, Task) {
-    // When bootstraping we're not expecting any transaction updates to come
-    get_mut_transaction_requests(&mut state).for_each(|request| {
-        if let TransactionRequest::Acknowledged {
-            has_pending_task, ..
-        } = request
-        {
-            *has_pending_task = false
-        }
-    });
+	// When bootstraping we're not expecting any transaction updates to come
+	get_mut_transaction_requests(&mut state).for_each(|request| {
+		if let TransactionRequest::Acknowledged {
+			has_pending_task, ..
+		} = request
+		{
+			*has_pending_task = false
+		}
+	});
 
-    match state.current_block_height {
-        None => (state, Task::GetContractBlockHeight),
-        Some(height) => (state, Task::FetchBitcoinBlock(height + 1)),
-    }
+	match state.current_block_height {
+		None => (state, Task::GetContractBlockHeight),
+		Some(height) => (state, Task::FetchBitcoinBlock(height + 1)),
+	}
 }
 
 /// The beating heart of Romeo.
 /// This function updates the system state in response to an I/O event.
-/// It returns any new I/O tasks the system need to perform alongside the updated state.
+/// It returns any new I/O tasks the system need to perform alongside the
+/// updated state.
 #[tracing::instrument(skip(config, state))]
-pub fn update(config: &Config, state: State, event: Event) -> (State, Vec<Task>) {
-    debug!("Handling update");
+pub fn update(
+	config: &Config,
+	state: State,
+	event: Event,
+) -> (State, Vec<Task>) {
+	debug!("Handling update");
 
-    match event {
-        Event::ContractBlockHeight(height) => process_contract_block_height(state, height),
-        Event::StacksTransactionUpdate(txid, status) => {
-            process_stacks_transaction_update(config, state, txid, status)
-        }
-        Event::BitcoinTransactionUpdate(txid, status) => {
-            process_bitcoin_transaction_update(config, state, txid, status)
-        }
-        Event::BitcoinBlock(height, block) => process_bitcoin_block(config, state, height, block),
-        Event::MintBroadcasted(deposit_info, txid) => {
-            process_mint_broadcasted(state, deposit_info, txid)
-        }
-        Event::BurnBroadcasted(_, _) => (state, vec![]),
-        Event::FulfillBroadcasted(_, _) => (state, vec![]),
-    }
+	match event {
+		Event::ContractBlockHeight(height) => {
+			process_contract_block_height(state, height)
+		}
+		Event::StacksTransactionUpdate(txid, status) => {
+			process_stacks_transaction_update(config, state, txid, status)
+		}
+		Event::BitcoinTransactionUpdate(txid, status) => {
+			process_bitcoin_transaction_update(config, state, txid, status)
+		}
+		Event::BitcoinBlock(height, block) => {
+			process_bitcoin_block(config, state, height, block)
+		}
+		Event::MintBroadcasted(deposit_info, txid) => {
+			process_mint_broadcasted(state, deposit_info, txid)
+		}
+		Event::BurnBroadcasted(_, _) => (state, vec![]),
+		Event::FulfillBroadcasted(_, _) => (state, vec![]),
+	}
 }
 
-fn process_contract_block_height(mut state: State, height: u32) -> (State, Vec<Task>) {
-    match state.current_block_height {
-        Some(current_height) => {
-            panic!(
-                "Got contract block height when state already contains it: {}",
-                current_height
-            )
-        }
-        None => {
-            state.current_block_height = Some(height);
+fn process_contract_block_height(
+	mut state: State,
+	height: u32,
+) -> (State, Vec<Task>) {
+	match state.current_block_height {
+		Some(current_height) => {
+			panic!(
+				"Got contract block height when state already contains it: {}",
+				current_height
+			)
+		}
+		None => {
+			state.current_block_height = Some(height);
 
-            (state, vec![Task::FetchBitcoinBlock(height + 1)])
-        }
-    }
+			(state, vec![Task::FetchBitcoinBlock(height + 1)])
+		}
+	}
 }
 
 fn process_bitcoin_block(
-    config: &Config,
-    mut state: State,
-    height: u32,
-    block: Block,
+	config: &Config,
+	mut state: State,
+	height: u32,
+	block: Block,
 ) -> (State, Vec<Task>) {
-    let deposits = parse_deposits(config, height, &block);
-    let withdrawals = parse_withdrawals(&block);
+	let deposits = parse_deposits(config, height, &block);
+	let withdrawals = parse_withdrawals(&block);
 
-    state.deposits.extend_from_slice(&deposits);
-    state.withdrawals.extend_from_slice(&withdrawals);
+	state.deposits.extend_from_slice(&deposits);
+	state.withdrawals.extend_from_slice(&withdrawals);
 
-    state.current_block_height = Some(height);
+	state.current_block_height = Some(height);
 
-    let mut tasks = create_transaction_status_update_tasks(&mut state);
-    tasks.push(Task::FetchBitcoinBlock(height + 1));
+	let mut tasks = create_transaction_status_update_tasks(&mut state);
+	tasks.push(Task::FetchBitcoinBlock(height + 1));
 
-    (state, tasks)
+	(state, tasks)
 }
 
 fn create_transaction_status_update_tasks(state: &mut State) -> Vec<Task> {
-    let mut tasks = vec![];
+	let mut tasks = vec![];
 
-    let mint_tasks = state
-        .deposits
-        .iter_mut()
-        .filter_map(|deposit| deposit.request_work());
+	let mint_tasks = state
+		.deposits
+		.iter_mut()
+		.filter_map(|deposit| deposit.request_work());
 
-    let burn_tasks: Vec<_> = state
-        .withdrawals
-        .iter_mut()
-        .filter_map(|withdrawal| withdrawal.burn())
-        .collect();
+	let burn_tasks: Vec<_> = state
+		.withdrawals
+		.iter_mut()
+		.filter_map(|withdrawal| withdrawal.burn())
+		.collect();
 
-    let fulfillment_tasks: Vec<_> = state
-        .withdrawals
-        .iter_mut()
-        .filter_map(|withdrawal| withdrawal.fulfill())
-        .collect();
+	let fulfillment_tasks: Vec<_> = state
+		.withdrawals
+		.iter_mut()
+		.filter_map(|withdrawal| withdrawal.fulfill())
+		.collect();
 
-    tasks.extend(mint_tasks);
-    tasks.extend(burn_tasks);
-    tasks.extend(fulfillment_tasks);
+	tasks.extend(mint_tasks);
+	tasks.extend(burn_tasks);
+	tasks.extend(fulfillment_tasks);
 
-    tasks
+	tasks
 }
 
 fn parse_deposits(config: &Config, height: u32, block: &Block) -> Vec<Deposit> {
-    block
-        .txdata
-        .iter()
-        .cloned()
-        .filter_map(|tx| {
-            let txid = tx.txid();
+	block
+		.txdata
+		.iter()
+		.cloned()
+		.filter_map(|tx| {
+			let txid = tx.txid();
 
-            op_return::deposit::Deposit::parse(config.bitcoin_credentials.network(), tx)
-                .ok()
-                .map(|parsed_deposit| Deposit {
-                    info: DepositInfo {
-                        txid,
-                        amount: parsed_deposit.amount,
-                        recipient: convert_principal_data(parsed_deposit.recipient),
-                        block_height: height,
-                    },
-                    mint: None,
-                })
-        })
-        .collect()
+			op_return::deposit::Deposit::parse(
+				config.bitcoin_credentials.network(),
+				tx,
+			)
+			.ok()
+			.map(|parsed_deposit| Deposit {
+				info: DepositInfo {
+					txid,
+					amount: parsed_deposit.amount,
+					recipient: convert_principal_data(parsed_deposit.recipient),
+					block_height: height,
+				},
+				mint: None,
+			})
+		})
+		.collect()
 }
 
-fn convert_principal_data(data: stacks_core::utils::PrincipalData) -> PrincipalData {
-    let bytes = data.serialize_to_vec();
+fn convert_principal_data(
+	data: stacks_core::utils::PrincipalData,
+) -> PrincipalData {
+	let bytes = data.serialize_to_vec();
 
-    PrincipalData::consensus_deserialize(&mut Cursor::new(bytes)).unwrap()
+	PrincipalData::consensus_deserialize(&mut Cursor::new(bytes)).unwrap()
 }
 
 fn parse_withdrawals(_block: &Block) -> Vec<Withdrawal> {
-    // TODO: #68
-    vec![]
+	// TODO: #68
+	vec![]
 }
 
 fn process_bitcoin_transaction_update(
-    _config: &Config,
-    state: State,
-    _txid: BitcoinTxId,
-    _status: TransactionStatus,
+	_config: &Config,
+	state: State,
+	_txid: BitcoinTxId,
+	_status: TransactionStatus,
 ) -> (State, Vec<Task>) {
-    // TODO: #67 and #68
+	// TODO: #67 and #68
 
-    (state, vec![])
+	(state, vec![])
 }
 
 fn process_stacks_transaction_update(
-    _config: &Config,
-    mut state: State,
-    txid: StacksTxId,
-    status: TransactionStatus,
+	_config: &Config,
+	mut state: State,
+	txid: StacksTxId,
+	status: TransactionStatus,
 ) -> (State, Vec<Task>) {
-    if status == TransactionStatus::Rejected {
-        panic!("Stacks transaction failed: {}", txid);
-    }
+	if status == TransactionStatus::Rejected {
+		panic!("Stacks transaction failed: {}", txid);
+	}
 
-    let statuses_updated: usize = get_mut_transaction_requests(&mut state)
+	let statuses_updated: usize = get_mut_transaction_requests(&mut state)
         .map(|response| {
             let status_updated = match response {
                 TransactionRequest::Acknowledged {
@@ -333,53 +351,53 @@ fn process_stacks_transaction_update(
         })
         .sum();
 
-    if statuses_updated != 1 {
-        panic!(
-            "Unexpected number of statuses updated: {}",
-            statuses_updated
-        );
-    }
+	if statuses_updated != 1 {
+		panic!(
+			"Unexpected number of statuses updated: {}",
+			statuses_updated
+		);
+	}
 
-    (state, vec![])
+	(state, vec![])
 }
 
 fn get_mut_transaction_requests(
-    state: &mut State,
+	state: &mut State,
 ) -> impl Iterator<Item = &mut TransactionRequest<StacksTxId>> {
-    let deposit_responses = state
-        .deposits
-        .iter_mut()
-        .filter_map(|deposit| deposit.mint.as_mut());
+	let deposit_responses = state
+		.deposits
+		.iter_mut()
+		.filter_map(|deposit| deposit.mint.as_mut());
 
-    let withdrawal_responses = state
-        .withdrawals
-        .iter_mut()
-        .filter_map(|withdrawal| withdrawal.burn.as_mut());
+	let withdrawal_responses = state
+		.withdrawals
+		.iter_mut()
+		.filter_map(|withdrawal| withdrawal.burn.as_mut());
 
-    deposit_responses.chain(withdrawal_responses)
+	deposit_responses.chain(withdrawal_responses)
 }
 
 fn process_mint_broadcasted(
-    mut state: State,
-    deposit_info: DepositInfo,
-    txid: StacksTxId,
+	mut state: State,
+	deposit_info: DepositInfo,
+	txid: StacksTxId,
 ) -> (State, Vec<Task>) {
-    let deposit = state
-        .deposits
-        .iter_mut()
-        .find(|deposit| deposit.info == deposit_info)
-        .expect("Could not find a deposit for the mint");
+	let deposit = state
+		.deposits
+		.iter_mut()
+		.find(|deposit| deposit.info == deposit_info)
+		.expect("Could not find a deposit for the mint");
 
-    assert!(
-        matches!(deposit.mint, Some(TransactionRequest::Created)),
-        "Newly minted deposit already has a mint acknowledged"
-    );
+	assert!(
+		matches!(deposit.mint, Some(TransactionRequest::Created)),
+		"Newly minted deposit already has a mint acknowledged"
+	);
 
-    deposit.mint = Some(TransactionRequest::Acknowledged {
-        txid,
-        status: TransactionStatus::Broadcasted,
-        has_pending_task: false,
-    });
+	deposit.mint = Some(TransactionRequest::Acknowledged {
+		txid,
+		status: TransactionStatus::Broadcasted,
+		has_pending_task: false,
+	});
 
-    (state, vec![])
+	(state, vec![])
 }

--- a/romeo/src/system.rs
+++ b/romeo/src/system.rs
@@ -1,257 +1,276 @@
 //! System
 
-use std::fs::create_dir_all;
-use std::io::Cursor;
+use std::{fs::create_dir_all, io::Cursor};
 
 use bdk::bitcoin::Txid as BitcoinTxId;
-use blockstack_lib::burnchains::Txid as StacksTxId;
-use blockstack_lib::chainstate::stacks::TransactionContractCall;
-use blockstack_lib::codec::StacksMessageCodec;
-use blockstack_lib::types::chainstate::StacksAddress;
-use blockstack_lib::types::chainstate::StacksPublicKey;
-
-use blockstack_lib::vm::ClarityName;
+use blockstack_lib::{
+	burnchains::Txid as StacksTxId,
+	chainstate::stacks::{
+		StacksTransaction, TransactionAuth, TransactionContractCall,
+		TransactionPayload, TransactionSpendingCondition, TransactionVersion,
+	},
+	codec::StacksMessageCodec,
+	types::chainstate::{StacksAddress, StacksPublicKey},
+	vm::{types::Value, ClarityName},
+};
 use stacks_core::codec::Codec;
-use tokio::fs::File;
-use tokio::fs::OpenOptions;
-use tokio::io::AsyncBufReadExt;
-use tokio::io::AsyncWriteExt;
-use tokio::io::BufReader;
-use tokio::io::BufWriter;
+use tokio::{
+	fs::{File, OpenOptions},
+	io::{AsyncBufReadExt, AsyncWriteExt, BufReader, BufWriter},
+	sync::mpsc,
+	task::JoinHandle,
+};
+use tracing::{debug, trace};
 
-use blockstack_lib::chainstate::stacks::StacksTransaction;
-use blockstack_lib::chainstate::stacks::TransactionAuth;
-use blockstack_lib::chainstate::stacks::TransactionPayload;
-use blockstack_lib::chainstate::stacks::TransactionSpendingCondition;
-use blockstack_lib::chainstate::stacks::TransactionVersion;
-use blockstack_lib::vm::types::Value;
-
-use tokio::sync::mpsc;
-use tokio::task::JoinHandle;
-use tracing::debug;
-use tracing::trace;
-
-use crate::bitcoin_client::rpc::RPCClient as BitcoinRPCClient;
-use crate::bitcoin_client::BitcoinClient;
-use crate::config::Config;
-use crate::event::Event;
-use crate::proof_data::ProofData;
-use crate::stacks_client::LockedClient;
-use crate::stacks_client::StacksClient;
-use crate::state;
-use crate::state::DepositInfo;
-use crate::task::Task;
+use crate::{
+	bitcoin_client::{rpc::RPCClient as BitcoinRPCClient, BitcoinClient},
+	config::Config,
+	event::Event,
+	proof_data::ProofData,
+	stacks_client::{LockedClient, StacksClient},
+	state,
+	state::DepositInfo,
+	task::Task,
+};
 
 /// The main run loop of this system.
-/// This function feeds all events to the `state::update` function and spawns all tasks returned from this function.
+/// This function feeds all events to the `state::update` function and spawns
+/// all tasks returned from this function.
 ///
 /// The system is bootstrapped by emitting the CreateAssetContract task.
 pub async fn run(config: Config) {
-    let (tx, mut rx) = mpsc::channel::<Event>(128); // TODO: Make capacity configurable
-    let bitcoin_client = BitcoinRPCClient::new(config.bitcoin_node_url.clone())
-        .expect("Failed to instantiate bitcoin client");
-    let stacks_client: LockedClient =
-        StacksClient::new(config.clone(), reqwest::Client::new()).into();
+	let (tx, mut rx) = mpsc::channel::<Event>(128); // TODO: Make capacity configurable
+	let bitcoin_client = BitcoinRPCClient::new(config.bitcoin_node_url.clone())
+		.expect("Failed to instantiate bitcoin client");
+	let stacks_client: LockedClient =
+		StacksClient::new(config.clone(), reqwest::Client::new()).into();
 
-    tracing::info!("Starting replay of persisted events");
-    let (mut storage, state) = Storage::load_and_replay(&config, state::State::default()).await;
-    tracing::info!("Replay finished with state: {:?}", state);
+	tracing::info!("Starting replay of persisted events");
+	let (mut storage, state) =
+		Storage::load_and_replay(&config, state::State::default()).await;
+	tracing::info!("Replay finished with state: {:?}", state);
 
-    let (mut state, bootstrap_task) = state::bootstrap(state);
+	let (mut state, bootstrap_task) = state::bootstrap(state);
 
-    // Bootstrap
-    spawn(
-        config.clone(),
-        bitcoin_client.clone(),
-        stacks_client.clone(),
-        bootstrap_task,
-        tx.clone(),
-    );
+	// Bootstrap
+	spawn(
+		config.clone(),
+		bitcoin_client.clone(),
+		stacks_client.clone(),
+		bootstrap_task,
+		tx.clone(),
+	);
 
-    while let Some(event) = rx.recv().await {
-        storage.record(&event).await;
+	while let Some(event) = rx.recv().await {
+		storage.record(&event).await;
 
-        let (next_state, tasks) = state::update(&config, state, event);
+		let (next_state, tasks) = state::update(&config, state, event);
 
-        trace!("State: {}", serde_json::to_string(&next_state).unwrap());
+		trace!("State: {}", serde_json::to_string(&next_state).unwrap());
 
-        for task in tasks {
-            spawn(
-                config.clone(),
-                bitcoin_client.clone(),
-                stacks_client.clone(),
-                task,
-                tx.clone(),
-            );
-        }
+		for task in tasks {
+			spawn(
+				config.clone(),
+				bitcoin_client.clone(),
+				stacks_client.clone(),
+				task,
+				tx.clone(),
+			);
+		}
 
-        state = next_state;
-    }
+		state = next_state;
+	}
 }
 
 struct Storage(BufWriter<File>);
 
 impl Storage {
-    async fn load_and_replay(config: &Config, mut state: state::State) -> (Self, state::State) {
-        create_dir_all(&config.state_directory).unwrap();
+	async fn load_and_replay(
+		config: &Config,
+		mut state: state::State,
+	) -> (Self, state::State) {
+		create_dir_all(&config.state_directory).unwrap();
 
-        let mut file = OpenOptions::new()
-            .create(true)
-            .read(true)
-            .write(true)
-            .append(true)
-            .open(config.state_directory.join("log.ndjson"))
-            .await
-            .unwrap();
+		let mut file = OpenOptions::new()
+			.create(true)
+			.read(true)
+			.write(true)
+			.append(true)
+			.open(config.state_directory.join("log.ndjson"))
+			.await
+			.unwrap();
 
-        let mut r = BufReader::new(&mut file).lines();
+		let mut r = BufReader::new(&mut file).lines();
 
-        while let Some(line) = r.next_line().await.unwrap() {
-            let event: Event = serde_json::from_str(&line).unwrap();
-            state = state::update(config, state, event).0;
-        }
+		while let Some(line) = r.next_line().await.unwrap() {
+			let event: Event = serde_json::from_str(&line).unwrap();
+			state = state::update(config, state, event).0;
+		}
 
-        (Self(BufWriter::new(file)), state)
-    }
+		(Self(BufWriter::new(file)), state)
+	}
 
-    async fn record(&mut self, event: &Event) {
-        let bytes = serde_json::to_vec(event).unwrap();
-        self.0.write_all(&bytes).await.unwrap();
-        self.0.write_all(b"\n").await.unwrap();
-        self.0.flush().await.unwrap();
-    }
+	async fn record(&mut self, event: &Event) {
+		let bytes = serde_json::to_vec(event).unwrap();
+		self.0.write_all(&bytes).await.unwrap();
+		self.0.write_all(b"\n").await.unwrap();
+		self.0.flush().await.unwrap();
+	}
 }
 
 #[tracing::instrument(skip(config, bitcoin_client, stacks_client, result))]
 fn spawn(
-    config: Config,
-    bitcoin_client: impl BitcoinClient + 'static,
-    stacks_client: LockedClient,
-    task: Task,
-    result: mpsc::Sender<Event>,
+	config: Config,
+	bitcoin_client: impl BitcoinClient + 'static,
+	stacks_client: LockedClient,
+	task: Task,
+	result: mpsc::Sender<Event>,
 ) -> JoinHandle<()> {
-    debug!("Spawning task");
+	debug!("Spawning task");
 
-    tokio::task::spawn(async move {
-        let event = run_task(&config, bitcoin_client, stacks_client, task).await;
-        result.send(event).await.expect("Failed to return event");
-    })
+	tokio::task::spawn(async move {
+		let event =
+			run_task(&config, bitcoin_client, stacks_client, task).await;
+		result.send(event).await.expect("Failed to return event");
+	})
 }
 
 async fn run_task(
-    config: &Config,
-    bitcoin_client: impl BitcoinClient,
-    stacks_client: LockedClient,
-    task: Task,
+	config: &Config,
+	bitcoin_client: impl BitcoinClient,
+	stacks_client: LockedClient,
+	task: Task,
 ) -> Event {
-    match task {
-        Task::GetContractBlockHeight => get_contract_block_height(config, stacks_client).await,
-        Task::CreateMint(deposit_info) => {
-            mint_asset(config, bitcoin_client, stacks_client, deposit_info).await
-        }
-        Task::CheckBitcoinTransactionStatus(txid) => {
-            check_bitcoin_transaction_status(config, txid).await
-        }
-        Task::CheckStacksTransactionStatus(txid) => {
-            check_stacks_transaction_status(stacks_client, txid).await
-        }
-        Task::FetchBitcoinBlock(block_height) => {
-            fetch_bitcoin_block(bitcoin_client, block_height).await
-        }
-        _ => panic!(),
-    }
+	match task {
+		Task::GetContractBlockHeight => {
+			get_contract_block_height(config, stacks_client).await
+		}
+		Task::CreateMint(deposit_info) => {
+			mint_asset(config, bitcoin_client, stacks_client, deposit_info)
+				.await
+		}
+		Task::CheckBitcoinTransactionStatus(txid) => {
+			check_bitcoin_transaction_status(config, txid).await
+		}
+		Task::CheckStacksTransactionStatus(txid) => {
+			check_stacks_transaction_status(stacks_client, txid).await
+		}
+		Task::FetchBitcoinBlock(block_height) => {
+			fetch_bitcoin_block(bitcoin_client, block_height).await
+		}
+		_ => panic!(),
+	}
 }
 
-async fn get_contract_block_height(config: &Config, client: LockedClient) -> Event {
-    let block_height = client
-        .lock()
-        .await
-        .get_contract_block_height(config.contract_name.clone())
-        .await
-        .expect("Could not get ");
+async fn get_contract_block_height(
+	config: &Config,
+	client: LockedClient,
+) -> Event {
+	let block_height = client
+		.lock()
+		.await
+		.get_contract_block_height(config.contract_name.clone())
+		.await
+		.expect("Could not get ");
 
-    Event::ContractBlockHeight(block_height)
+	Event::ContractBlockHeight(block_height)
 }
 
 async fn mint_asset(
-    config: &Config,
-    bitcoin_client: impl BitcoinClient,
-    stacks_client: LockedClient,
-    deposit_info: DepositInfo,
+	config: &Config,
+	bitcoin_client: impl BitcoinClient,
+	stacks_client: LockedClient,
+	deposit_info: DepositInfo,
 ) -> Event {
-    let (_, block) = bitcoin_client
-        .fetch_block(deposit_info.block_height)
-        .await
-        .expect("Failed to fetch block");
-    let index = block
-        .txdata
-        .iter()
-        .position(|tx| tx.txid() == deposit_info.txid)
-        .expect("Failed to find transaction in block");
-    let proof_data = ProofData::from_block_and_index(&block, index).to_values();
+	let (_, block) = bitcoin_client
+		.fetch_block(deposit_info.block_height)
+		.await
+		.expect("Failed to fetch block");
+	let index = block
+		.txdata
+		.iter()
+		.position(|tx| tx.txid() == deposit_info.txid)
+		.expect("Failed to find transaction in block");
+	let proof_data = ProofData::from_block_and_index(&block, index).to_values();
 
-    let public_key =
-        StacksPublicKey::from_slice(&config.stacks_credentials.public_key().serialize()).unwrap();
+	let public_key = StacksPublicKey::from_slice(
+		&config.stacks_credentials.public_key().serialize(),
+	)
+	.unwrap();
 
-    let tx_auth = TransactionAuth::Standard(
-        TransactionSpendingCondition::new_singlesig_p2pkh(public_key).unwrap(),
-    );
+	let tx_auth = TransactionAuth::Standard(
+		TransactionSpendingCondition::new_singlesig_p2pkh(public_key).unwrap(),
+	);
 
-    let function_args = vec![
-        Value::UInt(deposit_info.amount as u128),
-        Value::from(deposit_info.recipient.clone()),
-        proof_data.txid,
-        proof_data.block_height,
-        proof_data.merkle_path,
-        proof_data.tx_index,
-        proof_data.merkle_tree_depth,
-        proof_data.block_header,
-    ];
+	let function_args = vec![
+		Value::UInt(deposit_info.amount as u128),
+		Value::from(deposit_info.recipient.clone()),
+		proof_data.txid,
+		proof_data.block_height,
+		proof_data.merkle_path,
+		proof_data.tx_index,
+		proof_data.merkle_tree_depth,
+		proof_data.block_header,
+	];
 
-    let addr = StacksAddress::consensus_deserialize(&mut Cursor::new(
-        config.stacks_credentials.address().serialize_to_vec(),
-    ))
-    .unwrap();
+	let addr = StacksAddress::consensus_deserialize(&mut Cursor::new(
+		config.stacks_credentials.address().serialize_to_vec(),
+	))
+	.unwrap();
 
-    let tx_payload = TransactionPayload::ContractCall(TransactionContractCall {
-        address: addr,
-        contract_name: config.contract_name.clone(),
-        function_name: ClarityName::from("mint"),
-        function_args,
-    });
+	let tx_payload =
+		TransactionPayload::ContractCall(TransactionContractCall {
+			address: addr,
+			contract_name: config.contract_name.clone(),
+			function_name: ClarityName::from("mint"),
+			function_args,
+		});
 
-    let tx = StacksTransaction::new(TransactionVersion::Testnet, tx_auth, tx_payload);
+	let tx = StacksTransaction::new(
+		TransactionVersion::Testnet,
+		tx_auth,
+		tx_payload,
+	);
 
-    let txid = stacks_client
-        .lock()
-        .await
-        .sign_and_broadcast(tx)
-        .await
-        .expect("Unable to sign and broadcast the mint transaction");
+	let txid = stacks_client
+		.lock()
+		.await
+		.sign_and_broadcast(tx)
+		.await
+		.expect("Unable to sign and broadcast the mint transaction");
 
-    Event::MintBroadcasted(deposit_info, txid)
+	Event::MintBroadcasted(deposit_info, txid)
 }
 
-async fn check_bitcoin_transaction_status(_config: &Config, _txid: BitcoinTxId) -> Event {
-    todo!();
+async fn check_bitcoin_transaction_status(
+	_config: &Config,
+	_txid: BitcoinTxId,
+) -> Event {
+	todo!();
 }
 
-async fn check_stacks_transaction_status(client: LockedClient, txid: StacksTxId) -> Event {
-    let status = client
-        .lock()
-        .await
-        .get_transation_status(txid)
-        .await
-        .expect("Could not get transaction status");
+async fn check_stacks_transaction_status(
+	client: LockedClient,
+	txid: StacksTxId,
+) -> Event {
+	let status = client
+		.lock()
+		.await
+		.get_transation_status(txid)
+		.await
+		.expect("Could not get transaction status");
 
-    Event::StacksTransactionUpdate(txid, status)
+	Event::StacksTransactionUpdate(txid, status)
 }
 
-async fn fetch_bitcoin_block(client: impl BitcoinClient, block_height: u32) -> Event {
-    let (height, block) = client
-        .fetch_block(block_height)
-        .await
-        .expect("Failed to fetch block");
+async fn fetch_bitcoin_block(
+	client: impl BitcoinClient,
+	block_height: u32,
+) -> Event {
+	let (height, block) = client
+		.fetch_block(block_height)
+		.await
+		.expect("Failed to fetch block");
 
-    Event::BitcoinBlock(height, block)
+	Event::BitcoinBlock(height, block)
 }

--- a/romeo/src/task.rs
+++ b/romeo/src/task.rs
@@ -8,23 +8,24 @@ use crate::state;
 /// Represents I/O operations performed by the system
 #[derive(Debug)]
 pub enum Task {
-    /// Create and broadcast a mint stacks transaction
-    CreateMint(state::DepositInfo),
-    /// Create and broadcast a burn stacks transaction
-    CreateBurn(state::WithdrawalInfo),
-    /// Create and broadcast a fulfill bitcoin transaction
-    CreateFulfill(state::WithdrawalInfo),
+	/// Create and broadcast a mint stacks transaction
+	CreateMint(state::DepositInfo),
+	/// Create and broadcast a burn stacks transaction
+	CreateBurn(state::WithdrawalInfo),
+	/// Create and broadcast a fulfill bitcoin transaction
+	CreateFulfill(state::WithdrawalInfo),
 
-    /// Get the block height of the contract deployment
-    GetContractBlockHeight,
+	/// Get the block height of the contract deployment
+	GetContractBlockHeight,
 
-    /// Poll a bitcoin node for the status of a transaction
-    CheckBitcoinTransactionStatus(BitcoinTxId),
+	/// Poll a bitcoin node for the status of a transaction
+	CheckBitcoinTransactionStatus(BitcoinTxId),
 
-    /// Poll a stacks node for the status of a transaction
-    CheckStacksTransactionStatus(StacksTxId),
+	/// Poll a stacks node for the status of a transaction
+	CheckStacksTransactionStatus(StacksTxId),
 
-    /// Fetch a bitcoin block for the given block height from the current canonical bitcoin fork
-    /// If the block height is not provided, fetch the latest block
-    FetchBitcoinBlock(u32),
+	/// Fetch a bitcoin block for the given block height from the current
+	/// canonical bitcoin fork If the block height is not provided, fetch the
+	/// latest block
+	FetchBitcoinBlock(u32),
 }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,10 @@
+group_imports = "StdExternalCrate"
+imports_granularity = "Crate"
+format_code_in_doc_comments = true
+hard_tabs = true
+max_width = 80
+newline_style = "Unix"
+normalize_comments = true
+reorder_impl_items = true
+use_field_init_shorthand = true
+wrap_comments = true

--- a/sbtc-cli/src/commands/broadcast.rs
+++ b/sbtc-cli/src/commands/broadcast.rs
@@ -1,27 +1,28 @@
 use std::io::stdout;
 
 use bdk::{
-    bitcoin::{psbt::serialize::Deserialize, Transaction},
-    electrum_client::ElectrumApi,
+	bitcoin::{psbt::serialize::Deserialize, Transaction},
+	electrum_client::ElectrumApi,
 };
 use clap::Parser;
 use url::Url;
 
 #[derive(Parser, Debug, Clone)]
 pub struct BroadcastArgs {
-    /// Where to broadcast the transaction
-    node_url: Url,
+	/// Where to broadcast the transaction
+	node_url: Url,
 
-    /// The transaction to broadcast
-    tx: String,
+	/// The transaction to broadcast
+	tx: String,
 }
 
 pub fn broadcast_tx(broadcast: &BroadcastArgs) -> anyhow::Result<()> {
-    let client = bdk::electrum_client::Client::new(broadcast.node_url.as_str())?;
-    let tx = Transaction::deserialize(&hex::decode(&broadcast.tx)?)?;
+	let client =
+		bdk::electrum_client::Client::new(broadcast.node_url.as_str())?;
+	let tx = Transaction::deserialize(&hex::decode(&broadcast.tx)?)?;
 
-    client.transaction_broadcast(&tx)?;
-    serde_json::to_writer_pretty(stdout(), &tx.txid().to_string())?;
+	client.transaction_broadcast(&tx)?;
+	serde_json::to_writer_pretty(stdout(), &tx.txid().to_string())?;
 
-    Ok(())
+	Ok(())
 }

--- a/sbtc-cli/src/commands/deposit.rs
+++ b/sbtc-cli/src/commands/deposit.rs
@@ -1,14 +1,16 @@
 use std::{io::stdout, str::FromStr};
 
 use bdk::{
-    bitcoin::{
-        psbt::serialize::Serialize, Address as BitcoinAddress, Network as BitcoinNetwork,
-        PrivateKey,
-    },
-    blockchain::{ConfigurableBlockchain, ElectrumBlockchain, ElectrumBlockchainConfig},
-    database::MemoryDatabase,
-    template::P2Wpkh,
-    SyncOptions, Wallet,
+	bitcoin::{
+		psbt::serialize::Serialize, Address as BitcoinAddress,
+		Network as BitcoinNetwork, PrivateKey,
+	},
+	blockchain::{
+		ConfigurableBlockchain, ElectrumBlockchain, ElectrumBlockchainConfig,
+	},
+	database::MemoryDatabase,
+	template::P2Wpkh,
+	SyncOptions, Wallet,
 };
 use clap::Parser;
 use sbtc_core::operations::op_return::deposit::build_deposit_transaction;
@@ -19,70 +21,72 @@ use crate::commands::utils;
 
 #[derive(Parser, Debug, Clone)]
 pub struct DepositArgs {
-    /// Where to broadcast the transaction
-    #[clap(short('u'), long)]
-    node_url: Url,
+	/// Where to broadcast the transaction
+	#[clap(short('u'), long)]
+	node_url: Url,
 
-    /// Bitcoin WIF of the P2wPKH address
-    #[clap(short, long)]
-    wif: String,
+	/// Bitcoin WIF of the P2wPKH address
+	#[clap(short, long)]
+	wif: String,
 
-    /// Bitcoin network where the deposit will be broadcasted to
-    #[clap(short, long)]
-    network: BitcoinNetwork,
+	/// Bitcoin network where the deposit will be broadcasted to
+	#[clap(short, long)]
+	network: BitcoinNetwork,
 
-    /// Stacks address that will receive sBTC
-    #[clap(short, long)]
-    recipient: String,
+	/// Stacks address that will receive sBTC
+	#[clap(short, long)]
+	recipient: String,
 
-    /// The amount of sats to send
-    #[clap(short, long)]
-    amount: u64,
+	/// The amount of sats to send
+	#[clap(short, long)]
+	amount: u64,
 
-    /// Dkg wallet address
-    #[clap(short, long)]
-    dkg_wallet: String,
+	/// Dkg wallet address
+	#[clap(short, long)]
+	dkg_wallet: String,
 }
 
 pub fn build_deposit_tx(deposit: &DepositArgs) -> anyhow::Result<()> {
-    let private_key = PrivateKey::from_wif(&deposit.wif)?;
+	let private_key = PrivateKey::from_wif(&deposit.wif)?;
 
-    let blockchain = ElectrumBlockchain::from_config(&ElectrumBlockchainConfig {
-        url: deposit.node_url.as_str().to_string(),
-        socks5: None,
-        retry: 3,
-        timeout: Some(10),
-        stop_gap: 10,
-        validate_domain: false,
-    })?;
+	let blockchain =
+		ElectrumBlockchain::from_config(&ElectrumBlockchainConfig {
+			url: deposit.node_url.as_str().to_string(),
+			socks5: None,
+			retry: 3,
+			timeout: Some(10),
+			stop_gap: 10,
+			validate_domain: false,
+		})?;
 
-    let wallet = Wallet::new(
-        P2Wpkh(private_key),
-        Some(P2Wpkh(private_key)),
-        deposit.network,
-        MemoryDatabase::default(),
-    )?;
+	let wallet = Wallet::new(
+		P2Wpkh(private_key),
+		Some(P2Wpkh(private_key)),
+		deposit.network,
+		MemoryDatabase::default(),
+	)?;
 
-    wallet.sync(&blockchain, SyncOptions::default())?;
+	wallet.sync(&blockchain, SyncOptions::default())?;
 
-    let recipient_address = StacksAddress::try_from(deposit.recipient.as_str())?;
-    let dkg_address = BitcoinAddress::from_str(&deposit.dkg_wallet)?;
+	let recipient_address =
+		StacksAddress::try_from(deposit.recipient.as_str())?;
+	let dkg_address = BitcoinAddress::from_str(&deposit.dkg_wallet)?;
 
-    let tx = build_deposit_transaction(
-        wallet,
-        recipient_address.into(),
-        dkg_address,
-        deposit.amount,
-        deposit.network,
-    )?;
+	let tx = build_deposit_transaction(
+		wallet,
+		recipient_address.into(),
+		dkg_address,
+		deposit.amount,
+		deposit.network,
+	)?;
 
-    serde_json::to_writer_pretty(
-        stdout(),
-        &utils::TransactionData {
-            tx_id: tx.txid().to_string(),
-            tx_hex: hex::encode(tx.serialize()),
-        },
-    )?;
+	serde_json::to_writer_pretty(
+		stdout(),
+		&utils::TransactionData {
+			tx_id: tx.txid().to_string(),
+			tx_hex: hex::encode(tx.serialize()),
+		},
+	)?;
 
-    Ok(())
+	Ok(())
 }

--- a/sbtc-cli/src/commands/generate.rs
+++ b/sbtc-cli/src/commands/generate.rs
@@ -4,174 +4,188 @@ use bdk::bitcoin::Network as BitcoinNetwork;
 use clap::Parser;
 use serde_json::{Map, Value};
 use stacks_core::{
-    wallet::{BitcoinCredentials, Credentials, Wallet},
-    Network as StacksNetwork,
+	wallet::{BitcoinCredentials, Credentials, Wallet},
+	Network as StacksNetwork,
 };
 
 #[derive(Parser, Debug, Clone)]
 pub struct GenerateArgs {
-    /// Specify how to generate the credentials
-    #[command(subcommand)]
-    subcommand: GenerateSubcommand,
+	/// Specify how to generate the credentials
+	#[command(subcommand)]
+	subcommand: GenerateSubcommand,
 
-    /// Stacks network to generate credentials for
-    #[clap(short, long, default_value_t = StacksNetwork::Mainnet)]
-    stacks_network: StacksNetwork,
+	/// Stacks network to generate credentials for
+	#[clap(short, long, default_value_t = StacksNetwork::Mainnet)]
+	stacks_network: StacksNetwork,
 
-    /// Bitcoin network to generate credentials for
-    #[clap(short, long, default_value_t = BitcoinNetwork::Bitcoin)]
-    bitcoin_network: BitcoinNetwork,
+	/// Bitcoin network to generate credentials for
+	#[clap(short, long, default_value_t = BitcoinNetwork::Bitcoin)]
+	bitcoin_network: BitcoinNetwork,
 
-    /// How many accounts to generate
-    #[clap(short, long, default_value_t = 1)]
-    accounts: usize,
+	/// How many accounts to generate
+	#[clap(short, long, default_value_t = 1)]
+	accounts: usize,
 }
 
 #[derive(clap::Subcommand, Debug, Clone)]
 enum GenerateSubcommand {
-    New,
-    Mnemonic { mnemonic: String },
+	New,
+	Mnemonic { mnemonic: String },
 }
 
 pub fn generate(generate_args: &GenerateArgs) -> anyhow::Result<()> {
-    match &generate_args.subcommand {
-        GenerateSubcommand::New => {
-            let wallet = Wallet::random()?;
+	match &generate_args.subcommand {
+		GenerateSubcommand::New => {
+			let wallet = Wallet::random()?;
 
-            serde_json::to_writer_pretty(stdout(), &value_from_wallet(&wallet, generate_args))?;
-        }
-        GenerateSubcommand::Mnemonic { mnemonic } => {
-            let wallet = Wallet::new(mnemonic)?;
+			serde_json::to_writer_pretty(
+				stdout(),
+				&value_from_wallet(&wallet, generate_args),
+			)?;
+		}
+		GenerateSubcommand::Mnemonic { mnemonic } => {
+			let wallet = Wallet::new(mnemonic)?;
 
-            serde_json::to_writer_pretty(stdout(), &value_from_wallet(&wallet, generate_args))?;
-        }
-    };
+			serde_json::to_writer_pretty(
+				stdout(),
+				&value_from_wallet(&wallet, generate_args),
+			)?;
+		}
+	};
 
-    Ok(())
+	Ok(())
 }
 
 fn value_from_wallet(wallet: &Wallet, generate_args: &GenerateArgs) -> Value {
-    let mut map = Map::new();
+	let mut map = Map::new();
 
-    map.insert("mnemonic".into(), wallet.mnemonic().to_string().into());
-    map.insert(
-        "private_key".into(),
-        hex::encode(wallet.master_key().secret_bytes()).into(),
-    );
-    map.insert(
-        "wif".into(),
-        wallet.wif(generate_args.stacks_network).to_string().into(),
-    );
+	map.insert("mnemonic".into(), wallet.mnemonic().to_string().into());
+	map.insert(
+		"private_key".into(),
+		hex::encode(wallet.master_key().secret_bytes()).into(),
+	);
+	map.insert(
+		"wif".into(),
+		wallet.wif(generate_args.stacks_network).to_string().into(),
+	);
 
-    let mut credentials: Vec<Value> = Default::default();
+	let mut credentials: Vec<Value> = Default::default();
 
-    for i in 0..generate_args.accounts {
-        let mut creds = Map::new();
-        creds.insert(
-            "stacks".into(),
-            value_from_credentials(
-                wallet
-                    .credentials(generate_args.stacks_network, i as u32)
-                    .unwrap(),
-            ),
-        );
-        creds.insert(
-            "bitcoin".into(),
-            value_from_bitcoin_credentials(
-                wallet
-                    .bitcoin_credentials(generate_args.bitcoin_network, i as u32)
-                    .unwrap(),
-            ),
-        );
+	for i in 0..generate_args.accounts {
+		let mut creds = Map::new();
+		creds.insert(
+			"stacks".into(),
+			value_from_credentials(
+				wallet
+					.credentials(generate_args.stacks_network, i as u32)
+					.unwrap(),
+			),
+		);
+		creds.insert(
+			"bitcoin".into(),
+			value_from_bitcoin_credentials(
+				wallet
+					.bitcoin_credentials(
+						generate_args.bitcoin_network,
+						i as u32,
+					)
+					.unwrap(),
+			),
+		);
 
-        credentials.push(creds.into());
-    }
+		credentials.push(creds.into());
+	}
 
-    map.insert(
-        "credentials".into(),
-        credentials
-            .into_iter()
-            .enumerate()
-            .map(|(i, creds)| (i.to_string(), creds))
-            .collect::<Map<String, Value>>()
-            .into(),
-    );
+	map.insert(
+		"credentials".into(),
+		credentials
+			.into_iter()
+			.enumerate()
+			.map(|(i, creds)| (i.to_string(), creds))
+			.collect::<Map<String, Value>>()
+			.into(),
+	);
 
-    map.insert(
-        "network_stacks".into(),
-        generate_args
-            .stacks_network
-            .to_string()
-            .to_ascii_lowercase()
-            .into(),
-    );
-    map.insert(
-        "network_bitcoin".into(),
-        generate_args
-            .bitcoin_network
-            .to_string()
-            .to_ascii_lowercase()
-            .into(),
-    );
+	map.insert(
+		"network_stacks".into(),
+		generate_args
+			.stacks_network
+			.to_string()
+			.to_ascii_lowercase()
+			.into(),
+	);
+	map.insert(
+		"network_bitcoin".into(),
+		generate_args
+			.bitcoin_network
+			.to_string()
+			.to_ascii_lowercase()
+			.into(),
+	);
 
-    map.into()
+	map.into()
 }
 
 fn value_from_credentials(creds: Credentials) -> Value {
-    let mut stacks_creds = Map::new();
+	let mut stacks_creds = Map::new();
 
-    stacks_creds.insert(
-        "private_key".into(),
-        hex::encode(creds.private_key().secret_bytes()).into(),
-    );
-    stacks_creds.insert("public_key".into(), creds.public_key().to_string().into());
-    stacks_creds.insert("address".into(), creds.address().to_string().into());
-    stacks_creds.insert("wif".into(), creds.wif().to_string().into());
+	stacks_creds.insert(
+		"private_key".into(),
+		hex::encode(creds.private_key().secret_bytes()).into(),
+	);
+	stacks_creds
+		.insert("public_key".into(), creds.public_key().to_string().into());
+	stacks_creds.insert("address".into(), creds.address().to_string().into());
+	stacks_creds.insert("wif".into(), creds.wif().to_string().into());
 
-    stacks_creds.into()
+	stacks_creds.into()
 }
 
 fn value_from_bitcoin_credentials(creds: BitcoinCredentials) -> Value {
-    let mut btc_creds = Map::new();
+	let mut btc_creds = Map::new();
 
-    let mut btc_p2pkh_creds = Map::new();
-    btc_p2pkh_creds.insert(
-        "private_key".into(),
-        hex::encode(creds.private_key_p2pkh().secret_bytes()).into(),
-    );
-    btc_p2pkh_creds.insert(
-        "public_key".into(),
-        creds.public_key_p2pkh().to_string().into(),
-    );
-    btc_p2pkh_creds.insert("address".into(), creds.address_p2pkh().to_string().into());
-    btc_p2pkh_creds.insert("wif".into(), creds.wif_p2pkh().to_string().into());
-    btc_creds.insert("p2pkh".into(), btc_p2pkh_creds.into());
+	let mut btc_p2pkh_creds = Map::new();
+	btc_p2pkh_creds.insert(
+		"private_key".into(),
+		hex::encode(creds.private_key_p2pkh().secret_bytes()).into(),
+	);
+	btc_p2pkh_creds.insert(
+		"public_key".into(),
+		creds.public_key_p2pkh().to_string().into(),
+	);
+	btc_p2pkh_creds
+		.insert("address".into(), creds.address_p2pkh().to_string().into());
+	btc_p2pkh_creds.insert("wif".into(), creds.wif_p2pkh().to_string().into());
+	btc_creds.insert("p2pkh".into(), btc_p2pkh_creds.into());
 
-    let mut btc_p2wpkh_creds = Map::new();
-    btc_p2wpkh_creds.insert(
-        "private_key".into(),
-        hex::encode(creds.private_key_p2wpkh().secret_bytes()).into(),
-    );
-    btc_p2wpkh_creds.insert(
-        "public_key".into(),
-        creds.public_key_p2wpkh().to_string().into(),
-    );
-    btc_p2wpkh_creds.insert("address".into(), creds.address_p2wpkh().to_string().into());
-    btc_p2wpkh_creds.insert("wif".into(), creds.wif_p2wpkh().to_string().into());
-    btc_creds.insert("p2wpkh".into(), btc_p2wpkh_creds.into());
+	let mut btc_p2wpkh_creds = Map::new();
+	btc_p2wpkh_creds.insert(
+		"private_key".into(),
+		hex::encode(creds.private_key_p2wpkh().secret_bytes()).into(),
+	);
+	btc_p2wpkh_creds.insert(
+		"public_key".into(),
+		creds.public_key_p2wpkh().to_string().into(),
+	);
+	btc_p2wpkh_creds
+		.insert("address".into(), creds.address_p2wpkh().to_string().into());
+	btc_p2wpkh_creds
+		.insert("wif".into(), creds.wif_p2wpkh().to_string().into());
+	btc_creds.insert("p2wpkh".into(), btc_p2wpkh_creds.into());
 
-    let mut btc_p2tr_creds = Map::new();
-    btc_p2tr_creds.insert(
-        "private_key".into(),
-        hex::encode(creds.private_key_p2tr().secret_bytes()).into(),
-    );
-    btc_p2tr_creds.insert(
-        "public_key".into(),
-        creds.public_key_p2tr().to_string().into(),
-    );
-    btc_p2tr_creds.insert("address".into(), creds.address_p2tr().to_string().into());
-    btc_p2tr_creds.insert("wif".into(), creds.wif_p2tr().to_string().into());
-    btc_creds.insert("p2tr".into(), btc_p2tr_creds.into());
+	let mut btc_p2tr_creds = Map::new();
+	btc_p2tr_creds.insert(
+		"private_key".into(),
+		hex::encode(creds.private_key_p2tr().secret_bytes()).into(),
+	);
+	btc_p2tr_creds.insert(
+		"public_key".into(),
+		creds.public_key_p2tr().to_string().into(),
+	);
+	btc_p2tr_creds
+		.insert("address".into(), creds.address_p2tr().to_string().into());
+	btc_p2tr_creds.insert("wif".into(), creds.wif_p2tr().to_string().into());
+	btc_creds.insert("p2tr".into(), btc_p2tr_creds.into());
 
-    btc_creds.into()
+	btc_creds.into()
 }

--- a/sbtc-cli/src/commands/utils.rs
+++ b/sbtc-cli/src/commands/utils.rs
@@ -1,54 +1,53 @@
 use std::collections::{BTreeMap, HashMap};
 
 use bdk::bitcoin::{
-    blockdata::{opcodes::all::OP_RETURN, script::Builder},
-    Network, Script, TxOut,
+	blockdata::{opcodes::all::OP_RETURN, script::Builder},
+	Network, Script, TxOut,
 };
-
 use serde::Serialize;
 
 pub fn build_op_return_script(data: &[u8]) -> Script {
-    Builder::new()
-        .push_opcode(OP_RETURN)
-        .push_slice(data)
-        .into_script()
+	Builder::new()
+		.push_opcode(OP_RETURN)
+		.push_slice(data)
+		.into_script()
 }
 
 pub fn reorder_outputs(
-    outputs: impl IntoIterator<Item = TxOut>,
-    order: impl IntoIterator<Item = (Script, u64)>,
+	outputs: impl IntoIterator<Item = TxOut>,
+	order: impl IntoIterator<Item = (Script, u64)>,
 ) -> Vec<TxOut> {
-    let indices: HashMap<(Script, u64), usize> = order
-        .into_iter()
-        .enumerate()
-        .map(|(idx, val)| (val, idx))
-        .collect();
+	let indices: HashMap<(Script, u64), usize> = order
+		.into_iter()
+		.enumerate()
+		.map(|(idx, val)| (val, idx))
+		.collect();
 
-    let outputs_ordered: BTreeMap<usize, TxOut> = outputs
-        .into_iter()
-        .map(|txout| {
-            (
-                *indices
-                    .get(&(txout.script_pubkey.clone(), txout.value))
-                    .unwrap_or(&usize::MAX), // Change amount
-                txout,
-            )
-        })
-        .collect();
+	let outputs_ordered: BTreeMap<usize, TxOut> = outputs
+		.into_iter()
+		.map(|txout| {
+			(
+				*indices
+					.get(&(txout.script_pubkey.clone(), txout.value))
+					.unwrap_or(&usize::MAX), // Change amount
+				txout,
+			)
+		})
+		.collect();
 
-    outputs_ordered.into_values().collect()
+	outputs_ordered.into_values().collect()
 }
 
 pub fn magic_bytes(network: &Network) -> [u8; 2] {
-    match network {
-        Network::Bitcoin => [b'X', b'2'],
-        Network::Testnet => [b'T', b'2'],
-        _ => [b'i', b'd'],
-    }
+	match network {
+		Network::Bitcoin => [b'X', b'2'],
+		Network::Testnet => [b'T', b'2'],
+		_ => [b'i', b'd'],
+	}
 }
 
 #[derive(Serialize)]
 pub struct TransactionData {
-    pub tx_id: String,
-    pub tx_hex: String,
+	pub tx_id: String,
+	pub tx_hex: String,
 }

--- a/sbtc-cli/src/commands/withdraw.rs
+++ b/sbtc-cli/src/commands/withdraw.rs
@@ -2,178 +2,184 @@ use std::{io::stdout, iter::once, str::FromStr};
 
 use anyhow::anyhow;
 use bdk::{
-    bitcoin::{
-        psbt::{serialize::Serialize, PartiallySignedTransaction},
-        secp256k1::{Message, Secp256k1},
-        Address as BitcoinAddress, Network, Network as BitcoinNetwork, PrivateKey,
-    },
-    blockchain::{ConfigurableBlockchain, ElectrumBlockchain, ElectrumBlockchainConfig},
-    database::MemoryDatabase,
-    template::P2Wpkh,
-    SignOptions, SyncOptions, Wallet,
+	bitcoin::{
+		psbt::{serialize::Serialize, PartiallySignedTransaction},
+		secp256k1::{Message, Secp256k1},
+		Address as BitcoinAddress, Network, Network as BitcoinNetwork,
+		PrivateKey,
+	},
+	blockchain::{
+		ConfigurableBlockchain, ElectrumBlockchain, ElectrumBlockchainConfig,
+	},
+	database::MemoryDatabase,
+	template::P2Wpkh,
+	SignOptions, SyncOptions, Wallet,
 };
 use clap::Parser;
 use stacks_core::crypto::{sha256::Sha256Hasher, Hashing};
 use url::Url;
 
-use crate::commands::utils::TransactionData;
-use crate::commands::utils::{build_op_return_script, magic_bytes, reorder_outputs};
+use crate::commands::utils::{
+	build_op_return_script, magic_bytes, reorder_outputs, TransactionData,
+};
 
 #[derive(Parser, Debug, Clone)]
 pub struct WithdrawalArgs {
-    /// Where to broadcast the transaction
-    #[clap(short('u'), long)]
-    node_url: Url,
+	/// Where to broadcast the transaction
+	#[clap(short('u'), long)]
+	node_url: Url,
 
-    /// P2WPKH BTC private key in WIF format
-    #[clap(short, long)]
-    wif: String,
+	/// P2WPKH BTC private key in WIF format
+	#[clap(short, long)]
+	wif: String,
 
-    /// Bitcoin network where the withdrawal will be broadcasted to
-    #[clap(short, long)]
-    network: BitcoinNetwork,
+	/// Bitcoin network where the withdrawal will be broadcasted to
+	#[clap(short, long)]
+	network: BitcoinNetwork,
 
-    /// P2WPKH sBTC sender private key in WIF format
-    #[clap(short, long)]
-    sender_wif: String,
+	/// P2WPKH sBTC sender private key in WIF format
+	#[clap(short, long)]
+	sender_wif: String,
 
-    /// Bitcoin address that will receive BTC
-    #[clap(short, long)]
-    recipient: String,
+	/// Bitcoin address that will receive BTC
+	#[clap(short, long)]
+	recipient: String,
 
-    /// The amount of sats to send
-    #[clap(short, long)]
-    amount: u64,
+	/// The amount of sats to send
+	#[clap(short, long)]
+	amount: u64,
 
-    /// The amount of sats to send as the fulfillment fee
-    #[clap(short, long)]
-    fulfillment_fee: u64,
+	/// The amount of sats to send as the fulfillment fee
+	#[clap(short, long)]
+	fulfillment_fee: u64,
 
-    /// Dkg wallet address
-    #[clap(short, long)]
-    dkg_wallet: String,
+	/// Dkg wallet address
+	#[clap(short, long)]
+	dkg_wallet: String,
 }
 
 pub fn build_withdrawal_tx(withdrawal: &WithdrawalArgs) -> anyhow::Result<()> {
-    let private_key = PrivateKey::from_wif(&withdrawal.wif)?;
+	let private_key = PrivateKey::from_wif(&withdrawal.wif)?;
 
-    let blockchain = ElectrumBlockchain::from_config(&ElectrumBlockchainConfig {
-        url: withdrawal.node_url.as_str().to_string(),
-        socks5: None,
-        retry: 3,
-        timeout: Some(10),
-        stop_gap: 10,
-        validate_domain: false,
-    })?;
+	let blockchain =
+		ElectrumBlockchain::from_config(&ElectrumBlockchainConfig {
+			url: withdrawal.node_url.as_str().to_string(),
+			socks5: None,
+			retry: 3,
+			timeout: Some(10),
+			stop_gap: 10,
+			validate_domain: false,
+		})?;
 
-    let wallet = Wallet::new(
-        P2Wpkh(private_key),
-        Some(P2Wpkh(private_key)),
-        withdrawal.network,
-        MemoryDatabase::default(),
-    )?;
+	let wallet = Wallet::new(
+		P2Wpkh(private_key),
+		Some(P2Wpkh(private_key)),
+		withdrawal.network,
+		MemoryDatabase::default(),
+	)?;
 
-    wallet.sync(&blockchain, SyncOptions::default())?;
+	wallet.sync(&blockchain, SyncOptions::default())?;
 
-    let sender_private_key = PrivateKey::from_wif(&withdrawal.sender_wif)?;
-    let recipient = BitcoinAddress::from_str(&withdrawal.recipient)?;
-    let dkg_address = BitcoinAddress::from_str(&withdrawal.dkg_wallet)?;
+	let sender_private_key = PrivateKey::from_wif(&withdrawal.sender_wif)?;
+	let recipient = BitcoinAddress::from_str(&withdrawal.recipient)?;
+	let dkg_address = BitcoinAddress::from_str(&withdrawal.dkg_wallet)?;
 
-    let mut psbt = withdrawal_psbt(
-        &wallet,
-        &sender_private_key,
-        &recipient,
-        &dkg_address,
-        withdrawal.amount,
-        withdrawal.fulfillment_fee,
-        &withdrawal.network,
-    )?;
+	let mut psbt = withdrawal_psbt(
+		&wallet,
+		&sender_private_key,
+		&recipient,
+		&dkg_address,
+		withdrawal.amount,
+		withdrawal.fulfillment_fee,
+		&withdrawal.network,
+	)?;
 
-    wallet.sign(&mut psbt, SignOptions::default())?;
-    let tx = psbt.extract_tx();
+	wallet.sign(&mut psbt, SignOptions::default())?;
+	let tx = psbt.extract_tx();
 
-    serde_json::to_writer_pretty(
-        stdout(),
-        &TransactionData {
-            tx_id: tx.txid().to_string(),
-            tx_hex: hex::encode(tx.serialize()),
-        },
-    )?;
+	serde_json::to_writer_pretty(
+		stdout(),
+		&TransactionData {
+			tx_id: tx.txid().to_string(),
+			tx_hex: hex::encode(tx.serialize()),
+		},
+	)?;
 
-    Ok(())
+	Ok(())
 }
 
 fn withdrawal_psbt(
-    wallet: &Wallet<MemoryDatabase>,
-    sender_private_key: &PrivateKey,
-    recipient: &BitcoinAddress,
-    dkg_address: &BitcoinAddress,
-    amount: u64,
-    fulfillment_fee: u64,
-    network: &Network,
+	wallet: &Wallet<MemoryDatabase>,
+	sender_private_key: &PrivateKey,
+	recipient: &BitcoinAddress,
+	dkg_address: &BitcoinAddress,
+	amount: u64,
+	fulfillment_fee: u64,
+	network: &Network,
 ) -> anyhow::Result<PartiallySignedTransaction> {
-    let recipient_script = recipient.script_pubkey();
-    let dkg_wallet_script = dkg_address.script_pubkey();
+	let recipient_script = recipient.script_pubkey();
+	let dkg_wallet_script = dkg_address.script_pubkey();
 
-    // Check that we have enough to cover dust
-    let recipient_dust_amount = recipient_script.dust_value().to_sat();
-    let dkg_wallet_dust_amount = dkg_wallet_script.dust_value().to_sat();
+	// Check that we have enough to cover dust
+	let recipient_dust_amount = recipient_script.dust_value().to_sat();
+	let dkg_wallet_dust_amount = dkg_wallet_script.dust_value().to_sat();
 
-    if fulfillment_fee < dkg_wallet_dust_amount {
-        return Err(anyhow!(
-            "Provided fulfillment fee {} is less than the dust amount: {}",
-            fulfillment_fee,
-            dkg_wallet_dust_amount
-        ));
-    }
+	if fulfillment_fee < dkg_wallet_dust_amount {
+		return Err(anyhow!(
+			"Provided fulfillment fee {} is less than the dust amount: {}",
+			fulfillment_fee,
+			dkg_wallet_dust_amount
+		));
+	}
 
-    let op_return_script = build_op_return_script(&withdrawal_data(
-        recipient,
-        amount,
-        sender_private_key,
-        network,
-    ));
+	let op_return_script = build_op_return_script(&withdrawal_data(
+		recipient,
+		amount,
+		sender_private_key,
+		network,
+	));
 
-    let mut tx_builder = wallet.build_tx();
+	let mut tx_builder = wallet.build_tx();
 
-    let outputs = [
-        (op_return_script, 0),
-        (recipient_script, recipient_dust_amount),
-        (dkg_wallet_script, fulfillment_fee),
-    ];
+	let outputs = [
+		(op_return_script, 0),
+		(recipient_script, recipient_dust_amount),
+		(dkg_wallet_script, fulfillment_fee),
+	];
 
-    for (script, amount) in outputs.clone() {
-        tx_builder.add_recipient(script, amount);
-    }
+	for (script, amount) in outputs.clone() {
+		tx_builder.add_recipient(script, amount);
+	}
 
-    let (mut partial_tx, _) = tx_builder.finish()?;
+	let (mut partial_tx, _) = tx_builder.finish()?;
 
-    partial_tx.unsigned_tx.output = reorder_outputs(partial_tx.unsigned_tx.output, outputs);
+	partial_tx.unsigned_tx.output =
+		reorder_outputs(partial_tx.unsigned_tx.output, outputs);
 
-    Ok(partial_tx)
+	Ok(partial_tx)
 }
 
 fn withdrawal_data(
-    recipient: &BitcoinAddress,
-    amount: u64,
-    sender_private_key: &PrivateKey,
-    network: &Network,
+	recipient: &BitcoinAddress,
+	amount: u64,
+	sender_private_key: &PrivateKey,
+	network: &Network,
 ) -> Vec<u8> {
-    let mut msg = amount.to_be_bytes().to_vec();
-    msg.extend_from_slice(recipient.script_pubkey().as_bytes());
+	let mut msg = amount.to_be_bytes().to_vec();
+	msg.extend_from_slice(recipient.script_pubkey().as_bytes());
 
-    let msg_hash = Sha256Hasher::new(msg.as_slice());
-    let msg_ecdsa = Message::from_slice(msg_hash.as_bytes()).unwrap();
+	let msg_hash = Sha256Hasher::new(msg.as_slice());
+	let msg_ecdsa = Message::from_slice(msg_hash.as_bytes()).unwrap();
 
-    let (recovery_id, signature) = Secp256k1::new()
-        .sign_ecdsa_recoverable(&msg_ecdsa, &sender_private_key.inner)
-        .serialize_compact();
+	let (recovery_id, signature) = Secp256k1::new()
+		.sign_ecdsa_recoverable(&msg_ecdsa, &sender_private_key.inner)
+		.serialize_compact();
 
-    magic_bytes(network)
-        .into_iter()
-        .chain(once(b'>'))
-        .chain(amount.to_be_bytes())
-        .chain(once(recovery_id.to_i32() as u8))
-        .chain(signature)
-        .collect()
+	magic_bytes(network)
+		.into_iter()
+		.chain(once(b'>'))
+		.chain(amount.to_be_bytes())
+		.chain(once(recovery_id.to_i32() as u8))
+		.chain(signature)
+		.collect()
 }

--- a/sbtc-cli/src/main.rs
+++ b/sbtc-cli/src/main.rs
@@ -1,42 +1,45 @@
 #![forbid(missing_docs)]
 
-/*!
-sBTC CLI is a tool that allows you to generate and broadcast sBTC transactions.
-
-It also allows you to generate credentials needed to generate transactions and
-interact with the Bitcoin and Stacks networks.
-*/
+//! sBTC CLI is a tool that allows you to generate and broadcast sBTC
+//! transactions.
+//!
+//! It also allows you to generate credentials needed to generate transactions
+//! and interact with the Bitcoin and Stacks networks.
 
 use clap::{Parser, Subcommand};
 
-use crate::commands::broadcast::{broadcast_tx, BroadcastArgs};
-use crate::commands::deposit::{build_deposit_tx, DepositArgs};
-use crate::commands::generate::{generate, GenerateArgs};
-use crate::commands::withdraw::{build_withdrawal_tx, WithdrawalArgs};
+use crate::commands::{
+	broadcast::{broadcast_tx, BroadcastArgs},
+	deposit::{build_deposit_tx, DepositArgs},
+	generate::{generate, GenerateArgs},
+	withdraw::{build_withdrawal_tx, WithdrawalArgs},
+};
 
 mod commands;
 
 #[derive(Parser)]
 struct Cli {
-    #[command(subcommand)]
-    command: Command,
+	#[command(subcommand)]
+	command: Command,
 }
 
 #[derive(Subcommand, Debug, Clone)]
 enum Command {
-    Deposit(DepositArgs),
-    Withdraw(WithdrawalArgs),
-    Broadcast(BroadcastArgs),
-    GenerateFrom(GenerateArgs),
+	Deposit(DepositArgs),
+	Withdraw(WithdrawalArgs),
+	Broadcast(BroadcastArgs),
+	GenerateFrom(GenerateArgs),
 }
 
 fn main() -> Result<(), anyhow::Error> {
-    let args = Cli::parse();
+	let args = Cli::parse();
 
-    match args.command {
-        Command::Deposit(deposit_args) => build_deposit_tx(&deposit_args),
-        Command::Withdraw(withdrawal_args) => build_withdrawal_tx(&withdrawal_args),
-        Command::Broadcast(broadcast_args) => broadcast_tx(&broadcast_args),
-        Command::GenerateFrom(generate_args) => generate(&generate_args),
-    }
+	match args.command {
+		Command::Deposit(deposit_args) => build_deposit_tx(&deposit_args),
+		Command::Withdraw(withdrawal_args) => {
+			build_withdrawal_tx(&withdrawal_args)
+		}
+		Command::Broadcast(broadcast_args) => broadcast_tx(&broadcast_args),
+		Command::GenerateFrom(generate_args) => generate(&generate_args),
+	}
 }

--- a/sbtc-core/src/lib.rs
+++ b/sbtc-core/src/lib.rs
@@ -1,8 +1,6 @@
 #![forbid(missing_docs)]
 #![doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/README.md"))]
-/*!
-# sbtc-core library: a library for interacting with the sBTC protocol
-*/
+//! # sbtc-core library: a library for interacting with the sBTC protocol
 
 use bdk::electrum_client::Error as ElectrumError;
 use stacks_core::{contract_name::ContractNameError, StacksError};
@@ -17,27 +15,27 @@ pub mod signer;
 #[derive(Error, Debug)]
 /// sBTC error type
 pub enum SBTCError {
-    #[error("Bad contract name: {0}")]
-    /// Bad contract name
-    BadContractName(&'static str),
-    #[error("Data is malformed: {0}")]
-    /// Malformed data
-    MalformedData(&'static str),
-    #[error("{0}: {1}")]
-    /// Electrum error
-    ElectrumError(&'static str, ElectrumError),
-    #[error("{0}: {1}")]
-    /// BDK Error
-    BDKError(&'static str, bdk::Error),
-    #[error("Deposit amount {0} should be greater than dust amount {1}")]
-    /// Insufficient amount
-    AmountInsufficient(u64, u64),
-    /// Contract name error
-    #[error("Contract name error: {0}")]
-    ContractNameError(#[from] ContractNameError),
-    /// Stacks error
-    #[error("Stacks error: {0}")]
-    StacksError(#[from] StacksError),
+	#[error("Bad contract name: {0}")]
+	/// Bad contract name
+	BadContractName(&'static str),
+	#[error("Data is malformed: {0}")]
+	/// Malformed data
+	MalformedData(&'static str),
+	#[error("{0}: {1}")]
+	/// Electrum error
+	ElectrumError(&'static str, ElectrumError),
+	#[error("{0}: {1}")]
+	/// BDK Error
+	BDKError(&'static str, bdk::Error),
+	#[error("Deposit amount {0} should be greater than dust amount {1}")]
+	/// Insufficient amount
+	AmountInsufficient(u64, u64),
+	/// Contract name error
+	#[error("Contract name error: {0}")]
+	ContractNameError(#[from] ContractNameError),
+	/// Stacks error
+	#[error("Stacks error: {0}")]
+	StacksError(#[from] StacksError),
 }
 
 /// A helper type for sBTC results

--- a/sbtc-core/src/operations/commit_reveal/deposit.rs
+++ b/sbtc-core/src/operations/commit_reveal/deposit.rs
@@ -1,79 +1,79 @@
-/*!
-Primitives for sBTC commit reveal deposit transactions
-*/
+//! Primitives for sBTC commit reveal deposit transactions
 use std::io;
 
-use bdk::bitcoin::{Address as BitcoinAddress, Amount, Transaction, TxOut, XOnlyPublicKey};
+use bdk::bitcoin::{
+	Address as BitcoinAddress, Amount, Transaction, TxOut, XOnlyPublicKey,
+};
 use stacks_core::{codec::Codec, utils::PrincipalData};
 
 use crate::operations::{
-    commit_reveal::utils::{commit, reveal, CommitRevealResult, RevealInputs},
-    Opcode,
+	commit_reveal::utils::{commit, reveal, CommitRevealResult, RevealInputs},
+	Opcode,
 };
 
 /// Data to construct a commit reveal deposit transaction
 pub struct DepositData {
-    /// Address or contract to deposit to
-    pub principal: PrincipalData,
-    /// How much to send for the reveal fee
-    pub reveal_fee: Amount,
+	/// Address or contract to deposit to
+	pub principal: PrincipalData,
+	/// How much to send for the reveal fee
+	pub reveal_fee: Amount,
 }
 
 impl Codec for DepositData {
-    fn codec_serialize<W: io::Write>(&self, dest: &mut W) -> io::Result<()> {
-        Codec::codec_serialize(&Opcode::Deposit, dest)?;
-        self.principal.codec_serialize(dest)?;
-        self.reveal_fee.codec_serialize(dest)?;
+	fn codec_serialize<W: io::Write>(&self, dest: &mut W) -> io::Result<()> {
+		Codec::codec_serialize(&Opcode::Deposit, dest)?;
+		self.principal.codec_serialize(dest)?;
+		self.reveal_fee.codec_serialize(dest)?;
 
-        todo!()
-    }
+		todo!()
+	}
 
-    fn codec_deserialize<R: io::Read>(data: &mut R) -> io::Result<Self>
-    where
-        Self: Sized,
-    {
-        let opcode = Opcode::codec_deserialize(data)
-            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+	fn codec_deserialize<R: io::Read>(data: &mut R) -> io::Result<Self>
+	where
+		Self: Sized,
+	{
+		let opcode = Opcode::codec_deserialize(data)
+			.map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
 
-        if !matches!(opcode, Opcode::Deposit) {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "Invalid opcode, expected deposit",
-            ));
-        }
+		if !matches!(opcode, Opcode::Deposit) {
+			return Err(io::Error::new(
+				io::ErrorKind::InvalidData,
+				"Invalid opcode, expected deposit",
+			));
+		}
 
-        let principal = PrincipalData::codec_deserialize(data)?;
-        let reveal_fee = Amount::codec_deserialize(data)?;
+		let principal = PrincipalData::codec_deserialize(data)?;
+		let reveal_fee = Amount::codec_deserialize(data)?;
 
-        Ok(Self {
-            principal,
-            reveal_fee,
-        })
-    }
+		Ok(Self {
+			principal,
+			reveal_fee,
+		})
+	}
 }
 
 /// Constructs a deposit payment address
 pub fn deposit_commit_address(
-    deposit_data: DepositData,
-    revealer_key: &XOnlyPublicKey,
-    reclaim_key: &XOnlyPublicKey,
+	deposit_data: DepositData,
+	revealer_key: &XOnlyPublicKey,
+	reclaim_key: &XOnlyPublicKey,
 ) -> CommitRevealResult<BitcoinAddress> {
-    commit(&deposit_data.serialize_to_vec(), revealer_key, reclaim_key)
+	commit(&deposit_data.serialize_to_vec(), revealer_key, reclaim_key)
 }
 
 /// Constructs a transaction that reveals the deposit payment address
 pub fn deposit_reveal_unsigned_tx(
-    deposit_data: DepositData,
-    reveal_inputs: RevealInputs,
-    commit_amount: Amount,
-    peg_wallet_address: BitcoinAddress,
+	deposit_data: DepositData,
+	reveal_inputs: RevealInputs,
+	commit_amount: Amount,
+	peg_wallet_address: BitcoinAddress,
 ) -> CommitRevealResult<Transaction> {
-    let mut tx = reveal(&deposit_data.serialize_to_vec(), reveal_inputs)?;
+	let mut tx = reveal(&deposit_data.serialize_to_vec(), reveal_inputs)?;
 
-    tx.output.push(TxOut {
-        value: (commit_amount - deposit_data.reveal_fee).to_sat(),
-        script_pubkey: peg_wallet_address.script_pubkey(),
-    });
+	tx.output.push(TxOut {
+		value: (commit_amount - deposit_data.reveal_fee).to_sat(),
+		script_pubkey: peg_wallet_address.script_pubkey(),
+	});
 
-    Ok(tx)
+	Ok(tx)
 }

--- a/sbtc-core/src/operations/commit_reveal/mod.rs
+++ b/sbtc-core/src/operations/commit_reveal/mod.rs
@@ -1,6 +1,4 @@
-/*!
-Primitives for sBTC commit reveal transactions
-*/
+//! Primitives for sBTC commit reveal transactions
 pub mod deposit;
 pub mod utils;
 pub mod withdrawal_request;

--- a/sbtc-core/src/operations/commit_reveal/utils.rs
+++ b/sbtc-core/src/operations/commit_reveal/utils.rs
@@ -1,100 +1,107 @@
-/*!
-Utils for operation construction
-*/
+//! Utils for operation construction
 use std::{iter::once, num::TryFromIntError};
 
 use bdk::bitcoin::{
-    blockdata::{
-        opcodes::all::{OP_CHECKSIG, OP_DROP, OP_RETURN},
-        script::Builder,
-    },
-    schnorr::UntweakedPublicKey,
-    secp256k1::Secp256k1,
-    util::taproot::{LeafVersion, TaprootBuilder, TaprootBuilderError, TaprootSpendInfo},
-    Address as BitcoinAddress, Network, OutPoint, PackedLockTime, Script, Sequence, Transaction,
-    TxIn, TxOut, Witness, XOnlyPublicKey,
+	blockdata::{
+		opcodes::all::{OP_CHECKSIG, OP_DROP, OP_RETURN},
+		script::Builder,
+	},
+	schnorr::UntweakedPublicKey,
+	secp256k1::Secp256k1,
+	util::taproot::{
+		LeafVersion, TaprootBuilder, TaprootBuilderError, TaprootSpendInfo,
+	},
+	Address as BitcoinAddress, Network, OutPoint, PackedLockTime, Script,
+	Sequence, Transaction, TxIn, TxOut, Witness, XOnlyPublicKey,
 };
 use thiserror::Error;
 
 #[derive(Error, Debug)]
 /// Commit reveal error
 pub enum CommitRevealError {
-    #[error("Signature is invalid: {0}")]
-    /// Invalid recovery ID
-    InvalidRecoveryId(TryFromIntError),
-    #[error("Control block could not be built from script")]
-    /// No control block
-    NoControlBlock,
-    #[error("Could not build taproot spend info: {0}: {1}")]
-    /// Taproot error
-    InvalidTaproot(&'static str, TaprootBuilderError),
+	#[error("Signature is invalid: {0}")]
+	/// Invalid recovery ID
+	InvalidRecoveryId(TryFromIntError),
+	#[error("Control block could not be built from script")]
+	/// No control block
+	NoControlBlock,
+	#[error("Could not build taproot spend info: {0}: {1}")]
+	/// Taproot error
+	InvalidTaproot(&'static str, TaprootBuilderError),
 }
 
 /// Commit reveal result
 pub type CommitRevealResult<T> = Result<T, CommitRevealError>;
 
 fn internal_key() -> UntweakedPublicKey {
-    // Copied from BIP-0341 at https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#constructing-and-spending-taproot-outputs
-    // The BIP recommends a point lift_x(0x0250929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0).
-    // This hex string is copied from the lift_x argument with the first byte stripped.
-    let internal_key_vec =
-        hex::decode("50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0").unwrap();
+	// Copied from BIP-0341 at https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#constructing-and-spending-taproot-outputs
+	// The BIP recommends a point
+	// lift_x(0x0250929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0).
+	// This hex string is copied from the lift_x argument with the first byte
+	// stripped.
+	let internal_key_vec = hex::decode(
+		"50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+	)
+	.unwrap();
 
-    XOnlyPublicKey::from_slice(&internal_key_vec).expect("Could not build internal key")
+	XOnlyPublicKey::from_slice(&internal_key_vec)
+		.expect("Could not build internal key")
 }
 
 fn reveal_op_return_script(stacks_magic_bytes: &[u8; 2]) -> Script {
-    let op_return_bytes: Vec<u8> = stacks_magic_bytes
-        .iter()
-        .cloned()
-        .chain(once(b'w'))
-        .collect();
+	let op_return_bytes: Vec<u8> = stacks_magic_bytes
+		.iter()
+		.cloned()
+		.chain(once(b'w'))
+		.collect();
 
-    Builder::new()
-        .push_opcode(OP_RETURN)
-        .push_slice(&op_return_bytes)
-        .into_script()
+	Builder::new()
+		.push_opcode(OP_RETURN)
+		.push_slice(&op_return_bytes)
+		.into_script()
 }
 
 fn reclaim_script(reclaim_key: &XOnlyPublicKey) -> Script {
-    Builder::new()
-        .push_x_only_key(reclaim_key)
-        .push_opcode(OP_CHECKSIG)
-        .into_script()
+	Builder::new()
+		.push_x_only_key(reclaim_key)
+		.push_opcode(OP_CHECKSIG)
+		.into_script()
 }
 
 fn op_drop_script(data: &[u8], revealer_key: &XOnlyPublicKey) -> Script {
-    Builder::new()
-        .push_slice(data)
-        .push_opcode(OP_DROP)
-        .push_x_only_key(revealer_key)
-        .push_opcode(OP_CHECKSIG)
-        .into_script()
+	Builder::new()
+		.push_slice(data)
+		.push_opcode(OP_DROP)
+		.push_x_only_key(revealer_key)
+		.push_opcode(OP_CHECKSIG)
+		.into_script()
 }
 
-fn address_from_taproot_spend_info(spend_info: TaprootSpendInfo) -> BitcoinAddress {
-    let secp = Secp256k1::new(); // Impure call
+fn address_from_taproot_spend_info(
+	spend_info: TaprootSpendInfo,
+) -> BitcoinAddress {
+	let secp = Secp256k1::new(); // Impure call
 
-    BitcoinAddress::p2tr(
-        &secp,
-        spend_info.internal_key(),
-        spend_info.merkle_root(),
-        Network::Testnet, // TODO: Make sure to make this configurable
-    )
+	BitcoinAddress::p2tr(
+		&secp,
+		spend_info.internal_key(),
+		spend_info.merkle_root(),
+		Network::Testnet, // TODO: Make sure to make this configurable
+	)
 }
 
 fn taproot_spend_info(
-    data: &[u8],
-    revealer_key: &XOnlyPublicKey,
-    reclaim_key: &XOnlyPublicKey,
+	data: &[u8],
+	revealer_key: &XOnlyPublicKey,
+	reclaim_key: &XOnlyPublicKey,
 ) -> CommitRevealResult<TaprootSpendInfo> {
-    let reveal_script = op_drop_script(data, revealer_key);
-    let reclaim_script = reclaim_script(reclaim_key);
+	let reveal_script = op_drop_script(data, revealer_key);
+	let reclaim_script = reclaim_script(reclaim_key);
 
-    let secp = Secp256k1::new(); // Impure call
-    let internal_key = internal_key();
+	let secp = Secp256k1::new(); // Impure call
+	let internal_key = internal_key();
 
-    Ok(TaprootBuilder::new()
+	Ok(TaprootBuilder::new()
         .add_leaf(1, reveal_script)
         .map_err(|err| CommitRevealError::InvalidTaproot("Invalid reveal script", err))?
         .add_leaf(1, reclaim_script)
@@ -106,61 +113,61 @@ fn taproot_spend_info(
 
 /// Constructs a deposit address for the commit
 pub fn commit(
-    data: &[u8],
-    revealer_key: &XOnlyPublicKey,
-    reclaim_key: &XOnlyPublicKey,
+	data: &[u8],
+	revealer_key: &XOnlyPublicKey,
+	reclaim_key: &XOnlyPublicKey,
 ) -> CommitRevealResult<BitcoinAddress> {
-    let spend_info = taproot_spend_info(data, revealer_key, reclaim_key)?;
-    Ok(address_from_taproot_spend_info(spend_info))
+	let spend_info = taproot_spend_info(data, revealer_key, reclaim_key)?;
+	Ok(address_from_taproot_spend_info(spend_info))
 }
 
 /// Data for the construction of the reveal transaction
 pub struct RevealInputs<'r> {
-    /// Commit output
-    pub commit_output: OutPoint,
-    ///Magic bytes
-    pub stacks_magic_bytes: &'r [u8; 2],
-    /// Revealer key
-    pub revealer_key: &'r XOnlyPublicKey,
-    /// Reclaim key
-    pub reclaim_key: &'r XOnlyPublicKey,
+	/// Commit output
+	pub commit_output: OutPoint,
+	/// Magic bytes
+	pub stacks_magic_bytes: &'r [u8; 2],
+	/// Revealer key
+	pub revealer_key: &'r XOnlyPublicKey,
+	/// Reclaim key
+	pub reclaim_key: &'r XOnlyPublicKey,
 }
 
 /// Constructs a transaction that reveals the commit data
 pub fn reveal(
-    data: &[u8],
-    RevealInputs {
-        commit_output,
-        stacks_magic_bytes,
-        revealer_key,
-        reclaim_key,
-    }: RevealInputs,
+	data: &[u8],
+	RevealInputs {
+		commit_output,
+		stacks_magic_bytes,
+		revealer_key,
+		reclaim_key,
+	}: RevealInputs,
 ) -> CommitRevealResult<Transaction> {
-    let spend_info = taproot_spend_info(data, revealer_key, reclaim_key)?;
+	let spend_info = taproot_spend_info(data, revealer_key, reclaim_key)?;
 
-    let script = op_drop_script(data, revealer_key);
-    let control_block = spend_info
-        .control_block(&(script.clone(), LeafVersion::TapScript))
-        .ok_or(CommitRevealError::NoControlBlock)?;
+	let script = op_drop_script(data, revealer_key);
+	let control_block = spend_info
+		.control_block(&(script.clone(), LeafVersion::TapScript))
+		.ok_or(CommitRevealError::NoControlBlock)?;
 
-    let mut witness = Witness::new();
-    witness.push(script);
-    witness.push(control_block.serialize());
+	let mut witness = Witness::new();
+	witness.push(script);
+	witness.push(control_block.serialize());
 
-    let tx = Transaction {
-        version: 2,
-        lock_time: PackedLockTime::ZERO,
-        input: vec![TxIn {
-            previous_output: commit_output,
-            script_sig: Script::new(),
-            sequence: Sequence::MAX,
-            witness,
-        }],
-        output: vec![TxOut {
-            value: 0,
-            script_pubkey: reveal_op_return_script(stacks_magic_bytes),
-        }],
-    };
+	let tx = Transaction {
+		version: 2,
+		lock_time: PackedLockTime::ZERO,
+		input: vec![TxIn {
+			previous_output: commit_output,
+			script_sig: Script::new(),
+			sequence: Sequence::MAX,
+			witness,
+		}],
+		output: vec![TxOut {
+			value: 0,
+			script_pubkey: reveal_op_return_script(stacks_magic_bytes),
+		}],
+	};
 
-    Ok(tx)
+	Ok(tx)
 }

--- a/sbtc-core/src/operations/commit_reveal/withdrawal_request.rs
+++ b/sbtc-core/src/operations/commit_reveal/withdrawal_request.rs
@@ -1,95 +1,94 @@
-/*!
-Primitives for sBTC commit reveal withdrawal request transactions
-*/
+//! Primitives for sBTC commit reveal withdrawal request transactions
 use std::io;
 
 use bdk::bitcoin::{
-    secp256k1::ecdsa::RecoverableSignature, Address as BitcoinAddress, Amount, Transaction, TxOut,
-    XOnlyPublicKey,
+	secp256k1::ecdsa::RecoverableSignature, Address as BitcoinAddress, Amount,
+	Transaction, TxOut, XOnlyPublicKey,
 };
 use stacks_core::codec::Codec;
 
 use crate::operations::{
-    commit_reveal::utils::{commit, reveal, CommitRevealResult, RevealInputs},
-    Opcode,
+	commit_reveal::utils::{commit, reveal, CommitRevealResult, RevealInputs},
+	Opcode,
 };
 
 /// Data to construct a commit reveal withdrawal transaction
 pub struct WithdrawalData {
-    /// Amount to withdraw
-    pub amount: Amount,
-    /// Signature of the transaction
-    pub signature: RecoverableSignature,
-    /// How much to send for the reveal fee
-    pub reveal_fee: Amount,
+	/// Amount to withdraw
+	pub amount: Amount,
+	/// Signature of the transaction
+	pub signature: RecoverableSignature,
+	/// How much to send for the reveal fee
+	pub reveal_fee: Amount,
 }
 
 impl Codec for WithdrawalData {
-    fn codec_serialize<W: io::Write>(&self, dest: &mut W) -> io::Result<()> {
-        Codec::codec_serialize(&Opcode::WithdrawalRequest, dest)?;
-        self.amount.codec_serialize(dest)?;
-        self.signature.codec_serialize(dest)?;
-        self.reveal_fee.codec_serialize(dest)
-    }
+	fn codec_serialize<W: io::Write>(&self, dest: &mut W) -> io::Result<()> {
+		Codec::codec_serialize(&Opcode::WithdrawalRequest, dest)?;
+		self.amount.codec_serialize(dest)?;
+		self.signature.codec_serialize(dest)?;
+		self.reveal_fee.codec_serialize(dest)
+	}
 
-    fn codec_deserialize<R: io::Read>(data: &mut R) -> io::Result<Self>
-    where
-        Self: Sized,
-    {
-        let opcode = Opcode::codec_deserialize(data)
-            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+	fn codec_deserialize<R: io::Read>(data: &mut R) -> io::Result<Self>
+	where
+		Self: Sized,
+	{
+		let opcode = Opcode::codec_deserialize(data)
+			.map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
 
-        if !matches!(opcode, Opcode::WithdrawalRequest) {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "Invalid opcode, expected withdrawal request",
-            ));
-        }
+		if !matches!(opcode, Opcode::WithdrawalRequest) {
+			return Err(io::Error::new(
+				io::ErrorKind::InvalidData,
+				"Invalid opcode, expected withdrawal request",
+			));
+		}
 
-        let amount = Amount::codec_deserialize(data)?;
-        let signature = RecoverableSignature::codec_deserialize(data)?;
-        let reveal_fee = Amount::codec_deserialize(data)?;
+		let amount = Amount::codec_deserialize(data)?;
+		let signature = RecoverableSignature::codec_deserialize(data)?;
+		let reveal_fee = Amount::codec_deserialize(data)?;
 
-        Ok(Self {
-            amount,
-            signature,
-            reveal_fee,
-        })
-    }
+		Ok(Self {
+			amount,
+			signature,
+			reveal_fee,
+		})
+	}
 }
 
 /// Constructs a withdrawal payment address
 pub fn withdrawal_request_commit_address(
-    withdrawal_data: WithdrawalData,
-    revealer_key: &XOnlyPublicKey,
-    reclaim_key: &XOnlyPublicKey,
+	withdrawal_data: WithdrawalData,
+	revealer_key: &XOnlyPublicKey,
+	reclaim_key: &XOnlyPublicKey,
 ) -> CommitRevealResult<BitcoinAddress> {
-    commit(
-        &withdrawal_data.serialize_to_vec(),
-        revealer_key,
-        reclaim_key,
-    )
+	commit(
+		&withdrawal_data.serialize_to_vec(),
+		revealer_key,
+		reclaim_key,
+	)
 }
 
 /// Constructs a transaction that reveals the withdrawal payment address
 pub fn withdrawal_request_reveal_unsigned_tx(
-    withdrawal_data: WithdrawalData,
-    reveal_inputs: RevealInputs,
-    fulfillment_fee: Amount,
-    commit_amount: Amount,
-    peg_wallet_address: BitcoinAddress,
-    recipient_wallet_address: BitcoinAddress,
+	withdrawal_data: WithdrawalData,
+	reveal_inputs: RevealInputs,
+	fulfillment_fee: Amount,
+	commit_amount: Amount,
+	peg_wallet_address: BitcoinAddress,
+	recipient_wallet_address: BitcoinAddress,
 ) -> CommitRevealResult<Transaction> {
-    let mut tx = reveal(&withdrawal_data.serialize_to_vec(), reveal_inputs)?;
+	let mut tx = reveal(&withdrawal_data.serialize_to_vec(), reveal_inputs)?;
 
-    tx.output.push(TxOut {
-        value: (commit_amount - withdrawal_data.reveal_fee - fulfillment_fee).to_sat(),
-        script_pubkey: recipient_wallet_address.script_pubkey(),
-    });
-    tx.output.push(TxOut {
-        value: fulfillment_fee.to_sat(),
-        script_pubkey: peg_wallet_address.script_pubkey(),
-    });
+	tx.output.push(TxOut {
+		value: (commit_amount - withdrawal_data.reveal_fee - fulfillment_fee)
+			.to_sat(),
+		script_pubkey: recipient_wallet_address.script_pubkey(),
+	});
+	tx.output.push(TxOut {
+		value: fulfillment_fee.to_sat(),
+		script_pubkey: peg_wallet_address.script_pubkey(),
+	});
 
-    Ok(tx)
+	Ok(tx)
 }

--- a/sbtc-core/src/operations/mod.rs
+++ b/sbtc-core/src/operations/mod.rs
@@ -12,38 +12,38 @@ pub mod utils;
 #[derive(FromRepr, Debug, Clone, Copy)]
 #[repr(u8)]
 pub enum Opcode {
-    /// Deposit
-    Deposit = b'<',
-    /// Withdrawal request
-    WithdrawalRequest = b'>',
-    /// Withdrawal fulfillment
-    WithdrawalFulfillment = b'!',
-    /// Wallet handoff
-    WalletHandoff = b'H',
+	/// Deposit
+	Deposit = b'<',
+	/// Withdrawal request
+	WithdrawalRequest = b'>',
+	/// Withdrawal fulfillment
+	WithdrawalFulfillment = b'!',
+	/// Wallet handoff
+	WalletHandoff = b'H',
 }
 
 impl Codec for Opcode {
-    fn codec_serialize<W: io::Write>(&self, dest: &mut W) -> io::Result<()> {
-        dest.write_all(&[*self as u8])
-    }
+	fn codec_serialize<W: io::Write>(&self, dest: &mut W) -> io::Result<()> {
+		dest.write_all(&[*self as u8])
+	}
 
-    fn codec_deserialize<R: io::Read>(data: &mut R) -> io::Result<Self>
-    where
-        Self: Sized,
-    {
-        let mut buffer = [0; 1];
-        data.read_exact(&mut buffer)?;
+	fn codec_deserialize<R: io::Read>(data: &mut R) -> io::Result<Self>
+	where
+		Self: Sized,
+	{
+		let mut buffer = [0; 1];
+		data.read_exact(&mut buffer)?;
 
-        Self::from_repr(buffer[0])
-            .ok_or(io::Error::new(io::ErrorKind::InvalidData, "Invalid opcode"))
-    }
+		Self::from_repr(buffer[0])
+			.ok_or(io::Error::new(io::ErrorKind::InvalidData, "Invalid opcode"))
+	}
 }
 
 /// Returns the magic bytes for the provided network
 pub(crate) fn magic_bytes(network: Network) -> [u8; 2] {
-    match network {
-        Network::Bitcoin => [b'X', b'2'],
-        Network::Testnet => [b'T', b'2'],
-        _ => [b'i', b'd'],
-    }
+	match network {
+		Network::Bitcoin => [b'X', b'2'],
+		Network::Testnet => [b'T', b'2'],
+		_ => [b'i', b'd'],
+	}
 }

--- a/sbtc-core/src/operations/op_return/deposit.rs
+++ b/sbtc-core/src/operations/op_return/deposit.rs
@@ -1,391 +1,416 @@
-/*!
-Tools for the construction and parsing of the sBTC OP_RETURN deposit transactions.
-
-Deposit is a Bitcoin transaction with the output structure as below:
-
-1. data output
-2. payment to peg wallet address
-
-The data output should contain data in the following byte format:
-
-```text
-0     2  3                                                                    80
-|-----|--|---------------------------------------------------------------------|
- magic op                           deposit data
-```
-
-Where deposit data should be in the following format:
-
-```text
-3                                                      25 >= N <= 66          80
-|------------------------------------------------------------------|-----------|
-                           principal data                              extra
-                                                                       bytes
-```
-
-There are two types of principal data:
-
-- standard (includes only principal type, address version and address hash)
-- contract (includes everything from the last diagram)
-
-If the principal data is of the contract type, then the contract name cannot be
-longer than 40 characters.
-
-Principal data should be in the following format:
-
-```text
-3         4         5                25       26                         N <= 66
-|---------|---------|-----------------|--------|-------------------------------|
- principal  address       address      contract            contract
-   type     version        hash          name                name
-                                      length (N)
-```
-*/
+//! Tools for the construction and parsing of the sBTC OP_RETURN deposit
+//! transactions.
+//!
+//! Deposit is a Bitcoin transaction with the output structure as below:
+//!
+//! 1. data output
+//! 2. payment to peg wallet address
+//!
+//! The data output should contain data in the following byte format:
+//!
+//! ```text
+//! 0     2  3                                                                    80
+//! |-----|--|---------------------------------------------------------------------|
+//! magic op                           deposit data
+//! ```
+//!
+//! Where deposit data should be in the following format:
+//!
+//! ```text
+//! 3                                                      25 >= N <= 66          80
+//! |------------------------------------------------------------------|-----------|
+//! principal data                              extra
+//! bytes
+//! ```
+//!
+//! There are two types of principal data:
+//!
+//! - standard (includes only principal type, address version and address hash)
+//! - contract (includes everything from the last diagram)
+//!
+//! If the principal data is of the contract type, then the contract name cannot
+//! be longer than 40 characters.
+//!
+//! Principal data should be in the following format:
+//!
+//! ```text
+//! 3         4         5                25       26                         N <= 66
+//! |---------|---------|-----------------|--------|-------------------------------|
+//! principal  address       address      contract            contract
+//! type     version        hash          name                name
+//! length (N)
+//! ```
 use std::{collections::HashMap, io};
 
 use bdk::{
-    bitcoin::{
-        blockdata::opcodes::all::OP_RETURN, blockdata::script::Instruction,
-        psbt::PartiallySignedTransaction, Address as BitcoinAddress, Network, PrivateKey,
-        Transaction,
-    },
-    database::{BatchDatabase, MemoryDatabase},
-    SignOptions, Wallet,
+	bitcoin::{
+		blockdata::{opcodes::all::OP_RETURN, script::Instruction},
+		psbt::PartiallySignedTransaction,
+		Address as BitcoinAddress, Network, PrivateKey, Transaction,
+	},
+	database::{BatchDatabase, MemoryDatabase},
+	SignOptions, Wallet,
 };
 use stacks_core::{codec::Codec, utils::PrincipalData};
 
 use crate::{
-    operations::{
-        magic_bytes,
-        op_return::utils::{build_op_return_script, reorder_outputs},
-        utils::setup_wallet,
-        Opcode,
-    },
-    SBTCError, SBTCResult,
+	operations::{
+		magic_bytes,
+		op_return::utils::{build_op_return_script, reorder_outputs},
+		utils::setup_wallet,
+		Opcode,
+	},
+	SBTCError, SBTCResult,
 };
 
 /// Builds a complete deposit transaction
 pub fn build_deposit_transaction<T: BatchDatabase>(
-    wallet: Wallet<T>,
-    recipient: PrincipalData,
-    dkg_address: BitcoinAddress,
-    amount: u64,
-    network: Network,
+	wallet: Wallet<T>,
+	recipient: PrincipalData,
+	dkg_address: BitcoinAddress,
+	amount: u64,
+	network: Network,
 ) -> SBTCResult<Transaction> {
-    let mut tx_builder = wallet.build_tx();
+	let mut tx_builder = wallet.build_tx();
 
-    let deposit_data = DepositOutputData { network, recipient }.serialize_to_vec();
-    let op_return_script = build_op_return_script(&deposit_data);
+	let deposit_data =
+		DepositOutputData { network, recipient }.serialize_to_vec();
+	let op_return_script = build_op_return_script(&deposit_data);
 
-    let dkg_script = dkg_address.script_pubkey();
-    let dust_amount = dkg_script.dust_value().to_sat();
+	let dkg_script = dkg_address.script_pubkey();
+	let dust_amount = dkg_script.dust_value().to_sat();
 
-    if amount < dust_amount {
-        return Err(SBTCError::AmountInsufficient(amount, dust_amount));
-    }
+	if amount < dust_amount {
+		return Err(SBTCError::AmountInsufficient(amount, dust_amount));
+	}
 
-    let outputs = [(op_return_script, 0), (dkg_script, amount)];
+	let outputs = [(op_return_script, 0), (dkg_script, amount)];
 
-    for (script, amount) in outputs.clone() {
-        tx_builder.add_recipient(script, amount);
-    }
+	for (script, amount) in outputs.clone() {
+		tx_builder.add_recipient(script, amount);
+	}
 
-    let (mut partial_tx, _) = tx_builder
-        .finish()
-        .map_err(|err| SBTCError::BDKError("Could not finish the transaction", err))?;
+	let (mut partial_tx, _) = tx_builder.finish().map_err(|err| {
+		SBTCError::BDKError("Could not finish the transaction", err)
+	})?;
 
-    partial_tx.unsigned_tx.output = reorder_outputs(partial_tx.unsigned_tx.output, outputs);
+	partial_tx.unsigned_tx.output =
+		reorder_outputs(partial_tx.unsigned_tx.output, outputs);
 
-    wallet
-        .sign(&mut partial_tx, SignOptions::default())
-        .map_err(|err| SBTCError::BDKError("Could not sign the transaction", err))?;
+	wallet
+		.sign(&mut partial_tx, SignOptions::default())
+		.map_err(|err| {
+			SBTCError::BDKError("Could not sign the transaction", err)
+		})?;
 
-    Ok(partial_tx.extract_tx())
+	Ok(partial_tx.extract_tx())
 }
 
 #[derive(Debug, Clone)]
 /// The amount and recipient of a deposit request
 pub struct Deposit {
-    /// Amount of BTC to deposit
-    pub amount: u64,
-    /// Recipient to receive freshly minted sBTC
-    pub recipient: PrincipalData,
-    /// The address where the BTC was deposited
-    pub sbtc_wallet_address: BitcoinAddress,
-    /// Network which the transaction is on
-    pub network: Network,
+	/// Amount of BTC to deposit
+	pub amount: u64,
+	/// Recipient to receive freshly minted sBTC
+	pub recipient: PrincipalData,
+	/// The address where the BTC was deposited
+	pub sbtc_wallet_address: BitcoinAddress,
+	/// Network which the transaction is on
+	pub network: Network,
 }
 
 impl Deposit {
-    /// Parse a deposit from a transaction
-    pub fn parse(network: Network, tx: Transaction) -> Result<Self, DepositParseError> {
-        let mut output_iter = tx.output.into_iter();
+	/// Parse a deposit from a transaction
+	pub fn parse(
+		network: Network,
+		tx: Transaction,
+	) -> Result<Self, DepositParseError> {
+		let mut output_iter = tx.output.into_iter();
 
-        let data_output = output_iter
-            .next()
-            .ok_or(DepositParseError::InvalidOutputs)?;
+		let data_output = output_iter
+			.next()
+			.ok_or(DepositParseError::InvalidOutputs)?;
 
-        let mut instructions_iter = data_output.script_pubkey.instructions();
+		let mut instructions_iter = data_output.script_pubkey.instructions();
 
-        let Some(Ok(Instruction::Op(OP_RETURN))) = instructions_iter.next() else {
-            return Err(DepositParseError::NotSbtcOp);
-        };
+		let Some(Ok(Instruction::Op(OP_RETURN))) = instructions_iter.next()
+		else {
+			return Err(DepositParseError::NotSbtcOp);
+		};
 
-        let Some(Ok(Instruction::PushBytes(mut data))) = instructions_iter.next() else {
-            return Err(DepositParseError::NotSbtcOp);
-        };
+		let Some(Ok(Instruction::PushBytes(mut data))) =
+			instructions_iter.next()
+		else {
+			return Err(DepositParseError::NotSbtcOp);
+		};
 
-        let deposit_data = DepositOutputData::codec_deserialize(&mut data)
-            .map_err(|_| DepositParseError::NotSbtcOp)?;
+		let deposit_data = DepositOutputData::codec_deserialize(&mut data)
+			.map_err(|_| DepositParseError::NotSbtcOp)?;
 
-        let amount_output = output_iter
-            .next()
-            .ok_or(DepositParseError::InvalidOutputs)?;
+		let amount_output = output_iter
+			.next()
+			.ok_or(DepositParseError::InvalidOutputs)?;
 
-        let amount = amount_output.value;
-        let address = BitcoinAddress::from_script(&amount_output.script_pubkey, network)?;
+		let amount = amount_output.value;
+		let address =
+			BitcoinAddress::from_script(&amount_output.script_pubkey, network)?;
 
-        Ok(Self {
-            amount,
-            recipient: deposit_data.recipient,
-            sbtc_wallet_address: address,
-            network,
-        })
-    }
+		Ok(Self {
+			amount,
+			recipient: deposit_data.recipient,
+			sbtc_wallet_address: address,
+			network,
+		})
+	}
 }
 
 #[derive(thiserror::Error, Clone, Debug, Eq, PartialEq)]
 /// Errors occuring when parsing deposits
 pub enum DepositParseError {
-    /// Missing expected output
-    #[error("Missing an expected output")]
-    InvalidOutputs,
+	/// Missing expected output
+	#[error("Missing an expected output")]
+	InvalidOutputs,
 
-    /// Doesn't contain an OP_RETURN with the right opcode
-    #[error("Not an sBTC operation")]
-    NotSbtcOp,
+	/// Doesn't contain an OP_RETURN with the right opcode
+	#[error("Not an sBTC operation")]
+	NotSbtcOp,
 
-    /// Could not build address from script pubkey
-    #[error(transparent)]
-    AddressError(#[from] bdk::bitcoin::util::address::Error),
+	/// Could not build address from script pubkey
+	#[error(transparent)]
+	AddressError(#[from] bdk::bitcoin::util::address::Error),
 }
 
 #[derive(PartialEq, Eq, Debug)]
 /// Data for the sBTC OP_RETURN deposit transaction output
 pub struct DepositOutputData {
-    /// Network to be used for the transaction
-    network: Network,
-    /// Recipient of the deposit
-    recipient: PrincipalData,
+	/// Network to be used for the transaction
+	network: Network,
+	/// Recipient of the deposit
+	recipient: PrincipalData,
 }
 
 impl Codec for DepositOutputData {
-    fn codec_serialize<W: io::Write>(&self, dest: &mut W) -> io::Result<()> {
-        dest.write_all(&magic_bytes(self.network))?;
-        dest.write_all(&[Opcode::Deposit as u8])?;
-        self.recipient.codec_serialize(dest)
-    }
+	fn codec_serialize<W: io::Write>(&self, dest: &mut W) -> io::Result<()> {
+		dest.write_all(&magic_bytes(self.network))?;
+		dest.write_all(&[Opcode::Deposit as u8])?;
+		self.recipient.codec_serialize(dest)
+	}
 
-    fn codec_deserialize<R: io::Read>(data: &mut R) -> io::Result<Self>
-    where
-        Self: Sized,
-    {
-        let mut magic_bytes_buffer = [0; 2];
-        data.read_exact(&mut magic_bytes_buffer)?;
+	fn codec_deserialize<R: io::Read>(data: &mut R) -> io::Result<Self>
+	where
+		Self: Sized,
+	{
+		let mut magic_bytes_buffer = [0; 2];
+		data.read_exact(&mut magic_bytes_buffer)?;
 
-        let network_magic_bytes = [
-            Network::Bitcoin,
-            Network::Testnet,
-            Network::Signet,
-            Network::Regtest,
-        ]
-        .into_iter()
-        .map(|network| (magic_bytes(network), network))
-        .collect::<HashMap<[u8; 2], Network>>();
+		let network_magic_bytes = [
+			Network::Bitcoin,
+			Network::Testnet,
+			Network::Signet,
+			Network::Regtest,
+		]
+		.into_iter()
+		.map(|network| (magic_bytes(network), network))
+		.collect::<HashMap<[u8; 2], Network>>();
 
-        let network = network_magic_bytes
-            .get(&magic_bytes_buffer)
-            .cloned()
-            .ok_or(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("Unknown magic bytes: {:?}", magic_bytes_buffer),
-            ))?;
+		let network = network_magic_bytes
+			.get(&magic_bytes_buffer)
+			.cloned()
+			.ok_or(io::Error::new(
+				io::ErrorKind::InvalidData,
+				format!("Unknown magic bytes: {:?}", magic_bytes_buffer),
+			))?;
 
-        let opcode = Opcode::codec_deserialize(data)
-            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+		let opcode = Opcode::codec_deserialize(data)
+			.map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
 
-        if !matches!(opcode, Opcode::Deposit) {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("Invalid opcode, expected deposit: {:?}", opcode),
-            ));
-        }
+		if !matches!(opcode, Opcode::Deposit) {
+			return Err(io::Error::new(
+				io::ErrorKind::InvalidData,
+				format!("Invalid opcode, expected deposit: {:?}", opcode),
+			));
+		}
 
-        let recipient = PrincipalData::codec_deserialize(data)?;
+		let recipient = PrincipalData::codec_deserialize(data)?;
 
-        Ok(Self { network, recipient })
-    }
+		Ok(Self { network, recipient })
+	}
 }
 
 fn create_partially_signed_deposit_transaction(
-    wallet: &Wallet<MemoryDatabase>,
-    recipient: PrincipalData,
-    dkg_address: &BitcoinAddress,
-    amount: u64,
-    network: Network,
+	wallet: &Wallet<MemoryDatabase>,
+	recipient: PrincipalData,
+	dkg_address: &BitcoinAddress,
+	amount: u64,
+	network: Network,
 ) -> SBTCResult<PartiallySignedTransaction> {
-    let mut tx_builder = wallet.build_tx();
+	let mut tx_builder = wallet.build_tx();
 
-    let deposit_data = DepositOutputData { network, recipient }.serialize_to_vec();
-    let op_return_script = build_op_return_script(&deposit_data);
-    let dkg_script = dkg_address.script_pubkey();
-    let dust_amount = dkg_script.dust_value().to_sat();
+	let deposit_data =
+		DepositOutputData { network, recipient }.serialize_to_vec();
+	let op_return_script = build_op_return_script(&deposit_data);
+	let dkg_script = dkg_address.script_pubkey();
+	let dust_amount = dkg_script.dust_value().to_sat();
 
-    if amount < dust_amount {
-        return Err(SBTCError::AmountInsufficient(amount, dust_amount));
-    }
+	if amount < dust_amount {
+		return Err(SBTCError::AmountInsufficient(amount, dust_amount));
+	}
 
-    let outputs = [(op_return_script, 0), (dkg_script, amount)];
+	let outputs = [(op_return_script, 0), (dkg_script, amount)];
 
-    for (script, amount) in outputs.clone() {
-        tx_builder.add_recipient(script, amount);
-    }
+	for (script, amount) in outputs.clone() {
+		tx_builder.add_recipient(script, amount);
+	}
 
-    let (mut partial_tx, _) = tx_builder.finish().map_err(|err| {
-        SBTCError::BDKError("Could not finish the partially signed transaction", err)
-    })?;
+	let (mut partial_tx, _) = tx_builder.finish().map_err(|err| {
+		SBTCError::BDKError(
+			"Could not finish the partially signed transaction",
+			err,
+		)
+	})?;
 
-    partial_tx.unsigned_tx.output = reorder_outputs(partial_tx.unsigned_tx.output, outputs);
+	partial_tx.unsigned_tx.output =
+		reorder_outputs(partial_tx.unsigned_tx.output, outputs);
 
-    Ok(partial_tx)
+	Ok(partial_tx)
 }
 
 /// Construct a BTC transaction containing the provided sBTC deposit data
 pub fn deposit(
-    depositor_private_key: PrivateKey,
-    recipient: PrincipalData,
-    amount: u64,
-    dkg_address: &BitcoinAddress,
+	depositor_private_key: PrivateKey,
+	recipient: PrincipalData,
+	amount: u64,
+	dkg_address: &BitcoinAddress,
 ) -> SBTCResult<Transaction> {
-    let wallet = setup_wallet(depositor_private_key)?;
+	let wallet = setup_wallet(depositor_private_key)?;
 
-    let mut psbt = create_partially_signed_deposit_transaction(
-        &wallet,
-        recipient,
-        dkg_address,
-        amount,
-        depositor_private_key.network,
-    )?;
+	let mut psbt = create_partially_signed_deposit_transaction(
+		&wallet,
+		recipient,
+		dkg_address,
+		amount,
+		depositor_private_key.network,
+	)?;
 
-    wallet
-        .sign(&mut psbt, SignOptions::default())
-        .map_err(|err| SBTCError::BDKError("Could not sign transaction", err))?;
+	wallet
+		.sign(&mut psbt, SignOptions::default())
+		.map_err(|err| {
+			SBTCError::BDKError("Could not sign transaction", err)
+		})?;
 
-    Ok(psbt.extract_tx())
+	Ok(psbt.extract_tx())
 }
 
 #[cfg(test)]
 mod tests {
-    use bdk::bitcoin::secp256k1::Secp256k1;
-    use rand::{distributions::Alphanumeric, rngs::StdRng, Rng, SeedableRng};
-    use stacks_core::{
-        address::{AddressVersion, StacksAddress},
-        contract_name::{ContractName, CONTRACT_MAX_NAME_LENGTH},
-        utils::{PrincipalData, StandardPrincipalData},
-    };
+	use bdk::bitcoin::secp256k1::Secp256k1;
+	use rand::{distributions::Alphanumeric, rngs::StdRng, Rng, SeedableRng};
+	use stacks_core::{
+		address::{AddressVersion, StacksAddress},
+		contract_name::{ContractName, CONTRACT_MAX_NAME_LENGTH},
+		utils::{PrincipalData, StandardPrincipalData},
+	};
 
-    use super::*;
+	use super::*;
 
-    fn test_rng() -> StdRng {
-        StdRng::seed_from_u64(0)
-    }
+	fn test_rng() -> StdRng {
+		StdRng::seed_from_u64(0)
+	}
 
-    fn generate_address(rng: &mut impl Rng) -> StacksAddress {
-        let pk = Secp256k1::new().generate_keypair(rng).1;
+	fn generate_address(rng: &mut impl Rng) -> StacksAddress {
+		let pk = Secp256k1::new().generate_keypair(rng).1;
 
-        StacksAddress::p2pkh(AddressVersion::TestnetSingleSig, &pk)
-    }
+		StacksAddress::p2pkh(AddressVersion::TestnetSingleSig, &pk)
+	}
 
-    fn generate_contract_name(rng: &mut impl Rng) -> ContractName {
-        let contract_name_length: u8 = rng.gen_range(1..CONTRACT_MAX_NAME_LENGTH as u8);
+	fn generate_contract_name(rng: &mut impl Rng) -> ContractName {
+		let contract_name_length: u8 =
+			rng.gen_range(1..CONTRACT_MAX_NAME_LENGTH as u8);
 
-        let contract_name = {
-            let mut contract_name_char_iter = rng.sample_iter(&Alphanumeric).map(char::from);
+		let contract_name = {
+			let mut contract_name_char_iter =
+				rng.sample_iter(&Alphanumeric).map(char::from);
 
-            let first_letter = loop {
-                let letter = contract_name_char_iter.next().unwrap();
+			let first_letter = loop {
+				let letter = contract_name_char_iter.next().unwrap();
 
-                if letter.is_digit(10) {
-                    continue;
-                } else {
-                    break letter;
-                };
-            };
+				if letter.is_digit(10) {
+					continue;
+				} else {
+					break letter;
+				};
+			};
 
-            let other_letters = contract_name_char_iter.take(contract_name_length as usize - 1);
+			let other_letters =
+				contract_name_char_iter.take(contract_name_length as usize - 1);
 
-            let contract_name_string = [first_letter]
-                .into_iter()
-                .chain(other_letters)
-                .collect::<String>();
+			let contract_name_string = [first_letter]
+				.into_iter()
+				.chain(other_letters)
+				.collect::<String>();
 
-            ContractName::new(&contract_name_string).unwrap()
-        };
+			ContractName::new(&contract_name_string).unwrap()
+		};
 
-        contract_name
-    }
+		contract_name
+	}
 
-    fn generate_standard_principal_data(rng: &mut impl Rng) -> PrincipalData {
-        PrincipalData::Standard(StandardPrincipalData::new(
-            AddressVersion::TestnetSingleSig,
-            generate_address(rng),
-        ))
-    }
+	fn generate_standard_principal_data(rng: &mut impl Rng) -> PrincipalData {
+		PrincipalData::Standard(StandardPrincipalData::new(
+			AddressVersion::TestnetSingleSig,
+			generate_address(rng),
+		))
+	}
 
-    fn generate_contract_principal_data(rng: &mut impl Rng) -> PrincipalData {
-        PrincipalData::Contract(
-            StandardPrincipalData::new(AddressVersion::TestnetSingleSig, generate_address(rng)),
-            generate_contract_name(rng),
-        )
-    }
+	fn generate_contract_principal_data(rng: &mut impl Rng) -> PrincipalData {
+		PrincipalData::Contract(
+			StandardPrincipalData::new(
+				AddressVersion::TestnetSingleSig,
+				generate_address(rng),
+			),
+			generate_contract_name(rng),
+		)
+	}
 
-    fn generate_principal_data(rng: &mut impl Rng) -> PrincipalData {
-        let should_be_standard_principal: bool = rng.gen();
+	fn generate_principal_data(rng: &mut impl Rng) -> PrincipalData {
+		let should_be_standard_principal: bool = rng.gen();
 
-        if should_be_standard_principal {
-            generate_standard_principal_data(rng)
-        } else {
-            generate_contract_principal_data(rng)
-        }
-    }
+		if should_be_standard_principal {
+			generate_standard_principal_data(rng)
+		} else {
+			generate_contract_principal_data(rng)
+		}
+	}
 
-    #[test]
-    fn should_serialize_and_deserialize_deposit_output_data() {
-        let mut rng = test_rng();
+	#[test]
+	fn should_serialize_and_deserialize_deposit_output_data() {
+		let mut rng = test_rng();
 
-        for _ in 0..1000 {
-            let recipient = generate_principal_data(&mut rng);
-            let expected_data = DepositOutputData {
-                network: Network::Testnet,
-                recipient,
-            };
+		for _ in 0..1000 {
+			let recipient = generate_principal_data(&mut rng);
+			let expected_data = DepositOutputData {
+				network: Network::Testnet,
+				recipient,
+			};
 
-            let serialized_data = expected_data.serialize_to_vec();
-            let deserialized_data =
-                DepositOutputData::deserialize(&mut serialized_data.as_slice()).unwrap();
+			let serialized_data = expected_data.serialize_to_vec();
+			let deserialized_data =
+				DepositOutputData::deserialize(&mut serialized_data.as_slice())
+					.unwrap();
 
-            assert_eq!(deserialized_data, expected_data);
-        }
-    }
+			assert_eq!(deserialized_data, expected_data);
+		}
+	}
 
-    #[test]
-    fn deposit_parse_should_succeed_given_a_valid_transaction() {
-        let recipient: StacksAddress = "ST3RBZ4TZ3EK22SZRKGFZYBCKD7WQ5B8FFRS57TT6"
-            .try_into()
-            .unwrap();
-        let recipient: PrincipalData = recipient.into();
+	#[test]
+	fn deposit_parse_should_succeed_given_a_valid_transaction() {
+		let recipient: StacksAddress =
+			"ST3RBZ4TZ3EK22SZRKGFZYBCKD7WQ5B8FFRS57TT6"
+				.try_into()
+				.unwrap();
+		let recipient: PrincipalData = recipient.into();
 
-        let assertions = [
+		let assertions = [
             DepositParseScenario {
                 given_tx_hex: "010000000001019131d69f4616c2a17f3d2519a3dc697136a56846794e677982f565f79295e0370100000000feffffff0300000000000000001b6a1954323c051af0bf935f1ba62167f89c1fff2d9369f972ad0f7e6e0a020000000000225120b85fdda4ae0f69883280360a9b91555a2f23c5b9e34173fabec5d903416c2aaf7b850800000000001600147c969cfcab0d2ad171aa3f201c94b51b0e8eca6602473044022036663b723c79333f9c8b7d5d9db3b6cd301fc6bf82515e62303713eb69b4d18d0220548939af6e1d86fcf8a54da1f6942f25f36ed0488a0d3616c47daa49f59bc7b601210215bd6d522931e602fde924571eb472bc1db953484b29ba6542774ebbf083412329c62500",
                 expected_amount: 133742,
@@ -393,27 +418,27 @@ mod tests {
             }
         ];
 
-        for assertion in assertions {
-            assertion.assert()
-        }
-    }
+		for assertion in assertions {
+			assertion.assert()
+		}
+	}
 
-    struct DepositParseScenario {
-        given_tx_hex: &'static str,
-        expected_amount: u64,
-        expected_recipient: PrincipalData,
-    }
+	struct DepositParseScenario {
+		given_tx_hex: &'static str,
+		expected_amount: u64,
+		expected_recipient: PrincipalData,
+	}
 
-    impl DepositParseScenario {
-        fn assert(&self) {
-            use bdk::bitcoin::consensus::encode;
+	impl DepositParseScenario {
+		fn assert(&self) {
+			use bdk::bitcoin::consensus::encode;
 
-            let data = hex::decode(self.given_tx_hex).unwrap();
-            let tx: Transaction = encode::deserialize(&data).unwrap();
-            let deposit = Deposit::parse(Network::Testnet, tx).unwrap();
+			let data = hex::decode(self.given_tx_hex).unwrap();
+			let tx: Transaction = encode::deserialize(&data).unwrap();
+			let deposit = Deposit::parse(Network::Testnet, tx).unwrap();
 
-            assert_eq!(deposit.amount, self.expected_amount);
-            assert_eq!(deposit.recipient, self.expected_recipient);
-        }
-    }
+			assert_eq!(deposit.amount, self.expected_amount);
+			assert_eq!(deposit.recipient, self.expected_recipient);
+		}
+	}
 }

--- a/sbtc-core/src/operations/op_return/mod.rs
+++ b/sbtc-core/src/operations/op_return/mod.rs
@@ -1,6 +1,4 @@
-/*!
-Primitives for sBTC OP_RETURN transactions
-*/
+//! Primitives for sBTC OP_RETURN transactions
 pub mod deposit;
 pub mod utils;
 pub mod withdrawal_fulfillment;

--- a/sbtc-core/src/operations/op_return/utils.rs
+++ b/sbtc-core/src/operations/op_return/utils.rs
@@ -1,44 +1,42 @@
-/*!
-Utilities for sBTC OP_RETURN transactions
-*/
+//! Utilities for sBTC OP_RETURN transactions
 
 use std::collections::{BTreeMap, HashMap};
 
 use bdk::bitcoin::{
-    blockdata::{opcodes::all::OP_RETURN, script::Builder},
-    Script, TxOut,
+	blockdata::{opcodes::all::OP_RETURN, script::Builder},
+	Script, TxOut,
 };
 
 /// Builds an OP_RETURN script from the provided data
 pub(crate) fn build_op_return_script(data: &[u8]) -> Script {
-    Builder::new()
-        .push_opcode(OP_RETURN)
-        .push_slice(data)
-        .into_script()
+	Builder::new()
+		.push_opcode(OP_RETURN)
+		.push_slice(data)
+		.into_script()
 }
 
 /// Reorders outputs according to the provided order
 pub(crate) fn reorder_outputs(
-    outputs: impl IntoIterator<Item = TxOut>,
-    order: impl IntoIterator<Item = (Script, u64)>,
+	outputs: impl IntoIterator<Item = TxOut>,
+	order: impl IntoIterator<Item = (Script, u64)>,
 ) -> Vec<TxOut> {
-    let indices: HashMap<(Script, u64), usize> = order
-        .into_iter()
-        .enumerate()
-        .map(|(idx, val)| (val, idx))
-        .collect();
+	let indices: HashMap<(Script, u64), usize> = order
+		.into_iter()
+		.enumerate()
+		.map(|(idx, val)| (val, idx))
+		.collect();
 
-    let outputs_ordered: BTreeMap<usize, TxOut> = outputs
-        .into_iter()
-        .map(|txout| {
-            (
-                *indices
-                    .get(&(txout.script_pubkey.clone(), txout.value))
-                    .unwrap_or(&usize::MAX), // Change amount
-                txout,
-            )
-        })
-        .collect();
+	let outputs_ordered: BTreeMap<usize, TxOut> = outputs
+		.into_iter()
+		.map(|txout| {
+			(
+				*indices
+					.get(&(txout.script_pubkey.clone(), txout.value))
+					.unwrap_or(&usize::MAX), // Change amount
+				txout,
+			)
+		})
+		.collect();
 
-    outputs_ordered.into_values().collect()
+	outputs_ordered.into_values().collect()
 }

--- a/sbtc-core/src/operations/op_return/withdrawal_fulfillment.rs
+++ b/sbtc-core/src/operations/op_return/withdrawal_fulfillment.rs
@@ -1,28 +1,26 @@
-/*!
-Tools for the construction and parsing of the sBTC OP_RETURN withdrawal
-fulfillment transactions.
-
-Withdrawal fulfillment is a Bitcoin transaction with the output structure as
-below:
-
-1. data output
-2. Bitcoin address to send the BTC to
-
-The data output should contain data in the following byte format:
-
-```text
-0     2  3                                                                    80
-|-----|--|---------------------------------------------------------------------|
- magic op                      withdrawal fulfillment data
-```
-
-Where withdrawal fulfillment data should be in the following format:
-
-```text
-3                             35                                              80
-|------------------------------|-----------------------------------------------|
-            chain tip                             extra bytes
-*/
+//! Tools for the construction and parsing of the sBTC OP_RETURN withdrawal
+//! fulfillment transactions.
+//!
+//! Withdrawal fulfillment is a Bitcoin transaction with the output structure as
+//! below:
+//!
+//! 1. data output
+//! 2. Bitcoin address to send the BTC to
+//!
+//! The data output should contain data in the following byte format:
+//!
+//! ```text
+//! 0     2  3                                                                    80
+//! |-----|--|---------------------------------------------------------------------|
+//! magic op                      withdrawal fulfillment data
+//! ```
+//!
+//! Where withdrawal fulfillment data should be in the following format:
+//!
+//! ```text
+//! 3                             35                                              80
+//! |------------------------------|-----------------------------------------------|
+//! chain tip                             extra bytes
 
 use std::io;
 
@@ -30,21 +28,21 @@ use stacks_core::{codec::Codec, BlockId};
 
 /// The parsed data output from a withdrawal fulfillment transaction
 pub struct ParsedWithdrawalFulfillmentData {
-    /// The chain tip block ID
-    pub chain_tip: BlockId,
+	/// The chain tip block ID
+	pub chain_tip: BlockId,
 }
 
 impl Codec for ParsedWithdrawalFulfillmentData {
-    fn codec_serialize<W: io::Write>(&self, dest: &mut W) -> io::Result<()> {
-        self.chain_tip.codec_serialize(dest)
-    }
+	fn codec_serialize<W: io::Write>(&self, dest: &mut W) -> io::Result<()> {
+		self.chain_tip.codec_serialize(dest)
+	}
 
-    fn codec_deserialize<R: io::Read>(data: &mut R) -> io::Result<Self>
-    where
-        Self: Sized,
-    {
-        Ok(Self {
-            chain_tip: BlockId::codec_deserialize(data)?,
-        })
-    }
+	fn codec_deserialize<R: io::Read>(data: &mut R) -> io::Result<Self>
+	where
+		Self: Sized,
+	{
+		Ok(Self {
+			chain_tip: BlockId::codec_deserialize(data)?,
+		})
+	}
 }

--- a/sbtc-core/src/operations/op_return/withdrawal_request.rs
+++ b/sbtc-core/src/operations/op_return/withdrawal_request.rs
@@ -1,216 +1,223 @@
-/*!
-Tools for the construction and parsing of the sBTC OP_RETURN withdrawal request
-transactions.
-
-Withdrawal request is a Bitcoin transaction with the output structure as below:
-
-1. data output
-2. Bitcoin address to send the BTC to
-3. Fulfillment fee payment to the peg wallet
-
-The data output should contain data in the following byte format:
-
-```text
-0     2  3                                                                    80
-|-----|--|---------------------------------------------------------------------|
- magic op                       withdrawal request data
-```
-
-Where withdrawal request data should be in the following format:
-
-```text
-3         11                                                            76    80
-|----------|-------------------------------------------------------------|-----|
-   amount                            signature                            extra
-                                                                          bytes
-*/
+//! Tools for the construction and parsing of the sBTC OP_RETURN withdrawal
+//! request transactions.
+//!
+//! Withdrawal request is a Bitcoin transaction with the output structure as
+//! below:
+//!
+//! 1. data output
+//! 2. Bitcoin address to send the BTC to
+//! 3. Fulfillment fee payment to the peg wallet
+//!
+//! The data output should contain data in the following byte format:
+//!
+//! ```text
+//! 0     2  3                                                                    80
+//! |-----|--|---------------------------------------------------------------------|
+//! magic op                       withdrawal request data
+//! ```
+//!
+//! Where withdrawal request data should be in the following format:
+//!
+//! ```text
+//! 3         11                                                            76    80
+//! |----------|-------------------------------------------------------------|-----|
+//! amount                            signature                            extra
+//! bytes
 use std::{collections::HashMap, io};
 
 use bdk::{
-    bitcoin::{
-        psbt::PartiallySignedTransaction,
-        secp256k1::{ecdsa::RecoverableSignature, Message, Secp256k1},
-        Address as BitcoinAddress, Amount, Network, PrivateKey, Transaction,
-    },
-    database::MemoryDatabase,
-    SignOptions, Wallet,
+	bitcoin::{
+		psbt::PartiallySignedTransaction,
+		secp256k1::{ecdsa::RecoverableSignature, Message, Secp256k1},
+		Address as BitcoinAddress, Amount, Network, PrivateKey, Transaction,
+	},
+	database::MemoryDatabase,
+	SignOptions, Wallet,
 };
 use stacks_core::{
-    codec::Codec,
-    crypto::{sha256::Sha256Hasher, Hashing},
+	codec::Codec,
+	crypto::{sha256::Sha256Hasher, Hashing},
 };
 
 use crate::{
-    operations::{
-        magic_bytes,
-        op_return::utils::{build_op_return_script, reorder_outputs},
-        utils::setup_wallet,
-        Opcode,
-    },
-    SBTCError, SBTCResult,
+	operations::{
+		magic_bytes,
+		op_return::utils::{build_op_return_script, reorder_outputs},
+		utils::setup_wallet,
+		Opcode,
+	},
+	SBTCError, SBTCResult,
 };
 
 #[derive(PartialEq, Eq, Debug)]
 /// Data for the sBTC OP_RETURN withdrawal request transaction output
 pub struct WithdrawalRequestOutputData {
-    /// Network to be used for the transaction
-    pub network: Network,
-    /// Amount to withdraw
-    pub amount: Amount,
-    /// Signature of the withdrawal request amount and recipient address
-    pub signature: RecoverableSignature,
+	/// Network to be used for the transaction
+	pub network: Network,
+	/// Amount to withdraw
+	pub amount: Amount,
+	/// Signature of the withdrawal request amount and recipient address
+	pub signature: RecoverableSignature,
 }
 
 impl Codec for WithdrawalRequestOutputData {
-    fn codec_serialize<W: io::Write>(&self, dest: &mut W) -> io::Result<()> {
-        dest.write_all(&magic_bytes(self.network))?;
-        dest.write_all(&[Opcode::WithdrawalRequest as u8])?;
-        self.amount.codec_serialize(dest)?;
-        self.signature.codec_serialize(dest)
-    }
+	fn codec_serialize<W: io::Write>(&self, dest: &mut W) -> io::Result<()> {
+		dest.write_all(&magic_bytes(self.network))?;
+		dest.write_all(&[Opcode::WithdrawalRequest as u8])?;
+		self.amount.codec_serialize(dest)?;
+		self.signature.codec_serialize(dest)
+	}
 
-    fn codec_deserialize<R: io::Read>(data: &mut R) -> io::Result<Self>
-    where
-        Self: Sized,
-    {
-        let mut magic_bytes_buffer = [0; 2];
-        data.read_exact(&mut magic_bytes_buffer)?;
+	fn codec_deserialize<R: io::Read>(data: &mut R) -> io::Result<Self>
+	where
+		Self: Sized,
+	{
+		let mut magic_bytes_buffer = [0; 2];
+		data.read_exact(&mut magic_bytes_buffer)?;
 
-        let network_magic_bytes = [
-            Network::Bitcoin,
-            Network::Testnet,
-            Network::Signet,
-            Network::Regtest,
-        ]
-        .into_iter()
-        .map(|network| (magic_bytes(network), network))
-        .collect::<HashMap<[u8; 2], Network>>();
+		let network_magic_bytes = [
+			Network::Bitcoin,
+			Network::Testnet,
+			Network::Signet,
+			Network::Regtest,
+		]
+		.into_iter()
+		.map(|network| (magic_bytes(network), network))
+		.collect::<HashMap<[u8; 2], Network>>();
 
-        let network = network_magic_bytes
-            .get(&magic_bytes_buffer)
-            .cloned()
-            .ok_or(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("Unknown magic bytes: {:?}", magic_bytes_buffer),
-            ))?;
+		let network = network_magic_bytes
+			.get(&magic_bytes_buffer)
+			.cloned()
+			.ok_or(io::Error::new(
+				io::ErrorKind::InvalidData,
+				format!("Unknown magic bytes: {:?}", magic_bytes_buffer),
+			))?;
 
-        let opcode = Opcode::codec_deserialize(data)
-            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+		let opcode = Opcode::codec_deserialize(data)
+			.map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
 
-        if !matches!(opcode, Opcode::WithdrawalRequest) {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("Invalid opcode, expected withdrawal request: {:?}", opcode),
-            ));
-        }
+		if !matches!(opcode, Opcode::WithdrawalRequest) {
+			return Err(io::Error::new(
+				io::ErrorKind::InvalidData,
+				format!(
+					"Invalid opcode, expected withdrawal request: {:?}",
+					opcode
+				),
+			));
+		}
 
-        let amount = Amount::codec_deserialize(data)?;
-        let signature = RecoverableSignature::codec_deserialize(data)
-            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+		let amount = Amount::codec_deserialize(data)?;
+		let signature = RecoverableSignature::codec_deserialize(data)
+			.map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
 
-        Ok(Self {
-            network,
-            amount,
-            signature,
-        })
-    }
+		Ok(Self {
+			network,
+			amount,
+			signature,
+		})
+	}
 }
 
 fn sign_amount_and_recipient(
-    recipient: &BitcoinAddress,
-    amount: Amount,
-    sender_private_key: &PrivateKey,
+	recipient: &BitcoinAddress,
+	amount: Amount,
+	sender_private_key: &PrivateKey,
 ) -> RecoverableSignature {
-    let mut msg = amount.to_sat().to_be_bytes().to_vec();
-    msg.extend_from_slice(recipient.script_pubkey().as_bytes());
+	let mut msg = amount.to_sat().to_be_bytes().to_vec();
+	msg.extend_from_slice(recipient.script_pubkey().as_bytes());
 
-    let msg_hash = Sha256Hasher::hash(&msg);
-    let msg_ecdsa = Message::from_slice(msg_hash.as_ref()).unwrap();
+	let msg_hash = Sha256Hasher::hash(&msg);
+	let msg_ecdsa = Message::from_slice(msg_hash.as_ref()).unwrap();
 
-    Secp256k1::new().sign_ecdsa_recoverable(&msg_ecdsa, &sender_private_key.inner)
+	Secp256k1::new()
+		.sign_ecdsa_recoverable(&msg_ecdsa, &sender_private_key.inner)
 }
 
 fn withdrawal_psbt(
-    wallet: &Wallet<MemoryDatabase>,
-    sender_private_key: &PrivateKey,
-    recipient: &BitcoinAddress,
-    dkg_address: &BitcoinAddress,
-    amount: Amount,
-    fulfillment_fee: u64,
-    network: Network,
+	wallet: &Wallet<MemoryDatabase>,
+	sender_private_key: &PrivateKey,
+	recipient: &BitcoinAddress,
+	dkg_address: &BitcoinAddress,
+	amount: Amount,
+	fulfillment_fee: u64,
+	network: Network,
 ) -> SBTCResult<PartiallySignedTransaction> {
-    let recipient_script = recipient.script_pubkey();
-    let dkg_wallet_script = dkg_address.script_pubkey();
+	let recipient_script = recipient.script_pubkey();
+	let dkg_wallet_script = dkg_address.script_pubkey();
 
-    // Check that we have enough to cover dust
-    let recipient_dust_amount = recipient_script.dust_value().to_sat();
-    let dkg_wallet_dust_amount = dkg_wallet_script.dust_value().to_sat();
+	// Check that we have enough to cover dust
+	let recipient_dust_amount = recipient_script.dust_value().to_sat();
+	let dkg_wallet_dust_amount = dkg_wallet_script.dust_value().to_sat();
 
-    if fulfillment_fee < dkg_wallet_dust_amount {
-        return Err(SBTCError::AmountInsufficient(
-            fulfillment_fee,
-            dkg_wallet_dust_amount,
-        ));
-    }
+	if fulfillment_fee < dkg_wallet_dust_amount {
+		return Err(SBTCError::AmountInsufficient(
+			fulfillment_fee,
+			dkg_wallet_dust_amount,
+		));
+	}
 
-    let signature = sign_amount_and_recipient(recipient, amount, sender_private_key);
-    let op_return_script = build_op_return_script(
-        &WithdrawalRequestOutputData {
-            network,
-            amount,
-            signature,
-        }
-        .serialize_to_vec(),
-    );
+	let signature =
+		sign_amount_and_recipient(recipient, amount, sender_private_key);
+	let op_return_script = build_op_return_script(
+		&WithdrawalRequestOutputData {
+			network,
+			amount,
+			signature,
+		}
+		.serialize_to_vec(),
+	);
 
-    let mut tx_builder = wallet.build_tx();
+	let mut tx_builder = wallet.build_tx();
 
-    let outputs = [
-        (op_return_script, 0),
-        (recipient_script, recipient_dust_amount),
-        (dkg_wallet_script, fulfillment_fee),
-    ];
+	let outputs = [
+		(op_return_script, 0),
+		(recipient_script, recipient_dust_amount),
+		(dkg_wallet_script, fulfillment_fee),
+	];
 
-    for (script, amount) in outputs.clone() {
-        tx_builder.add_recipient(script, amount);
-    }
+	for (script, amount) in outputs.clone() {
+		tx_builder.add_recipient(script, amount);
+	}
 
-    let (mut partial_tx, _) = tx_builder.finish().map_err(|err| {
-        SBTCError::BDKError(
-            "Could not build partially signed withdrawal transaction",
-            err,
-        )
-    })?;
+	let (mut partial_tx, _) = tx_builder.finish().map_err(|err| {
+		SBTCError::BDKError(
+			"Could not build partially signed withdrawal transaction",
+			err,
+		)
+	})?;
 
-    partial_tx.unsigned_tx.output = reorder_outputs(partial_tx.unsigned_tx.output, outputs);
+	partial_tx.unsigned_tx.output =
+		reorder_outputs(partial_tx.unsigned_tx.output, outputs);
 
-    Ok(partial_tx)
+	Ok(partial_tx)
 }
 
 /// Construct a BTC transaction containing the provided sBTC withdrawal data
 pub fn build_withdrawal_tx(
-    withdrawer_bitcoin_private_key: PrivateKey,
-    withdrawer_stacks_private_key: PrivateKey,
-    receiver_address: BitcoinAddress,
-    amount: Amount,
-    fulfillment_fee: u64,
-    dkg_address: BitcoinAddress,
+	withdrawer_bitcoin_private_key: PrivateKey,
+	withdrawer_stacks_private_key: PrivateKey,
+	receiver_address: BitcoinAddress,
+	amount: Amount,
+	fulfillment_fee: u64,
+	dkg_address: BitcoinAddress,
 ) -> SBTCResult<Transaction> {
-    let wallet = setup_wallet(withdrawer_bitcoin_private_key)?;
+	let wallet = setup_wallet(withdrawer_bitcoin_private_key)?;
 
-    let mut psbt = withdrawal_psbt(
-        &wallet,
-        &withdrawer_stacks_private_key,
-        &receiver_address,
-        &dkg_address,
-        amount,
-        fulfillment_fee,
-        withdrawer_bitcoin_private_key.network,
-    )?;
+	let mut psbt = withdrawal_psbt(
+		&wallet,
+		&withdrawer_stacks_private_key,
+		&receiver_address,
+		&dkg_address,
+		amount,
+		fulfillment_fee,
+		withdrawer_bitcoin_private_key.network,
+	)?;
 
-    wallet
-        .sign(&mut psbt, SignOptions::default())
-        .map_err(|err| SBTCError::BDKError("Could not sign withdrawal transaction", err))?;
+	wallet
+		.sign(&mut psbt, SignOptions::default())
+		.map_err(|err| {
+			SBTCError::BDKError("Could not sign withdrawal transaction", err)
+		})?;
 
-    Ok(psbt.extract_tx())
+	Ok(psbt.extract_tx())
 }

--- a/sbtc-core/src/operations/utils.rs
+++ b/sbtc-core/src/operations/utils.rs
@@ -1,38 +1,40 @@
-/*!
-Utilities for sBTC transactions
-*/
+//! Utilities for sBTC transactions
 
 use bdk::{
-    bitcoin::PrivateKey, blockchain::ElectrumBlockchain, database::MemoryDatabase,
-    electrum_client::Client, template::P2Wpkh, SyncOptions, Wallet,
+	bitcoin::PrivateKey, blockchain::ElectrumBlockchain,
+	database::MemoryDatabase, electrum_client::Client, template::P2Wpkh,
+	SyncOptions, Wallet,
 };
 
 use crate::{SBTCError, SBTCResult};
 
 /// Initializes the electrum blockchain client
 pub(crate) fn init_blockchain() -> SBTCResult<ElectrumBlockchain> {
-    let client = Client::new("ssl://blockstream.info:993")
-        .map_err(|err| SBTCError::ElectrumError("Could not create Electrum client", err))?;
-    let blockchain = ElectrumBlockchain::from(client);
+	let client = Client::new("ssl://blockstream.info:993").map_err(|err| {
+		SBTCError::ElectrumError("Could not create Electrum client", err)
+	})?;
+	let blockchain = ElectrumBlockchain::from(client);
 
-    Ok(blockchain)
+	Ok(blockchain)
 }
 
 /// Set up an electrum wallet for sBTC operations
-pub(crate) fn setup_wallet(private_key: PrivateKey) -> SBTCResult<Wallet<MemoryDatabase>> {
-    let blockchain = init_blockchain()?;
+pub(crate) fn setup_wallet(
+	private_key: PrivateKey,
+) -> SBTCResult<Wallet<MemoryDatabase>> {
+	let blockchain = init_blockchain()?;
 
-    let wallet = Wallet::new(
-        P2Wpkh(private_key),
-        Some(P2Wpkh(private_key)),
-        private_key.network,
-        MemoryDatabase::default(),
-    )
-    .map_err(|err| SBTCError::BDKError("Could not open wallet", err))?;
+	let wallet = Wallet::new(
+		P2Wpkh(private_key),
+		Some(P2Wpkh(private_key)),
+		private_key.network,
+		MemoryDatabase::default(),
+	)
+	.map_err(|err| SBTCError::BDKError("Could not open wallet", err))?;
 
-    wallet
-        .sync(&blockchain, SyncOptions::default())
-        .map_err(|err| SBTCError::BDKError("Could not sync wallet", err))?;
+	wallet
+		.sync(&blockchain, SyncOptions::default())
+		.map_err(|err| SBTCError::BDKError("Could not sync wallet", err))?;
 
-    Ok(wallet)
+	Ok(wallet)
 }

--- a/sbtc-core/src/signer/config.rs
+++ b/sbtc-core/src/signer/config.rs
@@ -4,12 +4,12 @@ use stacks_core::address::StacksAddress;
 #[derive(Clone, Debug)]
 /// Configuration for the signer approval/denial
 pub struct Config {
-    /// The maximum dollar amount of a transaction that will be auto approved
-    pub auto_approve_max_amount: u64,
-    /// The public key of the signer being delegated to
-    pub delegate_public_key: PublicKey,
-    /// The BTC addresses to be auto denied
-    pub auto_deny_addresses_btc: Vec<BitcoinAddress>,
-    /// The STX addresses to be auto denied
-    pub auto_deny_addresses_stx: Vec<StacksAddress>,
+	/// The maximum dollar amount of a transaction that will be auto approved
+	pub auto_approve_max_amount: u64,
+	/// The public key of the signer being delegated to
+	pub delegate_public_key: PublicKey,
+	/// The BTC addresses to be auto denied
+	pub auto_deny_addresses_btc: Vec<BitcoinAddress>,
+	/// The STX addresses to be auto denied
+	pub auto_deny_addresses_stx: Vec<StacksAddress>,
 }

--- a/sbtc-core/src/signer/coordinator/mod.rs
+++ b/sbtc-core/src/signer/coordinator/mod.rs
@@ -5,21 +5,23 @@ pub mod roast;
 
 use std::collections::HashMap;
 
-use crate::SBTCResult;
-
-use bdk::bitcoin::{util::taproot::TaprootSpendInfo, PublicKey, Transaction as BitcoinTransaction};
+use bdk::bitcoin::{
+	util::taproot::TaprootSpendInfo, PublicKey,
+	Transaction as BitcoinTransaction,
+};
 use p256k1::ecdsa;
 use wsts::{bip340::SchnorrProof, common::Signature};
 
 use super::StacksTransaction;
+use crate::SBTCResult;
 
 #[derive(Default, Clone, Debug)]
 /// Signers' public keys required for weighted distributed signing
 pub struct PublicKeys {
-    /// Signer ids to public key mapping
-    pub signer_ids: HashMap<u32, ecdsa::PublicKey>,
-    /// Vote ids to public key mapping
-    pub vote_ids: HashMap<u32, ecdsa::PublicKey>,
+	/// Signer ids to public key mapping
+	pub signer_ids: HashMap<u32, ecdsa::PublicKey>,
+	/// Vote ids to public key mapping
+	pub vote_ids: HashMap<u32, ecdsa::PublicKey>,
 }
 
 /// TODO: Define the Message types for DKG round
@@ -33,40 +35,46 @@ pub struct PublicKeys {
 /// This could be a BTC transaction or a STX transaction
 /// depending on https://github.com/Trust-Machines/stacks-sbtc/pull/595
 pub enum SBTCTransaction {
-    /// A commit Bitcoin transaction
-    Commit(TaprootSpendInfo, BitcoinTransaction),
-    /// A withdrawal Stacks transaction
-    Withdawal(StacksTransaction),
+	/// A commit Bitcoin transaction
+	Commit(TaprootSpendInfo, BitcoinTransaction),
+	/// A withdrawal Stacks transaction
+	Withdawal(StacksTransaction),
 }
 
 /// Revealer trait for revealing BTC commit transactions
 pub trait Reveal {
-    /// Retrieve Commit transactions from Revealer service
-    fn commit_transactions(&self) -> SBTCResult<Vec<(TaprootSpendInfo, BitcoinTransaction)>>;
-    /// Validate the given commit transaction
-    fn validate_commit_transaction(
-        &self,
-        spend_info: TaprootSpendInfo,
-        tx: &BitcoinTransaction,
-    ) -> SBTCResult<bool>;
-    /// Create a reveal transaction from the BTC commit transaction
-    fn reveal_transaction(
-        &self,
-        spend_info: TaprootSpendInfo,
-        tx: &BitcoinTransaction,
-    ) -> SBTCResult<BitcoinTransaction>;
+	/// Retrieve Commit transactions from Revealer service
+	fn commit_transactions(
+		&self,
+	) -> SBTCResult<Vec<(TaprootSpendInfo, BitcoinTransaction)>>;
+	/// Validate the given commit transaction
+	fn validate_commit_transaction(
+		&self,
+		spend_info: TaprootSpendInfo,
+		tx: &BitcoinTransaction,
+	) -> SBTCResult<bool>;
+	/// Create a reveal transaction from the BTC commit transaction
+	fn reveal_transaction(
+		&self,
+		spend_info: TaprootSpendInfo,
+		tx: &BitcoinTransaction,
+	) -> SBTCResult<BitcoinTransaction>;
 }
 
-/// Coordinator trait for generating the sBTC wallet public key and running a signing round
+/// Coordinator trait for generating the sBTC wallet public key and running a
+/// signing round
 pub trait Coordinate {
-    /// Retrieve sBTC transactions from the blockchain
-    fn sbtc_transactions(&self) -> SBTCResult<Vec<SBTCTransaction>>;
-    /// Generate the sBTC wallet public key
-    fn generate_sbtc_wallet_public_key(&self, public_keys: &PublicKeys) -> SBTCResult<PublicKey>;
-    /// Run the signing round for the transaction
-    fn run_signing_round(
-        &self,
-        public_keys: &PublicKeys,
-        tx: &BitcoinTransaction,
-    ) -> SBTCResult<(Signature, SchnorrProof)>;
+	/// Retrieve sBTC transactions from the blockchain
+	fn sbtc_transactions(&self) -> SBTCResult<Vec<SBTCTransaction>>;
+	/// Generate the sBTC wallet public key
+	fn generate_sbtc_wallet_public_key(
+		&self,
+		public_keys: &PublicKeys,
+	) -> SBTCResult<PublicKey>;
+	/// Run the signing round for the transaction
+	fn run_signing_round(
+		&self,
+		public_keys: &PublicKeys,
+		tx: &BitcoinTransaction,
+	) -> SBTCResult<(Signature, SchnorrProof)>;
 }

--- a/sbtc-core/src/signer/coordinator/roast.rs
+++ b/sbtc-core/src/signer/coordinator/roast.rs
@@ -1,2 +1,2 @@
 // TODO: ROAST coordination logic
-//https://github.com/Trust-Machines/stacks-sbtc/issues/668
+// https://github.com/Trust-Machines/stacks-sbtc/issues/668

--- a/sbtc-core/src/signer/mod.rs
+++ b/sbtc-core/src/signer/mod.rs
@@ -3,15 +3,19 @@ pub mod config;
 /// sBTC coordinator module
 pub mod coordinator;
 
-use crate::SBTCError;
-use crate::{
-    signer::config::Config,
-    signer::coordinator::{Coordinate, PublicKeys, Reveal},
-    SBTCResult,
+use bdk::bitcoin::{
+	Address, Network, PrivateKey, PublicKey, Transaction as BitcoinTransaction,
 };
-use bdk::bitcoin::{Address, Network, PrivateKey, PublicKey, Transaction as BitcoinTransaction};
 use p256k1::ecdsa;
 use url::Url;
+
+use crate::{
+	signer::{
+		config::Config,
+		coordinator::{Coordinate, PublicKeys, Reveal},
+	},
+	SBTCError, SBTCResult,
+};
 
 /// A Stacks transaction
 /// TODO: replace with the core library's StacksTransaction
@@ -20,137 +24,162 @@ pub struct StacksTransaction {}
 /// An Bitcoin transaction needing to be SIGNED by the signer
 /// TODO: update with https://github.com/Trust-Machines/stacks-sbtc/pull/595
 pub enum SignableTransaction {
-    /// A reveal transaction
-    Reveal(BitcoinTransaction),
-    /// A withdrawal fulfillment Bitcoin transaction
-    WithdrawalFulfillment(BitcoinTransaction),
-    /// A Bitcoin sBTC wallet handoff transaction
-    Handoff(BitcoinTransaction),
+	/// A reveal transaction
+	Reveal(BitcoinTransaction),
+	/// A withdrawal fulfillment Bitcoin transaction
+	WithdrawalFulfillment(BitcoinTransaction),
+	/// A Bitcoin sBTC wallet handoff transaction
+	Handoff(BitcoinTransaction),
 }
 
 /// sBTC Keys trait for retrieving signer IDs, vote IDs, and public keys
 trait Keys {
-    /// Retrieve the current public keys for the signers and their vote ids
-    fn public_keys(&self) -> SBTCResult<PublicKeys>;
-    /// Get the ordered list of coordinator public keys for the given transaction
-    fn coordinator_public_keys(&self, tx: &BitcoinTransaction) -> SBTCResult<Vec<PublicKey>>;
+	/// Retrieve the current public keys for the signers and their vote ids
+	fn public_keys(&self) -> SBTCResult<PublicKeys>;
+	/// Get the ordered list of coordinator public keys for the given
+	/// transaction
+	fn coordinator_public_keys(
+		&self,
+		tx: &BitcoinTransaction,
+	) -> SBTCResult<Vec<PublicKey>>;
 }
 
 /// Sign trait for signing and verifying messages
 pub trait Sign {
-    /// Sign the given message
-    fn sign_message(&self, message: &[u8]) -> SBTCResult<Vec<u8>>;
-    /// Verify the message was signed by the given public key
-    fn verify_message(&self, public_key: &ecdsa::PublicKey, message: &[u8]) -> SBTCResult<bool>;
+	/// Sign the given message
+	fn sign_message(&self, message: &[u8]) -> SBTCResult<Vec<u8>>;
+	/// Verify the message was signed by the given public key
+	fn verify_message(
+		&self,
+		public_key: &ecdsa::PublicKey,
+		message: &[u8],
+	) -> SBTCResult<bool>;
 }
 
 /// Validator trait for validating pending Bitcoin transactions
 pub trait Validator {
-    /// Validate the given signable Bitcoin transaction
-    fn validate_transaction(&self, tx: &SignableTransaction) -> SBTCResult<bool>;
+	/// Validate the given signable Bitcoin transaction
+	fn validate_transaction(
+		&self,
+		tx: &SignableTransaction,
+	) -> SBTCResult<bool>;
 }
 
 /// sBTC compliant Signer
 pub struct Signer<S> {
-    /// Signer configuration
-    pub config: Config,
-    /// Signer private key
-    pub private_key: PrivateKey,
-    /// Network to use
-    pub network: Network,
-    /// The stacks node RPC URL
-    pub stacks_node_rpc_url: Url,
-    /// The bitcoin node RPC URL
-    pub bitcoin_node_rpc_url: Url,
-    /// The revealer RPC URL
-    pub revealer_rpc_url: Url,
-    /// The signer
-    pub signer: S,
+	/// Signer configuration
+	pub config: Config,
+	/// Signer private key
+	pub private_key: PrivateKey,
+	/// Network to use
+	pub network: Network,
+	/// The stacks node RPC URL
+	pub stacks_node_rpc_url: Url,
+	/// The bitcoin node RPC URL
+	pub bitcoin_node_rpc_url: Url,
+	/// The revealer RPC URL
+	pub revealer_rpc_url: Url,
+	/// The signer
+	pub signer: S,
 }
 
 impl<S: Sign + Coordinate + Reveal> Signer<S> {
-    // Public methods
+	// Public methods
 
-    /// Create a new signer
-    pub fn new(
-        config: Config,
-        private_key: PrivateKey,
-        network: Network,
-        stacks_node_rpc_url: Url,
-        bitcoin_node_rpc_url: Url,
-        revealer_rpc_url: Url,
-        signer: S,
-    ) -> Self {
-        Self {
-            config,
-            private_key,
-            network,
-            stacks_node_rpc_url,
-            bitcoin_node_rpc_url,
-            revealer_rpc_url,
-            signer,
-        }
-    }
+	/// Create a new signer
+	pub fn new(
+		config: Config,
+		private_key: PrivateKey,
+		network: Network,
+		stacks_node_rpc_url: Url,
+		bitcoin_node_rpc_url: Url,
+		revealer_rpc_url: Url,
+		signer: S,
+	) -> Self {
+		Self {
+			config,
+			private_key,
+			network,
+			stacks_node_rpc_url,
+			bitcoin_node_rpc_url,
+			revealer_rpc_url,
+			signer,
+		}
+	}
 
-    /// Sign approve the given transaction
-    pub fn approve(&self, _tx: &BitcoinTransaction) -> SBTCResult<()> {
-        todo!()
-    }
+	/// Sign approve the given transaction
+	pub fn approve(&self, _tx: &BitcoinTransaction) -> SBTCResult<()> {
+		todo!()
+	}
 
-    /// Sign deny the given transaction
-    pub fn deny(&self, _tx: &BitcoinTransaction) -> Result<(), SBTCError> {
-        todo!()
-    }
+	/// Sign deny the given transaction
+	pub fn deny(&self, _tx: &BitcoinTransaction) -> Result<(), SBTCError> {
+		todo!()
+	}
 
-    // Private methods
+	// Private methods
 
-    /// Fulfill the withdrawal request using the provided address
-    fn _fulfill_withdrawal_request(
-        &self,
-        _sbtc_wallet_address: &Address,
-        _tx: &StacksTransaction,
-    ) -> SBTCResult<()> {
-        todo!()
-    }
+	/// Fulfill the withdrawal request using the provided address
+	fn _fulfill_withdrawal_request(
+		&self,
+		_sbtc_wallet_address: &Address,
+		_tx: &StacksTransaction,
+	) -> SBTCResult<()> {
+		todo!()
+	}
 
-    /// Broadcast the transaction to the bitcoin network
-    fn _broadcast_transaction_bitcoin(&self, _tx: BitcoinTransaction) -> SBTCResult<()> {
-        todo!()
-    }
+	/// Broadcast the transaction to the bitcoin network
+	fn _broadcast_transaction_bitcoin(
+		&self,
+		_tx: BitcoinTransaction,
+	) -> SBTCResult<()> {
+		todo!()
+	}
 
-    /// Broadcast the transaction to the stacks network
-    fn _broadcast_transaction_stacks(&self, _tx: StacksTransaction) -> SBTCResult<()> {
-        todo!()
-    }
+	/// Broadcast the transaction to the stacks network
+	fn _broadcast_transaction_stacks(
+		&self,
+		_tx: StacksTransaction,
+	) -> SBTCResult<()> {
+		todo!()
+	}
 }
 
 impl<S> Keys for Signer<S> {
-    /// Retrieve the current public keys for the signers and their vote ids
-    fn public_keys(&self) -> SBTCResult<PublicKeys> {
-        todo!()
-    }
+	/// Retrieve the current public keys for the signers and their vote ids
+	fn public_keys(&self) -> SBTCResult<PublicKeys> {
+		todo!()
+	}
 
-    /// Get the ordered list of coordinator public keys for the given transaction
-    fn coordinator_public_keys(&self, _tx: &BitcoinTransaction) -> SBTCResult<Vec<PublicKey>> {
-        todo!()
-    }
+	/// Get the ordered list of coordinator public keys for the given
+	/// transaction
+	fn coordinator_public_keys(
+		&self,
+		_tx: &BitcoinTransaction,
+	) -> SBTCResult<Vec<PublicKey>> {
+		todo!()
+	}
 }
 
 impl<S> Validator for Signer<S> {
-    /// Validate the given sBTC transaction
-    fn validate_transaction(&self, tx: &SignableTransaction) -> SBTCResult<bool> {
-        // TODO: check all addresses involved in each transaction
-        match tx {
-            SignableTransaction::Reveal(_tx) => {
-                // TODO: retrieve the initiator from the originator transaction to verify it is not an auto deny address
-                todo!()
-            }
-            SignableTransaction::WithdrawalFulfillment(_tx) => {
-                todo!()
-            }
-            SignableTransaction::Handoff(_tx) => {
-                todo!()
-            }
-        }
-    }
+	/// Validate the given sBTC transaction
+	fn validate_transaction(
+		&self,
+		tx: &SignableTransaction,
+	) -> SBTCResult<bool> {
+		// TODO: check all addresses involved in each transaction
+		match tx {
+			SignableTransaction::Reveal(_tx) => {
+				// TODO: retrieve the initiator from the originator transaction
+				// to verify it is not an auto deny address
+				todo!()
+			}
+			SignableTransaction::WithdrawalFulfillment(_tx) => {
+				todo!()
+			}
+			SignableTransaction::Handoff(_tx) => {
+				todo!()
+			}
+		}
+	}
 }

--- a/stacks-core/src/address.rs
+++ b/stacks-core/src/address.rs
@@ -1,363 +1,368 @@
 use std::{
-    fmt,
-    io::{self, Read, Write},
+	fmt,
+	io::{self, Read, Write},
 };
 
 use bdk::bitcoin::{
-    blockdata::{opcodes::all::OP_CHECKMULTISIG, script::Builder},
-    secp256k1::PublicKey,
+	blockdata::{opcodes::all::OP_CHECKMULTISIG, script::Builder},
+	secp256k1::PublicKey,
 };
 use serde::Serialize;
 use strum::{EnumIter, FromRepr};
 
 use crate::{
-    c32::{decode_address, encode_address},
-    codec::Codec,
-    crypto::{
-        hash160::{Hash160Hasher, HASH160_LENGTH},
-        sha256::Sha256Hasher,
-        Hashing,
-    },
-    StacksError, StacksResult,
+	c32::{decode_address, encode_address},
+	codec::Codec,
+	crypto::{
+		hash160::{Hash160Hasher, HASH160_LENGTH},
+		sha256::Sha256Hasher,
+		Hashing,
+	},
+	StacksError, StacksResult,
 };
 
 /// Supported stacks address versions
 #[repr(u8)]
 #[derive(FromRepr, EnumIter, PartialEq, Eq, Copy, Clone, Debug)]
 pub enum AddressVersion {
-    /// Mainnet single sig address version
-    MainnetSingleSig = 22,
-    /// Mainnet multi sig address version
-    MainnetMultiSig = 20,
-    /// Testnet single sig address version
-    TestnetSingleSig = 26,
-    /// Testnet multi sig address version
-    TestnetMultiSig = 21,
+	/// Mainnet single sig address version
+	MainnetSingleSig = 22,
+	/// Mainnet multi sig address version
+	MainnetMultiSig = 20,
+	/// Testnet single sig address version
+	TestnetSingleSig = 26,
+	/// Testnet multi sig address version
+	TestnetMultiSig = 21,
 }
 
 impl TryFrom<u8> for AddressVersion {
-    type Error = StacksError;
+	type Error = StacksError;
 
-    fn try_from(value: u8) -> StacksResult<Self> {
-        AddressVersion::from_repr(value).ok_or(StacksError::InvalidAddressVersion(value))
-    }
+	fn try_from(value: u8) -> StacksResult<Self> {
+		AddressVersion::from_repr(value)
+			.ok_or(StacksError::InvalidAddressVersion(value))
+	}
 }
 
 /// A Stacks address
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(into = "String")]
 pub struct StacksAddress {
-    version: AddressVersion,
-    hash: Hash160Hasher,
+	version: AddressVersion,
+	hash: Hash160Hasher,
 }
 
 impl StacksAddress {
-    /// Create a new Stacks address from the given version and hash
-    pub fn new(version: AddressVersion, hash: Hash160Hasher) -> Self {
-        Self { version, hash }
-    }
+	/// Create a new Stacks address from the given version and hash
+	pub fn new(version: AddressVersion, hash: Hash160Hasher) -> Self {
+		Self { version, hash }
+	}
 
-    /// Get the address version
-    pub fn version(&self) -> AddressVersion {
-        self.version
-    }
+	/// Get the address version
+	pub fn version(&self) -> AddressVersion {
+		self.version
+	}
 
-    /// Get the address hash
-    pub fn hash(&self) -> &Hash160Hasher {
-        &self.hash
-    }
+	/// Get the address hash
+	pub fn hash(&self) -> &Hash160Hasher {
+		&self.hash
+	}
 
-    /// Create a new Stacks address with a pay-2-public-key-hash
-    pub fn p2pkh(version: AddressVersion, key: &PublicKey) -> Self {
-        Self::new(version, hash_p2pkh(key))
-    }
+	/// Create a new Stacks address with a pay-2-public-key-hash
+	pub fn p2pkh(version: AddressVersion, key: &PublicKey) -> Self {
+		Self::new(version, hash_p2pkh(key))
+	}
 
-    /// Create a new Stacks address with a pay-2-script-hash
-    pub fn p2sh<'a>(
-        version: AddressVersion,
-        keys: impl IntoIterator<Item = &'a PublicKey>,
-        signature_threshold: usize,
-    ) -> Self {
-        Self::new(version, hash_p2sh(keys, signature_threshold))
-    }
+	/// Create a new Stacks address with a pay-2-script-hash
+	pub fn p2sh<'a>(
+		version: AddressVersion,
+		keys: impl IntoIterator<Item = &'a PublicKey>,
+		signature_threshold: usize,
+	) -> Self {
+		Self::new(version, hash_p2sh(keys, signature_threshold))
+	}
 
-    /// Create a new Stacks address with a pay-2-witness-public-key-hash
-    pub fn p2wpkh(version: AddressVersion, key: &PublicKey) -> Self {
-        Self::new(version, hash_p2wpkh(key))
-    }
+	/// Create a new Stacks address with a pay-2-witness-public-key-hash
+	pub fn p2wpkh(version: AddressVersion, key: &PublicKey) -> Self {
+		Self::new(version, hash_p2wpkh(key))
+	}
 
-    /// Create a new Stacks address with a pay-2-witness-script-hash
-    pub fn p2wsh<'a>(
-        version: AddressVersion,
-        keys: impl IntoIterator<Item = &'a PublicKey>,
-        signature_threshold: usize,
-    ) -> Self {
-        Self::new(version, hash_p2wsh(keys, signature_threshold))
-    }
+	/// Create a new Stacks address with a pay-2-witness-script-hash
+	pub fn p2wsh<'a>(
+		version: AddressVersion,
+		keys: impl IntoIterator<Item = &'a PublicKey>,
+		signature_threshold: usize,
+	) -> Self {
+		Self::new(version, hash_p2wsh(keys, signature_threshold))
+	}
 }
 
 impl Codec for StacksAddress {
-    fn codec_serialize<W: Write>(&self, dest: &mut W) -> io::Result<()> {
-        assert_eq!(dest.write(&[self.version() as u8])?, 1);
-        dest.write_all(self.hash().as_ref())
-    }
+	fn codec_serialize<W: Write>(&self, dest: &mut W) -> io::Result<()> {
+		assert_eq!(dest.write(&[self.version() as u8])?, 1);
+		dest.write_all(self.hash().as_ref())
+	}
 
-    fn codec_deserialize<R: Read>(data: &mut R) -> io::Result<Self> {
-        let mut version_buffer = [0; 1];
-        data.read_exact(&mut version_buffer)?;
+	fn codec_deserialize<R: Read>(data: &mut R) -> io::Result<Self> {
+		let mut version_buffer = [0; 1];
+		data.read_exact(&mut version_buffer)?;
 
-        let version = AddressVersion::from_repr(version_buffer[0]).unwrap();
+		let version = AddressVersion::from_repr(version_buffer[0]).unwrap();
 
-        let mut hash_buffer = [0; HASH160_LENGTH];
-        data.read_exact(&mut hash_buffer)?;
+		let mut hash_buffer = [0; HASH160_LENGTH];
+		data.read_exact(&mut hash_buffer)?;
 
-        let hash = Hash160Hasher::from_bytes(&hash_buffer).unwrap();
+		let hash = Hash160Hasher::from_bytes(&hash_buffer).unwrap();
 
-        Ok(Self { version, hash })
-    }
+		Ok(Self { version, hash })
+	}
 }
 
 impl From<StacksAddress> for String {
-    fn from(address: StacksAddress) -> Self {
-        encode_address(address.version, address.hash.as_ref())
-    }
+	fn from(address: StacksAddress) -> Self {
+		encode_address(address.version, address.hash.as_ref())
+	}
 }
 
 impl TryFrom<&str> for StacksAddress {
-    type Error = StacksError;
+	type Error = StacksError;
 
-    fn try_from(address: &str) -> Result<Self, Self::Error> {
-        let (version, hash_bytes) =
-            decode_address(address).map_err::<StacksError, _>(|err| err.into())?;
+	fn try_from(address: &str) -> Result<Self, Self::Error> {
+		let (version, hash_bytes) = decode_address(address)
+			.map_err::<StacksError, _>(|err| err.into())?;
 
-        if hash_bytes.len() != HASH160_LENGTH {
-            return Err(StacksError::InvalidArguments(
-                "Invalid hash length for address",
-            ));
-        }
+		if hash_bytes.len() != HASH160_LENGTH {
+			return Err(StacksError::InvalidArguments(
+				"Invalid hash length for address",
+			));
+		}
 
-        let mut buffer = [0; HASH160_LENGTH];
-        buffer.copy_from_slice(&hash_bytes);
+		let mut buffer = [0; HASH160_LENGTH];
+		buffer.copy_from_slice(&hash_bytes);
 
-        Ok(Self::new(version, buffer.into()))
-    }
+		Ok(Self::new(version, buffer.into()))
+	}
 }
 
 impl fmt::Display for StacksAddress {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", encode_address(self.version, self.hash.as_ref()))
-    }
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		write!(f, "{}", encode_address(self.version, self.hash.as_ref()))
+	}
 }
 
 fn hash_p2pkh(key: &PublicKey) -> Hash160Hasher {
-    Hash160Hasher::new(key.serialize())
+	Hash160Hasher::new(key.serialize())
 }
 
 fn hash_p2sh<'a>(
-    pub_keys: impl IntoIterator<Item = &'a PublicKey>,
-    signature_threshold: usize,
+	pub_keys: impl IntoIterator<Item = &'a PublicKey>,
+	signature_threshold: usize,
 ) -> Hash160Hasher {
-    let mut builder = Builder::new();
-    let mut key_counter = 0;
+	let mut builder = Builder::new();
+	let mut key_counter = 0;
 
-    builder = builder.push_int(signature_threshold as i64);
+	builder = builder.push_int(signature_threshold as i64);
 
-    for key in pub_keys {
-        builder = builder.push_slice(&key.serialize());
-        key_counter += 1;
-    }
+	for key in pub_keys {
+		builder = builder.push_slice(&key.serialize());
+		key_counter += 1;
+	}
 
-    builder = builder.push_int(key_counter);
-    builder = builder.push_opcode(OP_CHECKMULTISIG);
+	builder = builder.push_int(key_counter);
+	builder = builder.push_opcode(OP_CHECKMULTISIG);
 
-    let script = builder.into_script();
-    let script_hash = Hash160Hasher::new(script.as_bytes());
+	let script = builder.into_script();
+	let script_hash = Hash160Hasher::new(script.as_bytes());
 
-    script_hash
+	script_hash
 }
 
 fn hash_p2wpkh(key: &PublicKey) -> Hash160Hasher {
-    let key_hash_hasher = Hash160Hasher::new(key.serialize());
-    let key_hash = key_hash_hasher.as_ref();
-    let key_hash_len = key_hash.len();
+	let key_hash_hasher = Hash160Hasher::new(key.serialize());
+	let key_hash = key_hash_hasher.as_ref();
+	let key_hash_len = key_hash.len();
 
-    let mut buff = Vec::with_capacity(key_hash_len + 2);
-    buff.push(0);
-    buff.push(key_hash_len as u8);
-    buff.extend_from_slice(key_hash);
+	let mut buff = Vec::with_capacity(key_hash_len + 2);
+	buff.push(0);
+	buff.push(key_hash_len as u8);
+	buff.extend_from_slice(key_hash);
 
-    Hash160Hasher::new(&buff)
+	Hash160Hasher::new(&buff)
 }
 
 fn hash_p2wsh<'a>(
-    pub_keys: impl IntoIterator<Item = &'a PublicKey>,
-    signature_threshold: usize,
+	pub_keys: impl IntoIterator<Item = &'a PublicKey>,
+	signature_threshold: usize,
 ) -> Hash160Hasher {
-    let mut script = vec![];
-    let mut key_count = 0;
+	let mut script = vec![];
+	let mut key_count = 0;
 
-    script.push(signature_threshold as u8 + 80);
+	script.push(signature_threshold as u8 + 80);
 
-    for pub_key in pub_keys {
-        let bytes = pub_key.serialize();
+	for pub_key in pub_keys {
+		let bytes = pub_key.serialize();
 
-        script.push(bytes.len() as u8);
-        script.extend_from_slice(&bytes);
-        key_count += 1;
-    }
+		script.push(bytes.len() as u8);
+		script.extend_from_slice(&bytes);
+		key_count += 1;
+	}
 
-    script.push(key_count + 80);
-    script.push(174);
+	script.push(key_count + 80);
+	script.push(174);
 
-    let digest = Sha256Hasher::new(&script);
-    let digest_bytes = digest.as_ref();
+	let digest = Sha256Hasher::new(&script);
+	let digest_bytes = digest.as_ref();
 
-    let mut buff = vec![];
-    buff.push(0);
-    buff.push(digest_bytes.len() as u8);
-    buff.extend_from_slice(digest_bytes);
+	let mut buff = vec![];
+	buff.push(0);
+	buff.push(digest_bytes.len() as u8);
+	buff.extend_from_slice(digest_bytes);
 
-    Hash160Hasher::new(&buff)
+	Hash160Hasher::new(&buff)
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::crypto::hash160::Hash160Hasher;
+	use super::*;
+	use crate::crypto::hash160::Hash160Hasher;
 
-    use super::*;
+	/// Sample data computed with these commands on MacOS:
+	///
+	/// ```
+	/// CREDENTIALS=$(stx make_keychain)
+	/// PUBLIC_KEY=$(echo $CREDENTIALS | jq -r .key_info.publicKey)
+	/// EXPECTED_HASH=$(echo $PUBLIC_KEY \
+	/// | xxd -r -p \
+	/// | openssl dgst -sha256 -binary \
+	/// | openssl dgst -ripemd160 -binary \
+	/// | xxd -p)
+	/// ```
+	#[test]
+	fn should_correctly_hash_p2pkh() {
+		let public_key_hex = "03556902f83defc6c63a7eb56a2d8ee4baee109f2126aac41e4f9e3a0835f34bc5";
+		let expected_hash_hex = "d24206d58967c61b6b302eb14cd254a8ae7e761a";
 
-    /**
-    Sample data computed with these commands on MacOS:
+		let pk = PublicKey::from_slice(&hex::decode(public_key_hex).unwrap())
+			.unwrap();
+		let hash_hex = hex::encode(hash_p2pkh(&pk).as_ref());
 
-    ```
-    CREDENTIALS=$(stx make_keychain)
-    PUBLIC_KEY=$(echo $CREDENTIALS | jq -r .key_info.publicKey)
-    EXPECTED_HASH=$(echo $PUBLIC_KEY \
-        | xxd -r -p \
-        | openssl dgst -sha256 -binary \
-        | openssl dgst -ripemd160 -binary \
-        | xxd -p)
-    ```
-    */
-    #[test]
-    fn should_correctly_hash_p2pkh() {
-        let public_key_hex = "03556902f83defc6c63a7eb56a2d8ee4baee109f2126aac41e4f9e3a0835f34bc5";
-        let expected_hash_hex = "d24206d58967c61b6b302eb14cd254a8ae7e761a";
+		assert_eq!(hash_hex, expected_hash_hex);
+	}
 
-        let pk = PublicKey::from_slice(&hex::decode(public_key_hex).unwrap()).unwrap();
-        let hash_hex = hex::encode(hash_p2pkh(&pk).as_ref());
+	/// Data obtained from from blockstack_lib throwaway code
+	#[test]
+	fn should_correctly_hash_p2sh() {
+		let pk_hex = "028cac21ac93bf697dc31da79e11aad8d285b2e2e81bcfc8de982179c6d468d339";
+		let addr_hash = "fc1058076c56333d7d2d9fbb936aefa632c0e7a8";
 
-        assert_eq!(hash_hex, expected_hash_hex);
-    }
+		let pk = PublicKey::from_slice(&hex::decode(pk_hex).unwrap()).unwrap();
+		let expected_hash: Hash160Hasher = hex::decode(addr_hash)
+			.unwrap()
+			.as_slice()
+			.try_into()
+			.unwrap();
 
-    /// Data obtained from from blockstack_lib throwaway code
-    #[test]
-    fn should_correctly_hash_p2sh() {
-        let pk_hex = "028cac21ac93bf697dc31da79e11aad8d285b2e2e81bcfc8de982179c6d468d339";
-        let addr_hash = "fc1058076c56333d7d2d9fbb936aefa632c0e7a8";
+		assert_eq!(hash_p2sh(&[pk], 1).as_ref(), expected_hash.as_ref());
+	}
 
-        let pk = PublicKey::from_slice(&hex::decode(pk_hex).unwrap()).unwrap();
-        let expected_hash: Hash160Hasher = hex::decode(addr_hash)
-            .unwrap()
-            .as_slice()
-            .try_into()
-            .unwrap();
+	/// Data obtained from from blockstack_lib throwaway code
+	#[test]
+	fn should_correctly_hash_p2sh_2_keys() {
+		let pk1_hex = "0325a1b9799db9852ee1c99280b20695b1889eff7ec0352d634912818d02f91f84";
+		let pk2_hex = "0279d7abd36d41d51e225efbbc8376a257051cecdf8b47eaffeb49b77547bc3bff";
+		let addr_hash = "073503b6e6ef916e4ab40f31abc83217c271d917";
 
-        assert_eq!(hash_p2sh(&[pk], 1).as_ref(), expected_hash.as_ref());
-    }
+		let pk1 =
+			PublicKey::from_slice(&hex::decode(pk1_hex).unwrap()).unwrap();
+		let pk2 =
+			PublicKey::from_slice(&hex::decode(pk2_hex).unwrap()).unwrap();
+		let expected_hash: Hash160Hasher = hex::decode(addr_hash)
+			.unwrap()
+			.as_slice()
+			.try_into()
+			.unwrap();
 
-    /// Data obtained from from blockstack_lib throwaway code
-    #[test]
-    fn should_correctly_hash_p2sh_2_keys() {
-        let pk1_hex = "0325a1b9799db9852ee1c99280b20695b1889eff7ec0352d634912818d02f91f84";
-        let pk2_hex = "0279d7abd36d41d51e225efbbc8376a257051cecdf8b47eaffeb49b77547bc3bff";
-        let addr_hash = "073503b6e6ef916e4ab40f31abc83217c271d917";
+		assert_eq!(hash_p2sh(&[pk1, pk2], 2).as_ref(), expected_hash.as_ref());
+	}
 
-        let pk1 = PublicKey::from_slice(&hex::decode(pk1_hex).unwrap()).unwrap();
-        let pk2 = PublicKey::from_slice(&hex::decode(pk2_hex).unwrap()).unwrap();
-        let expected_hash: Hash160Hasher = hex::decode(addr_hash)
-            .unwrap()
-            .as_slice()
-            .try_into()
-            .unwrap();
+	/// Data obtained from from blockstack_lib throwaway code
+	#[test]
+	fn should_correctly_hash_p2wsh() {
+		let pk_hex = "027cf49417052b14d73c3da78ec3c0c859380b19a4971fd8c63ded9037455dd84c";
+		let addr_hash = "599623097df78a0e962108bfb0f1f78ef1d15f57";
 
-        assert_eq!(hash_p2sh(&[pk1, pk2], 2).as_ref(), expected_hash.as_ref());
-    }
+		let pk = PublicKey::from_slice(&hex::decode(pk_hex).unwrap()).unwrap();
+		let expected_hash: Hash160Hasher = hex::decode(addr_hash)
+			.unwrap()
+			.as_slice()
+			.try_into()
+			.unwrap();
 
-    /// Data obtained from from blockstack_lib throwaway code
-    #[test]
-    fn should_correctly_hash_p2wsh() {
-        let pk_hex = "027cf49417052b14d73c3da78ec3c0c859380b19a4971fd8c63ded9037455dd84c";
-        let addr_hash = "599623097df78a0e962108bfb0f1f78ef1d15f57";
+		assert_eq!(hash_p2wsh(&[pk], 1).as_ref(), expected_hash.as_ref());
+	}
 
-        let pk = PublicKey::from_slice(&hex::decode(pk_hex).unwrap()).unwrap();
-        let expected_hash: Hash160Hasher = hex::decode(addr_hash)
-            .unwrap()
-            .as_slice()
-            .try_into()
-            .unwrap();
+	/// Data obtained from from blockstack_lib throwaway code
+	#[test]
+	fn should_correctly_hash_p2wsh_2_key() {
+		let pk1_hex = "037c6e4c27b3d39ab73c2cd2fdd2ea34cec3d9b6881a2a4a17e42fcafb6b64c3aa";
+		let pk2_hex = "03a544a1d3fb4238d5841647100c53e371a1d72f027857899256f0c754cf266491";
+		let addr_hash = "d5f3ddac2358f61088d951aead20c270a045d46d";
 
-        assert_eq!(hash_p2wsh(&[pk], 1).as_ref(), expected_hash.as_ref());
-    }
+		let pk1 =
+			PublicKey::from_slice(&hex::decode(pk1_hex).unwrap()).unwrap();
+		let pk2 =
+			PublicKey::from_slice(&hex::decode(pk2_hex).unwrap()).unwrap();
+		let expected_hash: Hash160Hasher = hex::decode(addr_hash)
+			.unwrap()
+			.as_slice()
+			.try_into()
+			.unwrap();
 
-    /// Data obtained from from blockstack_lib throwaway code
-    #[test]
-    fn should_correctly_hash_p2wsh_2_key() {
-        let pk1_hex = "037c6e4c27b3d39ab73c2cd2fdd2ea34cec3d9b6881a2a4a17e42fcafb6b64c3aa";
-        let pk2_hex = "03a544a1d3fb4238d5841647100c53e371a1d72f027857899256f0c754cf266491";
-        let addr_hash = "d5f3ddac2358f61088d951aead20c270a045d46d";
+		assert_eq!(hash_p2wsh(&[pk1, pk2], 2).as_ref(), expected_hash.as_ref());
+	}
 
-        let pk1 = PublicKey::from_slice(&hex::decode(pk1_hex).unwrap()).unwrap();
-        let pk2 = PublicKey::from_slice(&hex::decode(pk2_hex).unwrap()).unwrap();
-        let expected_hash: Hash160Hasher = hex::decode(addr_hash)
-            .unwrap()
-            .as_slice()
-            .try_into()
-            .unwrap();
+	/// Data obtained from from blockstack_lib throwaway code
+	#[test]
+	fn should_correctly_hash_p2wpkh() {
+		let pk_hex = "03528351fc1494c66b67e0857fd571e1de37985dd0cae987dbe71c47d2bc7a7712";
+		let addr_hash = "3bb7c80b72757b4bc94bd3cb09171500fb72b4ac";
 
-        assert_eq!(hash_p2wsh(&[pk1, pk2], 2).as_ref(), expected_hash.as_ref());
-    }
+		let pk = PublicKey::from_slice(&hex::decode(pk_hex).unwrap()).unwrap();
+		let expected_hash: Hash160Hasher = hex::decode(addr_hash)
+			.unwrap()
+			.as_slice()
+			.try_into()
+			.unwrap();
 
-    /// Data obtained from from blockstack_lib throwaway code
-    #[test]
-    fn should_correctly_hash_p2wpkh() {
-        let pk_hex = "03528351fc1494c66b67e0857fd571e1de37985dd0cae987dbe71c47d2bc7a7712";
-        let addr_hash = "3bb7c80b72757b4bc94bd3cb09171500fb72b4ac";
+		assert_eq!(hash_p2wpkh(&pk).as_ref(), expected_hash.as_ref());
+	}
 
-        let pk = PublicKey::from_slice(&hex::decode(pk_hex).unwrap()).unwrap();
-        let expected_hash: Hash160Hasher = hex::decode(addr_hash)
-            .unwrap()
-            .as_slice()
-            .try_into()
-            .unwrap();
+	/// Data generated with `stx make_keychain`
+	#[test]
+	fn should_create_correct_address_from_public_key() {
+		let public_key = "02e2ce887c1f1654936fbb7d4036749da5e7b9b64af406e1f3535c8f4336de1c6e";
+		let expected_address = "SPR4FMGJCD78NF4FRGPM621CW1KHNFEG0HSRDSPK";
 
-        assert_eq!(hash_p2wpkh(&pk).as_ref(), expected_hash.as_ref());
-    }
+		let addr = StacksAddress::p2pkh(
+			AddressVersion::MainnetSingleSig,
+			&PublicKey::from_slice(&hex::decode(public_key).unwrap()).unwrap(),
+		);
 
-    /// Data generated with `stx make_keychain`
-    #[test]
-    fn should_create_correct_address_from_public_key() {
-        let public_key = "02e2ce887c1f1654936fbb7d4036749da5e7b9b64af406e1f3535c8f4336de1c6e";
-        let expected_address = "SPR4FMGJCD78NF4FRGPM621CW1KHNFEG0HSRDSPK";
+		assert_eq!(addr.to_string(), expected_address);
+	}
 
-        let addr = StacksAddress::p2pkh(
-            AddressVersion::MainnetSingleSig,
-            &PublicKey::from_slice(&hex::decode(public_key).unwrap()).unwrap(),
-        );
+	/// Data generated with `stx make_keychain`
+	#[test]
+	fn should_create_correct_address_from_c32_encoded_string() {
+		let addr = "SPR4FMGJCD78NF4FRGPM621CW1KHNFEG0HSRDSPK";
+		let public_key_hex = "02e2ce887c1f1654936fbb7d4036749da5e7b9b64af406e1f3535c8f4336de1c6e";
+		let expected_hash = hash_p2pkh(
+			&PublicKey::from_slice(&hex::decode(public_key_hex).unwrap())
+				.unwrap(),
+		);
 
-        assert_eq!(addr.to_string(), expected_address);
-    }
+		let addr = StacksAddress::try_from(addr).unwrap();
 
-    /// Data generated with `stx make_keychain`
-    #[test]
-    fn should_create_correct_address_from_c32_encoded_string() {
-        let addr = "SPR4FMGJCD78NF4FRGPM621CW1KHNFEG0HSRDSPK";
-        let public_key_hex = "02e2ce887c1f1654936fbb7d4036749da5e7b9b64af406e1f3535c8f4336de1c6e";
-        let expected_hash =
-            hash_p2pkh(&PublicKey::from_slice(&hex::decode(public_key_hex).unwrap()).unwrap());
-
-        let addr = StacksAddress::try_from(addr).unwrap();
-
-        assert_eq!(addr.hash(), &expected_hash);
-    }
+		assert_eq!(addr.hash(), &expected_hash);
+	}
 }

--- a/stacks-core/src/c32.rs
+++ b/stacks-core/src/c32.rs
@@ -1,322 +1,334 @@
 use once_cell::sync::Lazy;
 
 use crate::{
-    address::AddressVersion,
-    crypto::{sha256::DoubleSha256Hasher, Hashing},
+	address::AddressVersion,
+	crypto::{sha256::DoubleSha256Hasher, Hashing},
 };
 
 const C32_ALPHABET: &[u8; 32] = b"0123456789ABCDEFGHJKMNPQRSTVWXYZ";
 
 static C32_BYTE_MAP: Lazy<[Option<u8>; 128]> = Lazy::new(|| {
-    let mut table: [Option<u8>; 128] = [None; 128];
+	let mut table: [Option<u8>; 128] = [None; 128];
 
-    let alphabet: [char; 32] = C32_ALPHABET
-        .iter()
-        .map(|byte| *byte as char)
-        .collect::<Vec<_>>()
-        .try_into()
-        .unwrap();
+	let alphabet: [char; 32] = C32_ALPHABET
+		.iter()
+		.map(|byte| *byte as char)
+		.collect::<Vec<_>>()
+		.try_into()
+		.unwrap();
 
-    alphabet.iter().enumerate().for_each(|(i, x)| {
-        table[*x as usize] = Some(i as u8);
-    });
+	alphabet.iter().enumerate().for_each(|(i, x)| {
+		table[*x as usize] = Some(i as u8);
+	});
 
-    alphabet
-        .iter()
-        .map(|c| c.to_ascii_lowercase())
-        .enumerate()
-        .for_each(|(i, x)| {
-            table[x as usize] = Some(i as u8);
-        });
+	alphabet
+		.iter()
+		.map(|c| c.to_ascii_lowercase())
+		.enumerate()
+		.for_each(|(i, x)| {
+			table[x as usize] = Some(i as u8);
+		});
 
-    [('O', '0'), ('L', '1'), ('I', '1')]
-        .into_iter()
-        .for_each(|special_pair| {
-            let i = alphabet
-                .iter()
-                .enumerate()
-                .find(|(_, a)| **a == special_pair.1)
-                .unwrap()
-                .0;
+	[('O', '0'), ('L', '1'), ('I', '1')]
+		.into_iter()
+		.for_each(|special_pair| {
+			let i = alphabet
+				.iter()
+				.enumerate()
+				.find(|(_, a)| **a == special_pair.1)
+				.unwrap()
+				.0;
 
-            table[special_pair.0 as usize] = Some(i as u8);
-            table[special_pair.0.to_ascii_lowercase() as usize] = Some(i as u8);
-        });
+			table[special_pair.0 as usize] = Some(i as u8);
+			table[special_pair.0.to_ascii_lowercase() as usize] = Some(i as u8);
+		});
 
-    table
+	table
 });
 
 fn encode_overhead(len: usize) -> usize {
-    (len * 8 + 4) / 5
+	(len * 8 + 4) / 5
 }
 
 fn decode_underhead(len: usize) -> usize {
-    len / (8f64 / 5f64).ceil() as usize
+	len / (8f64 / 5f64).ceil() as usize
 }
 
 #[derive(thiserror::Error, Clone, Debug, Eq, PartialEq)]
 /// C32 error type
 pub enum C32Error {
-    /// Invalid C32 string.
-    #[error("Invalid C32 string")]
-    InvalidC32,
-    /// Invalid character.
-    #[error("Invalid C32 character: {0}")]
-    InvalidChar(char),
-    /// Invalid checksum.
-    #[error("Invalid C32 checksum - expected {0:?}, got {1:?}")]
-    InvalidChecksum([u8; 4], Vec<u8>),
-    /// Invalid C32 address.
-    #[error("Invalid C32 address: {0}")]
-    InvalidAddress(String),
-    /// Invalid C32 address.
-    #[error("Invalid C32 address version: {0}")]
-    InvalidVersion(u8),
-    /// Conversion error, from utf8.
-    #[error(transparent)]
-    FromUtf8Error(#[from] std::string::FromUtf8Error),
-    /// Integer conversion error.
-    #[error(transparent)]
-    IntConversionError(#[from] std::num::TryFromIntError),
+	/// Invalid C32 string.
+	#[error("Invalid C32 string")]
+	InvalidC32,
+	/// Invalid character.
+	#[error("Invalid C32 character: {0}")]
+	InvalidChar(char),
+	/// Invalid checksum.
+	#[error("Invalid C32 checksum - expected {0:?}, got {1:?}")]
+	InvalidChecksum([u8; 4], Vec<u8>),
+	/// Invalid C32 address.
+	#[error("Invalid C32 address: {0}")]
+	InvalidAddress(String),
+	/// Invalid C32 address.
+	#[error("Invalid C32 address version: {0}")]
+	InvalidVersion(u8),
+	/// Conversion error, from utf8.
+	#[error(transparent)]
+	FromUtf8Error(#[from] std::string::FromUtf8Error),
+	/// Integer conversion error.
+	#[error(transparent)]
+	IntConversionError(#[from] std::num::TryFromIntError),
 }
 /// C32 encode the given data
 pub fn encode(data: impl AsRef<[u8]>) -> String {
-    let data = data.as_ref();
+	let data = data.as_ref();
 
-    let mut encoded = Vec::with_capacity(encode_overhead(data.len()));
-    let mut buffer = 0u32;
-    let mut bits = 0;
+	let mut encoded = Vec::with_capacity(encode_overhead(data.len()));
+	let mut buffer = 0u32;
+	let mut bits = 0;
 
-    for byte in data.iter().rev() {
-        buffer |= (*byte as u32) << bits;
-        bits += 8;
+	for byte in data.iter().rev() {
+		buffer |= (*byte as u32) << bits;
+		bits += 8;
 
-        while bits >= 5 {
-            encoded.push(C32_ALPHABET[(buffer & 0x1F) as usize]);
-            buffer >>= 5;
-            bits -= 5;
-        }
-    }
+		while bits >= 5 {
+			encoded.push(C32_ALPHABET[(buffer & 0x1F) as usize]);
+			buffer >>= 5;
+			bits -= 5;
+		}
+	}
 
-    if bits > 0 {
-        encoded.push(C32_ALPHABET[(buffer & 0x1F) as usize]);
-    }
+	if bits > 0 {
+		encoded.push(C32_ALPHABET[(buffer & 0x1F) as usize]);
+	}
 
-    while let Some(i) = encoded.pop() {
-        if i != C32_ALPHABET[0] {
-            encoded.push(i);
-            break;
-        }
-    }
+	while let Some(i) = encoded.pop() {
+		if i != C32_ALPHABET[0] {
+			encoded.push(i);
+			break;
+		}
+	}
 
-    for i in data {
-        if *i == 0 {
-            encoded.push(C32_ALPHABET[0]);
-        } else {
-            break;
-        }
-    }
+	for i in data {
+		if *i == 0 {
+			encoded.push(C32_ALPHABET[0]);
+		} else {
+			break;
+		}
+	}
 
-    encoded.reverse();
+	encoded.reverse();
 
-    String::from_utf8(encoded).unwrap()
+	String::from_utf8(encoded).unwrap()
 }
 
 /// C32 decode the given data
 pub fn decode(input: impl AsRef<str>) -> Result<Vec<u8>, C32Error> {
-    let input = input.as_ref().as_bytes();
+	let input = input.as_ref().as_bytes();
 
-    if !input.is_ascii() {
-        return Err(C32Error::InvalidC32);
-    }
+	if !input.is_ascii() {
+		return Err(C32Error::InvalidC32);
+	}
 
-    let mut decoded = Vec::with_capacity(decode_underhead(input.len()));
-    let mut carry = 0u16;
-    let mut carry_bits = 0;
+	let mut decoded = Vec::with_capacity(decode_underhead(input.len()));
+	let mut carry = 0u16;
+	let mut carry_bits = 0;
 
-    for byte in input.iter().rev() {
-        let Some(bits) = C32_BYTE_MAP.get(*byte as usize).unwrap() else {
-            return Err(C32Error::InvalidChar(*byte as char));
-        };
+	for byte in input.iter().rev() {
+		let Some(bits) = C32_BYTE_MAP.get(*byte as usize).unwrap() else {
+			return Err(C32Error::InvalidChar(*byte as char));
+		};
 
-        carry |= (u16::from(*bits)) << carry_bits;
-        carry_bits += 5;
+		carry |= (u16::from(*bits)) << carry_bits;
+		carry_bits += 5;
 
-        if carry_bits >= 8 {
-            decoded.push((carry & 0xFF) as u8);
-            carry >>= 8;
-            carry_bits -= 8;
-        }
-    }
+		if carry_bits >= 8 {
+			decoded.push((carry & 0xFF) as u8);
+			carry >>= 8;
+			carry_bits -= 8;
+		}
+	}
 
-    if carry_bits > 0 {
-        decoded.push(u8::try_from(carry)?);
-    }
+	if carry_bits > 0 {
+		decoded.push(u8::try_from(carry)?);
+	}
 
-    while let Some(i) = decoded.pop() {
-        if i != 0 {
-            decoded.push(i);
-            break;
-        }
-    }
+	while let Some(i) = decoded.pop() {
+		if i != 0 {
+			decoded.push(i);
+			break;
+		}
+	}
 
-    for byte in input.iter() {
-        if *byte == b'0' {
-            decoded.push(0);
-        } else {
-            break;
-        }
-    }
+	for byte in input.iter() {
+		if *byte == b'0' {
+			decoded.push(0);
+		} else {
+			break;
+		}
+	}
 
-    decoded.reverse();
+	decoded.reverse();
 
-    Ok(decoded)
+	Ok(decoded)
 }
 
 /// C32 encode the given data with a version check
-pub fn version_check_encode(version: AddressVersion, data: impl AsRef<[u8]>) -> String {
-    let data = data.as_ref();
+pub fn version_check_encode(
+	version: AddressVersion,
+	data: impl AsRef<[u8]>,
+) -> String {
+	let data = data.as_ref();
 
-    let mut buffer = vec![version as u8];
-    buffer.extend_from_slice(data);
+	let mut buffer = vec![version as u8];
+	buffer.extend_from_slice(data);
 
-    let checksum = DoubleSha256Hasher::new(&buffer).checksum();
-    buffer.extend_from_slice(&checksum);
+	let checksum = DoubleSha256Hasher::new(&buffer).checksum();
+	buffer.extend_from_slice(&checksum);
 
-    let mut encoded = encode(&buffer[1..]);
-    encoded.insert(0, C32_ALPHABET[version as usize] as char);
+	let mut encoded = encode(&buffer[1..]);
+	encoded.insert(0, C32_ALPHABET[version as usize] as char);
 
-    encoded
+	encoded
 }
 
 /// C32 decode the given data with a version check
-pub fn version_check_decode(input: impl AsRef<str>) -> Result<(AddressVersion, Vec<u8>), C32Error> {
-    let input = input.as_ref();
+pub fn version_check_decode(
+	input: impl AsRef<str>,
+) -> Result<(AddressVersion, Vec<u8>), C32Error> {
+	let input = input.as_ref();
 
-    if !input.is_ascii() {
-        return Err(C32Error::InvalidC32);
-    }
+	if !input.is_ascii() {
+		return Err(C32Error::InvalidC32);
+	}
 
-    let (encoded_version_bytes, encoded_data_bytes) = input.split_at(1);
+	let (encoded_version_bytes, encoded_data_bytes) = input.split_at(1);
 
-    let decoded_version_bytes = decode(encoded_version_bytes)?;
-    let decoded_version_byte = *decoded_version_bytes.first().unwrap();
-    let decoded_data_bytes = decode(encoded_data_bytes)?;
+	let decoded_version_bytes = decode(encoded_version_bytes)?;
+	let decoded_version_byte = *decoded_version_bytes.first().unwrap();
+	let decoded_data_bytes = decode(encoded_data_bytes)?;
 
-    if decoded_data_bytes.len() < 4 {
-        return Err(C32Error::InvalidC32);
-    }
+	if decoded_data_bytes.len() < 4 {
+		return Err(C32Error::InvalidC32);
+	}
 
-    let (data_bytes, expected_checksum) = decoded_data_bytes.split_at(decoded_data_bytes.len() - 4);
+	let (data_bytes, expected_checksum) =
+		decoded_data_bytes.split_at(decoded_data_bytes.len() - 4);
 
-    let mut buffer_to_check = vec![decoded_version_byte];
-    buffer_to_check.extend_from_slice(data_bytes);
+	let mut buffer_to_check = vec![decoded_version_byte];
+	buffer_to_check.extend_from_slice(data_bytes);
 
-    let computed_checksum = DoubleSha256Hasher::new(buffer_to_check).checksum();
+	let computed_checksum = DoubleSha256Hasher::new(buffer_to_check).checksum();
 
-    if computed_checksum != expected_checksum {
-        return Err(C32Error::InvalidChecksum(
-            computed_checksum,
-            expected_checksum.to_vec(),
-        ));
-    }
+	if computed_checksum != expected_checksum {
+		return Err(C32Error::InvalidChecksum(
+			computed_checksum,
+			expected_checksum.to_vec(),
+		));
+	}
 
-    Ok((
-        decoded_version_byte
-            .try_into()
-            .map_err(|_| C32Error::InvalidVersion(decoded_version_byte))?,
-        data_bytes.to_vec(),
-    ))
+	Ok((
+		decoded_version_byte
+			.try_into()
+			.map_err(|_| C32Error::InvalidVersion(decoded_version_byte))?,
+		data_bytes.to_vec(),
+	))
 }
 
 /// C32 encode the given data as an address
-pub fn encode_address(version: AddressVersion, data: impl AsRef<[u8]>) -> String {
-    let encoded = version_check_encode(version, data);
-    let address = format!("S{}", encoded);
+pub fn encode_address(
+	version: AddressVersion,
+	data: impl AsRef<[u8]>,
+) -> String {
+	let encoded = version_check_encode(version, data);
+	let address = format!("S{}", encoded);
 
-    address
+	address
 }
 
 /// C32 decode the given address string
-pub fn decode_address(address: impl AsRef<str>) -> Result<(AddressVersion, Vec<u8>), C32Error> {
-    let address = address.as_ref();
+pub fn decode_address(
+	address: impl AsRef<str>,
+) -> Result<(AddressVersion, Vec<u8>), C32Error> {
+	let address = address.as_ref();
 
-    if !address.starts_with('S') || address.len() <= 5 {
-        return Err(C32Error::InvalidAddress(address.to_string()));
-    }
+	if !address.starts_with('S') || address.len() <= 5 {
+		return Err(C32Error::InvalidAddress(address.to_string()));
+	}
 
-    version_check_decode(&address[1..])
+	version_check_decode(&address[1..])
 }
 
 #[cfg(test)]
 mod tests {
-    use rand::{thread_rng, Rng, RngCore};
-    use strum::IntoEnumIterator;
+	use rand::{thread_rng, Rng, RngCore};
+	use strum::IntoEnumIterator;
 
-    use crate::address::AddressVersion;
+	use super::{decode_address, encode, encode_address};
+	use crate::address::AddressVersion;
 
-    use super::{decode_address, encode, encode_address};
+	#[test]
+	fn test_c32_encode() {
+		let input = vec![1, 2, 3, 4, 6, 1, 2, 6, 2, 3, 6, 9, 4, 0, 0];
+		let encoded = encode(&input);
 
-    #[test]
-    fn test_c32_encode() {
-        let input = vec![1, 2, 3, 4, 6, 1, 2, 6, 2, 3, 6, 9, 4, 0, 0];
-        let encoded = encode(&input);
+		assert_eq!(encoded, "41061060410C0G30R4G8000");
+	}
 
-        assert_eq!(encoded, "41061060410C0G30R4G8000");
-    }
+	#[test]
+	fn test_c32_decode() {
+		let input = vec![1, 2, 3, 4, 6, 1, 2, 6, 2, 3, 6, 9, 4, 0, 0];
+		let encoded = encode(&input);
+		let decoded = super::decode(encoded).unwrap();
 
-    #[test]
-    fn test_c32_decode() {
-        let input = vec![1, 2, 3, 4, 6, 1, 2, 6, 2, 3, 6, 9, 4, 0, 0];
-        let encoded = encode(&input);
-        let decoded = super::decode(encoded).unwrap();
+		assert_eq!(input, decoded);
+	}
 
-        assert_eq!(input, decoded);
-    }
+	#[test]
+	fn test_c32_check() {
+		let version = AddressVersion::MainnetSingleSig;
+		let data = hex::encode("8a4d3f2e55c87f964bae8b2963b3a824a2e9c9ab")
+			.into_bytes();
 
-    #[test]
-    fn test_c32_check() {
-        let version = AddressVersion::MainnetSingleSig;
-        let data = hex::encode("8a4d3f2e55c87f964bae8b2963b3a824a2e9c9ab").into_bytes();
+		let encoded = encode_address(version, &data);
+		let (decoded_version, decoded) = decode_address(encoded).unwrap();
 
-        let encoded = encode_address(version, &data);
-        let (decoded_version, decoded) = decode_address(encoded).unwrap();
+		assert_eq!(decoded, data);
+		assert_eq!(decoded_version, version);
+	}
 
-        assert_eq!(decoded, data);
-        assert_eq!(decoded_version, version);
-    }
+	#[test]
+	fn test_c32_randomized_input() {
+		let mut rng = thread_rng();
 
-    #[test]
-    fn test_c32_randomized_input() {
-        let mut rng = thread_rng();
+		for _ in 0..1000 {
+			let len = rng.gen_range(10..=10);
+			let mut input = vec![0u8; len];
+			rng.fill_bytes(&mut input);
 
-        for _ in 0..1000 {
-            let len = rng.gen_range(10..=10);
-            let mut input = vec![0u8; len];
-            rng.fill_bytes(&mut input);
+			let encoded_bytes = encode(&input);
+			let encoded = encoded_bytes.clone();
+			let decoded = super::decode(encoded.clone()).unwrap();
 
-            let encoded_bytes = encode(&input);
-            let encoded = encoded_bytes.clone();
-            let decoded = super::decode(encoded.clone()).unwrap();
+			assert_eq!(decoded, input);
+		}
+	}
 
-            assert_eq!(decoded, input);
-        }
-    }
+	#[test]
+	fn test_c32_check_randomized_input() {
+		let mut rng = thread_rng();
 
-    #[test]
-    fn test_c32_check_randomized_input() {
-        let mut rng = thread_rng();
+		for _ in 0..1000 {
+			let bytes = rng.gen::<[u8; 20]>();
 
-        for _ in 0..1000 {
-            let bytes = rng.gen::<[u8; 20]>();
+			for version in AddressVersion::iter() {
+				let encoded = encode_address(version, &bytes);
+				let (decoded_version, decoded) =
+					decode_address(encoded).unwrap();
 
-            for version in AddressVersion::iter() {
-                let encoded = encode_address(version, &bytes);
-                let (decoded_version, decoded) = decode_address(encoded).unwrap();
-
-                assert_eq!(decoded, bytes);
-                assert_eq!(decoded_version, version);
-            }
-        }
-    }
+				assert_eq!(decoded, bytes);
+				assert_eq!(decoded_version, version);
+			}
+		}
+	}
 }

--- a/stacks-core/src/codec.rs
+++ b/stacks-core/src/codec.rs
@@ -1,11 +1,9 @@
-/*!
-Module for serializing and deserializing Stacks data types
-*/
+//! Module for serializing and deserializing Stacks data types
 use std::io;
 
 use bdk::bitcoin::{
-    secp256k1::ecdsa::{RecoverableSignature, RecoveryId},
-    Amount,
+	secp256k1::ecdsa::{RecoverableSignature, RecoveryId},
+	Amount,
 };
 use thiserror::Error;
 
@@ -14,9 +12,9 @@ use crate::StacksResult;
 #[derive(Error, Debug)]
 /// Codec error
 pub enum CodecError {
-    #[error("Could not serialize or deserialize: {0}")]
-    /// Io error
-    IoError(#[from] io::Error),
+	#[error("Could not serialize or deserialize: {0}")]
+	/// Io error
+	IoError(#[from] io::Error),
 }
 
 /// Codec result
@@ -24,77 +22,78 @@ pub type CodecResult<T> = Result<T, CodecError>;
 
 /// Serializing and deserializing Stacks data types
 pub trait Codec {
-    /// Serialize to a writer
-    fn codec_serialize<W: io::Write>(&self, dest: &mut W) -> io::Result<()>;
-    /// Deserialize from a reader
-    fn codec_deserialize<R: io::Read>(data: &mut R) -> io::Result<Self>
-    where
-        Self: Sized;
+	/// Serialize to a writer
+	fn codec_serialize<W: io::Write>(&self, dest: &mut W) -> io::Result<()>;
+	/// Deserialize from a reader
+	fn codec_deserialize<R: io::Read>(data: &mut R) -> io::Result<Self>
+	where
+		Self: Sized;
 
-    /// Serialize to a writer and return a StacksResult
-    fn serialize<W: io::Write>(&self, dest: &mut W) -> StacksResult<()> {
-        self.codec_serialize(dest)
-            .map_err(|err| CodecError::IoError(err).into())
-    }
+	/// Serialize to a writer and return a StacksResult
+	fn serialize<W: io::Write>(&self, dest: &mut W) -> StacksResult<()> {
+		self.codec_serialize(dest)
+			.map_err(|err| CodecError::IoError(err).into())
+	}
 
-    /// Deserialize from a reader and return a StacksResult
-    fn deserialize<R: io::Read>(data: &mut R) -> StacksResult<Self>
-    where
-        Self: Sized,
-    {
-        Self::codec_deserialize(data).map_err(|err| CodecError::IoError(err).into())
-    }
+	/// Deserialize from a reader and return a StacksResult
+	fn deserialize<R: io::Read>(data: &mut R) -> StacksResult<Self>
+	where
+		Self: Sized,
+	{
+		Self::codec_deserialize(data)
+			.map_err(|err| CodecError::IoError(err).into())
+	}
 
-    /// Serialize to a vector
-    fn serialize_to_vec(&self) -> Vec<u8> {
-        let mut buffer = vec![];
+	/// Serialize to a vector
+	fn serialize_to_vec(&self) -> Vec<u8> {
+		let mut buffer = vec![];
 
-        self.serialize(&mut buffer).unwrap();
+		self.serialize(&mut buffer).unwrap();
 
-        buffer
-    }
+		buffer
+	}
 }
 
 impl Codec for Amount {
-    fn codec_serialize<W: io::Write>(&self, dest: &mut W) -> io::Result<()> {
-        dest.write_all(&self.to_sat().to_be_bytes())
-    }
+	fn codec_serialize<W: io::Write>(&self, dest: &mut W) -> io::Result<()> {
+		dest.write_all(&self.to_sat().to_be_bytes())
+	}
 
-    fn codec_deserialize<R: io::Read>(data: &mut R) -> io::Result<Self>
-    where
-        Self: Sized,
-    {
-        let mut buffer = [0; 8];
-        data.read_exact(&mut buffer)?;
+	fn codec_deserialize<R: io::Read>(data: &mut R) -> io::Result<Self>
+	where
+		Self: Sized,
+	{
+		let mut buffer = [0; 8];
+		data.read_exact(&mut buffer)?;
 
-        Ok(Self::from_sat(u64::from_be_bytes(buffer)))
-    }
+		Ok(Self::from_sat(u64::from_be_bytes(buffer)))
+	}
 }
 
 impl Codec for RecoverableSignature {
-    fn codec_serialize<W: io::Write>(&self, dest: &mut W) -> io::Result<()> {
-        let (id, signature) = self.serialize_compact();
+	fn codec_serialize<W: io::Write>(&self, dest: &mut W) -> io::Result<()> {
+		let (id, signature) = self.serialize_compact();
 
-        let id: u8 = id.to_i32().try_into().unwrap();
+		let id: u8 = id.to_i32().try_into().unwrap();
 
-        dest.write_all(&[id])?;
-        dest.write_all(&signature)
-    }
+		dest.write_all(&[id])?;
+		dest.write_all(&signature)
+	}
 
-    fn codec_deserialize<R: io::Read>(data: &mut R) -> io::Result<Self>
-    where
-        Self: Sized,
-    {
-        let mut id_buffer = [0; 1];
-        data.read_exact(&mut id_buffer)?;
+	fn codec_deserialize<R: io::Read>(data: &mut R) -> io::Result<Self>
+	where
+		Self: Sized,
+	{
+		let mut id_buffer = [0; 1];
+		data.read_exact(&mut id_buffer)?;
 
-        let id = RecoveryId::from_i32(id_buffer[0] as i32)
-            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+		let id = RecoveryId::from_i32(id_buffer[0] as i32)
+			.map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
 
-        let mut signature_buffer = [0; 64];
-        data.read_exact(&mut signature_buffer)?;
+		let mut signature_buffer = [0; 64];
+		data.read_exact(&mut signature_buffer)?;
 
-        Self::from_compact(&signature_buffer, id)
-            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))
-    }
+		Self::from_compact(&signature_buffer, id)
+			.map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))
+	}
 }

--- a/stacks-core/src/contract_name.rs
+++ b/stacks-core/src/contract_name.rs
@@ -1,11 +1,9 @@
-/*!
-Contract name type and parsing
-*/
+//! Contract name type and parsing
 use std::{
-    borrow::Borrow,
-    fmt::{Display, Formatter},
-    io::{self, Read},
-    ops::Deref,
+	borrow::Borrow,
+	fmt::{Display, Formatter},
+	io::{self, Read},
+	ops::Deref,
 };
 
 use once_cell::sync::Lazy;
@@ -21,32 +19,35 @@ pub const CONTRACT_MAX_NAME_LENGTH: usize = 40;
 
 /// Regex string for contract names
 pub static CONTRACT_NAME_REGEX_STRING: Lazy<String> = Lazy::new(|| {
-    format!(
-        r#"([a-zA-Z](([a-zA-Z0-9]|[-_])){{{},{}}})"#,
-        CONTRACT_MIN_NAME_LENGTH - 1,
-        CONTRACT_MAX_NAME_LENGTH - 1
-    )
+	format!(
+		r#"([a-zA-Z](([a-zA-Z0-9]|[-_])){{{},{}}})"#,
+		CONTRACT_MIN_NAME_LENGTH - 1,
+		CONTRACT_MAX_NAME_LENGTH - 1
+	)
 });
 
 /// Regex for contract names
 pub static CONTRACT_NAME_REGEX: Lazy<Regex> = Lazy::new(|| {
-    regex::Regex::new(format!("^{}$|^__transient$", CONTRACT_NAME_REGEX_STRING.as_str()).as_str())
-        .unwrap()
+	regex::Regex::new(
+		format!("^{}$|^__transient$", CONTRACT_NAME_REGEX_STRING.as_str())
+			.as_str(),
+	)
+	.unwrap()
 });
 
 #[derive(Error, Debug)]
 /// Error type for contract name parsing
 pub enum ContractNameError {
-    #[error(
-        "Length should be between {} and {}",
-        CONTRACT_MIN_NAME_LENGTH,
-        CONTRACT_MAX_NAME_LENGTH
-    )]
-    /// Invalid length
-    InvalidLength,
-    #[error("Format should follow the contract name specification")]
-    /// Invalid format
-    InvalidFormat,
+	#[error(
+		"Length should be between {} and {}",
+		CONTRACT_MIN_NAME_LENGTH,
+		CONTRACT_MAX_NAME_LENGTH
+	)]
+	/// Invalid length
+	InvalidLength,
+	#[error("Format should follow the contract name specification")]
+	/// Invalid format
+	InvalidFormat,
 }
 
 #[derive(PartialEq, Eq, Debug, Clone)]
@@ -54,83 +55,84 @@ pub enum ContractNameError {
 pub struct ContractName(String);
 
 impl ContractName {
-    /// Create a new contract name from the given string
-    pub fn new(contract_name: &str) -> Result<Self, ContractNameError> {
-        if contract_name.len() < CONTRACT_MIN_NAME_LENGTH
-            && contract_name.len() > CONTRACT_MAX_NAME_LENGTH
-        {
-            Err(ContractNameError::InvalidLength)
-        } else if CONTRACT_NAME_REGEX.is_match(contract_name) {
-            Ok(Self(contract_name.to_string()))
-        } else {
-            Err(ContractNameError::InvalidFormat)
-        }
-    }
+	/// Create a new contract name from the given string
+	pub fn new(contract_name: &str) -> Result<Self, ContractNameError> {
+		if contract_name.len() < CONTRACT_MIN_NAME_LENGTH
+			&& contract_name.len() > CONTRACT_MAX_NAME_LENGTH
+		{
+			Err(ContractNameError::InvalidLength)
+		} else if CONTRACT_NAME_REGEX.is_match(contract_name) {
+			Ok(Self(contract_name.to_string()))
+		} else {
+			Err(ContractNameError::InvalidFormat)
+		}
+	}
 }
 
 impl Codec for ContractName {
-    fn codec_serialize<W: io::Write>(&self, dest: &mut W) -> io::Result<()> {
-        dest.write_all(&[self.len() as u8])?;
-        dest.write_all(self.as_bytes())
-    }
+	fn codec_serialize<W: io::Write>(&self, dest: &mut W) -> io::Result<()> {
+		dest.write_all(&[self.len() as u8])?;
+		dest.write_all(self.as_bytes())
+	}
 
-    fn codec_deserialize<R: io::Read>(data: &mut R) -> io::Result<Self>
-    where
-        Self: Sized,
-    {
-        let mut length_buffer = [0u8; 1];
-        data.read_exact(&mut length_buffer)?;
-        let contract_name_length = length_buffer[0] as usize;
+	fn codec_deserialize<R: io::Read>(data: &mut R) -> io::Result<Self>
+	where
+		Self: Sized,
+	{
+		let mut length_buffer = [0u8; 1];
+		data.read_exact(&mut length_buffer)?;
+		let contract_name_length = length_buffer[0] as usize;
 
-        let mut name_buffer = Vec::with_capacity(contract_name_length);
-        data.take(contract_name_length as u64)
-            .read_to_end(&mut name_buffer)?;
+		let mut name_buffer = Vec::with_capacity(contract_name_length);
+		data.take(contract_name_length as u64)
+			.read_to_end(&mut name_buffer)?;
 
-        let contract_name_string = String::from_utf8(name_buffer)
-            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+		let contract_name_string = String::from_utf8(name_buffer)
+			.map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
 
-        Self::new(&contract_name_string)
-            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))
-    }
+		Self::new(&contract_name_string)
+			.map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))
+	}
 }
 
 impl TryFrom<&str> for ContractName {
-    type Error = ContractNameError;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
-        ContractName::new(value)
-    }
+	type Error = ContractNameError;
+
+	fn try_from(value: &str) -> Result<Self, Self::Error> {
+		ContractName::new(value)
+	}
 }
 
 impl AsRef<str> for ContractName {
-    fn as_ref(&self) -> &str {
-        self.0.as_ref()
-    }
+	fn as_ref(&self) -> &str {
+		self.0.as_ref()
+	}
 }
 
 impl Deref for ContractName {
-    type Target = str;
+	type Target = str;
 
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
+	fn deref(&self) -> &Self::Target {
+		&self.0
+	}
 }
 
 impl Borrow<str> for ContractName {
-    fn borrow(&self) -> &str {
-        self.as_ref()
-    }
+	fn borrow(&self) -> &str {
+		self.as_ref()
+	}
 }
 
 // From conversion is fallible for this type
 #[allow(clippy::from_over_into)]
 impl Into<String> for ContractName {
-    fn into(self) -> String {
-        self.0
-    }
+	fn into(self) -> String {
+		self.0
+	}
 }
 
 impl Display for ContractName {
-    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-        self.0.fmt(f)
-    }
+	fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+		self.0.fmt(f)
+	}
 }

--- a/stacks-core/src/crypto/hash160.rs
+++ b/stacks-core/src/crypto/hash160.rs
@@ -1,49 +1,50 @@
 use ripemd::{Digest, Ripemd160};
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    crypto::{Hasher, Hashing, Hex},
-    StacksError, StacksResult,
-};
-
 use super::sha256::Sha256Hasher;
+use crate::{
+	crypto::{Hasher, Hashing, Hex},
+	StacksError, StacksResult,
+};
 
 pub(crate) const HASH160_LENGTH: usize = 20;
 
-#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(
+	Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord,
+)]
 #[serde(try_from = "Hex")]
 #[serde(into = "Hex")]
 /// Hash160 hash type
 pub struct Hash160Hashing([u8; HASH160_LENGTH]);
 
 impl Hashing<HASH160_LENGTH> for Hash160Hashing {
-    fn hash(data: &[u8]) -> Self {
-        Self(Ripemd160::digest(Sha256Hasher::new(data)).into())
-    }
+	fn hash(data: &[u8]) -> Self {
+		Self(Ripemd160::digest(Sha256Hasher::new(data)).into())
+	}
 
-    fn as_bytes(&self) -> &[u8] {
-        &self.0
-    }
+	fn as_bytes(&self) -> &[u8] {
+		&self.0
+	}
 
-    fn from_bytes(bytes: &[u8]) -> StacksResult<Self> {
-        Ok(Self(bytes.try_into()?))
-    }
+	fn from_bytes(bytes: &[u8]) -> StacksResult<Self> {
+		Ok(Self(bytes.try_into()?))
+	}
 }
 
 // From conversion is fallible for this type
 #[allow(clippy::from_over_into)]
 impl Into<Hex> for Hash160Hashing {
-    fn into(self) -> Hex {
-        Hex(hex::encode(self.as_bytes()))
-    }
+	fn into(self) -> Hex {
+		Hex(hex::encode(self.as_bytes()))
+	}
 }
 
 impl TryFrom<Hex> for Hash160Hashing {
-    type Error = StacksError;
+	type Error = StacksError;
 
-    fn try_from(value: Hex) -> Result<Self, Self::Error> {
-        Self::from_bytes(&hex::decode(value.0)?)
-    }
+	fn try_from(value: Hex) -> Result<Self, Self::Error> {
+		Self::from_bytes(&hex::decode(value.0)?)
+	}
 }
 
 /// Hash160 hasher type
@@ -51,16 +52,16 @@ pub type Hash160Hasher = Hasher<Hash160Hashing, HASH160_LENGTH>;
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+	use super::*;
 
-    #[test]
-    fn should_sha256_hash_correctly() {
-        let plaintext = "Hello world";
-        let expected_hash_hex = "f5e95668dadf6fdef8521f7e1aa8a5e650c9f849";
+	#[test]
+	fn should_sha256_hash_correctly() {
+		let plaintext = "Hello world";
+		let expected_hash_hex = "f5e95668dadf6fdef8521f7e1aa8a5e650c9f849";
 
-        assert_eq!(
-            hex::encode(Hash160Hasher::hash(plaintext.as_bytes())),
-            expected_hash_hex
-        );
-    }
+		assert_eq!(
+			hex::encode(Hash160Hasher::hash(plaintext.as_bytes())),
+			expected_hash_hex
+		);
+	}
 }

--- a/stacks-core/src/crypto/mod.rs
+++ b/stacks-core/src/crypto/mod.rs
@@ -17,121 +17,123 @@ struct Hex(String);
 
 /// Hashing trait
 pub trait Hashing<const LENGTH: usize>: Clone + Sized {
-    /// Hash the given data
-    fn hash(data: &[u8]) -> Self;
-    /// Get the bytes of the hash
-    fn as_bytes(&self) -> &[u8];
-    /// Attempt to create a hash from the given bytes
-    fn from_bytes(bytes: &[u8]) -> StacksResult<Self>;
-    /// Create a hash from the given bytes
-    fn new(value: impl AsRef<[u8]>) -> Self {
-        Self::hash(value.as_ref())
-    }
+	/// Hash the given data
+	fn hash(data: &[u8]) -> Self;
+	/// Get the bytes of the hash
+	fn as_bytes(&self) -> &[u8];
+	/// Attempt to create a hash from the given bytes
+	fn from_bytes(bytes: &[u8]) -> StacksResult<Self>;
+	/// Create a hash from the given bytes
+	fn new(value: impl AsRef<[u8]>) -> Self {
+		Self::hash(value.as_ref())
+	}
 
-    /// Create a zeroed hash
-    fn zeroes() -> Self {
-        Self::from_bytes(vec![0; LENGTH].as_slice()).unwrap()
-    }
+	/// Create a zeroed hash
+	fn zeroes() -> Self {
+		Self::from_bytes(vec![0; LENGTH].as_slice()).unwrap()
+	}
 
-    /// Get the checksum of the hash
-    fn checksum(&self) -> [u8; CHECKSUM_LENGTH] {
-        self.as_bytes()[0..CHECKSUM_LENGTH].try_into().unwrap()
-    }
+	/// Get the checksum of the hash
+	fn checksum(&self) -> [u8; CHECKSUM_LENGTH] {
+		self.as_bytes()[0..CHECKSUM_LENGTH].try_into().unwrap()
+	}
 
-    /// Attempt to create a hash from the given hex bytes
-    fn from_hex(data: impl AsRef<str>) -> StacksResult<Self> {
-        Self::from_bytes(&hex::decode(data.as_ref().as_bytes())?)
-    }
+	/// Attempt to create a hash from the given hex bytes
+	fn from_hex(data: impl AsRef<str>) -> StacksResult<Self> {
+		Self::from_bytes(&hex::decode(data.as_ref().as_bytes())?)
+	}
 
-    /// Get the hex representation of the hash
-    fn to_hex(&self) -> String {
-        hex::encode(self.as_bytes())
-    }
+	/// Get the hex representation of the hash
+	fn to_hex(&self) -> String {
+		hex::encode(self.as_bytes())
+	}
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(
+	Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord,
+)]
 #[serde(try_from = "Hex")]
 #[serde(into = "Hex")]
 /// The hasher type
 pub struct Hasher<T, const LENGTH: usize>(T)
 where
-    T: Hashing<LENGTH>;
+	T: Hashing<LENGTH>;
 
 impl<T, const LENGTH: usize> Hashing<LENGTH> for Hasher<T, LENGTH>
 where
-    T: Hashing<LENGTH>,
+	T: Hashing<LENGTH>,
 {
-    fn hash(data: &[u8]) -> Self {
-        Self(T::hash(data))
-    }
+	fn hash(data: &[u8]) -> Self {
+		Self(T::hash(data))
+	}
 
-    fn as_bytes(&self) -> &[u8] {
-        T::as_bytes(&self.0)
-    }
+	fn as_bytes(&self) -> &[u8] {
+		T::as_bytes(&self.0)
+	}
 
-    fn from_bytes(bytes: &[u8]) -> StacksResult<Self> {
-        Ok(Self(T::from_bytes(bytes)?))
-    }
+	fn from_bytes(bytes: &[u8]) -> StacksResult<Self> {
+		Ok(Self(T::from_bytes(bytes)?))
+	}
 }
 
 impl<T, const LENGTH: usize> AsRef<[u8]> for Hasher<T, LENGTH>
 where
-    T: Hashing<LENGTH>,
+	T: Hashing<LENGTH>,
 {
-    fn as_ref(&self) -> &[u8] {
-        self.as_bytes()
-    }
+	fn as_ref(&self) -> &[u8] {
+		self.as_bytes()
+	}
 }
 
 impl<T, const LENGTH: usize> TryFrom<&[u8]> for Hasher<T, LENGTH>
 where
-    T: Hashing<LENGTH>,
+	T: Hashing<LENGTH>,
 {
-    type Error = StacksError;
+	type Error = StacksError;
 
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Self::from_bytes(value)
-    }
+	fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+		Self::from_bytes(value)
+	}
 }
 
 impl<T, const LENGTH: usize> From<[u8; LENGTH]> for Hasher<T, LENGTH>
 where
-    T: Hashing<LENGTH>,
+	T: Hashing<LENGTH>,
 {
-    fn from(value: [u8; LENGTH]) -> Self {
-        Self::from_bytes(&value).unwrap()
-    }
+	fn from(value: [u8; LENGTH]) -> Self {
+		Self::from_bytes(&value).unwrap()
+	}
 }
 
 impl<T, const LENGTH: usize> Default for Hasher<T, LENGTH>
 where
-    T: Hashing<LENGTH>,
+	T: Hashing<LENGTH>,
 {
-    fn default() -> Self {
-        Self::zeroes()
-    }
+	fn default() -> Self {
+		Self::zeroes()
+	}
 }
 
 // From conversion is fallible for this type
 #[allow(clippy::from_over_into)]
 impl<T, const LENGTH: usize> Into<Hex> for Hasher<T, LENGTH>
 where
-    T: Hashing<LENGTH>,
+	T: Hashing<LENGTH>,
 {
-    fn into(self) -> Hex {
-        Hex(hex::encode(self.as_bytes()))
-    }
+	fn into(self) -> Hex {
+		Hex(hex::encode(self.as_bytes()))
+	}
 }
 
 impl<T, const LENGTH: usize> TryFrom<Hex> for Hasher<T, LENGTH>
 where
-    T: Hashing<LENGTH>,
+	T: Hashing<LENGTH>,
 {
-    type Error = StacksError;
+	type Error = StacksError;
 
-    fn try_from(value: Hex) -> Result<Self, Self::Error> {
-        Self::from_bytes(&hex::decode(value.0)?)
-    }
+	fn try_from(value: Hex) -> Result<Self, Self::Error> {
+		Self::from_bytes(&hex::decode(value.0)?)
+	}
 }
 
 /// Stacks private key

--- a/stacks-core/src/crypto/sha256.rs
+++ b/stacks-core/src/crypto/sha256.rs
@@ -3,46 +3,48 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::{
-    crypto::{Hasher, Hashing, Hex},
-    StacksError, StacksResult,
+	crypto::{Hasher, Hashing, Hex},
+	StacksError, StacksResult,
 };
 
 pub(crate) const SHA256_LENGTH: usize = 32;
 
-#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(
+	Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord,
+)]
 #[serde(try_from = "Hex")]
 #[serde(into = "Hex")]
 /// The Sha256 hashing type
 pub struct Sha256Hashing([u8; SHA256_LENGTH]);
 
 impl Hashing<SHA256_LENGTH> for Sha256Hashing {
-    fn hash(data: &[u8]) -> Self {
-        Self(Sha256::digest(data).into())
-    }
+	fn hash(data: &[u8]) -> Self {
+		Self(Sha256::digest(data).into())
+	}
 
-    fn as_bytes(&self) -> &[u8] {
-        &self.0
-    }
+	fn as_bytes(&self) -> &[u8] {
+		&self.0
+	}
 
-    fn from_bytes(bytes: &[u8]) -> StacksResult<Self> {
-        Ok(Self(bytes.try_into()?))
-    }
+	fn from_bytes(bytes: &[u8]) -> StacksResult<Self> {
+		Ok(Self(bytes.try_into()?))
+	}
 }
 
 // From conversion is fallible for this type
 #[allow(clippy::from_over_into)]
 impl Into<Hex> for Sha256Hashing {
-    fn into(self) -> Hex {
-        Hex(hex::encode(self.as_bytes()))
-    }
+	fn into(self) -> Hex {
+		Hex(hex::encode(self.as_bytes()))
+	}
 }
 
 impl TryFrom<Hex> for Sha256Hashing {
-    type Error = StacksError;
+	type Error = StacksError;
 
-    fn try_from(value: Hex) -> Result<Self, Self::Error> {
-        Self::from_bytes(&hex::decode(value.0)?)
-    }
+	fn try_from(value: Hex) -> Result<Self, Self::Error> {
+		Self::from_bytes(&hex::decode(value.0)?)
+	}
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -50,33 +52,33 @@ impl TryFrom<Hex> for Sha256Hashing {
 pub struct DoubleSha256Hashing(Sha256Hashing);
 
 impl Hashing<SHA256_LENGTH> for DoubleSha256Hashing {
-    fn hash(data: &[u8]) -> Self {
-        Self(Sha256Hashing::hash(Sha256Hashing::hash(data).as_bytes()))
-    }
+	fn hash(data: &[u8]) -> Self {
+		Self(Sha256Hashing::hash(Sha256Hashing::hash(data).as_bytes()))
+	}
 
-    fn as_bytes(&self) -> &[u8] {
-        self.0.as_bytes()
-    }
+	fn as_bytes(&self) -> &[u8] {
+		self.0.as_bytes()
+	}
 
-    fn from_bytes(bytes: &[u8]) -> StacksResult<Self> {
-        Ok(Self(Sha256Hashing::from_bytes(bytes)?))
-    }
+	fn from_bytes(bytes: &[u8]) -> StacksResult<Self> {
+		Ok(Self(Sha256Hashing::from_bytes(bytes)?))
+	}
 }
 
 // From conversion is fallible for this type
 #[allow(clippy::from_over_into)]
 impl Into<Hex> for DoubleSha256Hashing {
-    fn into(self) -> Hex {
-        Hex(hex::encode(self.as_bytes()))
-    }
+	fn into(self) -> Hex {
+		Hex(hex::encode(self.as_bytes()))
+	}
 }
 
 impl TryFrom<Hex> for DoubleSha256Hashing {
-    type Error = StacksError;
+	type Error = StacksError;
 
-    fn try_from(value: Hex) -> Result<Self, Self::Error> {
-        Self::from_bytes(&hex::decode(value.0)?)
-    }
+	fn try_from(value: Hex) -> Result<Self, Self::Error> {
+		Self::from_bytes(&hex::decode(value.0)?)
+	}
 }
 
 /// The Sha256 hasher type
@@ -86,67 +88,73 @@ pub type DoubleSha256Hasher = Hasher<DoubleSha256Hashing, SHA256_LENGTH>;
 
 #[cfg(test)]
 mod tests {
-    use crate::uint::Uint256;
+	use super::*;
+	use crate::uint::Uint256;
 
-    use super::*;
+	#[test]
+	fn should_sha256_hash_correctly() {
+		let plaintext = "Hello world";
+		let expected_hash_hex =
+			"64ec88ca00b268e5ba1a35678a1b5316d212f4f366b2477232534a8aeca37f3c";
 
-    #[test]
-    fn should_sha256_hash_correctly() {
-        let plaintext = "Hello world";
-        let expected_hash_hex = "64ec88ca00b268e5ba1a35678a1b5316d212f4f366b2477232534a8aeca37f3c";
+		assert_eq!(
+			hex::encode(Sha256Hasher::hash(plaintext.as_bytes())),
+			expected_hash_hex
+		);
+	}
 
-        assert_eq!(
-            hex::encode(Sha256Hasher::hash(plaintext.as_bytes())),
-            expected_hash_hex
-        );
-    }
+	#[test]
+	fn should_sha256_checksum_correctly() {
+		let plaintext = "Hello world";
+		let expected_checksum_hex = "64ec88ca";
 
-    #[test]
-    fn should_sha256_checksum_correctly() {
-        let plaintext = "Hello world";
-        let expected_checksum_hex = "64ec88ca";
+		assert_eq!(
+			hex::encode(Sha256Hasher::hash(plaintext.as_bytes()).checksum()),
+			expected_checksum_hex
+		);
+	}
 
-        assert_eq!(
-            hex::encode(Sha256Hasher::hash(plaintext.as_bytes()).checksum()),
-            expected_checksum_hex
-        );
-    }
+	#[test]
+	fn should_double_sha256_hash_correctly() {
+		let plaintext = "Hello world";
+		let expected_hash_hex =
+			"f6dc724d119649460e47ce719139e521e082be8a9755c5bece181de046ee65fe";
 
-    #[test]
-    fn should_double_sha256_hash_correctly() {
-        let plaintext = "Hello world";
-        let expected_hash_hex = "f6dc724d119649460e47ce719139e521e082be8a9755c5bece181de046ee65fe";
+		assert_eq!(
+			hex::encode(
+				DoubleSha256Hasher::hash(plaintext.as_bytes()).as_bytes()
+			),
+			expected_hash_hex
+		);
+	}
 
-        assert_eq!(
-            hex::encode(DoubleSha256Hasher::hash(plaintext.as_bytes()).as_bytes()),
-            expected_hash_hex
-        );
-    }
+	#[test]
+	fn should_double_sha256_checksum_correctly() {
+		let plaintext = "Hello world";
+		let expected_checksum_hex = "f6dc724d";
 
-    #[test]
-    fn should_double_sha256_checksum_correctly() {
-        let plaintext = "Hello world";
-        let expected_checksum_hex = "f6dc724d";
+		assert_eq!(
+			hex::encode(
+				DoubleSha256Hasher::hash(plaintext.as_bytes()).checksum()
+			),
+			expected_checksum_hex
+		);
+	}
 
-        assert_eq!(
-            hex::encode(DoubleSha256Hasher::hash(plaintext.as_bytes()).checksum()),
-            expected_checksum_hex
-        );
-    }
+	#[test]
+	fn should_convert_to_uint_correctly() {
+		let expected_num = Uint256::from(0xDEADBEEFDEADBEEF as u64) << 64
+			| Uint256::from(0x0102030405060708 as u64);
+		let num_bytes = hex::decode(
+			"0807060504030201efbeaddeefbeadde00000000000000000000000000000000",
+		)
+		.unwrap();
 
-    #[test]
-    fn should_convert_to_uint_correctly() {
-        let expected_num = Uint256::from(0xDEADBEEFDEADBEEF as u64) << 64
-            | Uint256::from(0x0102030405060708 as u64);
-        let num_bytes =
-            hex::decode("0807060504030201efbeaddeefbeadde00000000000000000000000000000000")
-                .unwrap();
+		let hash = Sha256Hashing(num_bytes.try_into().unwrap());
 
-        let hash = Sha256Hashing(num_bytes.try_into().unwrap());
-
-        assert_eq!(
-            expected_num,
-            Uint256::from_le_bytes(hash.as_bytes()).unwrap()
-        );
-    }
+		assert_eq!(
+			expected_num,
+			Uint256::from_le_bytes(hash.as_bytes()).unwrap()
+		);
+	}
 }

--- a/stacks-core/src/crypto/wif.rs
+++ b/stacks-core/src/crypto/wif.rs
@@ -1,141 +1,145 @@
-/*!
-WIF parsing and construction of Stacks private keys.
-*/
+//! WIF parsing and construction of Stacks private keys.
 
 use bdk::bitcoin::util::base58;
 use strum::{Display, EnumIter, FromRepr, IntoEnumIterator};
 
-use crate::{
-    crypto::{sha256::DoubleSha256Hasher, PrivateKey},
-    Network, StacksError, StacksResult,
-};
-
 use super::Hashing;
+use crate::{
+	crypto::{sha256::DoubleSha256Hasher, PrivateKey},
+	Network, StacksError, StacksResult,
+};
 
 /// Contains validated WIF bytes. It assumess compression is always used.
 pub struct WIF([u8; WIF_LENGTH]);
 
 impl WIF {
-    /// Constructs a WIF from a network and private key
-    pub fn new(network: Network, private_key: PrivateKey) -> Self {
-        let mut bytes = [0u8; WIF_LENGTH];
-        bytes[0] = WIFPrefix::from(network) as u8;
-        bytes[1..33].copy_from_slice(&private_key.secret_bytes());
-        bytes[33] = 0x01;
+	/// Constructs a WIF from a network and private key
+	pub fn new(network: Network, private_key: PrivateKey) -> Self {
+		let mut bytes = [0u8; WIF_LENGTH];
+		bytes[0] = WIFPrefix::from(network) as u8;
+		bytes[1..33].copy_from_slice(&private_key.secret_bytes());
+		bytes[33] = 0x01;
 
-        let bytes_to_hash = bytes[..34].to_vec();
-        bytes[34..].copy_from_slice(&DoubleSha256Hasher::new(bytes_to_hash).as_bytes()[..4]);
+		let bytes_to_hash = bytes[..34].to_vec();
+		bytes[34..].copy_from_slice(
+			&DoubleSha256Hasher::new(bytes_to_hash).as_bytes()[..4],
+		);
 
-        Self(bytes)
-    }
+		Self(bytes)
+	}
 
-    /// Attempts to parse a WIF from a byte slice
-    pub fn from_bytes(bytes: impl AsRef<[u8]>) -> StacksResult<Self> {
-        let bytes: [u8; WIF_LENGTH] = bytes.as_ref().try_into()?;
+	/// Attempts to parse a WIF from a byte slice
+	pub fn from_bytes(bytes: impl AsRef<[u8]>) -> StacksResult<Self> {
+		let bytes: [u8; WIF_LENGTH] = bytes.as_ref().try_into()?;
 
-        let wif = Self(bytes);
-        wif.validate()?;
+		let wif = Self(bytes);
+		wif.validate()?;
 
-        Ok(wif)
-    }
+		Ok(wif)
+	}
 
-    fn validate(&self) -> StacksResult<()> {
-        let valid_network_byte = WIFPrefix::iter().any(|prefix| prefix as u8 == self.0[0]);
-        let valid_private_key = PrivateKey::from_slice(&self.0[1..33]).is_ok();
-        let valid_compression_byte = self.0[33] == 0x01;
-        let valid_checksum = DoubleSha256Hasher::new(&self.0[..34]).as_ref()[..4] == self.0[34..];
+	fn validate(&self) -> StacksResult<()> {
+		let valid_network_byte =
+			WIFPrefix::iter().any(|prefix| prefix as u8 == self.0[0]);
+		let valid_private_key = PrivateKey::from_slice(&self.0[1..33]).is_ok();
+		let valid_compression_byte = self.0[33] == 0x01;
+		let valid_checksum = DoubleSha256Hasher::new(&self.0[..34]).as_ref()
+			[..4] == self.0[34..];
 
-        if valid_network_byte && valid_private_key && valid_compression_byte && valid_checksum {
-            Ok(())
-        } else {
-            Err(StacksError::InvalidData("WIF is invalid"))
-        }
-    }
+		if valid_network_byte
+			&& valid_private_key
+			&& valid_compression_byte
+			&& valid_checksum
+		{
+			Ok(())
+		} else {
+			Err(StacksError::InvalidData("WIF is invalid"))
+		}
+	}
 
-    /// Returns the network
-    pub fn network(&self) -> StacksResult<Network> {
-        match WIFPrefix::from_repr(self.0[0]) {
-            Some(WIFPrefix::Mainnet) => Ok(Network::Mainnet),
-            Some(WIFPrefix::Testnet) => Ok(Network::Testnet),
-            _ => Err(StacksError::InvalidData("Unknown network byte")),
-        }
-    }
+	/// Returns the network
+	pub fn network(&self) -> StacksResult<Network> {
+		match WIFPrefix::from_repr(self.0[0]) {
+			Some(WIFPrefix::Mainnet) => Ok(Network::Mainnet),
+			Some(WIFPrefix::Testnet) => Ok(Network::Testnet),
+			_ => Err(StacksError::InvalidData("Unknown network byte")),
+		}
+	}
 
-    /// Returns the private key
-    pub fn private_key(&self) -> StacksResult<PrivateKey> {
-        Ok(PrivateKey::from_slice(&self.0[1..33])?)
-    }
+	/// Returns the private key
+	pub fn private_key(&self) -> StacksResult<PrivateKey> {
+		Ok(PrivateKey::from_slice(&self.0[1..33])?)
+	}
 }
 
-/**
-WIF length consists of:
-
-1. [WIFPrefix] byte
-2. Private key bytes (32 bytes)
-3. Compression byte
-4. Checksum bytes ( 4 bytes)
-*/
+/// WIF length consists of:
+///
+/// 1. [WIFPrefix] byte
+/// 2. Private key bytes (32 bytes)
+/// 3. Compression byte
+/// 4. Checksum bytes ( 4 bytes)
 pub const WIF_LENGTH: usize = 38;
 
 /// WIF network prefix byte
 #[derive(Debug, Clone, Copy, Display, PartialEq, Eq, EnumIter, FromRepr)]
 #[repr(u8)]
 pub enum WIFPrefix {
-    /// Mainnet
-    Mainnet = 128,
-    /// Testnet
-    Testnet = 239,
+	/// Mainnet
+	Mainnet = 128,
+	/// Testnet
+	Testnet = 239,
 }
 
 impl From<Network> for WIFPrefix {
-    fn from(value: Network) -> Self {
-        match value {
-            Network::Mainnet => Self::Mainnet,
-            Network::Testnet => Self::Testnet,
-        }
-    }
+	fn from(value: Network) -> Self {
+		match value {
+			Network::Mainnet => Self::Mainnet,
+			Network::Testnet => Self::Testnet,
+		}
+	}
 }
 
 impl TryFrom<String> for WIF {
-    type Error = StacksError;
+	type Error = StacksError;
 
-    fn try_from(value: String) -> Result<Self, Self::Error> {
-        let wif = Self::from_bytes(base58::from(&value)?)?;
-        wif.validate()?;
+	fn try_from(value: String) -> Result<Self, Self::Error> {
+		let wif = Self::from_bytes(base58::from(&value)?)?;
+		wif.validate()?;
 
-        Ok(wif)
-    }
+		Ok(wif)
+	}
 }
 
 impl ToString for WIF {
-    fn to_string(&self) -> String {
-        base58::encode_slice(&self.0)
-    }
+	fn to_string(&self) -> String {
+		base58::encode_slice(&self.0)
+	}
 }
 
 #[cfg(test)]
 mod tests {
 
-    use bdk::bitcoin::secp256k1::Secp256k1;
-    use rand::thread_rng;
+	use bdk::bitcoin::secp256k1::Secp256k1;
+	use rand::thread_rng;
 
-    use super::*;
+	use super::*;
 
-    #[test]
-    fn wif() {
-        let pk = Secp256k1::new().generate_keypair(&mut thread_rng()).0;
+	#[test]
+	fn wif() {
+		let pk = Secp256k1::new().generate_keypair(&mut thread_rng()).0;
 
-        for network in Network::iter() {
-            let wif = WIF::new(network, pk);
+		for network in Network::iter() {
+			let wif = WIF::new(network, pk);
 
-            assert_eq!(wif.network().unwrap(), network);
-            assert_eq!(wif.private_key().unwrap(), pk);
+			assert_eq!(wif.network().unwrap(), network);
+			assert_eq!(wif.private_key().unwrap(), pk);
 
-            let bitcoin_pk = bdk::bitcoin::PrivateKey::from_wif(&wif.to_string()).unwrap();
+			let bitcoin_pk =
+				bdk::bitcoin::PrivateKey::from_wif(&wif.to_string()).unwrap();
 
-            assert_eq!(pk.secret_bytes().as_slice(), &bitcoin_pk.to_bytes());
-            assert_eq!(wif.to_string(), bitcoin_pk.to_wif());
-            assert_eq!(bitcoin_pk.network, network.into());
-        }
-    }
+			assert_eq!(pk.secret_bytes().as_slice(), &bitcoin_pk.to_bytes());
+			assert_eq!(wif.to_string(), bitcoin_pk.to_wif());
+			assert_eq!(bitcoin_pk.network, network.into());
+		}
+	}
 }

--- a/stacks-core/src/lib.rs
+++ b/stacks-core/src/lib.rs
@@ -1,8 +1,6 @@
 #![forbid(missing_docs)]
 #![doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/README.md"))]
-/*!
-# stacks-core library: a library for interacting with the Stacks protocol
-*/
+//! # stacks-core library: a library for interacting with the Stacks protocol
 
 use std::{array::TryFromSliceError, io};
 
@@ -30,42 +28,42 @@ pub mod wallet;
 /// Error type for the stacks-core library
 #[derive(Error, Debug)]
 pub enum StacksError {
-    #[error("Invalid arguments: {0}")]
-    /// Invalid arguments
-    InvalidArguments(&'static str),
-    #[error("Could not crackford32 encode or decode: {0}")]
-    /// C32 encoding or decoding error
-    C32Error(#[from] c32::C32Error),
-    #[error("Address version is invalid: {0}")]
-    /// Invalid address version
-    InvalidAddressVersion(u8),
-    #[error("Could not build array from slice: {0}")]
-    /// Invalid slice length
-    InvalidSliceLength(#[from] TryFromSliceError),
-    #[error("Could not encode or decode hex: {0}")]
-    /// Hex encoding or decoding error due
-    BadHex(#[from] hex::FromHexError),
-    #[error("Could not create Uint from {0} bytes")]
-    /// Invalid Uint bytes
-    InvalidUintBytes(usize),
-    #[error("Codec error: {0}")]
-    /// Codec error
-    CodecError(#[from] CodecError),
-    #[error("Invalid data: {0}")]
-    /// Invalid data
-    InvalidData(&'static str),
-    /// BIP32 Error
-    #[error("BIP32 error: {0}")]
-    BIP32(#[from] bdk::bitcoin::util::bip32::Error),
-    /// BIP32 Error
-    #[error("BIP39 error: {0}")]
-    BIP39(#[from] bdk::keys::bip39::Error),
-    /// SECP Error
-    #[error("SECP error: {0}")]
-    SECP(#[from] bdk::bitcoin::secp256k1::Error),
-    /// Base58 Error
-    #[error("Base58 error: {0}")]
-    Base58(#[from] bdk::bitcoin::util::base58::Error),
+	#[error("Invalid arguments: {0}")]
+	/// Invalid arguments
+	InvalidArguments(&'static str),
+	#[error("Could not crackford32 encode or decode: {0}")]
+	/// C32 encoding or decoding error
+	C32Error(#[from] c32::C32Error),
+	#[error("Address version is invalid: {0}")]
+	/// Invalid address version
+	InvalidAddressVersion(u8),
+	#[error("Could not build array from slice: {0}")]
+	/// Invalid slice length
+	InvalidSliceLength(#[from] TryFromSliceError),
+	#[error("Could not encode or decode hex: {0}")]
+	/// Hex encoding or decoding error due
+	BadHex(#[from] hex::FromHexError),
+	#[error("Could not create Uint from {0} bytes")]
+	/// Invalid Uint bytes
+	InvalidUintBytes(usize),
+	#[error("Codec error: {0}")]
+	/// Codec error
+	CodecError(#[from] CodecError),
+	#[error("Invalid data: {0}")]
+	/// Invalid data
+	InvalidData(&'static str),
+	/// BIP32 Error
+	#[error("BIP32 error: {0}")]
+	BIP32(#[from] bdk::bitcoin::util::bip32::Error),
+	/// BIP32 Error
+	#[error("BIP39 error: {0}")]
+	BIP39(#[from] bdk::keys::bip39::Error),
+	/// SECP Error
+	#[error("SECP error: {0}")]
+	SECP(#[from] bdk::bitcoin::secp256k1::Error),
+	/// Base58 Error
+	#[error("Base58 error: {0}")]
+	Base58(#[from] bdk::bitcoin::util::base58::Error),
 }
 
 /// Result type for the stacks-core library
@@ -75,84 +73,84 @@ pub type StacksResult<T> = Result<T, StacksError>;
 pub struct BlockId(Uint256);
 
 impl BlockId {
-    /// Creates a new StacksBlockId from a slice of bytes
-    pub fn new(number: Uint256) -> StacksResult<Self> {
-        Ok(Self(number))
-    }
+	/// Creates a new StacksBlockId from a slice of bytes
+	pub fn new(number: Uint256) -> StacksResult<Self> {
+		Ok(Self(number))
+	}
 }
 
 impl Codec for BlockId {
-    fn codec_serialize<W: io::Write>(&self, dest: &mut W) -> io::Result<()> {
-        self.0.codec_serialize(dest)
-    }
+	fn codec_serialize<W: io::Write>(&self, dest: &mut W) -> io::Result<()> {
+		self.0.codec_serialize(dest)
+	}
 
-    fn codec_deserialize<R: io::Read>(data: &mut R) -> io::Result<Self>
-    where
-        Self: Sized,
-    {
-        Ok(Self(Uint256::codec_deserialize(data)?))
-    }
+	fn codec_deserialize<R: io::Read>(data: &mut R) -> io::Result<Self>
+	where
+		Self: Sized,
+	{
+		Ok(Self(Uint256::codec_deserialize(data)?))
+	}
 }
 
 /// Stacks network kind
 #[repr(u8)]
 #[derive(
-    Debug,
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    EnumString,
-    Display,
-    EnumIter,
-    FromRepr,
-    Serialize,
-    Deserialize,
+	Debug,
+	Clone,
+	Copy,
+	PartialEq,
+	Eq,
+	EnumString,
+	Display,
+	EnumIter,
+	FromRepr,
+	Serialize,
+	Deserialize,
 )]
 #[strum(ascii_case_insensitive)]
 #[strum(serialize_all = "lowercase")]
 #[serde(try_from = "String", into = "String")]
 pub enum Network {
-    /// Mainnet
-    Mainnet = 0,
-    /// Testnet
-    Testnet = 1,
+	/// Mainnet
+	Mainnet = 0,
+	/// Testnet
+	Testnet = 1,
 }
 
 impl TryFrom<String> for Network {
-    type Error = strum::ParseError;
+	type Error = strum::ParseError;
 
-    fn try_from(value: String) -> Result<Self, Self::Error> {
-        Self::try_from(value.as_str())
-    }
+	fn try_from(value: String) -> Result<Self, Self::Error> {
+		Self::try_from(value.as_str())
+	}
 }
 
 // Other way around is fallible, so we don't implement it
 #[allow(clippy::from_over_into)]
 impl Into<String> for Network {
-    fn into(self) -> String {
-        self.to_string()
-    }
+	fn into(self) -> String {
+		self.to_string()
+	}
 }
 
 // For some reason From impl fails to compile
 #[allow(clippy::from_over_into)]
 impl Into<Network> for BitcoinNetwork {
-    fn into(self) -> Network {
-        match self {
-            BitcoinNetwork::Bitcoin => Network::Mainnet,
-            _ => Network::Testnet,
-        }
-    }
+	fn into(self) -> Network {
+		match self {
+			BitcoinNetwork::Bitcoin => Network::Mainnet,
+			_ => Network::Testnet,
+		}
+	}
 }
 
 // For some reason From impl fails to compile
 #[allow(clippy::from_over_into)]
 impl Into<BitcoinNetwork> for Network {
-    fn into(self) -> BitcoinNetwork {
-        match self {
-            Network::Mainnet => BitcoinNetwork::Bitcoin,
-            Network::Testnet => BitcoinNetwork::Testnet,
-        }
-    }
+	fn into(self) -> BitcoinNetwork {
+		match self {
+			Network::Mainnet => BitcoinNetwork::Bitcoin,
+			Network::Testnet => BitcoinNetwork::Testnet,
+		}
+	}
 }

--- a/stacks-core/src/uint.rs
+++ b/stacks-core/src/uint.rs
@@ -1,25 +1,24 @@
 use std::{
-    cmp::Ordering,
-    fmt, io,
-    mem::transmute,
-    ops::{Add, BitAnd, BitOr, BitXor, Div, Mul, Not, Shl, Shr, Sub},
+	cmp::Ordering,
+	fmt, io,
+	mem::transmute,
+	ops::{Add, BitAnd, BitOr, BitXor, Div, Mul, Not, Shl, Shr, Sub},
 };
 
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    codec::Codec,
-    crypto::{
-        sha256::{DoubleSha256Hasher, SHA256_LENGTH},
-        Hashing,
-    },
-    StacksError, StacksResult,
+	codec::Codec,
+	crypto::{
+		sha256::{DoubleSha256Hasher, SHA256_LENGTH},
+		Hashing,
+	},
+	StacksError, StacksResult,
 };
 
-/**
-A structure that represents large integers and provides basic arithmetic.
-It accepts a const generic `N` which controls the number of u64s used to represent the number.
-*/
+/// A structure that represents large integers and provides basic arithmetic.
+/// It accepts a const generic `N` which controls the number of u64s used to
+/// represent the number.
 #[derive(Serialize, Deserialize, PartialEq, Eq, Clone, Copy)]
 #[serde(try_from = "Vec<u64>")]
 #[serde(into = "Vec<u64>")]
@@ -27,565 +26,572 @@ It accepts a const generic `N` which controls the number of u64s used to represe
 pub struct Uint<const N: usize>([u64; N]);
 
 impl<const N: usize> Uint<N> {
-    /// The maximum value that can be represented by this type
-    pub const MAX: Self = Self([0xffffffffffffffff; N]);
-    /// The minimum value that can be represented by this type
-    pub const MIN: Self = Self([0; N]);
+	/// The maximum value that can be represented by this type
+	pub const MAX: Self = Self([0xffffffffffffffff; N]);
+	/// The minimum value that can be represented by this type
+	pub const MIN: Self = Self([0; N]);
 
-    /// Build a Uint from a u64 array
-    pub fn from_u64_array(data: [u64; N]) -> Self {
-        Self(data)
-    }
+	/// Build a Uint from a u64 array
+	pub fn from_u64_array(data: [u64; N]) -> Self {
+		Self(data)
+	}
 
-    /// Conversion to u32
-    pub fn low_u32(&self) -> u32 {
-        self.0[0] as u32
-    }
+	/// Conversion to u32
+	pub fn low_u32(&self) -> u32 {
+		self.0[0] as u32
+	}
 
-    /// Conversion to u64
-    pub fn low_u64(&self) -> u64 {
-        self.0[0]
-    }
+	/// Conversion to u64
+	pub fn low_u64(&self) -> u64 {
+		self.0[0]
+	}
 
-    /// Return the least number of bits needed to represent the number
-    pub fn bits(&self) -> usize {
-        for i in 1..N {
-            if self.0[N - i] > 0 {
-                return (0x40 * (N - i + 1)) - self.0[N - i].leading_zeros() as usize;
-            }
-        }
+	/// Return the least number of bits needed to represent the number
+	pub fn bits(&self) -> usize {
+		for i in 1..N {
+			if self.0[N - i] > 0 {
+				return (0x40 * (N - i + 1))
+					- self.0[N - i].leading_zeros() as usize;
+			}
+		}
 
-        0x40 - self.0[0].leading_zeros() as usize
-    }
+		0x40 - self.0[0].leading_zeros() as usize
+	}
 
-    /// Multiply by a u32
-    pub fn mul_u32(self, other: u32) -> Self {
-        let mut carry = [0u64; N];
-        let mut ret = [0u64; N];
+	/// Multiply by a u32
+	pub fn mul_u32(self, other: u32) -> Self {
+		let mut carry = [0u64; N];
+		let mut ret = [0u64; N];
 
-        for i in 0..N {
-            let not_last_word = i < N - 1;
-            let upper = other as u64 * (self.0[i] >> 32);
-            let lower = other as u64 * (self.0[i] & 0xFFFFFFFF);
+		for i in 0..N {
+			let not_last_word = i < N - 1;
+			let upper = other as u64 * (self.0[i] >> 32);
+			let lower = other as u64 * (self.0[i] & 0xFFFFFFFF);
 
-            if not_last_word {
-                carry[i + 1] += upper >> 32;
-            }
+			if not_last_word {
+				carry[i + 1] += upper >> 32;
+			}
 
-            let (sum, overflow) = lower.overflowing_add(upper << 32);
-            ret[i] = sum;
+			let (sum, overflow) = lower.overflowing_add(upper << 32);
+			ret[i] = sum;
 
-            if overflow && not_last_word {
-                carry[i + 1] += 1;
-            }
-        }
+			if overflow && not_last_word {
+				carry[i + 1] += 1;
+			}
+		}
 
-        Self(ret) + Self(carry)
-    }
+		Self(ret) + Self(carry)
+	}
 
-    /// To litte-endian byte array
-    pub fn to_le_bytes(&self) -> Vec<u8> {
-        let mut buffer = vec![0; N * 8];
+	/// To litte-endian byte array
+	pub fn to_le_bytes(&self) -> Vec<u8> {
+		let mut buffer = vec![0; N * 8];
 
-        self.0
-            .iter()
-            .flat_map(|part| part.to_le_bytes())
-            .enumerate()
-            .for_each(|(i, byte)| buffer[i] = byte);
+		self.0
+			.iter()
+			.flat_map(|part| part.to_le_bytes())
+			.enumerate()
+			.for_each(|(i, byte)| buffer[i] = byte);
 
-        buffer
-    }
+		buffer
+	}
 
-    /// To big-endian byte array
-    pub fn to_be_bytes(&self) -> Vec<u8> {
-        let mut ret = vec![0; N * 8];
+	/// To big-endian byte array
+	pub fn to_be_bytes(&self) -> Vec<u8> {
+		let mut ret = vec![0; N * 8];
 
-        for i in 0..N {
-            let word_end = N * 8 - (i * 8);
-            let word_start = word_end - 8;
+		for i in 0..N {
+			let word_end = N * 8 - (i * 8);
+			let word_start = word_end - 8;
 
-            ret[word_start..word_end].copy_from_slice(&self.0[i].to_be_bytes());
-        }
+			ret[word_start..word_end].copy_from_slice(&self.0[i].to_be_bytes());
+		}
 
-        ret
-    }
+		ret
+	}
 
-    /// Build from a little-endian hex string (padding expected)
-    pub fn from_le_bytes(bytes: impl AsRef<[u8]>) -> StacksResult<Self> {
-        let bytes = bytes.as_ref();
+	/// Build from a little-endian hex string (padding expected)
+	pub fn from_le_bytes(bytes: impl AsRef<[u8]>) -> StacksResult<Self> {
+		let bytes = bytes.as_ref();
 
-        if bytes.len() % 8 != 0 {
-            return Err(StacksError::InvalidUintBytes(bytes.len()));
-        }
+		if bytes.len() % 8 != 0 {
+			return Err(StacksError::InvalidUintBytes(bytes.len()));
+		}
 
-        if bytes.len() / 8 != N {
-            return Err(StacksError::InvalidUintBytes(bytes.len()));
-        }
+		if bytes.len() / 8 != N {
+			return Err(StacksError::InvalidUintBytes(bytes.len()));
+		}
 
-        let mut ret = [0u64; N];
-        for i in 0..(bytes.len() / 8) {
-            let mut next_bytes = [0u8; 8];
-            next_bytes.copy_from_slice(&bytes[8 * i..(8 * (i + 1))]);
+		let mut ret = [0u64; N];
+		for i in 0..(bytes.len() / 8) {
+			let mut next_bytes = [0u8; 8];
+			next_bytes.copy_from_slice(&bytes[8 * i..(8 * (i + 1))]);
 
-            let next = u64::from_le_bytes(next_bytes);
+			let next = u64::from_le_bytes(next_bytes);
 
-            ret[i] = next;
-        }
+			ret[i] = next;
+		}
 
-        Ok(Self(ret))
-    }
+		Ok(Self(ret))
+	}
 
-    /// Build from a big-endian hex string (padding expected)
-    pub fn from_be_bytes(bytes: impl AsRef<[u8]>) -> StacksResult<Self> {
-        let bytes = bytes.as_ref();
+	/// Build from a big-endian hex string (padding expected)
+	pub fn from_be_bytes(bytes: impl AsRef<[u8]>) -> StacksResult<Self> {
+		let bytes = bytes.as_ref();
 
-        if bytes.len() % 8 != 0 {
-            return Err(StacksError::InvalidUintBytes(bytes.len()));
-        }
+		if bytes.len() % 8 != 0 {
+			return Err(StacksError::InvalidUintBytes(bytes.len()));
+		}
 
-        if bytes.len() / 8 != N {
-            return Err(StacksError::InvalidUintBytes(bytes.len()));
-        }
+		if bytes.len() / 8 != N {
+			return Err(StacksError::InvalidUintBytes(bytes.len()));
+		}
 
-        let mut ret = [0u64; N];
-        for i in 0..(bytes.len() / 8) {
-            let mut next_bytes = [0u8; 8];
-            next_bytes.copy_from_slice(&bytes[8 * i..(8 * (i + 1))]);
+		let mut ret = [0u64; N];
+		for i in 0..(bytes.len() / 8) {
+			let mut next_bytes = [0u8; 8];
+			next_bytes.copy_from_slice(&bytes[8 * i..(8 * (i + 1))]);
 
-            let next = u64::from_be_bytes(next_bytes);
+			let next = u64::from_be_bytes(next_bytes);
 
-            ret[(bytes.len() / 8) - 1 - i] = next;
-        }
+			ret[(bytes.len() / 8) - 1 - i] = next;
+		}
 
-        Ok(Self(ret))
-    }
+		Ok(Self(ret))
+	}
 
-    /// Convert to a little-endian hex string
-    pub fn to_le_hex(&self) -> String {
-        hex::encode(self.to_le_bytes())
-    }
+	/// Convert to a little-endian hex string
+	pub fn to_le_hex(&self) -> String {
+		hex::encode(self.to_le_bytes())
+	}
 
-    /// Convert to a big-endian hex string
-    pub fn to_be_hex(&self) -> String {
-        hex::encode(self.to_be_bytes())
-    }
+	/// Convert to a big-endian hex string
+	pub fn to_be_hex(&self) -> String {
+		hex::encode(self.to_be_bytes())
+	}
 
-    /// Build from a little-endian hex string
-    pub fn from_le_hex(data: impl AsRef<str>) -> StacksResult<Self> {
-        Self::from_le_bytes(hex::decode(data.as_ref())?)
-    }
+	/// Build from a little-endian hex string
+	pub fn from_le_hex(data: impl AsRef<str>) -> StacksResult<Self> {
+		Self::from_le_bytes(hex::decode(data.as_ref())?)
+	}
 
-    /// Build from a big-endian hex string
-    pub fn from_be_hex(data: impl AsRef<str>) -> StacksResult<Self> {
-        Self::from_be_bytes(hex::decode(data.as_ref())?)
-    }
+	/// Build from a big-endian hex string
+	pub fn from_be_hex(data: impl AsRef<str>) -> StacksResult<Self> {
+		Self::from_be_bytes(hex::decode(data.as_ref())?)
+	}
 
-    /// Wrapping add by one operation
-    pub fn increment(&mut self) {
-        let &mut Uint(ref mut arr) = self;
+	/// Wrapping add by one operation
+	pub fn increment(&mut self) {
+		let &mut Uint(ref mut arr) = self;
 
-        for item in arr.iter_mut().take(N) {
-            *item = item.wrapping_add(1);
+		for item in arr.iter_mut().take(N) {
+			*item = item.wrapping_add(1);
 
-            if *item != 0 {
-                break;
-            }
-        }
-    }
+			if *item != 0 {
+				break;
+			}
+		}
+	}
 
-    /// Create a new Uint from the provided Uint
-    pub fn from_uint<const M: usize>(source: impl AsRef<Uint<M>>) -> Self {
-        assert!(M < N, "Cannot convert larger Uint to smaller");
+	/// Create a new Uint from the provided Uint
+	pub fn from_uint<const M: usize>(source: impl AsRef<Uint<M>>) -> Self {
+		assert!(M < N, "Cannot convert larger Uint to smaller");
 
-        let source = source.as_ref();
-        let mut dest = [0u64; N];
+		let source = source.as_ref();
+		let mut dest = [0u64; N];
 
-        dest[..M].copy_from_slice(&source.0[..M]);
+		dest[..M].copy_from_slice(&source.0[..M]);
 
-        Uint(dest)
-    }
+		Uint(dest)
+	}
 
-    /// Create a new Uint from the provided Uint, truncating if necessary
-    pub fn from_uint_lossy<const M: usize>(source: impl AsRef<Uint<M>>) -> Self {
-        let source = source.as_ref();
-        let mut dest = [0u64; N];
-        let bytes_shared = M.min(N);
+	/// Create a new Uint from the provided Uint, truncating if necessary
+	pub fn from_uint_lossy<const M: usize>(
+		source: impl AsRef<Uint<M>>,
+	) -> Self {
+		let source = source.as_ref();
+		let mut dest = [0u64; N];
+		let bytes_shared = M.min(N);
 
-        dest[..bytes_shared].copy_from_slice(&source.0[..bytes_shared]);
+		dest[..bytes_shared].copy_from_slice(&source.0[..bytes_shared]);
 
-        Uint(dest)
-    }
+		Uint(dest)
+	}
 
-    /// Convert to a smaller Uint
-    pub fn to_uint<const M: usize>(&self) -> Uint<M> {
-        assert!(M >= N, "Cannot convert larger Uint to smaller");
+	/// Convert to a smaller Uint
+	pub fn to_uint<const M: usize>(&self) -> Uint<M> {
+		assert!(M >= N, "Cannot convert larger Uint to smaller");
 
-        let mut dest = [0u64; M];
+		let mut dest = [0u64; M];
 
-        dest[..M].copy_from_slice(&self.0[..M]);
+		dest[..M].copy_from_slice(&self.0[..M]);
 
-        Uint(dest)
-    }
+		Uint(dest)
+	}
 
-    /// Convert to a smaller Uint, truncating if necessary
-    pub fn to_uint_lossy<const M: usize>(&self) -> Uint<M> {
-        let mut dest = [0u64; M];
-        let bytes_shared = M.min(N);
+	/// Convert to a smaller Uint, truncating if necessary
+	pub fn to_uint_lossy<const M: usize>(&self) -> Uint<M> {
+		let mut dest = [0u64; M];
+		let bytes_shared = M.min(N);
 
-        dest[..bytes_shared].copy_from_slice(&self.0[..bytes_shared]);
+		dest[..bytes_shared].copy_from_slice(&self.0[..bytes_shared]);
 
-        Uint(dest)
-    }
+		Uint(dest)
+	}
 
-    fn one() -> Self {
-        let mut ret = [0; N];
-        ret[0] = 1;
+	fn one() -> Self {
+		let mut ret = [0; N];
+		ret[0] = 1;
 
-        Uint(ret)
-    }
+		Uint(ret)
+	}
 }
 
 impl<const N: usize> Add<Uint<N>> for Uint<N> {
-    type Output = Self;
+	type Output = Self;
 
-    fn add(self, other: Self) -> Self {
-        let Self(ref me) = self;
-        let Self(ref you) = other;
+	fn add(self, other: Self) -> Self {
+		let Self(ref me) = self;
+		let Self(ref you) = other;
 
-        let mut ret = [0u64; N];
-        let mut carry = [0u64; N];
-        let mut b_carry = false;
+		let mut ret = [0u64; N];
+		let mut carry = [0u64; N];
+		let mut b_carry = false;
 
-        for i in 0..N {
-            ret[i] = me[i].wrapping_add(you[i]);
-            if i < N - 1 && ret[i] < me[i] {
-                carry[i + 1] = 1;
-                b_carry = true;
-            }
-        }
+		for i in 0..N {
+			ret[i] = me[i].wrapping_add(you[i]);
+			if i < N - 1 && ret[i] < me[i] {
+				carry[i + 1] = 1;
+				b_carry = true;
+			}
+		}
 
-        if b_carry {
-            Self(ret) + Self(carry)
-        } else {
-            Self(ret)
-        }
-    }
+		if b_carry {
+			Self(ret) + Self(carry)
+		} else {
+			Self(ret)
+		}
+	}
 }
 
 impl<const N: usize> Sub<Uint<N>> for Uint<N> {
-    type Output = Self;
+	type Output = Self;
 
-    fn sub(self, other: Self) -> Self {
-        self + !other + Self::one()
-    }
+	fn sub(self, other: Self) -> Self {
+		self + !other + Self::one()
+	}
 }
 
 impl<const N: usize> Mul<Uint<N>> for Uint<N> {
-    type Output = Self;
+	type Output = Self;
 
-    fn mul(self, other: Self) -> Self {
-        let mut me = Self::MIN;
+	fn mul(self, other: Self) -> Self {
+		let mut me = Self::MIN;
 
-        for i in 0..(2 * N) {
-            let to_mul = (other >> (32 * i)).low_u32();
-            me = me + (self.mul_u32(to_mul) << (32 * i));
-        }
-        me
-    }
+		for i in 0..(2 * N) {
+			let to_mul = (other >> (32 * i)).low_u32();
+			me = me + (self.mul_u32(to_mul) << (32 * i));
+		}
+		me
+	}
 }
 
 impl<const N: usize> Div<Uint<N>> for Uint<N> {
-    type Output = Self;
+	type Output = Self;
 
-    fn div(self, other: Self) -> Self {
-        let mut sub_copy = self;
-        let mut shift_copy = other;
-        let mut ret = [0u64; N];
+	fn div(self, other: Self) -> Self {
+		let mut sub_copy = self;
+		let mut shift_copy = other;
+		let mut ret = [0u64; N];
 
-        let my_bits = self.bits();
-        let your_bits = other.bits();
+		let my_bits = self.bits();
+		let your_bits = other.bits();
 
-        // Check for division by 0
-        assert!(your_bits != 0);
+		// Check for division by 0
+		assert!(your_bits != 0);
 
-        // Early return in case we are dividing by a larger number than us
-        if my_bits < your_bits {
-            return Self(ret);
-        }
+		// Early return in case we are dividing by a larger number than us
+		if my_bits < your_bits {
+			return Self(ret);
+		}
 
-        // Bitwise long division
-        let mut shift = my_bits - your_bits;
-        shift_copy = shift_copy << shift;
+		// Bitwise long division
+		let mut shift = my_bits - your_bits;
+		shift_copy = shift_copy << shift;
 
-        loop {
-            if sub_copy >= shift_copy {
-                ret[shift / 64] |= 1 << (shift % 64);
-                sub_copy = sub_copy - shift_copy;
-            }
-            shift_copy = shift_copy >> 1;
+		loop {
+			if sub_copy >= shift_copy {
+				ret[shift / 64] |= 1 << (shift % 64);
+				sub_copy = sub_copy - shift_copy;
+			}
+			shift_copy = shift_copy >> 1;
 
-            if shift == 0 {
-                break;
-            }
+			if shift == 0 {
+				break;
+			}
 
-            shift -= 1;
-        }
+			shift -= 1;
+		}
 
-        Self(ret)
-    }
+		Self(ret)
+	}
 }
 
 impl<const N: usize> Ord for Uint<N> {
-    fn cmp(&self, other: &Self) -> ::std::cmp::Ordering {
-        // manually implement comparison to get little-endian ordering
-        // (we need this for our numeric types; non-numeric ones shouldn't
-        // be ordered anyway except to put them in BTrees or whatever, and
-        // they don't care how we order as long as we're consisistent).
-        for i in 0..N {
-            if self.0[N - 1 - i] < other.0[N - 1 - i] {
-                return Ordering::Less;
-            }
+	fn cmp(&self, other: &Self) -> ::std::cmp::Ordering {
+		// manually implement comparison to get little-endian ordering
+		// (we need this for our numeric types; non-numeric ones shouldn't
+		// be ordered anyway except to put them in BTrees or whatever, and
+		// they don't care how we order as long as we're consisistent).
+		for i in 0..N {
+			if self.0[N - 1 - i] < other.0[N - 1 - i] {
+				return Ordering::Less;
+			}
 
-            if self.0[N - 1 - i] > other.0[N - 1 - i] {
-                return Ordering::Greater;
-            }
-        }
+			if self.0[N - 1 - i] > other.0[N - 1 - i] {
+				return Ordering::Greater;
+			}
+		}
 
-        Ordering::Equal
-    }
+		Ordering::Equal
+	}
 }
 
 impl<const N: usize> PartialOrd for Uint<N> {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
+	fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+		Some(self.cmp(other))
+	}
 }
 
 impl<const N: usize> Default for Uint<N> {
-    fn default() -> Self {
-        Self::MIN
-    }
+	fn default() -> Self {
+		Self::MIN
+	}
 }
 
 impl<const N: usize> BitAnd<Uint<N>> for Uint<N> {
-    type Output = Uint<N>;
+	type Output = Uint<N>;
 
-    fn bitand(self, other: Uint<N>) -> Self {
-        let Uint(ref arr1) = self;
-        let Uint(ref arr2) = other;
+	fn bitand(self, other: Uint<N>) -> Self {
+		let Uint(ref arr1) = self;
+		let Uint(ref arr2) = other;
 
-        let mut ret = [0u64; N];
-        for i in 0..N {
-            ret[i] = arr1[i] & arr2[i];
-        }
+		let mut ret = [0u64; N];
+		for i in 0..N {
+			ret[i] = arr1[i] & arr2[i];
+		}
 
-        Uint(ret)
-    }
+		Uint(ret)
+	}
 }
 
 impl<const N: usize> BitXor<Uint<N>> for Uint<N> {
-    type Output = Uint<N>;
+	type Output = Uint<N>;
 
-    fn bitxor(self, other: Uint<N>) -> Self {
-        let Uint(ref arr1) = self;
-        let Uint(ref arr2) = other;
+	fn bitxor(self, other: Uint<N>) -> Self {
+		let Uint(ref arr1) = self;
+		let Uint(ref arr2) = other;
 
-        let mut ret = [0u64; N];
-        for i in 0..N {
-            ret[i] = arr1[i] ^ arr2[i];
-        }
+		let mut ret = [0u64; N];
+		for i in 0..N {
+			ret[i] = arr1[i] ^ arr2[i];
+		}
 
-        Uint(ret)
-    }
+		Uint(ret)
+	}
 }
 
 impl<const N: usize> BitOr<Uint<N>> for Uint<N> {
-    type Output = Uint<N>;
+	type Output = Uint<N>;
 
-    fn bitor(self, other: Uint<N>) -> Self {
-        let Uint(ref arr1) = self;
-        let Uint(ref arr2) = other;
+	fn bitor(self, other: Uint<N>) -> Self {
+		let Uint(ref arr1) = self;
+		let Uint(ref arr2) = other;
 
-        let mut ret = [0u64; N];
-        for i in 0..N {
-            ret[i] = arr1[i] | arr2[i];
-        }
+		let mut ret = [0u64; N];
+		for i in 0..N {
+			ret[i] = arr1[i] | arr2[i];
+		}
 
-        Uint(ret)
-    }
+		Uint(ret)
+	}
 }
 
 impl<const N: usize> Not for Uint<N> {
-    type Output = Uint<N>;
+	type Output = Uint<N>;
 
-    fn not(self) -> Self {
-        let Uint(ref arr) = self;
+	fn not(self) -> Self {
+		let Uint(ref arr) = self;
 
-        let mut ret = [0u64; N];
-        for i in 0..N {
-            ret[i] = !arr[i];
-        }
+		let mut ret = [0u64; N];
+		for i in 0..N {
+			ret[i] = !arr[i];
+		}
 
-        Uint(ret)
-    }
+		Uint(ret)
+	}
 }
 
 impl<const N: usize> Shl<usize> for Uint<N> {
-    type Output = Uint<N>;
+	type Output = Uint<N>;
 
-    fn shl(self, shift: usize) -> Self {
-        let Uint(ref original) = self;
-        let word_shift = shift / 64;
-        let bit_shift = shift % 64;
+	fn shl(self, shift: usize) -> Self {
+		let Uint(ref original) = self;
+		let word_shift = shift / 64;
+		let bit_shift = shift % 64;
 
-        let mut ret = [0u64; N];
-        for i in 0..N {
-            // Shift
-            if bit_shift < 64 && i + word_shift < N {
-                ret[i + word_shift] += original[i] << bit_shift;
-            }
+		let mut ret = [0u64; N];
+		for i in 0..N {
+			// Shift
+			if bit_shift < 64 && i + word_shift < N {
+				ret[i + word_shift] += original[i] << bit_shift;
+			}
 
-            // Carry
-            if bit_shift > 0 && i + word_shift + 1 < N {
-                ret[i + word_shift + 1] += original[i] >> (64 - bit_shift);
-            }
-        }
+			// Carry
+			if bit_shift > 0 && i + word_shift + 1 < N {
+				ret[i + word_shift + 1] += original[i] >> (64 - bit_shift);
+			}
+		}
 
-        Uint(ret)
-    }
+		Uint(ret)
+	}
 }
 
 impl<const N: usize> Shr<usize> for Uint<N> {
-    type Output = Uint<N>;
+	type Output = Uint<N>;
 
-    fn shr(self, shift: usize) -> Self {
-        let Uint(ref original) = self;
-        let word_shift = shift / 64;
-        let bit_shift = shift % 64;
+	fn shr(self, shift: usize) -> Self {
+		let Uint(ref original) = self;
+		let word_shift = shift / 64;
+		let bit_shift = shift % 64;
 
-        let mut ret = [0u64; N];
-        for i in word_shift..N {
-            // Shift
-            ret[i - word_shift] += original[i] >> bit_shift;
+		let mut ret = [0u64; N];
+		for i in word_shift..N {
+			// Shift
+			ret[i - word_shift] += original[i] >> bit_shift;
 
-            // Carry
-            if bit_shift > 0 && i < N - 1 {
-                ret[i - word_shift] += original[i + 1] << (64 - bit_shift);
-            }
-        }
+			// Carry
+			if bit_shift > 0 && i < N - 1 {
+				ret[i - word_shift] += original[i + 1] << (64 - bit_shift);
+			}
+		}
 
-        Uint(ret)
-    }
+		Uint(ret)
+	}
 }
 
 impl<const N: usize> AsRef<Uint<N>> for Uint<N> {
-    fn as_ref(&self) -> &Uint<N> {
-        self
-    }
+	fn as_ref(&self) -> &Uint<N> {
+		self
+	}
 }
 
 impl<const N: usize> fmt::Debug for Uint<N> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let Uint(data) = self;
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		let Uint(data) = self;
 
-        write!(f, "0x")?;
+		write!(f, "0x")?;
 
-        for ch in data.iter().rev() {
-            write!(f, "{:016x}", ch)?;
-        }
+		for ch in data.iter().rev() {
+			write!(f, "{:016x}", ch)?;
+		}
 
-        Ok(())
-    }
+		Ok(())
+	}
 }
 
 impl<const N: usize> fmt::Display for Uint<N> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        <dyn fmt::Debug>::fmt(self, f)
-    }
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		<dyn fmt::Debug>::fmt(self, f)
+	}
 }
 
 impl<const N: usize> From<u8> for Uint<N> {
-    fn from(value: u8) -> Self {
-        (value as u64).into()
-    }
+	fn from(value: u8) -> Self {
+		(value as u64).into()
+	}
 }
 
 impl<const N: usize> From<u16> for Uint<N> {
-    fn from(value: u16) -> Self {
-        (value as u64).into()
-    }
+	fn from(value: u16) -> Self {
+		(value as u64).into()
+	}
 }
 
 impl<const N: usize> From<u32> for Uint<N> {
-    fn from(value: u32) -> Self {
-        (value as u64).into()
-    }
+	fn from(value: u32) -> Self {
+		(value as u64).into()
+	}
 }
 
 impl<const N: usize> From<u64> for Uint<N> {
-    fn from(value: u64) -> Self {
-        let mut ret = [0; N];
-        ret[0] = value;
+	fn from(value: u64) -> Self {
+		let mut ret = [0; N];
+		ret[0] = value;
 
-        Self(ret)
-    }
+		Self(ret)
+	}
 }
 
 impl<const N: usize> From<u128> for Uint<N> {
-    fn from(value: u128) -> Self {
-        let mut ret = [0u64; N];
+	fn from(value: u128) -> Self {
+		let mut ret = [0u64; N];
 
-        ret[0] = value as u64;
-        ret[1] = (value >> 64) as u64;
+		ret[0] = value as u64;
+		ret[1] = (value >> 64) as u64;
 
-        Self(ret)
-    }
+		Self(ret)
+	}
 }
 
 impl<const N: usize> Codec for Uint<N> {
-    fn codec_serialize<W: io::Write>(&self, dest: &mut W) -> io::Result<()> {
-        dest.write_all(&self.to_be_bytes())
-    }
+	fn codec_serialize<W: io::Write>(&self, dest: &mut W) -> io::Result<()> {
+		dest.write_all(&self.to_be_bytes())
+	}
 
-    fn codec_deserialize<R: io::Read>(data: &mut R) -> io::Result<Self>
-    where
-        Self: Sized,
-    {
-        let mut buffer = vec![0u8; N * 8];
-        data.read_exact(&mut buffer)?;
+	fn codec_deserialize<R: io::Read>(data: &mut R) -> io::Result<Self>
+	where
+		Self: Sized,
+	{
+		let mut buffer = vec![0u8; N * 8];
+		data.read_exact(&mut buffer)?;
 
-        Self::from_be_bytes(buffer)
-            .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "Could not deserialize Uint"))
-    }
+		Self::from_be_bytes(buffer).map_err(|_| {
+			io::Error::new(
+				io::ErrorKind::InvalidData,
+				"Could not deserialize Uint",
+			)
+		})
+	}
 }
 
 impl From<DoubleSha256Hasher> for Uint256 {
-    fn from(value: DoubleSha256Hasher) -> Self {
-        let buffer: [u8; SHA256_LENGTH] = value.as_bytes().try_into().unwrap();
+	fn from(value: DoubleSha256Hasher) -> Self {
+		let buffer: [u8; SHA256_LENGTH] = value.as_bytes().try_into().unwrap();
 
-        let mut ret: [u64; 4] = unsafe { transmute(buffer) };
-        for x in ret.iter_mut() {
-            *x = x.to_le();
-        }
+		let mut ret: [u64; 4] = unsafe { transmute(buffer) };
+		for x in ret.iter_mut() {
+			*x = x.to_le();
+		}
 
-        Uint256::from_u64_array(ret)
-    }
+		Uint256::from_u64_array(ret)
+	}
 }
 
 // From conversion is fallible for this type
 #[allow(clippy::from_over_into)]
 impl<const N: usize> Into<Vec<u64>> for Uint<N> {
-    fn into(self) -> Vec<u64> {
-        self.0.to_vec()
-    }
+	fn into(self) -> Vec<u64> {
+		self.0.to_vec()
+	}
 }
 
 impl<const N: usize> TryFrom<Vec<u64>> for Uint<N> {
-    type Error = StacksError;
+	type Error = StacksError;
 
-    fn try_from(value: Vec<u64>) -> Result<Self, Self::Error> {
-        Ok(Self(value.as_slice().try_into()?))
-    }
+	fn try_from(value: Vec<u64>) -> Result<Self, Self::Error> {
+		Ok(Self(value.as_slice().try_into()?))
+	}
 }
 
 /// A 256-bit unsigned integer
@@ -595,332 +601,414 @@ pub type Uint512 = Uint<8>;
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+	use super::*;
 
-    impl<const N: usize> Uint<N> {
-        fn bit(&self, index: usize) -> bool {
-            let &Uint(ref arr) = self;
+	impl<const N: usize> Uint<N> {
+		fn bit(&self, index: usize) -> bool {
+			let &Uint(ref arr) = self;
 
-            arr[index / 64] & (1 << (index % 64)) != 0
-        }
+			arr[index / 64] & (1 << (index % 64)) != 0
+		}
 
-        fn bit_slice(&self, start: usize, end: usize) -> Self {
-            (*self >> start).mask(end - start)
-        }
+		fn bit_slice(&self, start: usize, end: usize) -> Self {
+			(*self >> start).mask(end - start)
+		}
 
-        fn mask(&self, n: usize) -> Self {
-            let &Uint(ref arr) = self;
+		fn mask(&self, n: usize) -> Self {
+			let &Uint(ref arr) = self;
 
-            let mut ret = [0; N];
-            for i in 0..N {
-                if n >= 0x40 * (i + 1) {
-                    ret[i] = arr[i];
-                } else {
-                    ret[i] = arr[i] & ((1 << (n - 0x40 * i)) - 1);
-                    break;
-                }
-            }
+			let mut ret = [0; N];
+			for i in 0..N {
+				if n >= 0x40 * (i + 1) {
+					ret[i] = arr[i];
+				} else {
+					ret[i] = arr[i] & ((1 << (n - 0x40 * i)) - 1);
+					break;
+				}
+			}
 
-            Uint(ret)
-        }
-    }
+			Uint(ret)
+		}
+	}
 
-    #[test]
-    fn should_convert_from_u32() {
-        assert_eq!(Uint256::from(1337u32), Uint256::from(1337u64));
-    }
+	#[test]
+	fn should_convert_from_u32() {
+		assert_eq!(Uint256::from(1337u32), Uint256::from(1337u64));
+	}
 
-    #[test]
-    pub fn uint256_bits_test() {
-        assert_eq!(Uint256::from(255u64).bits(), 8);
-        assert_eq!(Uint256::from(256u64).bits(), 9);
-        assert_eq!(Uint256::from(300u64).bits(), 9);
-        assert_eq!(Uint256::from(60000u64).bits(), 16);
-        assert_eq!(Uint256::from(70000u64).bits(), 17);
+	#[test]
+	pub fn uint256_bits_test() {
+		assert_eq!(Uint256::from(255u64).bits(), 8);
+		assert_eq!(Uint256::from(256u64).bits(), 9);
+		assert_eq!(Uint256::from(300u64).bits(), 9);
+		assert_eq!(Uint256::from(60000u64).bits(), 16);
+		assert_eq!(Uint256::from(70000u64).bits(), 17);
 
-        // Try to read the following lines out loud quickly
-        let mut shl = Uint256::from(70000u64);
-        shl = shl << 100;
-        assert_eq!(shl.bits(), 117);
-        shl = shl << 100;
-        assert_eq!(shl.bits(), 217);
-        shl = shl << 100;
-        assert_eq!(shl.bits(), 0);
+		// Try to read the following lines out loud quickly
+		let mut shl = Uint256::from(70000u64);
+		shl = shl << 100;
+		assert_eq!(shl.bits(), 117);
+		shl = shl << 100;
+		assert_eq!(shl.bits(), 217);
+		shl = shl << 100;
+		assert_eq!(shl.bits(), 0);
 
-        // Bit set check
-        assert!(!Uint256::from(10u64).bit(0));
-        assert!(Uint256::from(10u64).bit(1));
-        assert!(!Uint256::from(10u64).bit(2));
-        assert!(Uint256::from(10u64).bit(3));
-        assert!(!Uint256::from(10u64).bit(4));
-    }
+		// Bit set check
+		assert!(!Uint256::from(10u64).bit(0));
+		assert!(Uint256::from(10u64).bit(1));
+		assert!(!Uint256::from(10u64).bit(2));
+		assert!(Uint256::from(10u64).bit(3));
+		assert!(!Uint256::from(10u64).bit(4));
+	}
 
-    #[test]
-    pub fn uint256_display_test() {
-        assert_eq!(
+	#[test]
+	pub fn uint256_display_test() {
+		assert_eq!(
             format!("{}", Uint256::from(0xDEADBEEFu64)),
             "0x00000000000000000000000000000000000000000000000000000000deadbeef"
         );
-        assert_eq!(
+		assert_eq!(
             format!("{}", Uint256::from(u64::MAX)),
             "0x000000000000000000000000000000000000000000000000ffffffffffffffff"
         );
 
-        let max_val = Uint256::from_u64_array([
-            0xFFFFFFFFFFFFFFFF,
-            0xFFFFFFFFFFFFFFFF,
-            0xFFFFFFFFFFFFFFFF,
-            0xFFFFFFFFFFFFFFFF,
-        ]);
+		let max_val = Uint256::from_u64_array([
+			0xFFFFFFFFFFFFFFFF,
+			0xFFFFFFFFFFFFFFFF,
+			0xFFFFFFFFFFFFFFFF,
+			0xFFFFFFFFFFFFFFFF,
+		]);
 
-        assert_eq!(
+		assert_eq!(
             format!("{}", max_val),
             "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
         );
-    }
+	}
 
-    #[test]
-    pub fn uint256_comp_test() {
-        let small = Uint256::from_u64_array([10u64, 0, 0, 0]);
-        let big = Uint256::from_u64_array([0x8C8C3EE70C644118u64, 0x0209E7378231E632, 0, 0]);
-        let bigger = Uint256::from_u64_array([0x9C8C3EE70C644118u64, 0x0209E7378231E632, 0, 0]);
-        let biggest = Uint256::from_u64_array([0x5C8C3EE70C644118u64, 0x0209E7378231E632, 0, 1]);
+	#[test]
+	pub fn uint256_comp_test() {
+		let small = Uint256::from_u64_array([10u64, 0, 0, 0]);
+		let big = Uint256::from_u64_array([
+			0x8C8C3EE70C644118u64,
+			0x0209E7378231E632,
+			0,
+			0,
+		]);
+		let bigger = Uint256::from_u64_array([
+			0x9C8C3EE70C644118u64,
+			0x0209E7378231E632,
+			0,
+			0,
+		]);
+		let biggest = Uint256::from_u64_array([
+			0x5C8C3EE70C644118u64,
+			0x0209E7378231E632,
+			0,
+			1,
+		]);
 
-        dbg!(&bigger, &biggest);
+		dbg!(&bigger, &biggest);
 
-        assert!(small < big);
-        assert!(big < bigger);
-        assert!(bigger < biggest);
-        assert!(bigger <= biggest);
-        assert!(biggest <= biggest);
-        assert!(bigger >= big);
-        assert!(bigger >= small);
-        assert!(small <= small);
-    }
+		assert!(small < big);
+		assert!(big < bigger);
+		assert!(bigger < biggest);
+		assert!(bigger <= biggest);
+		assert!(biggest <= biggest);
+		assert!(bigger >= big);
+		assert!(bigger >= small);
+		assert!(small <= small);
+	}
 
-    #[test]
-    pub fn uint256_arithmetic_test() {
-        let init = Uint256::from(0xDEADBEEFDEADBEEFu64);
-        let copy = init;
+	#[test]
+	pub fn uint256_arithmetic_test() {
+		let init = Uint256::from(0xDEADBEEFDEADBEEFu64);
+		let copy = init;
 
-        let add = init + copy;
-        assert_eq!(
-            add,
-            Uint256::from_u64_array([0xBD5B7DDFBD5B7DDEu64, 1, 0, 0])
-        );
-        // Bitshifts
-        let shl = add << 88;
-        assert_eq!(
-            shl,
-            Uint256::from_u64_array([0u64, 0xDFBD5B7DDE000000, 0x1BD5B7D, 0])
-        );
-        let shr = shl >> 40;
-        assert_eq!(
-            shr,
-            Uint256::from_u64_array([0x7DDE000000000000u64, 0x0001BD5B7DDFBD5B, 0, 0])
-        );
-        // Increment
-        let mut incr = shr;
-        incr.increment();
-        assert_eq!(
-            incr,
-            Uint256::from_u64_array([0x7DDE000000000001u64, 0x0001BD5B7DDFBD5B, 0, 0])
-        );
-        // Subtraction
-        let sub = incr - init;
-        assert_eq!(
-            sub,
-            Uint256::from_u64_array([0x9F30411021524112u64, 0x0001BD5B7DDFBD5A, 0, 0])
-        );
-        // Multiplication
-        let mult = sub.mul_u32(300);
-        assert_eq!(
-            mult,
-            Uint256::from_u64_array([0x8C8C3EE70C644118u64, 0x0209E7378231E632, 0, 0])
-        );
-        // Division
-        assert_eq!(
-            Uint256::from(105u64) / Uint256::from(5u64),
-            Uint256::from(21u64)
-        );
-        let div = mult / Uint256::from(300u64);
+		let add = init + copy;
+		assert_eq!(
+			add,
+			Uint256::from_u64_array([0xBD5B7DDFBD5B7DDEu64, 1, 0, 0])
+		);
+		// Bitshifts
+		let shl = add << 88;
+		assert_eq!(
+			shl,
+			Uint256::from_u64_array([0u64, 0xDFBD5B7DDE000000, 0x1BD5B7D, 0])
+		);
+		let shr = shl >> 40;
+		assert_eq!(
+			shr,
+			Uint256::from_u64_array([
+				0x7DDE000000000000u64,
+				0x0001BD5B7DDFBD5B,
+				0,
+				0
+			])
+		);
+		// Increment
+		let mut incr = shr;
+		incr.increment();
+		assert_eq!(
+			incr,
+			Uint256::from_u64_array([
+				0x7DDE000000000001u64,
+				0x0001BD5B7DDFBD5B,
+				0,
+				0
+			])
+		);
+		// Subtraction
+		let sub = incr - init;
+		assert_eq!(
+			sub,
+			Uint256::from_u64_array([
+				0x9F30411021524112u64,
+				0x0001BD5B7DDFBD5A,
+				0,
+				0
+			])
+		);
+		// Multiplication
+		let mult = sub.mul_u32(300);
+		assert_eq!(
+			mult,
+			Uint256::from_u64_array([
+				0x8C8C3EE70C644118u64,
+				0x0209E7378231E632,
+				0,
+				0
+			])
+		);
+		// Division
+		assert_eq!(
+			Uint256::from(105u64) / Uint256::from(5u64),
+			Uint256::from(21u64)
+		);
+		let div = mult / Uint256::from(300u64);
 
-        dbg!(mult, Uint256::from(300u64), div);
+		dbg!(mult, Uint256::from(300u64), div);
 
-        assert_eq!(
-            div,
-            Uint256::from_u64_array([0x9F30411021524112u64, 0x0001BD5B7DDFBD5A, 0, 0])
-        );
-        // TODO: bit inversion
-    }
+		assert_eq!(
+			div,
+			Uint256::from_u64_array([
+				0x9F30411021524112u64,
+				0x0001BD5B7DDFBD5A,
+				0,
+				0
+			])
+		);
+		// TODO: bit inversion
+	}
 
-    #[test]
-    pub fn mul_u32_test() {
-        let u64_val = Uint256::from(0xDEADBEEFDEADBEEFu64);
+	#[test]
+	pub fn mul_u32_test() {
+		let u64_val = Uint256::from(0xDEADBEEFDEADBEEFu64);
 
-        let u96_res = u64_val.mul_u32(0xFFFFFFFF);
-        let u128_res = u96_res.mul_u32(0xFFFFFFFF);
-        let u160_res = u128_res.mul_u32(0xFFFFFFFF);
-        let u192_res = u160_res.mul_u32(0xFFFFFFFF);
-        let u224_res = u192_res.mul_u32(0xFFFFFFFF);
-        let u256_res = u224_res.mul_u32(0xFFFFFFFF);
+		let u96_res = u64_val.mul_u32(0xFFFFFFFF);
+		let u128_res = u96_res.mul_u32(0xFFFFFFFF);
+		let u160_res = u128_res.mul_u32(0xFFFFFFFF);
+		let u192_res = u160_res.mul_u32(0xFFFFFFFF);
+		let u224_res = u192_res.mul_u32(0xFFFFFFFF);
+		let u256_res = u224_res.mul_u32(0xFFFFFFFF);
 
-        assert_eq!(
-            u96_res,
-            Uint256::from_u64_array([0xffffffff21524111u64, 0xDEADBEEE, 0, 0])
-        );
-        assert_eq!(
-            u128_res,
-            Uint256::from_u64_array([0x21524111DEADBEEFu64, 0xDEADBEEE21524110, 0, 0])
-        );
-        assert_eq!(
-            u160_res,
-            Uint256::from_u64_array([0xBD5B7DDD21524111u64, 0x42A4822200000001, 0xDEADBEED, 0])
-        );
-        assert_eq!(
-            u192_res,
-            Uint256::from_u64_array([
-                0x63F6C333DEADBEEFu64,
-                0xBD5B7DDFBD5B7DDB,
-                0xDEADBEEC63F6C334,
-                0
-            ])
-        );
-        assert_eq!(
-            u224_res,
-            Uint256::from_u64_array([
-                0x7AB6FBBB21524111u64,
-                0xFFFFFFFBA69B4558,
-                0x854904485964BAAA,
-                0xDEADBEEB
-            ])
-        );
-        assert_eq!(
-            u256_res,
-            Uint256::from_u64_array([
-                0xA69B4555DEADBEEFu64,
-                0xA69B455CD41BB662,
-                0xD41BB662A69B4550,
-                0xDEADBEEAA69B455C
-            ])
-        );
-    }
+		assert_eq!(
+			u96_res,
+			Uint256::from_u64_array([0xffffffff21524111u64, 0xDEADBEEE, 0, 0])
+		);
+		assert_eq!(
+			u128_res,
+			Uint256::from_u64_array([
+				0x21524111DEADBEEFu64,
+				0xDEADBEEE21524110,
+				0,
+				0
+			])
+		);
+		assert_eq!(
+			u160_res,
+			Uint256::from_u64_array([
+				0xBD5B7DDD21524111u64,
+				0x42A4822200000001,
+				0xDEADBEED,
+				0
+			])
+		);
+		assert_eq!(
+			u192_res,
+			Uint256::from_u64_array([
+				0x63F6C333DEADBEEFu64,
+				0xBD5B7DDFBD5B7DDB,
+				0xDEADBEEC63F6C334,
+				0
+			])
+		);
+		assert_eq!(
+			u224_res,
+			Uint256::from_u64_array([
+				0x7AB6FBBB21524111u64,
+				0xFFFFFFFBA69B4558,
+				0x854904485964BAAA,
+				0xDEADBEEB
+			])
+		);
+		assert_eq!(
+			u256_res,
+			Uint256::from_u64_array([
+				0xA69B4555DEADBEEFu64,
+				0xA69B455CD41BB662,
+				0xD41BB662A69B4550,
+				0xDEADBEEAA69B455C
+			])
+		);
+	}
 
-    #[test]
-    pub fn multiplication_test() {
-        let u64_val = Uint256::from(0xDEADBEEFDEADBEEFu64);
+	#[test]
+	pub fn multiplication_test() {
+		let u64_val = Uint256::from(0xDEADBEEFDEADBEEFu64);
 
-        let u128_res = u64_val * u64_val;
+		let u128_res = u64_val * u64_val;
 
-        assert_eq!(
-            u128_res,
-            Uint256::from_u64_array([0x048D1354216DA321u64, 0xC1B1CD13A4D13D46, 0, 0])
-        );
+		assert_eq!(
+			u128_res,
+			Uint256::from_u64_array([
+				0x048D1354216DA321u64,
+				0xC1B1CD13A4D13D46,
+				0,
+				0
+			])
+		);
 
-        let u256_res = u128_res * u128_res;
+		let u256_res = u128_res * u128_res;
 
-        assert_eq!(
-            u256_res,
-            Uint256::from_u64_array([
-                0xF4E166AAD40D0A41u64,
-                0xF5CF7F3618C2C886u64,
-                0x4AFCFF6F0375C608u64,
-                0x928D92B4D7F5DF33u64
-            ])
-        );
-    }
+		assert_eq!(
+			u256_res,
+			Uint256::from_u64_array([
+				0xF4E166AAD40D0A41u64,
+				0xF5CF7F3618C2C886u64,
+				0x4AFCFF6F0375C608u64,
+				0x928D92B4D7F5DF33u64
+			])
+		);
+	}
 
-    #[test]
-    pub fn uint256_bitslice_test() {
-        let init = Uint256::from(0xDEADBEEFDEADBEEFu64);
-        let add = init + (init << 64);
-        assert_eq!(add.bit_slice(64, 128), init);
-        assert_eq!(add.mask(64), init);
-    }
+	#[test]
+	pub fn uint256_bitslice_test() {
+		let init = Uint256::from(0xDEADBEEFDEADBEEFu64);
+		let add = init + (init << 64);
+		assert_eq!(add.bit_slice(64, 128), init);
+		assert_eq!(add.mask(64), init);
+	}
 
-    #[test]
-    pub fn uint256_extreme_bitshift_test() {
-        // Shifting a u64 by 64 bits gives an undefined value, so make sure that
-        // we're doing the Right Thing here
-        let init = Uint256::from(0xDEADBEEFDEADBEEFu64);
+	#[test]
+	pub fn uint256_extreme_bitshift_test() {
+		// Shifting a u64 by 64 bits gives an undefined value, so make sure that
+		// we're doing the Right Thing here
+		let init = Uint256::from(0xDEADBEEFDEADBEEFu64);
 
-        assert_eq!(
-            init << 64,
-            Uint256::from_u64_array([0, 0xDEADBEEFDEADBEEF, 0, 0])
-        );
-        let add = (init << 64) + init;
-        assert_eq!(
-            add,
-            Uint256::from_u64_array([0xDEADBEEFDEADBEEF, 0xDEADBEEFDEADBEEF, 0, 0])
-        );
-        assert_eq!(
-            add >> 0,
-            Uint256::from_u64_array([0xDEADBEEFDEADBEEF, 0xDEADBEEFDEADBEEF, 0, 0])
-        );
-        assert_eq!(
-            add << 0,
-            Uint256::from_u64_array([0xDEADBEEFDEADBEEF, 0xDEADBEEFDEADBEEF, 0, 0])
-        );
-        assert_eq!(
-            add >> 64,
-            Uint256::from_u64_array([0xDEADBEEFDEADBEEF, 0, 0, 0])
-        );
-        assert_eq!(
-            add << 64,
-            Uint256::from_u64_array([0, 0xDEADBEEFDEADBEEF, 0xDEADBEEFDEADBEEF, 0])
-        );
-    }
+		assert_eq!(
+			init << 64,
+			Uint256::from_u64_array([0, 0xDEADBEEFDEADBEEF, 0, 0])
+		);
+		let add = (init << 64) + init;
+		assert_eq!(
+			add,
+			Uint256::from_u64_array([
+				0xDEADBEEFDEADBEEF,
+				0xDEADBEEFDEADBEEF,
+				0,
+				0
+			])
+		);
+		assert_eq!(
+			add >> 0,
+			Uint256::from_u64_array([
+				0xDEADBEEFDEADBEEF,
+				0xDEADBEEFDEADBEEF,
+				0,
+				0
+			])
+		);
+		assert_eq!(
+			add << 0,
+			Uint256::from_u64_array([
+				0xDEADBEEFDEADBEEF,
+				0xDEADBEEFDEADBEEF,
+				0,
+				0
+			])
+		);
+		assert_eq!(
+			add >> 64,
+			Uint256::from_u64_array([0xDEADBEEFDEADBEEF, 0, 0, 0])
+		);
+		assert_eq!(
+			add << 64,
+			Uint256::from_u64_array([
+				0,
+				0xDEADBEEFDEADBEEF,
+				0xDEADBEEFDEADBEEF,
+				0
+			])
+		);
+	}
 
-    #[test]
-    pub fn hex_codec() {
-        let init =
-            Uint256::from(0xDEADBEEFDEADBEEFu64) << 64 | Uint256::from(0x0102030405060708u64);
+	#[test]
+	pub fn hex_codec() {
+		let init = Uint256::from(0xDEADBEEFDEADBEEFu64) << 64
+			| Uint256::from(0x0102030405060708u64);
 
-        // little-endian representation
-        let hex_init = "0807060504030201efbeaddeefbeadde00000000000000000000000000000000";
-        assert_eq!(
-            Uint256::from_le_bytes(&hex::decode(hex_init).unwrap()).unwrap(),
-            init
-        );
-        assert_eq!(hex::encode(init.to_le_bytes()), hex_init);
-        assert_eq!(Uint256::from_le_bytes(&init.to_le_bytes()).unwrap(), init);
+		// little-endian representation
+		let hex_init =
+			"0807060504030201efbeaddeefbeadde00000000000000000000000000000000";
+		assert_eq!(
+			Uint256::from_le_bytes(&hex::decode(hex_init).unwrap()).unwrap(),
+			init
+		);
+		assert_eq!(hex::encode(init.to_le_bytes()), hex_init);
+		assert_eq!(Uint256::from_le_bytes(&init.to_le_bytes()).unwrap(), init);
 
-        // big-endian representation
-        let hex_init = "00000000000000000000000000000000deadbeefdeadbeef0102030405060708";
-        assert_eq!(
-            Uint256::from_be_bytes(&hex::decode(hex_init).unwrap()).unwrap(),
-            init
-        );
-        assert_eq!(hex::encode(init.to_be_bytes()), hex_init);
-        assert_eq!(Uint256::from_be_bytes(&init.to_be_bytes()).unwrap(), init);
-    }
+		// big-endian representation
+		let hex_init =
+			"00000000000000000000000000000000deadbeefdeadbeef0102030405060708";
+		assert_eq!(
+			Uint256::from_be_bytes(&hex::decode(hex_init).unwrap()).unwrap(),
+			init
+		);
+		assert_eq!(hex::encode(init.to_be_bytes()), hex_init);
+		assert_eq!(Uint256::from_be_bytes(&init.to_be_bytes()).unwrap(), init);
+	}
 
-    #[test]
-    pub fn uint_increment_test() {
-        let mut value = Uint256::from_u64_array([0xffffffffffffffff, 0, 0, 0]);
-        value.increment();
-        assert_eq!(value, Uint256::from_u64_array([0, 1, 0, 0]));
+	#[test]
+	pub fn uint_increment_test() {
+		let mut value = Uint256::from_u64_array([0xffffffffffffffff, 0, 0, 0]);
+		value.increment();
+		assert_eq!(value, Uint256::from_u64_array([0, 1, 0, 0]));
 
-        value = Uint256::from_u64_array([0xffffffffffffffff, 0xffffffffffffffff, 0, 0]);
-        value.increment();
-        assert_eq!(value, Uint256::from_u64_array([0, 0, 1, 0]));
+		value = Uint256::from_u64_array([
+			0xffffffffffffffff,
+			0xffffffffffffffff,
+			0,
+			0,
+		]);
+		value.increment();
+		assert_eq!(value, Uint256::from_u64_array([0, 0, 1, 0]));
 
-        value = Uint256::from_u64_array([
-            0xffffffffffffffff,
-            0xffffffffffffffff,
-            0xffffffffffffffff,
-            0,
-        ]);
-        value.increment();
-        assert_eq!(value, Uint256::from_u64_array([0, 0, 0, 1]));
+		value = Uint256::from_u64_array([
+			0xffffffffffffffff,
+			0xffffffffffffffff,
+			0xffffffffffffffff,
+			0,
+		]);
+		value.increment();
+		assert_eq!(value, Uint256::from_u64_array([0, 0, 0, 1]));
 
-        value = Uint256::from_u64_array([
-            0xffffffffffffffff,
-            0xffffffffffffffff,
-            0xffffffffffffffff,
-            0xffffffffffffffff,
-        ]);
-        value.increment();
-        assert_eq!(value, Uint256::from_u64_array([0, 0, 0, 0]));
-    }
+		value = Uint256::from_u64_array([
+			0xffffffffffffffff,
+			0xffffffffffffffff,
+			0xffffffffffffffff,
+			0xffffffffffffffff,
+		]);
+		value.increment();
+		assert_eq!(value, Uint256::from_u64_array([0, 0, 0, 0]));
+	}
 }

--- a/stacks-core/src/utils.rs
+++ b/stacks-core/src/utils.rs
@@ -3,9 +3,9 @@ use std::io;
 use strum::FromRepr;
 
 use crate::{
-    address::{AddressVersion, StacksAddress},
-    codec::Codec,
-    contract_name::ContractName,
+	address::{AddressVersion, StacksAddress},
+	codec::Codec,
+	contract_name::ContractName,
 };
 
 #[derive(PartialEq, Eq, Debug, Clone)]
@@ -13,182 +13,203 @@ use crate::{
 pub struct StandardPrincipalData(pub AddressVersion, pub StacksAddress);
 
 impl StandardPrincipalData {
-    /// Create a new standard principal data type from the provided address version and stacks address
-    pub fn new(version: AddressVersion, address: StacksAddress) -> Self {
-        Self(version, address)
-    }
+	/// Create a new standard principal data type from the provided address
+	/// version and stacks address
+	pub fn new(version: AddressVersion, address: StacksAddress) -> Self {
+		Self(version, address)
+	}
 }
 
 impl Codec for StandardPrincipalData {
-    fn codec_serialize<W: io::Write>(&self, dest: &mut W) -> io::Result<()> {
-        self.1.codec_serialize(dest)
-    }
+	fn codec_serialize<W: io::Write>(&self, dest: &mut W) -> io::Result<()> {
+		self.1.codec_serialize(dest)
+	}
 
-    fn codec_deserialize<R: io::Read>(data: &mut R) -> io::Result<Self>
-    where
-        Self: Sized,
-    {
-        let addr = StacksAddress::codec_deserialize(data)?;
+	fn codec_deserialize<R: io::Read>(data: &mut R) -> io::Result<Self>
+	where
+		Self: Sized,
+	{
+		let addr = StacksAddress::codec_deserialize(data)?;
 
-        Ok(Self(addr.version(), addr))
-    }
+		Ok(Self(addr.version(), addr))
+	}
 }
 
 impl From<StacksAddress> for StandardPrincipalData {
-    fn from(address: StacksAddress) -> Self {
-        Self(address.version(), address)
-    }
+	fn from(address: StacksAddress) -> Self {
+		Self(address.version(), address)
+	}
 }
 
 #[derive(PartialEq, Eq, Debug, Clone)]
 /// Principal Data type
 pub enum PrincipalData {
-    /// Standard principal data type
-    Standard(StandardPrincipalData),
-    /// Contract principal data type
-    Contract(StandardPrincipalData, ContractName),
+	/// Standard principal data type
+	Standard(StandardPrincipalData),
+	/// Contract principal data type
+	Contract(StandardPrincipalData, ContractName),
 }
 
 #[repr(u8)]
 #[derive(FromRepr, Debug, Clone, Copy)]
 enum PrincipalTypeByte {
-    Standard = 0x05,
-    Contract = 0x06,
+	Standard = 0x05,
+	Contract = 0x06,
 }
 
 impl Codec for PrincipalData {
-    fn codec_serialize<W: io::Write>(&self, dest: &mut W) -> io::Result<()> {
-        match self {
-            Self::Standard(data) => {
-                dest.write_all(&[PrincipalTypeByte::Standard as u8])?;
-                data.codec_serialize(dest)
-            }
-            Self::Contract(data, contract_name) => {
-                dest.write_all(&[PrincipalTypeByte::Contract as u8])?;
-                data.codec_serialize(dest)?;
-                contract_name.codec_serialize(dest)
-            }
-        }
-    }
+	fn codec_serialize<W: io::Write>(&self, dest: &mut W) -> io::Result<()> {
+		match self {
+			Self::Standard(data) => {
+				dest.write_all(&[PrincipalTypeByte::Standard as u8])?;
+				data.codec_serialize(dest)
+			}
+			Self::Contract(data, contract_name) => {
+				dest.write_all(&[PrincipalTypeByte::Contract as u8])?;
+				data.codec_serialize(dest)?;
+				contract_name.codec_serialize(dest)
+			}
+		}
+	}
 
-    fn codec_deserialize<R: io::Read>(data: &mut R) -> io::Result<Self>
-    where
-        Self: Sized,
-    {
-        let mut type_buffer = [0u8; 1];
-        data.read_exact(&mut type_buffer)?;
+	fn codec_deserialize<R: io::Read>(data: &mut R) -> io::Result<Self>
+	where
+		Self: Sized,
+	{
+		let mut type_buffer = [0u8; 1];
+		data.read_exact(&mut type_buffer)?;
 
-        let principal_type = PrincipalTypeByte::from_repr(type_buffer[0]).ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("Invalid principal type: {}", type_buffer[0]),
-            )
-        })?;
+		let principal_type = PrincipalTypeByte::from_repr(type_buffer[0])
+			.ok_or_else(|| {
+				io::Error::new(
+					io::ErrorKind::InvalidData,
+					format!("Invalid principal type: {}", type_buffer[0]),
+				)
+			})?;
 
-        match principal_type {
-            PrincipalTypeByte::Standard => {
-                let standard_data = StandardPrincipalData::codec_deserialize(data)?;
+		match principal_type {
+			PrincipalTypeByte::Standard => {
+				let standard_data =
+					StandardPrincipalData::codec_deserialize(data)?;
 
-                Ok(Self::Standard(standard_data))
-            }
-            PrincipalTypeByte::Contract => {
-                let standard_data = StandardPrincipalData::codec_deserialize(data)?;
-                let contract_name = ContractName::codec_deserialize(data)?;
+				Ok(Self::Standard(standard_data))
+			}
+			PrincipalTypeByte::Contract => {
+				let standard_data =
+					StandardPrincipalData::codec_deserialize(data)?;
+				let contract_name = ContractName::codec_deserialize(data)?;
 
-                Ok(Self::Contract(standard_data, contract_name))
-            }
-        }
-    }
+				Ok(Self::Contract(standard_data, contract_name))
+			}
+		}
+	}
 }
 
 impl From<StacksAddress> for PrincipalData {
-    fn from(address: StacksAddress) -> Self {
-        Self::Standard(StandardPrincipalData::from(address))
-    }
+	fn from(address: StacksAddress) -> Self {
+		Self::Standard(StandardPrincipalData::from(address))
+	}
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::crypto::hash160::Hash160Hasher;
+	use super::*;
+	use crate::crypto::hash160::Hash160Hasher;
 
-    use super::*;
+	#[test]
+	fn should_serialize_standard_principal_data() {
+		let addr = StacksAddress::new(
+			AddressVersion::TestnetSingleSig,
+			Hash160Hasher::default(),
+		);
+		let data = PrincipalData::Standard(StandardPrincipalData(
+			addr.version(),
+			addr.clone(),
+		));
 
-    #[test]
-    fn should_serialize_standard_principal_data() {
-        let addr = StacksAddress::new(AddressVersion::TestnetSingleSig, Hash160Hasher::default());
-        let data = PrincipalData::Standard(StandardPrincipalData(addr.version(), addr.clone()));
+		let mut expected_bytes = vec![];
 
-        let mut expected_bytes = vec![];
+		expected_bytes.push(PrincipalTypeByte::Standard as u8);
+		expected_bytes.push(addr.version() as u8);
+		expected_bytes.extend(addr.hash().as_ref());
 
-        expected_bytes.push(PrincipalTypeByte::Standard as u8);
-        expected_bytes.push(addr.version() as u8);
-        expected_bytes.extend(addr.hash().as_ref());
+		let serialized = data.serialize_to_vec();
 
-        let serialized = data.serialize_to_vec();
+		assert_eq!(serialized, expected_bytes);
+	}
 
-        assert_eq!(serialized, expected_bytes);
-    }
+	#[test]
+	fn should_deserialize_standard_principal_data() {
+		let addr = StacksAddress::new(
+			AddressVersion::TestnetSingleSig,
+			Hash160Hasher::default(),
+		);
+		let expected_principal_data = PrincipalData::Standard(
+			StandardPrincipalData(addr.version(), addr.clone()),
+		);
 
-    #[test]
-    fn should_deserialize_standard_principal_data() {
-        let addr = StacksAddress::new(AddressVersion::TestnetSingleSig, Hash160Hasher::default());
-        let expected_principal_data =
-            PrincipalData::Standard(StandardPrincipalData(addr.version(), addr.clone()));
+		let mut expected_bytes = vec![];
 
-        let mut expected_bytes = vec![];
+		expected_bytes.push(PrincipalTypeByte::Standard as u8);
+		expected_bytes.push(addr.version() as u8);
+		expected_bytes.extend(addr.hash().as_ref());
 
-        expected_bytes.push(PrincipalTypeByte::Standard as u8);
-        expected_bytes.push(addr.version() as u8);
-        expected_bytes.extend(addr.hash().as_ref());
+		let serialized = expected_principal_data.serialize_to_vec();
+		let deserialized =
+			PrincipalData::deserialize(&mut &serialized[..]).unwrap();
 
-        let serialized = expected_principal_data.serialize_to_vec();
-        let deserialized = PrincipalData::deserialize(&mut &serialized[..]).unwrap();
+		assert_eq!(deserialized, expected_principal_data);
+	}
 
-        assert_eq!(deserialized, expected_principal_data);
-    }
+	#[test]
+	fn should_serialize_contract_principal_data() {
+		let addr = StacksAddress::new(
+			AddressVersion::TestnetSingleSig,
+			Hash160Hasher::default(),
+		);
+		let contract = ContractName::new("helloworld").unwrap();
+		let data = PrincipalData::Contract(
+			StandardPrincipalData(addr.version(), addr.clone()),
+			contract.clone(),
+		);
 
-    #[test]
-    fn should_serialize_contract_principal_data() {
-        let addr = StacksAddress::new(AddressVersion::TestnetSingleSig, Hash160Hasher::default());
-        let contract = ContractName::new("helloworld").unwrap();
-        let data = PrincipalData::Contract(
-            StandardPrincipalData(addr.version(), addr.clone()),
-            contract.clone(),
-        );
+		let mut expected_bytes = vec![];
 
-        let mut expected_bytes = vec![];
+		expected_bytes.push(PrincipalTypeByte::Contract as u8);
+		expected_bytes.push(addr.version() as u8);
+		expected_bytes.extend(addr.hash().as_ref());
+		expected_bytes.push(contract.len() as u8);
+		expected_bytes.extend(contract.as_bytes());
 
-        expected_bytes.push(PrincipalTypeByte::Contract as u8);
-        expected_bytes.push(addr.version() as u8);
-        expected_bytes.extend(addr.hash().as_ref());
-        expected_bytes.push(contract.len() as u8);
-        expected_bytes.extend(contract.as_bytes());
+		let serialized = data.serialize_to_vec();
 
-        let serialized = data.serialize_to_vec();
+		assert_eq!(serialized, expected_bytes);
+	}
 
-        assert_eq!(serialized, expected_bytes);
-    }
+	#[test]
+	fn should_deserialize_contract_principal_data() {
+		let addr = StacksAddress::new(
+			AddressVersion::TestnetSingleSig,
+			Hash160Hasher::default(),
+		);
+		let contract = ContractName::new("helloworld").unwrap();
+		let expected_principal_data = PrincipalData::Contract(
+			StandardPrincipalData(addr.version(), addr.clone()),
+			contract.clone(),
+		);
 
-    #[test]
-    fn should_deserialize_contract_principal_data() {
-        let addr = StacksAddress::new(AddressVersion::TestnetSingleSig, Hash160Hasher::default());
-        let contract = ContractName::new("helloworld").unwrap();
-        let expected_principal_data = PrincipalData::Contract(
-            StandardPrincipalData(addr.version(), addr.clone()),
-            contract.clone(),
-        );
+		let mut expected_bytes = vec![];
 
-        let mut expected_bytes = vec![];
+		expected_bytes.push(PrincipalTypeByte::Contract as u8);
+		expected_bytes.push(addr.version() as u8);
+		expected_bytes.extend(addr.hash().as_ref());
+		expected_bytes.push(contract.len() as u8);
+		expected_bytes.extend(contract.as_bytes());
 
-        expected_bytes.push(PrincipalTypeByte::Contract as u8);
-        expected_bytes.push(addr.version() as u8);
-        expected_bytes.extend(addr.hash().as_ref());
-        expected_bytes.push(contract.len() as u8);
-        expected_bytes.extend(contract.as_bytes());
+		let serialized = expected_principal_data.serialize_to_vec();
+		let deserialized =
+			PrincipalData::deserialize(&mut &serialized[..]).unwrap();
 
-        let serialized = expected_principal_data.serialize_to_vec();
-        let deserialized = PrincipalData::deserialize(&mut &serialized[..]).unwrap();
-
-        assert_eq!(deserialized, expected_principal_data);
-    }
+		assert_eq!(deserialized, expected_principal_data);
+	}
 }

--- a/stacks-core/src/wallet.rs
+++ b/stacks-core/src/wallet.rs
@@ -1,294 +1,315 @@
-/*!
-Exposes tools to create and manage Stacks credentials.
-*/
+//! Exposes tools to create and manage Stacks credentials.
 
 use std::str::FromStr;
 
-use bdk::bitcoin::secp256k1::Secp256k1;
-use bdk::bitcoin::util::bip32::{DerivationPath, ExtendedPrivKey};
-use bdk::bitcoin::{
-    Address as BitcoinAddress, AddressType as BitcoinAddressType, Network as BitcoinNetwork,
+use bdk::{
+	bitcoin::{
+		secp256k1::Secp256k1,
+		util::bip32::{DerivationPath, ExtendedPrivKey},
+		Address as BitcoinAddress, AddressType as BitcoinAddressType,
+		Network as BitcoinNetwork,
+	},
+	keys::bip39::Mnemonic,
 };
-use bdk::keys::bip39::Mnemonic;
 use rand::random;
 use serde::{Deserialize, Serialize};
 
-use crate::address::{AddressVersion, StacksAddress};
-use crate::crypto::wif::WIF;
-use crate::StacksError;
 use crate::{
-    crypto::{PrivateKey, PublicKey},
-    Network, StacksResult,
+	address::{AddressVersion, StacksAddress},
+	crypto::{wif::WIF, PrivateKey, PublicKey},
+	Network, StacksError, StacksResult,
 };
 
 /// Computes Stacks derivation paths
 pub fn stacks_derivation_path(index: u32) -> StacksResult<DerivationPath> {
-    Ok(DerivationPath::from_str(&format!(
-        "m/44'/5757'/0'/0/{}",
-        index
-    ))?)
+	Ok(DerivationPath::from_str(&format!(
+		"m/44'/5757'/0'/0/{}",
+		index
+	))?)
 }
 
 /// Computes Bitcoin derivation paths
 pub fn bitcoin_derivation_path(
-    network: BitcoinNetwork,
-    kind: BitcoinAddressType,
-    index: u32,
+	network: BitcoinNetwork,
+	kind: BitcoinAddressType,
+	index: u32,
 ) -> StacksResult<DerivationPath> {
-    let mut path = "m/".to_string();
+	let mut path = "m/".to_string();
 
-    match kind {
-        BitcoinAddressType::P2pkh => path.push_str("44'/"),
-        BitcoinAddressType::P2wpkh => path.push_str("84'/"),
-        BitcoinAddressType::P2tr => path.push_str("86'/"),
-        _ => return Err(StacksError::InvalidArguments("Invalid Bitcoin addres type")),
-    };
+	match kind {
+		BitcoinAddressType::P2pkh => path.push_str("44'/"),
+		BitcoinAddressType::P2wpkh => path.push_str("84'/"),
+		BitcoinAddressType::P2tr => path.push_str("86'/"),
+		_ => {
+			return Err(StacksError::InvalidArguments(
+				"Invalid Bitcoin addres type",
+			))
+		}
+	};
 
-    match network {
-        BitcoinNetwork::Bitcoin => path.push_str("0'/"),
-        _ => path.push_str("1'/"),
-    }
+	match network {
+		BitcoinNetwork::Bitcoin => path.push_str("0'/"),
+		_ => path.push_str("1'/"),
+	}
 
-    path.push_str(&format!("{}'/0/0", index));
+	path.push_str(&format!("{}'/0/0", index));
 
-    Ok(DerivationPath::from_str(&path)?)
+	Ok(DerivationPath::from_str(&path)?)
 }
 
 /// Derives a key from a master key and a derivation path
-pub fn derive_key(master_key: ExtendedPrivKey, path: DerivationPath) -> ExtendedPrivKey {
-    master_key.derive_priv(&Secp256k1::new(), &path).unwrap()
+pub fn derive_key(
+	master_key: ExtendedPrivKey,
+	path: DerivationPath,
+) -> ExtendedPrivKey {
+	master_key.derive_priv(&Secp256k1::new(), &path).unwrap()
 }
 
 /// Wallet of credentials
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Wallet {
-    master_key: ExtendedPrivKey,
-    mnemonic: Mnemonic,
+	master_key: ExtendedPrivKey,
+	mnemonic: Mnemonic,
 }
 
 impl Wallet {
-    /// Creates a wallet from the network, mnemonic, and optional passphrase
-    pub fn new(mnemonic: impl AsRef<str>) -> StacksResult<Self> {
-        let mnemonic = Mnemonic::from_str(mnemonic.as_ref())?;
+	/// Creates a wallet from the network, mnemonic, and optional passphrase
+	pub fn new(mnemonic: impl AsRef<str>) -> StacksResult<Self> {
+		let mnemonic = Mnemonic::from_str(mnemonic.as_ref())?;
 
-        // Bitcoin network is irrelevant for extended private keys
-        let master_key =
-            ExtendedPrivKey::new_master(BitcoinNetwork::Bitcoin, &mnemonic.to_seed(""))?;
+		// Bitcoin network is irrelevant for extended private keys
+		let master_key = ExtendedPrivKey::new_master(
+			BitcoinNetwork::Bitcoin,
+			&mnemonic.to_seed(""),
+		)?;
 
-        Ok(Self {
-            master_key,
-            mnemonic,
-        })
-    }
+		Ok(Self {
+			master_key,
+			mnemonic,
+		})
+	}
 
-    /// Creates a random wallet
-    pub fn random() -> StacksResult<Self> {
-        let entropy: [u8; 32] = random();
-        let mnemonic = Mnemonic::from_entropy(&entropy)?;
+	/// Creates a random wallet
+	pub fn random() -> StacksResult<Self> {
+		let entropy: [u8; 32] = random();
+		let mnemonic = Mnemonic::from_entropy(&entropy)?;
 
-        Self::new(mnemonic.to_string())
-    }
+		Self::new(mnemonic.to_string())
+	}
 
-    /// Returns the mnemonic of the wallet
-    pub fn mnemonic(&self) -> Mnemonic {
-        self.mnemonic.clone()
-    }
+	/// Returns the mnemonic of the wallet
+	pub fn mnemonic(&self) -> Mnemonic {
+		self.mnemonic.clone()
+	}
 
-    /// Returns the master key of the wallet
-    pub fn master_key(&self) -> PrivateKey {
-        self.master_key.private_key
-    }
+	/// Returns the master key of the wallet
+	pub fn master_key(&self) -> PrivateKey {
+		self.master_key.private_key
+	}
 
-    /// Returns the WIF of the wallet
-    pub fn wif(&self, network: Network) -> WIF {
-        WIF::new(network, self.master_key())
-    }
+	/// Returns the WIF of the wallet
+	pub fn wif(&self, network: Network) -> WIF {
+		WIF::new(network, self.master_key())
+	}
 
-    /// Returns the credentials at the given index
-    pub fn credentials(&self, network: Network, index: u32) -> StacksResult<Credentials> {
-        Credentials::new(network, self.master_key, index)
-    }
+	/// Returns the credentials at the given index
+	pub fn credentials(
+		&self,
+		network: Network,
+		index: u32,
+	) -> StacksResult<Credentials> {
+		Credentials::new(network, self.master_key, index)
+	}
 
-    /// Returns the Bitcoin credentials at the given index
-    pub fn bitcoin_credentials(
-        &self,
-        network: BitcoinNetwork,
-        index: u32,
-    ) -> StacksResult<BitcoinCredentials> {
-        BitcoinCredentials::new(network, self.master_key, index)
-    }
+	/// Returns the Bitcoin credentials at the given index
+	pub fn bitcoin_credentials(
+		&self,
+		network: BitcoinNetwork,
+		index: u32,
+	) -> StacksResult<BitcoinCredentials> {
+		BitcoinCredentials::new(network, self.master_key, index)
+	}
 }
 
 /// Credentials that can be used to sign transactions
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Credentials {
-    network: Network,
-    private_key: PrivateKey,
+	network: Network,
+	private_key: PrivateKey,
 }
 
 impl Credentials {
-    /// Creates credentials from the network and private key
-    pub fn new(network: Network, master_key: ExtendedPrivKey, index: u32) -> StacksResult<Self> {
-        let private_key = derive_key(master_key, stacks_derivation_path(index)?)
-            .to_priv()
-            .inner;
+	/// Creates credentials from the network and private key
+	pub fn new(
+		network: Network,
+		master_key: ExtendedPrivKey,
+		index: u32,
+	) -> StacksResult<Self> {
+		let private_key =
+			derive_key(master_key, stacks_derivation_path(index)?)
+				.to_priv()
+				.inner;
 
-        Ok(Self {
-            network,
-            private_key,
-        })
-    }
+		Ok(Self {
+			network,
+			private_key,
+		})
+	}
 
-    /// Returns the Stacks network
-    pub fn network(&self) -> Network {
-        self.network
-    }
+	/// Returns the Stacks network
+	pub fn network(&self) -> Network {
+		self.network
+	}
 
-    /// Returns the private key
-    pub fn private_key(&self) -> PrivateKey {
-        self.private_key
-    }
+	/// Returns the private key
+	pub fn private_key(&self) -> PrivateKey {
+		self.private_key
+	}
 
-    /// Returns the public key
-    pub fn public_key(&self) -> PublicKey {
-        self.private_key.public_key(&Secp256k1::new())
-    }
+	/// Returns the public key
+	pub fn public_key(&self) -> PublicKey {
+		self.private_key.public_key(&Secp256k1::new())
+	}
 
-    /// Returns the Stacks P2PKH address
-    pub fn address(&self) -> StacksAddress {
-        let version = match self.network {
-            Network::Mainnet => AddressVersion::MainnetSingleSig,
-            Network::Testnet => AddressVersion::TestnetSingleSig,
-        };
+	/// Returns the Stacks P2PKH address
+	pub fn address(&self) -> StacksAddress {
+		let version = match self.network {
+			Network::Mainnet => AddressVersion::MainnetSingleSig,
+			Network::Testnet => AddressVersion::TestnetSingleSig,
+		};
 
-        StacksAddress::p2pkh(version, &self.public_key())
-    }
+		StacksAddress::p2pkh(version, &self.public_key())
+	}
 
-    /// Returns the WIF
-    pub fn wif(&self) -> WIF {
-        WIF::new(self.network(), self.private_key())
-    }
+	/// Returns the WIF
+	pub fn wif(&self) -> WIF {
+		WIF::new(self.network(), self.private_key())
+	}
 }
 
 /// Bitcoin Credentials that can be used to sign transactions
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BitcoinCredentials {
-    network: BitcoinNetwork,
-    private_key_p2pkh: PrivateKey,
-    private_key_p2wpkh: PrivateKey,
-    private_key_p2tr: PrivateKey,
+	network: BitcoinNetwork,
+	private_key_p2pkh: PrivateKey,
+	private_key_p2wpkh: PrivateKey,
+	private_key_p2tr: PrivateKey,
 }
 
 impl BitcoinCredentials {
-    /// Creates Bitcoin credentials from the Bitcoin network and private key
-    pub fn new(
-        network: BitcoinNetwork,
-        master_key: ExtendedPrivKey,
-        index: u32,
-    ) -> StacksResult<Self> {
-        let private_key_p2pkh = derive_key(
-            master_key,
-            bitcoin_derivation_path(network, BitcoinAddressType::P2pkh, index)?,
-        )
-        .to_priv()
-        .inner;
+	/// Creates Bitcoin credentials from the Bitcoin network and private key
+	pub fn new(
+		network: BitcoinNetwork,
+		master_key: ExtendedPrivKey,
+		index: u32,
+	) -> StacksResult<Self> {
+		let private_key_p2pkh = derive_key(
+			master_key,
+			bitcoin_derivation_path(network, BitcoinAddressType::P2pkh, index)?,
+		)
+		.to_priv()
+		.inner;
 
-        let private_key_p2wpkh = derive_key(
-            master_key,
-            bitcoin_derivation_path(network, BitcoinAddressType::P2wpkh, index)?,
-        )
-        .to_priv()
-        .inner;
+		let private_key_p2wpkh = derive_key(
+			master_key,
+			bitcoin_derivation_path(
+				network,
+				BitcoinAddressType::P2wpkh,
+				index,
+			)?,
+		)
+		.to_priv()
+		.inner;
 
-        let private_key_p2tr = derive_key(
-            master_key,
-            bitcoin_derivation_path(network, BitcoinAddressType::P2tr, index)?,
-        )
-        .to_priv()
-        .inner;
+		let private_key_p2tr = derive_key(
+			master_key,
+			bitcoin_derivation_path(network, BitcoinAddressType::P2tr, index)?,
+		)
+		.to_priv()
+		.inner;
 
-        Ok(Self {
-            network,
-            private_key_p2pkh,
-            private_key_p2wpkh,
-            private_key_p2tr,
-        })
-    }
+		Ok(Self {
+			network,
+			private_key_p2pkh,
+			private_key_p2wpkh,
+			private_key_p2tr,
+		})
+	}
 
-    /// Returns the Bitcoin network
-    pub fn network(&self) -> BitcoinNetwork {
-        self.network
-    }
+	/// Returns the Bitcoin network
+	pub fn network(&self) -> BitcoinNetwork {
+		self.network
+	}
 
-    /// Returns the Bitcoin P2PKH private key
-    pub fn private_key_p2pkh(&self) -> PrivateKey {
-        self.private_key_p2pkh
-    }
+	/// Returns the Bitcoin P2PKH private key
+	pub fn private_key_p2pkh(&self) -> PrivateKey {
+		self.private_key_p2pkh
+	}
 
-    /// Returns the Bitcoin P22PKH private key
-    pub fn private_key_p2wpkh(&self) -> PrivateKey {
-        self.private_key_p2wpkh
-    }
+	/// Returns the Bitcoin P22PKH private key
+	pub fn private_key_p2wpkh(&self) -> PrivateKey {
+		self.private_key_p2wpkh
+	}
 
-    /// Returns the Bitcoin P2TR private key
-    pub fn private_key_p2tr(&self) -> PrivateKey {
-        self.private_key_p2tr
-    }
+	/// Returns the Bitcoin P2TR private key
+	pub fn private_key_p2tr(&self) -> PrivateKey {
+		self.private_key_p2tr
+	}
 
-    /// Returns the Bitcoin P2PKH public key
-    pub fn public_key_p2pkh(&self) -> PublicKey {
-        self.private_key_p2pkh.public_key(&Secp256k1::new())
-    }
+	/// Returns the Bitcoin P2PKH public key
+	pub fn public_key_p2pkh(&self) -> PublicKey {
+		self.private_key_p2pkh.public_key(&Secp256k1::new())
+	}
 
-    /// Returns the Bitcoin P2WPKH public key
-    pub fn public_key_p2wpkh(&self) -> PublicKey {
-        self.private_key_p2wpkh.public_key(&Secp256k1::new())
-    }
+	/// Returns the Bitcoin P2WPKH public key
+	pub fn public_key_p2wpkh(&self) -> PublicKey {
+		self.private_key_p2wpkh.public_key(&Secp256k1::new())
+	}
 
-    /// Returns the Bitcoin P2TR public key
-    pub fn public_key_p2tr(&self) -> PublicKey {
-        self.private_key_p2tr.public_key(&Secp256k1::new())
-    }
+	/// Returns the Bitcoin P2TR public key
+	pub fn public_key_p2tr(&self) -> PublicKey {
+		self.private_key_p2tr.public_key(&Secp256k1::new())
+	}
 
-    /// Returns the Bitcoin P2PKH address
-    pub fn address_p2pkh(&self) -> BitcoinAddress {
-        BitcoinAddress::p2pkh(
-            &bdk::bitcoin::PublicKey::new(self.public_key_p2pkh()),
-            self.network(),
-        )
-    }
+	/// Returns the Bitcoin P2PKH address
+	pub fn address_p2pkh(&self) -> BitcoinAddress {
+		BitcoinAddress::p2pkh(
+			&bdk::bitcoin::PublicKey::new(self.public_key_p2pkh()),
+			self.network(),
+		)
+	}
 
-    /// Returns the Bitcoin P2WPKH address
-    pub fn address_p2wpkh(&self) -> BitcoinAddress {
-        BitcoinAddress::p2wpkh(
-            &bdk::bitcoin::PublicKey::new(self.public_key_p2wpkh()),
-            self.network(),
-        )
-        .unwrap()
-    }
+	/// Returns the Bitcoin P2WPKH address
+	pub fn address_p2wpkh(&self) -> BitcoinAddress {
+		BitcoinAddress::p2wpkh(
+			&bdk::bitcoin::PublicKey::new(self.public_key_p2wpkh()),
+			self.network(),
+		)
+		.unwrap()
+	}
 
-    /// Returns the Bitcoin P2TR address
-    pub fn address_p2tr(&self) -> BitcoinAddress {
-        BitcoinAddress::p2tr(
-            &Secp256k1::new(),
-            self.public_key_p2tr().x_only_public_key().0,
-            None,
-            self.network(),
-        )
-    }
+	/// Returns the Bitcoin P2TR address
+	pub fn address_p2tr(&self) -> BitcoinAddress {
+		BitcoinAddress::p2tr(
+			&Secp256k1::new(),
+			self.public_key_p2tr().x_only_public_key().0,
+			None,
+			self.network(),
+		)
+	}
 
-    /// Returns the WIF for P2PKH
-    pub fn wif_p2pkh(&self) -> WIF {
-        WIF::new(self.network().into(), self.private_key_p2pkh())
-    }
+	/// Returns the WIF for P2PKH
+	pub fn wif_p2pkh(&self) -> WIF {
+		WIF::new(self.network().into(), self.private_key_p2pkh())
+	}
 
-    /// Returns the WIF for P2WPKH
-    pub fn wif_p2wpkh(&self) -> WIF {
-        WIF::new(self.network().into(), self.private_key_p2wpkh())
-    }
+	/// Returns the WIF for P2WPKH
+	pub fn wif_p2wpkh(&self) -> WIF {
+		WIF::new(self.network().into(), self.private_key_p2wpkh())
+	}
 
-    /// Returns the WIF for P2TR
-    pub fn wif_p2tr(&self) -> WIF {
-        WIF::new(self.network().into(), self.private_key_p2tr())
-    }
+	/// Returns the WIF for P2TR
+	pub fn wif_p2tr(&self) -> WIF {
+		WIF::new(self.network().into(), self.private_key_p2tr())
+	}
 }


### PR DESCRIPTION
Using nightly cargo fmt rules is a bit tricky as they won't work during normal `cargo fmt` calls. You need to specifically run `cargo +nightly fmt` for them to run.

Nevertheless, it will be good enough to run them from time to time. If you're able to add `+nightly` to your editors it'll run every time.

**Note**: Only one file is actually changed, the `rustfmt.toml`, everything else is automatically reformatted.