### PR TITLE
devenv: reintroduce sbtc-bridge-api

### DIFF
--- a/devenv/README.md
+++ b/devenv/README.md
@@ -57,6 +57,7 @@ There is a helper script at the top level directory to facilitate logging:
 ./log stacks-api
 ./log stacks-explorer
 ./log postgres
+./log mongodb
 ./log miner
 ./log sbtc
 ./log electrs

--- a/devenv/README.md
+++ b/devenv/README.md
@@ -62,6 +62,7 @@ There is a helper script at the top level directory to facilitate logging:
 ./log sbtc
 ./log electrs
 ./log sbtc-bridge-web
+./log sbtc-bridge-api
 ```
 ## Services
 
@@ -110,7 +111,11 @@ The sBTC bridge app is running at:
 http://127.0.0.1:8080/
 ```
 ### sBTC Bridge API
-TBD
+The sBTC bridge api is running at:
+
+```
+http://127.0.0.1:3010/
+```
 
 ### Electrs (Electrum Rust Server)
 The electrs service is running at:

--- a/devenv/docker-compose.yml
+++ b/devenv/docker-compose.yml
@@ -197,7 +197,7 @@ services:
       bitcoinExplorerUrl: http://bitcoin-explorer:3002/api
       stacksExplorerUrl: http://stacks-explorer:3000
       stacksApi: http://stacks-api:3999
-      sbtcContractId: ST1R1061ZT6KPJXQ7PAXPFB6ZAZ6ZWW28G8HXK9G5.related-pink-tick
+      sbtcContractId: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.asset
       mongoDbUrl: mongodb
       mongoDbName: devnet
       mongoUser: devnet

--- a/devenv/docker-compose.yml
+++ b/devenv/docker-compose.yml
@@ -166,6 +166,42 @@ services:
       RUST_BACKTRACE: 1
     volumes:
       - $PWD/sbtc/docker/config.json:/romeo/config.json
+  sbtc-bridge-api:
+    image: sbtc-bridge-api:latest
+    container_name: sbtc-bridge-api
+    build:
+      context: ./sbtc-bridge-api/docker
+      args:
+        BRIDGE_GIT_URI: https://github.com/stacks-network/sbtc-bridge-api.git
+        BRIDGE_GIT_BRANCH: main
+    depends_on:
+      - bitcoin
+      - miner
+      - stacks
+      - stacks-api
+      - postgres
+      - stacks-explorer
+      - bitcoin-explorer
+      - mongodb
+      - sbtc
+    ports:
+      - 3010:3010
+    environment:
+      NODE_ENV: dev
+      btcSchnorrReveal: changeme
+      btcSchnorrReclaim: changeme
+      btcNode: bitcoin:18443
+      btcRpcUser: devnet
+      btcRpcPwd: devnet
+      network: testnet
+      bitcoinExplorerUrl: http://bitcoin-explorer:3002/api
+      stacksExplorerUrl: http://stacks-explorer:3000
+      stacksApi: http://stacks-api:3999
+      sbtcContractId: ST1R1061ZT6KPJXQ7PAXPFB6ZAZ6ZWW28G8HXK9G5.related-pink-tick
+      mongoDbUrl: mongodb
+      mongoDbName: devnet
+      mongoUser: devnet
+      mongoPwd: devnet
   sbtc-bridge-web:
     image: sbtc-bridge-web:latest
     container_name: sbtc-bridge-web
@@ -179,5 +215,6 @@ services:
       - bitcoin-explorer
       - miner
       - sbtc
+      - sbtc-bridge-api
     ports:
       - 8080:8080

--- a/devenv/docker-compose.yml
+++ b/devenv/docker-compose.yml
@@ -27,6 +27,15 @@ services:
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
+  mongodb:
+    image: mongo:6.0
+    container_name: mongodb
+    ports:
+      - 27017:27017
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: devnet
+      MONGO_INITDB_ROOT_PASSWORD: devnet
+      MONGO_INITDB_DATABASE: devnet
   miner:
     image: miner:latest
     container_name: miner

