### PR TITLE
devenv/bitcoin; reduce image size

### DIFF
--- a/devenv/bitcoin/docker/Dockerfile
+++ b/devenv/bitcoin/docker/Dockerfile
@@ -1,12 +1,10 @@
-FROM debian:stable-slim
+FROM debian:stable-slim as builder
 MAINTAINER Tyler Baker <tyler@trustmachines.co>
 
 ARG VERSION=25.0
 
 RUN apt-get update && apt-get install -y \
     wget \
-    ca-certificates \
-    coreutils \
     file \
   && rm -rf /var/lib/apt/lists/*
 
@@ -14,21 +12,24 @@ RUN file /bin/bash | grep -q x86-64 && echo x86_64-linux-gnu > /tmp/arch || true
 RUN file /bin/bash | grep -q aarch64 && echo aarch64-linux-gnu > /tmp/arch || true
 RUN file /bin/bash | grep -q EABI5 && echo arm-linux-gnueabihf > /tmp/arch || true
 
-WORKDIR /src
-
 RUN wget https://bitcoincore.org/bin/bitcoin-core-${VERSION}/bitcoin-${VERSION}-$(cat /tmp/arch).tar.gz 
 
 RUN wget https://bitcoincore.org/bin/bitcoin-core-${VERSION}/SHA256SUMS
 
-RUN cat SHA256SUMS | grep bitcoin-${VERSION}-$(cat /tmp/arch).tar.gz | sha256sum -c \
-  && tar xzvf bitcoin-${VERSION}-$(cat /tmp/arch).tar.gz \
-  && mkdir /root/.bitcoin \
-  && mv bitcoin-${VERSION}/bin/* /usr/local/bin/ \
-  && rm -rf bitcoin-${VERSION}/ \
-  && rm -rf bitcoin-${VERSION}-$(cat /tmp/arch).tar.gz \
-  && rm SHA256SUMS
+RUN cat SHA256SUMS | grep bitcoin-${VERSION}-$(cat /tmp/arch).tar.gz | sha256sum -c && \
+    mkdir /bitcoin && \
+    tar -xzvf bitcoin-${VERSION}-$(cat /tmp/arch).tar.gz -C /bitcoin --strip-components=1
 
-ADD entrypoint.sh /usr/local/bin/entrypoint.sh
+FROM debian:stable-slim as runtime
+
+RUN apt-get update && apt-get install -y \
+    ca-certificates \
+    coreutils \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /bitcoin/bin/* /usr/local/bin
+
+ADD entrypoint.sh /usr/local/bin
 RUN chmod a+x /usr/local/bin/entrypoint.sh
 
-ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+ENTRYPOINT ["entrypoint.sh"]

--- a/devenv/bitcoin/docker/entrypoint.sh
+++ b/devenv/bitcoin/docker/entrypoint.sh
@@ -2,14 +2,9 @@
 
 set -x
 
-BTC_DIR=/root/.bitcoin
-BITCOIN_CONF=${BITCOIN_DIR}/bitcoin.conf
-
 #-rpcuser=${BTC_RPCUSER} -rpcpassword=${BTC_RPCPASSWORD}
 
 # bitcoind needs creds set in the conf file for remote RPC auth
 #echo '[regtest]' > ${BITCOIN_CONF}
-echo 'rpcuser=devnet' >> ${BITCOIN_CONF}
-echo 'rpcpassword=devnet' >> ${BITCOIN_CONF}
 
-bitcoind -chain=${BTC_NETWORK} -conf=${BITCOIN_CONF} -datadir=${BTC_DIR} -txindex=${BTC_TXINDEX} -rpcuser=${BTC_RPCUSER} -rpcpassword=${BTC_RPCPASSWORD} -printtoconsole=${BTC_PRINTTOCONSOLE} -disablewallet=${BTC_DISABLEWALLET} -rpcbind=${BTC_RPCBIND} -rpcallowip=${BTC_RPCALLOWIP}  
+bitcoind -chain=${BTC_NETWORK} -txindex=${BTC_TXINDEX} -rpcuser=${BTC_RPCUSER} -rpcpassword=${BTC_RPCPASSWORD} -printtoconsole=${BTC_PRINTTOCONSOLE} -disablewallet=${BTC_DISABLEWALLET} -rpcbind=${BTC_RPCBIND} -rpcallowip=${BTC_RPCALLOWIP}


### PR DESCRIPTION
Arguments take precedence over .conf settings.
'BTC_DIR' and 'BITCOIN_CONF' are the defaults. 
I'm removing inconsequential settings.

Trimmed a little the bitcoin image.

before:
REPOSITORY         TAG         IMAGE ID       CREATED          SIZE
bitcoin            latest      2b42dda19db1   13 seconds ago   240MB

after:
REPOSITORY         TAG         IMAGE ID       CREATED              SIZE
bitcoin            latest      59846c49482f   About a minute ago   184MB
