### PR TITLE
Additional sBTC clarity mini tests

### DIFF
--- a/romeo/asset-contract/Clarinet.toml
+++ b/romeo/asset-contract/Clarinet.toml
@@ -23,6 +23,11 @@ path = 'tests/asset_test.clar'
 clarity_version = 2
 epoch = 2.4
 
+[contracts.clarity-bitcoin-mini_test]
+path = 'tests/clarity-bitcoin-mini_test.clar'
+clarity_version = 2
+epoch = 2.4
+
 [repl.analysis]
 passes = ['check_checker']
 

--- a/romeo/asset-contract/contracts/clarity-bitcoin-mini.clar
+++ b/romeo/asset-contract/contracts/clarity-bitcoin-mini.clar
@@ -10,6 +10,7 @@
 (define-constant ERR-PROOF-TOO-SHORT (err u8))
 (define-constant ERR-INVALID-BLOCK-HEADER-LENGTH (err u9))
 
+
 (define-constant block-header-merkle-root-start u36)
 (define-constant block-header-merkle-root-end u68)
 

--- a/romeo/asset-contract/tests/clarity-bitcoin-mini_test.clar
+++ b/romeo/asset-contract/tests/clarity-bitcoin-mini_test.clar
@@ -1,0 +1,29 @@
+(define-constant test-contract-principal (as-contract tx-sender))
+(define-constant zero-address 'SP000000000000000000002Q6VF78)
+
+(define-public (add-burnchain-block-header-hash (burn-height uint) (header (buff 80)))
+  (contract-call? .clarity-bitcoin-mini debug-insert-burn-header-hash (contract-call? .clarity-bitcoin-mini reverse-buff32 (sha256 (sha256 header))) burn-height)
+)
+
+(define-public (prepare)
+	(begin
+    ;; 1
+    (unwrap-panic (add-burnchain-block-header-hash u807525 0x00001733539613a8d931b08f0d3f746879572a6d3e12623b16d20000000000000000000034f521522fba52c2c5c75609d261b490ee620661319ab23c68f24d756ff4ced801230265ae32051718d9aadb))
+    (ok true)
+    )
+)
+
+;; @name verify set block header
+(define-public (test-verify-block-header)
+    (let (
+    (burnchain-block-height u807525)
+    ;; block id: 0000000000000000000104cf6179ece70fe28f1f6a24126e8d8c91d42d5eafb4
+    (raw-block-header 0x00001733539613a8d931b08f0d3f746879572a6d3e12623b16d20000000000000000000034f521522fba52c2c5c75609d261b490ee620661319ab23c68f24d756ff4ced801230265ae32051718d9aadb)
+  )
+    ;; prepare
+    (ok (contract-call? .clarity-bitcoin-mini verify-block-header
+      0x00001733539613a8d931b08f0d3f746879572a6d3e12623b16d20000000000000000000034f521522fba52c2c5c75609d261b490ee620661319ab23c68f24d756ff4ced801230265ae32051718d9aadb
+      burnchain-block-height
+    ))
+  )
+)

--- a/romeo/asset-contract/tests/clarity-bitcoin-mini_test.clar
+++ b/romeo/asset-contract/tests/clarity-bitcoin-mini_test.clar
@@ -1,4 +1,5 @@
 (define-constant ERR-ERROR-EXPECTED (err u99001))
+(define-constant ERR-OK-EXPECTED (err u99002))
 (define-constant ERR-HEADER-HEIGHT-MISMATCH (err u6))
 (define-constant ERR-INVALID-MERKLE-PROOF (err u7))
 (define-constant ERR-PROOF-TOO-SHORT (err u8))
@@ -9,9 +10,10 @@
 
 (define-public (prepare)
 	(begin
-        ;; 1
         (unwrap-panic (add-burnchain-block-header-hash u807525 0x00001733539613a8d931b08f0d3f746879572a6d3e12623b16d20000000000000000000034f521522fba52c2c5c75609d261b490ee620661319ab23c68f24d756ff4ced801230265ae32051718d9aadb))
         (unwrap-panic (add-burnchain-block-header-hash u2431087 0x0000a02065bc9201b5b5a1d695a18e4d5efe5d52d8ccc4129a2499141d000000000000009160ba7ae5f29f9632dc0cd89f466ee64e2dddfde737a40808ddc147cd82406f18b8486488a127199842cec7))
+        (unwrap-panic (add-burnchain-block-header-hash u2501368 0x00600120df8b67bf9774d6a73cea577aa415b44154dd77c84472106546020000000000002d131ab39fcffcf300e7c9edc133d762c2d7854c753ab59afc5ca4961700559250a70465fcff031ac912deb6))
+        (unwrap-panic (add-burnchain-block-header-hash u2501351 0x0060bf24490b72dd2e08d0f14f7ff058412f296c48d87f1717aae3ca8002000000000000854a0d71830a5c8f52f5cee4552f7a61d6996d2dd3d57a452301c41692c61d874da60465fcff031a0a885ddf))
         (ok true)))
 
 ;; @name check verify-block-header
@@ -38,12 +40,10 @@
         (proof {
             tx-index: u3,
             hashes: (list 0xb2d7ec769ce60ebc0c8fb9cc37f0ad7481690fc176b82c8d17d3c05da80fea6b 0x122f3217765b6e8f3163f6725d4aa3d303e4ffe4b99a5e85fb4ff91a026c17a8),
-            tree-depth: u2}))
+            tree-depth: u2})
+        (proof-response (unwrap! (contract-call? .clarity-bitcoin-mini verify-merkle-proof hash-wtx-le merkle-root proof) ERR-OK-EXPECTED)))
 
