### PR TITLE
gh/workflows: pr: add devenv build test

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -106,3 +106,23 @@ jobs:
           verbose: false
           flags: unittests
           ignore: tests
+  devenv:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            devenv:
+              - 'devenv/**'
+
+      - name: Checkout
+        if: steps.changes.outputs.devenv == 'true'
+        uses: actions/checkout@v3
+
+      - name: Build devenv containers
+        if: steps.changes.outputs.devenv == 'true'
+        run: ./devenv/build.sh  


### PR DESCRIPTION
## Summary of Changes

Add a github workflow to build test the devenv containers. This will only trigger when changes are made under the `devenv/` directory. 

https://github.com/stacks-network/sbtc/pull/211 highlights the need for basic build testing.

## Testing

### Risks

None, as this is adding a test

### How were these changes tested?

Tested actions on fork of repo

### What future testing should occur?

We may want to publish built container images to a registry.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
