### PR TITLE
gh/workflows: daily: add devenv build

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -73,3 +73,13 @@ jobs:
           publish-delay: 1000 # Wait 1 second between publishing dependencies.
           ignore-unpublished-changes: true
           registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+    devenv:
+      timeout-minutes: 120
+      runs-on: ubuntu-latest
+      steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Build devenv containers
+        run: ./devenv/build.sh

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -109,7 +109,7 @@ jobs:
           flags: unittests
           ignore: tests
   devenv:
-    timeout-minutes: 60
+    timeout-minutes: 120
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read


### PR DESCRIPTION
## Summary of Changes

Add devenv container builds to the daily workflow. This is a follow up to: https://github.com/stacks-network/sbtc/pull/212 which it was discussed it would be ideal to build test devenv as part of the daily workflow.

## Testing

### Risks

No risks, as this adds additional testing

### How were these changes tested?

Tested daily workflow in repo fork

### What future testing should occur?

Monitor daily workflow results, and fix as needed.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