-            (asserts! (is-ok (contract-call? .clarity-bitcoin-mini verify-merkle-proof
-                hash-wtx-le
-                merkle-root
-                proof)) ERR-INVALID-MERKLE-PROOF)
+            (asserts! proof-response ERR-INVALID-MERKLE-PROOF)
 
             (ok true)))
 
@@ -57,12 +57,10 @@
         (proof {
             tx-index: u2,
             hashes: (list 0x1bd75b05fec22e8436fa721115f5a8843ba3d2d17640df9653303b186c6a3701 0x073782910dca06f17d09828a116b1b991e1255d1da2f541a465e681e11ebf32b),
-            tree-depth: u2}))
+            tree-depth: u2})
+        (proof-response (unwrap! (contract-call? .clarity-bitcoin-mini verify-merkle-proof hash-wtx-le merkle-root proof) ERR-OK-EXPECTED)))
 
-            (asserts! (is-ok (contract-call? .clarity-bitcoin-mini verify-merkle-proof
-                hash-wtx-le
-                merkle-root
-                proof)) ERR-INVALID-MERKLE-PROOF)
+            (asserts! proof-response ERR-INVALID-MERKLE-PROOF)
 
             (ok true)))
 
@@ -76,12 +74,10 @@
         (proof {
             tx-index: u2,
             hashes: (list 0x29c233c7a7b9237cc201b570af1013dd051f79f3fb39e73731afe58c3bcce09c 0xf18cd848313c7f988409dc15555ab4301aa9237ddbac3552ac01700c9c5fd454),
-            tree-depth: u2}))
-
-            (asserts! (is-ok (contract-call? .clarity-bitcoin-mini verify-merkle-proof
-                hash-wtx-le
-                merkle-root
-                proof)) ERR-INVALID-MERKLE-PROOF)
+            tree-depth: u2})
+        (proof-response (unwrap! (contract-call? .clarity-bitcoin-mini verify-merkle-proof hash-wtx-le merkle-root proof) ERR-OK-EXPECTED)))
+            
+            (asserts! proof-response ERR-INVALID-MERKLE-PROOF)
 
             (ok true)))
 
@@ -102,5 +98,5 @@
             merkle-root
             proof)))
             (asserts! (is-err proof-result) ERR-ERROR-EXPECTED)
-		    (asserts! (is-eq proof-result ERR-PROOF-TOO-SHORT) (err (unwrap-err-panic proof-result)))
+		    (asserts! (is-eq proof-result ERR-PROOF-TOO-SHORT) ERR-ERROR-EXPECTED)
             (ok true)))

--- a/romeo/asset-contract/tests/clarity-bitcoin-mini_test.clar
+++ b/romeo/asset-contract/tests/clarity-bitcoin-mini_test.clar
@@ -1,4 +1,5 @@
 (define-constant ERR-ERROR-EXPECTED (err u99001))
+(define-constant ERR-HEADER-HEIGHT-MISMATCH (err u6))
 (define-constant ERR-INVALID-MERKLE-PROOF (err u7))
 (define-constant ERR-PROOF-TOO-SHORT (err u8))
 
@@ -19,9 +20,12 @@
         (burnchain-block-height u807525)
         ;; block id: 0000000000000000000104cf6179ece70fe28f1f6a24126e8d8c91d42d5eafb4
         (raw-block-header 0x00001733539613a8d931b08f0d3f746879572a6d3e12623b16d20000000000000000000034f521522fba52c2c5c75609d261b490ee620661319ab23c68f24d756ff4ced801230265ae32051718d9aadb))
