### PR TITLE
[sBTC DR] Add option for hiro api key

### DIFF
--- a/romeo/src/config.rs
+++ b/romeo/src/config.rs
@@ -53,6 +53,9 @@ pub struct Config {
 
 	/// sBTC asset contract name
 	pub contract_name: ContractName,
+
+	/// optional api key used for the stacks node
+	pub hiro_api_key: Option<String>,
 }
 
 impl Config {
@@ -77,6 +80,7 @@ impl Config {
 			wallet.credentials(config_file.stacks_network, 0)?;
 		let bitcoin_credentials =
 			wallet.bitcoin_credentials(config_file.bitcoin_network, 0)?;
+		let hiro_api_key = config_file.hiro_api_key;
 
 		Ok(Self {
 			state_directory,
@@ -90,6 +94,7 @@ impl Config {
 			contract_name: ContractName::from(
 				config_file.contract_name.as_str(),
 			),
+			hiro_api_key,
 		})
 	}
 }
@@ -127,6 +132,9 @@ struct ConfigFile {
 
 	/// sBTC asset contract name
 	pub contract_name: String,
+
+	/// optional api key used for the stacks node
+	pub hiro_api_key: Option<String>,
 }
 
 impl ConfigFile {


### PR DESCRIPTION
## Summary of Changes
This PR
* adds a config option for an api key for the stacks node when using the hiro infrastructure
* fixes #197 

## Testing

### Risks
As this is an optional config, the risks are limited.

### How were these changes tested?
Not yet tested.

### What future testing should occur?
* Manual testing to launch romeo with and without the hiro-api-key config
* More integration tests

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