--- a/devenv/mongodb/docker-compose-mongodb.yml
+++ b/devenv/mongodb/docker-compose-mongodb.yml
@@ -1,0 +1,14 @@
+version: "3.2"
+
+services:
+  mongodb:
+    image: mongo:6.0   
+    container_name: mongodb 
+    build:
+      context: ./docker
+    ports:
+      - 27017:27017
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: devnet
+      MONGO_INITDB_ROOT_PASSWORD: devnet
+      MONGO_INITDB_DATABASE: devnet

--- a/devenv/mongodb/down.sh
+++ b/devenv/mongodb/down.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker compose -f docker-compose-mongodb.yml down

--- a/devenv/mongodb/up.sh
+++ b/devenv/mongodb/up.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker compose -f docker-compose-mongodb.yml up -d

--- a/devenv/sbtc-bridge-api/docker-compose-sbtc-bridge-api.yml
+++ b/devenv/sbtc-bridge-api/docker-compose-sbtc-bridge-api.yml
@@ -6,7 +6,24 @@ services:
     container_name: sbtc-bridge-api   
     build:
       context: ./docker
-    environment:
-      - PORT=80
+      args:
+        BRIDGE_GIT_URI: https://github.com/stacks-network/sbtc-bridge-api.git
+        BRIDGE_GIT_BRANCH: main
     ports:
-      - "80:80"
+      - 3010:3010
+    environment:
+      NODE_ENV: dev
+      btcSchnorrReveal: changeme
+      btcSchnorrReclaim: changeme
+      btcNode: bitcoin:18443
+      btcRpcUser: devnet
+      btcRpcPwd: devnet
+      network: testnet
+      bitcoinExplorerUrl: http://bitcoin-explorer:3002/api
+      stacksExplorerUrl: http://stacks-explorer:3000
+      stacksApi: http://stacks-api:3999
+      sbtcContractId: ST1R1061ZT6KPJXQ7PAXPFB6ZAZ6ZWW28G8HXK9G5.related-pink-tick
+      mongoDbUrl: mongodb
+      mongoDbName: devnet
+      mongoUser: devnet
+      mongoPwd: devnet

--- a/devenv/sbtc-bridge-api/docker-compose-sbtc-bridge-api.yml
+++ b/devenv/sbtc-bridge-api/docker-compose-sbtc-bridge-api.yml
@@ -22,7 +22,7 @@ services:
       bitcoinExplorerUrl: http://bitcoin-explorer:3002/api
       stacksExplorerUrl: http://stacks-explorer:3000
       stacksApi: http://stacks-api:3999
-      sbtcContractId: ST1R1061ZT6KPJXQ7PAXPFB6ZAZ6ZWW28G8HXK9G5.related-pink-tick
+      sbtcContractId: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.asset
       mongoDbUrl: mongodb
       mongoDbName: devnet
       mongoUser: devnet

--- a/devenv/sbtc-bridge-api/docker/Dockerfile
+++ b/devenv/sbtc-bridge-api/docker/Dockerfile
@@ -1,8 +1,8 @@
 FROM node:19-alpine
 
 ARG SBTC_VERSION='Alpha'
-ARG SBTC_GIT_URI='https://github.com/stacks-network/sbtc-bridge-api.git'
-ARG SBTC_GIT_BRANCH='main'
+ARG BRIDGE_GIT_URI='https://github.com/stacks-network/sbtc-bridge-api.git'
+ARG BRIDGE_GIT_BRANCH='main'
 
 # Set the environment variables
 ENV PORT 7010
@@ -13,7 +13,7 @@ WORKDIR /app
 RUN apk add --no-cache git
 
 # Bundle app source
-RUN git clone ${SBTC_GIT_URI} -b ${SBTC_GIT_BRANCH} .
+RUN git clone ${BRIDGE_GIT_URI} -b ${BRIDGE_GIT_BRANCH} .
 
 WORKDIR /app/sbtc-bridge-api
 


### PR DESCRIPTION
## Description
This PR fixes the sbtc-bridge-api in devnet. It also requires the use of mongodb which has been added as well.

## Checklist
- [x] Additions and modifications are documented
- [x] Additions and modifications are tested

re: https://github.com/stacks-network/sbtc/issues/141