-            (ok (contract-call? .clarity-bitcoin-mini verify-block-header
+            
+            (asserts! (contract-call? .clarity-bitcoin-mini verify-block-header
                 0x00001733539613a8d931b08f0d3f746879572a6d3e12623b16d20000000000000000000034f521522fba52c2c5c75609d261b490ee620661319ab23c68f24d756ff4ced801230265ae32051718d9aadb
-                burnchain-block-height))))
+                burnchain-block-height) ERR-HEADER-HEIGHT-MISMATCH)
+
+            (ok true)))
 
 ;; @name check valid verify-merkle-proof-1
 (define-public (test-verify-merkle-proof-pass)

--- a/romeo/asset-contract/tests/clarity-bitcoin-mini_test.clar
+++ b/romeo/asset-contract/tests/clarity-bitcoin-mini_test.clar
@@ -13,7 +13,7 @@
         (unwrap-panic (add-burnchain-block-header-hash u807525 0x00001733539613a8d931b08f0d3f746879572a6d3e12623b16d20000000000000000000034f521522fba52c2c5c75609d261b490ee620661319ab23c68f24d756ff4ced801230265ae32051718d9aadb))
         (unwrap-panic (add-burnchain-block-header-hash u2431087 0x0000a02065bc9201b5b5a1d695a18e4d5efe5d52d8ccc4129a2499141d000000000000009160ba7ae5f29f9632dc0cd89f466ee64e2dddfde737a40808ddc147cd82406f18b8486488a127199842cec7))
         (unwrap-panic (add-burnchain-block-header-hash u2501368 0x00600120df8b67bf9774d6a73cea577aa415b44154dd77c84472106546020000000000002d131ab39fcffcf300e7c9edc133d762c2d7854c753ab59afc5ca4961700559250a70465fcff031ac912deb6))
-        (unwrap-panic (add-burnchain-block-header-hash u2501351 0x0060bf24490b72dd2e08d0f14f7ff058412f296c48d87f1717aae3ca8002000000000000854a0d71830a5c8f52f5cee4552f7a61d6996d2dd3d57a452301c41692c61d874da60465fcff031a0a885ddf))
+        (unwrap-panic (add-burnchain-block-header-hash u2430921 0x00004020070e3e8245969a60d47d780670d9e05dbbd860927341dda51d000000000000007ecc2f605412dddfe6e5c7798ec114004e6eda96f7045baf653c26ded334cfe27766466488a127199541c0a6))
         (ok true)))
 
 ;; @name check verify-block-header
@@ -26,7 +26,6 @@
             (asserts! (contract-call? .clarity-bitcoin-mini verify-block-header
                 0x00001733539613a8d931b08f0d3f746879572a6d3e12623b16d20000000000000000000034f521522fba52c2c5c75609d261b490ee620661319ab23c68f24d756ff4ced801230265ae32051718d9aadb
                 burnchain-block-height) ERR-HEADER-HEIGHT-MISMATCH)
-
             (ok true)))
 
 ;; @name check valid verify-merkle-proof-1
@@ -42,9 +41,7 @@
             hashes: (list 0xb2d7ec769ce60ebc0c8fb9cc37f0ad7481690fc176b82c8d17d3c05da80fea6b 0x122f3217765b6e8f3163f6725d4aa3d303e4ffe4b99a5e85fb4ff91a026c17a8),
             tree-depth: u2})
         (proof-response (unwrap! (contract-call? .clarity-bitcoin-mini verify-merkle-proof hash-wtx-le merkle-root proof) ERR-OK-EXPECTED)))
-
             (asserts! proof-response ERR-INVALID-MERKLE-PROOF)
-
             (ok true)))
 
 ;; @name check valid verify-merkle-proof-2
@@ -56,29 +53,25 @@
         (merkle-root 0x73cbac43da0bffeb8161d9da16f9106ea0d13f6c29b4fb031a61282d1b7f4255)
         (proof {
             tx-index: u2,
-            hashes: (list 0x1bd75b05fec22e8436fa721115f5a8843ba3d2d17640df9653303b186c6a3701 0x073782910dca06f17d09828a116b1b991e1255d1da2f541a465e681e11ebf32b),
+            hashes: (list 0x073782910dca06f17d09828a116b1b991e1255d1da2f541a465e681e11ebf32b 0x1bd75b05fec22e8436fa721115f5a8843ba3d2d17640df9653303b186c6a3701),
             tree-depth: u2})
         (proof-response (unwrap! (contract-call? .clarity-bitcoin-mini verify-merkle-proof hash-wtx-le merkle-root proof) ERR-OK-EXPECTED)))
