### PR TITLE
don't deploy if build fails

### DIFF
--- a/devenv/up.sh
+++ b/devenv/up.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
 
 ./build.sh
-docker compose up -d
+if [ $? -eq 0 ] 
+then
+  docker compose up -d
+else
+  echo "Build failed, not starting devenv"
+fi


### PR DESCRIPTION
## Description
The `up.sh` script was not checking the return code of the build script, so it will try to start the deployment even if the build fails. We should only deploy if the build was a success. 

## Checklist
- [x] Additions and modifications are documented
- [x] Additions and modifications are tested
