### PR TITLE
Only use btc tx once

### DIFF
--- a/romeo/asset-contract/tests/asset_test.clar
+++ b/romeo/asset-contract/tests/asset_test.clar
@@ -9,6 +9,8 @@
 
 (define-constant err-invalid-caller (err u4))
 (define-constant err-forbidden (err u403))
+(define-constant err-btc-tx-already-used (err u500))
+(define-constant err-expected-err (err u9999))
 
 (define-constant test-burn-height u1)
 (define-constant test-block-header 0x02000000000000000000000000000000000000000000000000000000000000000000000075b8bf903d0153e1463862811283ffbec83f55411c9fa5bd24e4207dee0dc1f1000000000000000000000000)
@@ -18,6 +20,32 @@
 (define-constant test-tree-depth u1)
 (define-constant test-merkle-proof (list 0x582b1900f55dad47d575138e91321c441d174e20a43336780c352a0b556ecc8b))
 
+;; testnet block 2
+(define-constant test-burn-height-2 u2)
+(define-constant test-block-header-2 0x020000002840bc6c31378c0a314609fb50f21811c5370f7df387b30d109d620000000000a9858cc9be942ea7459f026b09e3c25287706bc3d0d9ba2d59d8ea39168c6ce72400065227f1001c4a0c9887)
+(define-constant test-block-header-hash-2 0x0000000000977ac3d9f5261efc88a3c2d25af92a91350750d00ad67744fa8d03)
+(define-constant test-txid-2 0x3fe5373efdada483b5fa7bdf2249d8274f1b8c04ab5a98bce3edfb732d8e2f86)
+(define-constant test-tx-index-2 u1)
+(define-constant test-tree-depth-2 u1)
+(define-constant test-merkle-proof-2 (list 0xf823d9b527ee0427d95d355d03e95bd30639cda85bcf65050ca32bd7d11ee1f7))
+
+;; used to mint for contract
+(define-constant test-burn-height-3 u3)
+(define-constant test-block-header-3 0x00000000000000000000000000000000000000000000000000000000000000000000000019f249885791b56b8b24ddb8d625522a6fb42629a56cad300da6213a808005b2000000000000000000000000)
+(define-constant test-block-header-hash-3 0x2ee611e1b02c558e838f531b6fa3e33dd66747ca57532bee2be4efd9f3d85292)
+(define-constant test-txid-3 0x6801cb417573220564c3cec34dd39a0879e24ea75a7ca1ba6a3b8c11c1c6c6b3)
+(define-constant test-tx-index-3 u1)
+(define-constant test-tree-depth-3 u1)
+(define-constant test-merkle-proof-3 (list 0xcfd12454d95e1f7af0f7e183862b5adf8bf7be7414c7afb0c549f360b960471d))
+
+;; used to burn
+(define-constant test-burn-height-4 u4)
+(define-constant test-block-header-4 0x00000000000000000000000000000000000000000000000000000000000000000000000041918a58bf1189a6eaeb80766ddea620363cf3f4e4a93ab101b0bb3b08e5eed1000000000000000000000000)
+(define-constant test-block-header-hash-4 0xf83d0cb1e608b3402de733bd655a644714309801edb151ae274e0ccb03cfc981)
+(define-constant test-txid-4 0x2d1f657e970f724c4cd690494152a83bd297cd10e86ed930daa2dd76576d974c)
+(define-constant test-tx-index-4 u1)
+(define-constant test-tree-depth-4 u1)
+(define-constant test-merkle-proof-4 (list 0xe79e0239e1f9d0f23613387a4831495fd5179943419bcad3a2c20c6931ab1abc))
 
 (define-private (assert-eq (result (response bool uint)) (compare (response bool uint)) (message (string-ascii 100)))
 	(ok (asserts! (is-eq result compare) (err message)))
@@ -32,7 +60,14 @@
 )
 
 (define-public (prepare-insert-header-hash)
-	(ok (asserts! (unwrap-panic (contract-call? .clarity-bitcoin-mini debug-insert-burn-header-hash test-block-header-hash test-burn-height)) (err "Block header hash insert failed")))
+	(begin
+		(asserts! (unwrap-panic (contract-call? .clarity-bitcoin-mini debug-insert-burn-header-hash test-block-header-hash test-burn-height)) (err "Block header hash insert failed"))
+		(asserts! (unwrap-panic (contract-call? .clarity-bitcoin-mini debug-insert-burn-header-hash test-block-header-hash-2 test-burn-height-2)) (err "Block header hash-2 insert failed"))
+		(asserts! (unwrap-panic (contract-call? .clarity-bitcoin-mini debug-insert-burn-header-hash test-block-header-hash-3 test-burn-height-3)) (err "Block header hash-3 insert failed"))
+		(asserts! (unwrap-panic (contract-call? .clarity-bitcoin-mini debug-insert-burn-header-hash test-block-header-hash-4 test-burn-height-4)) (err "Block header hash-4 insert failed"))
+		(ok true)
+
+	)
 )
 
 (define-public (prepare-revoke-contract-owner)
@@ -44,9 +79,9 @@
 	(begin
 		;; Mint some tokens to test principals.
 		(try! (prepare-insert-header-hash))
-		(unwrap! (contract-call? .asset mint u10000000 wallet-1 test-txid u1 test-merkle-proof test-tx-index test-tree-depth test-block-header) (err "Mint to wallet-1 failed"))
-		(unwrap! (contract-call? .asset mint u10000000 wallet-2 test-txid u1 test-merkle-proof test-tx-index test-tree-depth test-block-header) (err "Mint to wallet-2 failed"))
-		(unwrap! (contract-call? .asset mint u10000000 (as-contract tx-sender) test-txid u1 test-merkle-proof test-tx-index test-tree-depth test-block-header) (err "Mint to asset_test failed"))
+		(unwrap! (contract-call? .asset mint u10000000 wallet-1 test-txid test-burn-height test-merkle-proof test-tx-index test-tree-depth test-block-header) (err "Mint to wallet-1 failed"))
+		(unwrap! (contract-call? .asset mint u10000000 wallet-2 test-txid-2 test-burn-height-2 test-merkle-proof-2 test-tx-index-2 test-tree-depth-2 test-block-header-2) (err "Mint to wallet-2 failed"))
+		(unwrap! (contract-call? .asset mint u10000000 (as-contract tx-sender) test-txid-3 test-burn-height-3 test-merkle-proof-3 test-tx-index-3 test-tree-depth-3 test-block-header-3) (err "Mint to asset_test failed"))
 		(ok true)
 	)
 )