-
             (asserts! proof-response ERR-INVALID-MERKLE-PROOF)
-
             (ok true)))
 
 ;; @name check valid verify-merkle-proof-3
 (define-public (test-verify-merkle-proof-pass-3)
     (let (
-        ;; hash256 wtx raw hex of tx c519ca51369814a3277c4dd381757b0e49e52d5250ffb374d6283b99ec5ae875
-        (hash-wtx-le 0x29c233c7a7b9237cc201b570af1013dd051f79f3fb39e73731afe58c3bcce09c)
+        ;; hash256 wtx raw hex of tx f95ece8dde2672891df03a79ed6099c0de4ebfdaee3c31145fe497946368cbb0
+        (hash-wtx-le 0x060f653adf158c9765994dcc38c2d29c4722b4415e56468aae2908cc26d5b7fc)
         ;; witness merkle root found in coinbase op_return (below concatenated with 32-bytes of 0x00 then hash256)
-        (merkle-root 0xdf3e48b1d8b0c86358205f8b40e149ba040ef0d6bf556e29169e369887686b02)
+        (merkle-root 0x366c4677e2f40e524b773344401f1de980ec9a9cb3453620cd1ff652b9c1d53e)
         (proof {
             tx-index: u2,
-            hashes: (list 0x29c233c7a7b9237cc201b570af1013dd051f79f3fb39e73731afe58c3bcce09c 0xf18cd848313c7f988409dc15555ab4301aa9237ddbac3552ac01700c9c5fd454),
+            hashes: (list 0x060f653adf158c9765994dcc38c2d29c4722b4415e56468aae2908cc26d5b7fc 0x438e9befc51be8d8570386ce9b5050e75ddcd410c92d0e7693b11c82b4c73f2f),
             tree-depth: u2})
         (proof-response (unwrap! (contract-call? .clarity-bitcoin-mini verify-merkle-proof hash-wtx-le merkle-root proof) ERR-OK-EXPECTED)))
-            
             (asserts! proof-response ERR-INVALID-MERKLE-PROOF)
-
             (ok true)))
 
 ;; @name check incorrect verify-merkle-proof (too short)
@@ -92,11 +85,7 @@
             hashes: (list 0xb2d7ec769ce60ebc0c8fb9cc37f0ad7481690fc176b82c8d17d3c05da80fea6b),
             tree-depth: u2}    
         )
-        (proof-result
-            (contract-call? .clarity-bitcoin-mini verify-merkle-proof
-            hash-wtx-le
-            merkle-root
-            proof)))
+        (proof-result (contract-call? .clarity-bitcoin-mini verify-merkle-proof hash-wtx-le merkle-root proof)))
             (asserts! (is-err proof-result) ERR-ERROR-EXPECTED)
 		    (asserts! (is-eq proof-result ERR-PROOF-TOO-SHORT) ERR-ERROR-EXPECTED)
             (ok true)))

