### PR TITLE
missing fields in config.json

### DIFF
--- a/devenv/sbtc/docker/config.json
+++ b/devenv/sbtc/docker/config.json
@@ -1,5 +1,6 @@
 {
-  "network": "testnet",
+  "stacks_network": "testnet",
+  "bitcoin_network": "regtest",
   "state_directory": "./state",
   "wif": "YOUR_WIF_CREDENTIALS",
   "mnemonic": "YOUR_MNEMONIC_PHRASES",


### PR DESCRIPTION
Running romeo with the config file in devenv/sbtc/docker/config.json fails to deserialize with trace

```Stack backtrace:
   0: anyhow::error::<impl core::convert::From<E> for anyhow::Error>::from
             at /home/cg/.cargo/registry/src/index.crates.io-6f17d22bba15001f/anyhow-1.0.75/src/error.rs:551:25
   1: <core::result::Result<T,F> as core::ops::try_trait::FromResidual<core::result::Result<core::convert::Infallible,E>>>::from_residual
             at /rustc/249595b7523fc07a99c1adee90b1947739ca0e5b/library/core/src/result.rs:1962:27
   2: romeo::config::ConfigFile::from_path
             at ./src/config.rs:114:12
   3: romeo::config::Config::from_path
             at ./src/config.rs:56:27
   4: romeo::main::{{closure}}
             at ./src/main.rs:13:18
   5: tokio::runtime::park::CachedParkThread::block_on::{{closure}}
             at /home/cg/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.32.0/src/runtime/park.rs:282:63
   6: tokio::runtime::coop::with_budget
             at /home/cg/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.32.0/src/runtime/coop.rs:107:5
   7: tokio::runtime::coop::budget
             at /home/cg/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.32.0/src/runtime/coop.rs:73:5
   8: tokio::runtime::park::CachedParkThread::block_on
             at /home/cg/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.32.0/src/runtime/park.rs:282:31
   9: tokio::runtime::context::blocking::BlockingRegionGuard::block_on
             at /home/cg/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.32.0/src/runtime/context/blocking.rs:66:9
  10: tokio::runtime::scheduler::multi_thread::MultiThread::block_on::{{closure}}
             at /home/cg/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.32.0/src/runtime/scheduler/multi_thread/mod.rs:87:13
  11: tokio::runtime::context::runtime::enter_runtime
             at /home/cg/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.32.0/src/runtime/context/runtime.rs:65:16
  12: tokio::runtime::scheduler::multi_thread::MultiThread::block_on
             at /home/cg/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.32.0/src/runtime/scheduler/multi_thread/mod.rs:86:9
  13: tokio::runtime::runtime::Runtime::block_on
             at /home/cg/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.32.0/src/runtime/runtime.rs:349:45
  14: romeo::main
             at ./src/main.rs:17:5
  15: core::ops::function::FnOnce::call_once
             at /rustc/249595b7523fc07a99c1adee90b1947739ca0e5b/library/core/src/ops/function.rs:250:5
  16: std::sys_common::backtrace::__rust_begin_short_backtrace
             at /rustc/249595b7523fc07a99c1adee90b1947739ca0e5b/library/std/src/sys_common/backtrace.rs:154:18
  17: std::rt::lang_start::{{closure}}
             at /rustc/249595b7523fc07a99c1adee90b1947739ca0e5b/library/std/src/rt.rs:166:18
  18: core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once
             at /rustc/249595b7523fc07a99c1adee90b1947739ca0e5b/library/core/src/ops/function.rs:284:13
  19: std::panicking::try::do_call
             at /rustc/249595b7523fc07a99c1adee90b1947739ca0e5b/library/std/src/panicking.rs:524:40
  20: std::panicking::try
             at /rustc/249595b7523fc07a99c1adee90b1947739ca0e5b/library/std/src/panicking.rs:488:19
  21: std::panic::catch_unwind
             at /rustc/249595b7523fc07a99c1adee90b1947739ca0e5b/library/std/src/panic.rs:142:14
  22: std::rt::lang_start_internal::{{closure}}
             at /rustc/249595b7523fc07a99c1adee90b1947739ca0e5b/library/std/src/rt.rs:148:48
  23: std::panicking::try::do_call
             at /rustc/249595b7523fc07a99c1adee90b1947739ca0e5b/library/std/src/panicking.rs:524:40
  24: std::panicking::try
             at /rustc/249595b7523fc07a99c1adee90b1947739ca0e5b/library/std/src/panicking.rs:488:19
  25: std::panic::catch_unwind
             at /rustc/249595b7523fc07a99c1adee90b1947739ca0e5b/library/std/src/panic.rs:142:14
  26: std::rt::lang_start_internal
             at /rustc/249595b7523fc07a99c1adee90b1947739ca0e5b/library/std/src/rt.rs:148:20
  27: std::rt::lang_start
             at /rustc/249595b7523fc07a99c1adee90b1947739ca0e5b/library/std/src/rt.rs:165:17
```


 Any clues on what the fields should look like?