### PR TITLE
Use local repo instead of git

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.*
+target
+Cargo.lock
+devenv/*
+coverage
+romeo/testing/
+romeo/asset-contract/.test
+romeo/asset-contract/.coverage
+

--- a/devenv/build.sh
+++ b/devenv/build.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
-docker compose build
+CWD=$(dirname "$0")
+docker compose -f $CWD/docker-compose.yml build

--- a/devenv/docker-compose.yml
+++ b/devenv/docker-compose.yml
@@ -144,11 +144,8 @@ services:
     image: sbtc:latest
     container_name: sbtc
     build:
-      context: ./sbtc/docker
-      args:
-        SBTC_VERSION: 'Alpha Romeo'
-        GIT_URI: 'https://github.com/Trust-Machines/stacks-sbtc.git'
-        GIT_BRANCH: 'main'
+      context: ./../
+      dockerfile: ./devenv/sbtc/docker/Dockerfile
     depends_on:
       - bitcoin
       - stacks

--- a/devenv/sbtc/docker-compose-sbtc.yml
+++ b/devenv/sbtc/docker-compose-sbtc.yml
@@ -5,10 +5,7 @@ services:
     image: sbtc:latest
     container_name: sbtc
     build:
-      context: ./docker
-      args:
-        SBTC_VERSION: 'Alpha Romeo'
-        GIT_URI: 'https://github.com/Trust-Machines/stacks-sbtc.git'
-        GIT_BRANCH: 'main'
+      context: ./../../
+      dockerfile: ./devenv/sbtc/docker/Dockerfile
     volumes:
       - $PWD/docker/config.json:/src/romeo/src/config.json

--- a/devenv/sbtc/docker/Dockerfile
+++ b/devenv/sbtc/docker/Dockerfile
@@ -1,18 +1,14 @@
 FROM rust:alpine
 
-ARG SBTC_VERSION='Alpha Romeo'
-ARG SBTC_GIT_URI='https://github.com/stacks-network/sbtc.git'
-ARG SBTC_GIT_BRANCH='main'
-
 WORKDIR /src
 
 RUN apk add --no-cache g++ musl-dev git openssl-dev clang-dev libsecp256k1-dev
 
-RUN git clone ${SBTC_GIT_URI} -b ${SBTC_GIT_BRANCH} .
-
 RUN cargo install --version 0.36.13 cargo-make
 
 RUN rustup component add rustfmt
+
+COPY ./../../../ .
 
 RUN RUSTFLAGS="-C target-feature=-crt-static" cargo install --path sbtc-cli
 


### PR DESCRIPTION
## Description
To make development of sBTC easier, lets copy the contents of the users current repo, and build it inside the Dockerfile for devenv.

## Checklist
- [X] Adjust build context to include entire repo
- [X] Ensure the build script can be called from any directory
- [X] Add a .dockerignore file to prevent unnecessary rebuilds

Implements: https://github.com/stacks-network/sbtc/issues/133