--- a/romeo/asset-contract/tests/clarity-bitcoin-mini_test.clar
+++ b/romeo/asset-contract/tests/clarity-bitcoin-mini_test.clar
@@ -30,7 +30,27 @@
         (merkle-root 0x15424423c2614c23aceec8d732b5330c21ff3a306f52243fbeef47a192c65c86)
         (proof {
             tx-index: u3,
-            hashes: (list 0xb2d7ec769ce60ebc0c8fb9cc37f0ad7481690fc176b82c8d17d3c05da80fea6b 0x122f3217765b6e8f3163f6725d4aa3d303e4ffe4b99a5e85fb4ff91a026c17a8)
+            hashes: (list 0xb2d7ec769ce60ebc0c8fb9cc37f0ad7481690fc176b82c8d17d3c05da80fea6b 0x122f3217765b6e8f3163f6725d4aa3d303e4ffe4b99a5e85fb4ff91a026c17a8),
+            tree-depth: u2})
+        )
+
+        (ok (contract-call? .clarity-bitcoin-mini verify-merkle-proof
+            hash-wtx-le
+            merkle-root
+            proof)
+        )
+    )
+)
+
+;; @name check valid verify-merkle-proof-2
+(define-public (test-verify-merkle-proof-pass-2)
+    (let (
+        (raw-wtx 0x02000000000101abb563d92ef886a675d41613c5cab151eac8aa7dc4168781daa8f0beb227b4a40100000000ffffffff02d2040000000000001600145c74e4e48fe9dd1ed747676cb9e43e40aeb398669210000000000000160014a43b692f36cb5ab3657580c96daf80f82fd5b1c70247304402204c9c4f0c4da81aea6dc9d4efa0f3c93881c0443b71362388586634edbfe7e26d02203b5c593a4e2d45f92bb8c5f469887b07cd4a06b2d2f0ee9c5587c2f71c446951012103eb16b2ab368f56f92ae70f24edc57c40519feade64d55029acecbba4ffca9b9800000000)
+        (hash-wtx-le 0x3755aa59e30e045e8e9ccc31ff8c4cbc445f804a329287073d27eed965b9e4cb)
+        (merkle-root 0x15424423c2614c23aceec8d732b5330c21ff3a306f52243fbeef47a192c65c86)
+        (proof {
+            tx-index: u3,
+            hashes: (list 0xb2d7ec769ce60ebc0c8fb9cc37f0ad7481690fc176b82c8d17d3c05da80fea6b 0x122f3217765b6e8f3163f6725d4aa3d303e4ffe4b99a5e85fb4ff91a026c17a8),
             tree-depth: u2})
         )
 
@@ -51,7 +71,7 @@
         (merkle-root 0x15424423c2614c23aceec8d732b5330c21ff3a306f52243fbeef47a192c65c86)
         (proof {
             tx-index: u3,
-            hashes: (list 0xb2d7ec769ce60ebc0c8fb9cc37f0ad7481690fc176b82c8d17d3c05da80fea6b 0x122f3217765b6e8f3163f6725d4aa3d303e4ffe4b99a5e85fb4ff91a026c17a8)
+            hashes: (list 0xb2d7ec769ce60ebc0c8fb9cc37f0ad7481690fc176b82c8d17d3c05da80fea6b 0x122f3217765b6e8f3163f6725d4aa3d303e4ffe4b99a5e85fb4ff91a026c17a8),
             tree-depth: u2})
         )
 

--- a/romeo/asset-contract/tests/clarity-bitcoin-mini_test.clar
+++ b/romeo/asset-contract/tests/clarity-bitcoin-mini_test.clar
@@ -9,6 +9,7 @@
 	(begin
         ;; 1
         (unwrap-panic (add-burnchain-block-header-hash u807525 0x00001733539613a8d931b08f0d3f746879572a6d3e12623b16d20000000000000000000034f521522fba52c2c5c75609d261b490ee620661319ab23c68f24d756ff4ced801230265ae32051718d9aadb))
+        (unwrap-panic (add-burnchain-block-header-hash u2431087 0x0000a02065bc9201b5b5a1d695a18e4d5efe5d52d8ccc4129a2499141d000000000000009160ba7ae5f29f9632dc0cd89f466ee64e2dddfde737a40808ddc147cd82406f18b8486488a127199842cec7))
         (ok true)))
 
 ;; @name check verify-block-header
@@ -22,50 +23,68 @@
                 0x00001733539613a8d931b08f0d3f746879572a6d3e12623b16d20000000000000000000034f521522fba52c2c5c75609d261b490ee620661319ab23c68f24d756ff4ced801230265ae32051718d9aadb
                 burnchain-block-height))))
 
-;; @name check valid verify-merkle-proof
+;; @name check valid verify-merkle-proof-1
 (define-public (test-verify-merkle-proof-pass)
     (let (
-        (raw-wtx 0x0200000000010218f905443202116524547142bd55b69335dfc4e4c66ff3afaaaab6267b557c4b030000000000000000e0dbdf1039321ab7a2626ca5458e766c6107690b1a1923e075c4f691cc4928ac0000000000000000000220a10700000000002200208730dbfaa29c49f00312812aa12a62335113909711deb8da5ecedd14688188363c5f26010000000022512036f4ff452cb82e505436e73d0a8b630041b71e037e5997290ba1fe0ae7f4d8d50140a50417be5a056f63e052294cb20643f83038d5cd90e2f90c1ad3f80180026cb99d78cd4480fadbbc5b9cad5fb2248828fb21549e7cb3f7dbd7aefd2d541bd34f0140acde555b7689eae41d5ccf872bb32a270893bdaa1defc828b76c282f6c87fc387d7d4343c5f7288cfd9aa5da0765c7740ca97e44a0205a1abafa279b530d5fe36d182500)
+        ;; hash256 wtx raw hex of tx 3b3a7a31c949048fabf759e670a55ffd5b9472a12e748b684db5d264b6852084
         (hash-wtx-le 0x04117dc370c45b8a44bf86a3ae4fa8d0b186b5b27d50939cda7501723fa12ec6)
+        ;; witness merkle root found in coinbase op_return (below concatenated with 32-bytes of 0x00 then hash256)
         (merkle-root 0x15424423c2614c23aceec8d732b5330c21ff3a306f52243fbeef47a192c65c86)
+        ;; witness proof
         (proof {
             tx-index: u3,
             hashes: (list 0xb2d7ec769ce60ebc0c8fb9cc37f0ad7481690fc176b82c8d17d3c05da80fea6b 0x122f3217765b6e8f3163f6725d4aa3d303e4ffe4b99a5e85fb4ff91a026c17a8),
-            tree-depth: u2})
-        )
+            tree-depth: u2}))
 
