### PR TITLE
Propagate error when an error field is present in the request response.

### DIFF
--- a/romeo/src/stacks_client.rs
+++ b/romeo/src/stacks_client.rs
@@ -2,7 +2,7 @@
 
 use std::{io::Cursor, sync::Arc, time::Duration};
 
-use anyhow::anyhow;
+use anyhow::{anyhow, Error};
 use blockstack_lib::{
 	burnchains::Txid as StacksTxId,
 	chainstate::stacks::{
@@ -219,7 +219,11 @@ impl StacksClient {
 			})
 			.await?;
 
-		Ok(res["block_height"].as_u64().unwrap() as u32)
+		if let Some(err) = res["error"].as_str() {
+			Err(Error::msg(err.to_string()))
+		} else {
+			Ok(res["block_height"].as_u64().unwrap() as u32)
+		}
 	}
 
 	/// Get the Bitcoin block height for a Stacks block height


### PR DESCRIPTION
## Description

When the request fails, I expect the error field to be present and propagated as an error.

Expected:
```
2023-09-29T05:40:19.736443664Z thread 'tokio-runtime-worker' panicked at 'Could not get block height: cannot find contract by ID ST2GEN9CVCJNZPDH7Z7NPWRG6Z67GH3WWYAS4DGRA.sbtc-alpha-romeo-testing', romeo/src/system.rs:192:10
```