@@ -66,8 +101,8 @@
 ;; @caller deployer
 (define-public (test-protocol-mint-twice)
 	(begin
-		(try! (contract-call? .asset mint u10000000 wallet-1 test-txid u1 test-merkle-proof test-tx-index test-tree-depth test-block-header))
-		(contract-call? .asset mint u10000000 wallet-1 test-txid u1 test-merkle-proof test-tx-index test-tree-depth test-block-header)
+		(unwrap! (contract-call? .asset mint u10000000 wallet-1 test-txid u1 test-merkle-proof test-tx-index test-tree-depth test-block-header) (err "Should succeed"))
+		(assert-eq (contract-call? .asset mint u10000000 wallet-1 test-txid u1 test-merkle-proof test-tx-index test-tree-depth test-block-header) err-btc-tx-already-used "Should have failed with err-btc-tx-already-used")
 	)
 )
 
@@ -81,7 +116,7 @@
 ;; @name Protocol can burn tokens
 ;; @caller deployer
 (define-public (test-protocol-burn)
-	(contract-call? .asset burn u10000000 wallet-2 test-txid u1 test-merkle-proof test-tx-index test-tree-depth test-block-header)
+	(contract-call? .asset burn u10000000 wallet-2 test-txid-4 u4 test-merkle-proof-4 test-tx-index-4 test-tree-depth-4 test-block-header-4)
 )
 
 ;; @name Non-protocol contracts cannot burn tokens


### PR DESCRIPTION
## Summary of Changes
This PR 
* changes the asset contract so that mints and burns with the same btc tx will fail when used more than once
* fixes #116 

## Testing

### Risks
Engine might not handle failed mints and burns correctly.

Users might think that the contract verifies all of the content of the text. It does not, the contract only verifies that the btc tx was not yet used for minting or burning.

### How were these changes tested?
manual in devenv

### What future testing should occur?
Automated integration test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