-        (ok (contract-call? .clarity-bitcoin-mini verify-merkle-proof
-            hash-wtx-le
-            merkle-root
-            proof)
-        )
+            (ok (asserts! (is-ok (contract-call? .clarity-bitcoin-mini verify-merkle-proof
+                hash-wtx-le
+                merkle-root
+                proof)) (err u5)))
     )
 )
 
 ;; @name check valid verify-merkle-proof-2
 (define-public (test-verify-merkle-proof-pass-2)
     (let (
-        (raw-wtx 0x02000000000101abb563d92ef886a675d41613c5cab151eac8aa7dc4168781daa8f0beb227b4a40100000000ffffffff02d2040000000000001600145c74e4e48fe9dd1ed747676cb9e43e40aeb398669210000000000000160014a43b692f36cb5ab3657580c96daf80f82fd5b1c70247304402204c9c4f0c4da81aea6dc9d4efa0f3c93881c0443b71362388586634edbfe7e26d02203b5c593a4e2d45f92bb8c5f469887b07cd4a06b2d2f0ee9c5587c2f71c446951012103eb16b2ab368f56f92ae70f24edc57c40519feade64d55029acecbba4ffca9b9800000000)
-        (hash-wtx-le 0x3755aa59e30e045e8e9ccc31ff8c4cbc445f804a329287073d27eed965b9e4cb)
-        (merkle-root 0x15424423c2614c23aceec8d732b5330c21ff3a306f52243fbeef47a192c65c86)
+        ;; hash256 wtx raw hex of tx 0ba1d831915fb5d9bbd4c19665ebf12157ee6aaf1d81e054b667bb5539e77bd8
+        (hash-wtx-le 0x073782910dca06f17d09828a116b1b991e1255d1da2f541a465e681e11ebf32b)
+        ;; witness merkle root found in coinbase op_return (below concatenated with 32-bytes of 0x00 then hash256)
+        (merkle-root 0x73cbac43da0bffeb8161d9da16f9106ea0d13f6c29b4fb031a61282d1b7f4255)
         (proof {
-            tx-index: u3,
-            hashes: (list 0xb2d7ec769ce60ebc0c8fb9cc37f0ad7481690fc176b82c8d17d3c05da80fea6b 0x122f3217765b6e8f3163f6725d4aa3d303e4ffe4b99a5e85fb4ff91a026c17a8),
-            tree-depth: u2})
-        )
+            tx-index: u2,
+            hashes: (list 0x1bd75b05fec22e8436fa721115f5a8843ba3d2d17640df9653303b186c6a3701 0x073782910dca06f17d09828a116b1b991e1255d1da2f541a465e681e11ebf32b),
+            tree-depth: u2}))
 
-        (ok (contract-call? .clarity-bitcoin-mini verify-merkle-proof
-            hash-wtx-le
-            merkle-root
-            proof)
-        )
+            (ok (contract-call? .clarity-bitcoin-mini verify-merkle-proof
+                hash-wtx-le
+                merkle-root
+                proof)
+            )
+    )
+)
+
+;; @name check valid verify-merkle-proof-3
+(define-public (test-verify-merkle-proof-pass-3)
+    (let (
+        ;; hash256 wtx raw hex of tx c519ca51369814a3277c4dd381757b0e49e52d5250ffb374d6283b99ec5ae875
+        (hash-wtx-le 0x29c233c7a7b9237cc201b570af1013dd051f79f3fb39e73731afe58c3bcce09c)
+        ;; witness merkle root found in coinbase op_return (below concatenated with 32-bytes of 0x00 then hash256)
+        (merkle-root 0xdf3e48b1d8b0c86358205f8b40e149ba040ef0d6bf556e29169e369887686b02)
+        (proof {
+            tx-index: u2,
+            hashes: (list 0x29c233c7a7b9237cc201b570af1013dd051f79f3fb39e73731afe58c3bcce09c 0xf18cd848313c7f988409dc15555ab4301aa9237ddbac3552ac01700c9c5fd454),
+            tree-depth: u2}))
+
+            (contract-call? .clarity-bitcoin-mini verify-merkle-proof
+                hash-wtx-le
+                merkle-root
+                proof)
     )
 )
 
 ;; @name check incorrect valid verify-merkle-proof
 (define-public (test-incorrect-verify-merkle-proof-pass)
     (let (
-        (raw-wtx 0x0200000000010218f905443202116524547142bd55b69335dfc4e4c66ff3afaaaab6267b557c4b030000000000000000e0dbdf1039321ab7a2626ca5458e766c6107690b1a1923e075c4f691cc4928ac0000000000000000000220a10700000000002200208730dbfaa29c49f00312812aa12a62335113909711deb8da5ecedd14688188363c5f26010000000022512036f4ff452cb82e505436e73d0a8b630041b71e037e5997290ba1fe0ae7f4d8d50140a50417be5a056f63e052294cb20643f83038d5cd90e2f90c1ad3f80180026cb99d78cd4480fadbbc5b9cad5fb2248828fb21549e7cb3f7dbd7aefd2d541bd34f0140acde555b7689eae41d5ccf872bb32a270893bdaa1defc828b76c282f6c87fc387d7d4343c5f7288cfd9aa5da0765c7740ca97e44a0205a1abafa279b530d5fe36d182500)
         (hash-wtx-le 0x04117dc370c45b8a44bf86a3ae4fa8d0b186b5b27d50939cda7501723fa12ec6)
         (hash-wtx-be 0xc62ea13f720175da9c93507db2b586b1d0a84faea386bf448a5bc470c37d1104)
         (merkle-root 0x15424423c2614c23aceec8d732b5330c21ff3a306f52243fbeef47a192c65c86)

--- a/romeo/asset-contract/tests/clarity-bitcoin-mini_test.clar
+++ b/romeo/asset-contract/tests/clarity-bitcoin-mini_test.clar
@@ -7,23 +7,58 @@
 
 (define-public (prepare)
 	(begin
-    ;; 1
-    (unwrap-panic (add-burnchain-block-header-hash u807525 0x00001733539613a8d931b08f0d3f746879572a6d3e12623b16d20000000000000000000034f521522fba52c2c5c75609d261b490ee620661319ab23c68f24d756ff4ced801230265ae32051718d9aadb))
-    (ok true)
+        ;; 1
+        (unwrap-panic (add-burnchain-block-header-hash u807525 0x00001733539613a8d931b08f0d3f746879572a6d3e12623b16d20000000000000000000034f521522fba52c2c5c75609d261b490ee620661319ab23c68f24d756ff4ced801230265ae32051718d9aadb))
+        (ok true)))
+
+;; @name check verify-block-header
+(define-public (test-verify-block-header)
+    (let (
+        (burnchain-block-height u807525)
+        ;; block id: 0000000000000000000104cf6179ece70fe28f1f6a24126e8d8c91d42d5eafb4
+        (raw-block-header 0x00001733539613a8d931b08f0d3f746879572a6d3e12623b16d20000000000000000000034f521522fba52c2c5c75609d261b490ee620661319ab23c68f24d756ff4ced801230265ae32051718d9aadb))
+        ;; prepare
+            (ok (contract-call? .clarity-bitcoin-mini verify-block-header
+                0x00001733539613a8d931b08f0d3f746879572a6d3e12623b16d20000000000000000000034f521522fba52c2c5c75609d261b490ee620661319ab23c68f24d756ff4ced801230265ae32051718d9aadb
+                burnchain-block-height))))
+
+;; @name check valid verify-merkle-proof
+(define-public (test-verify-merkle-proof-pass)
+    (let (
+        (raw-wtx 0x0200000000010218f905443202116524547142bd55b69335dfc4e4c66ff3afaaaab6267b557c4b030000000000000000e0dbdf1039321ab7a2626ca5458e766c6107690b1a1923e075c4f691cc4928ac0000000000000000000220a10700000000002200208730dbfaa29c49f00312812aa12a62335113909711deb8da5ecedd14688188363c5f26010000000022512036f4ff452cb82e505436e73d0a8b630041b71e037e5997290ba1fe0ae7f4d8d50140a50417be5a056f63e052294cb20643f83038d5cd90e2f90c1ad3f80180026cb99d78cd4480fadbbc5b9cad5fb2248828fb21549e7cb3f7dbd7aefd2d541bd34f0140acde555b7689eae41d5ccf872bb32a270893bdaa1defc828b76c282f6c87fc387d7d4343c5f7288cfd9aa5da0765c7740ca97e44a0205a1abafa279b530d5fe36d182500)
+        (hash-wtx-le 0x04117dc370c45b8a44bf86a3ae4fa8d0b186b5b27d50939cda7501723fa12ec6)
+        (merkle-root 0x15424423c2614c23aceec8d732b5330c21ff3a306f52243fbeef47a192c65c86)
+        (proof {
+            tx-index: u3,
+            hashes: (list 0xb2d7ec769ce60ebc0c8fb9cc37f0ad7481690fc176b82c8d17d3c05da80fea6b 0x122f3217765b6e8f3163f6725d4aa3d303e4ffe4b99a5e85fb4ff91a026c17a8)
+            tree-depth: u2})
+        )
+
+        (ok (contract-call? .clarity-bitcoin-mini verify-merkle-proof
+            hash-wtx-le
+            merkle-root
+            proof)
+        )
     )
 )
 
-;; @name verify set block header
-(define-public (test-verify-block-header)
+;; @name check incorrect valid verify-merkle-proof
+(define-public (test-incorrect-verify-merkle-proof-pass)
     (let (
-    (burnchain-block-height u807525)
-    ;; block id: 0000000000000000000104cf6179ece70fe28f1f6a24126e8d8c91d42d5eafb4
-    (raw-block-header 0x00001733539613a8d931b08f0d3f746879572a6d3e12623b16d20000000000000000000034f521522fba52c2c5c75609d261b490ee620661319ab23c68f24d756ff4ced801230265ae32051718d9aadb)
-  )
-    ;; prepare
-    (ok (contract-call? .clarity-bitcoin-mini verify-block-header
-      0x00001733539613a8d931b08f0d3f746879572a6d3e12623b16d20000000000000000000034f521522fba52c2c5c75609d261b490ee620661319ab23c68f24d756ff4ced801230265ae32051718d9aadb
-      burnchain-block-height
-    ))
-  )
+        (raw-wtx 0x0200000000010218f905443202116524547142bd55b69335dfc4e4c66ff3afaaaab6267b557c4b030000000000000000e0dbdf1039321ab7a2626ca5458e766c6107690b1a1923e075c4f691cc4928ac0000000000000000000220a10700000000002200208730dbfaa29c49f00312812aa12a62335113909711deb8da5ecedd14688188363c5f26010000000022512036f4ff452cb82e505436e73d0a8b630041b71e037e5997290ba1fe0ae7f4d8d50140a50417be5a056f63e052294cb20643f83038d5cd90e2f90c1ad3f80180026cb99d78cd4480fadbbc5b9cad5fb2248828fb21549e7cb3f7dbd7aefd2d541bd34f0140acde555b7689eae41d5ccf872bb32a270893bdaa1defc828b76c282f6c87fc387d7d4343c5f7288cfd9aa5da0765c7740ca97e44a0205a1abafa279b530d5fe36d182500)
+        (hash-wtx-le 0x04117dc370c45b8a44bf86a3ae4fa8d0b186b5b27d50939cda7501723fa12ec6)
+        (hash-wtx-be 0xc62ea13f720175da9c93507db2b586b1d0a84faea386bf448a5bc470c37d1104)
+        (merkle-root 0x15424423c2614c23aceec8d732b5330c21ff3a306f52243fbeef47a192c65c86)
+        (proof {
+            tx-index: u3,
+            hashes: (list 0xb2d7ec769ce60ebc0c8fb9cc37f0ad7481690fc176b82c8d17d3c05da80fea6b 0x122f3217765b6e8f3163f6725d4aa3d303e4ffe4b99a5e85fb4ff91a026c17a8)
+            tree-depth: u2})
+        )
+
+        (ok (is-err (contract-call? .clarity-bitcoin-mini verify-merkle-proof
+            hash-wtx-be
+            merkle-root
+            proof))
+        )
+    )
 )


### PR DESCRIPTION
# sBTC Clarity-Bitcoin-Mini Tests
## Summary of Changes

This PR is meant to add a handful of Clarity unit tests for the clarity-bitcoin-mini.clar file found in romeo/asset-contract. These tests are unit tests for varying clarity & bitcoin logic such as: verify-block-header & verify-merkle-proof.

## Testing

### Risks

The largest risk with this PR & logic likely lies in the 'prepare' setup & in generating false unit-test positives due to complexity in clarity -> typescripts tests & to required preparation.

### How were these changes tested?

These tests were locally tested using clarinet unit testing, specifically generating the non-traditional ./scripts/test.sh  tests written primarily in Clarity.

To replicate the tests found here, cd into romeo/asset-contract then run ./scripts/test.sh. 

### What future testing should occur?

While this first round of tests focused on the functions mentioned above, it'd make sense to focus future testing on the (was-txid-mined ...) logic as well as additional unit tests on fundamental helper functions such as (reverse-buffs ...).

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
