### PR TITLE
utils: use container based cli

### DIFF
--- a/devenv/sbtc/bin/sbtc
+++ b/devenv/sbtc/bin/sbtc
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-docker exec -it sbtc sbtc $@
+docker exec -it sbtc sbtc "$@"

--- a/devenv/utils/deposit.sh
+++ b/devenv/utils/deposit.sh
@@ -13,13 +13,15 @@ stacks_address=$(source $dir/get_credentials.sh | jq -r '.credentials["1"].stack
 
 amount=$((RANDOM%9000+1000))
 
-json=$(sbtc deposit \
+json=$($dir/../sbtc/bin/sbtc deposit \
     -w $btc_wif \
     -n regtest \
     -r $stacks_address \
     -a $amount \
     -d $btc_p2tr_address \
-    -u localhost:60401)
+    -u electrs:60401)
+
+echo $json
 
 if [ $? -ne 0 ]; then
     echo 'The deposit failed, did you forget to run "mine_btc.sh"?'
@@ -28,4 +30,6 @@ fi
 
 tx=$(echo -n $json | jq -r .hex)
 
-sbtc broadcast localhost:60401 $tx | jq -r .
+echo $tx
+
+$dir/../sbtc/bin/sbtc broadcast electrs:60401 $tx | jq -r .

--- a/devenv/utils/get_credentials.sh
+++ b/devenv/utils/get_credentials.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
+dir="$(dirname "$0")"
+
 # Returns the default credentials for the devnet
 
 mnemonic="twice kind fence tip hidden tilt action fragile skin nothing glory cousin green tomorrow spring wrist shed math olympic multiply hip blue scout claw"
 
-sbtc generate-from -s testnet -b regtest --accounts 2 mnemonic "$mnemonic"
+$dir/../sbtc/bin/sbtc generate-from -s testnet -b regtest --accounts 2 mnemonic "$mnemonic"

--- a/devenv/utils/mine_btc.sh
+++ b/devenv/utils/mine_btc.sh
@@ -12,4 +12,4 @@ fi
 
 btc_address=$(source $dir/get_credentials.sh | jq -r '.credentials["1"].bitcoin.p2wpkh.address')
 
-bitcoin-cli -rpcconnect=localhost -rpcport=18443 -rpcuser=devnet -rpcpassword=devnet generatetoaddress $num_blocks $btc_address
+$dir/../bitcoin/bin/bitcoin-cli generatetoaddress $num_blocks $btc_address

--- a/devenv/utils/withdraw.sh
+++ b/devenv/utils/withdraw.sh
@@ -18,7 +18,7 @@ stacks_wif=$(source $dir/get_credentials.sh | jq -r '.credentials["1"].stacks.wi
 amount=$((RANDOM%1000+1000))
 fulfillment_fee=$((RANDOM%1000+1000))
 
-json=$(sbtc withdraw \
+json=$($dir/../sbtc/bin/sbtc withdraw \
     -w $btc_wif \
     -n regtest \
     -d $stacks_wif \
@@ -26,7 +26,7 @@ json=$(sbtc withdraw \
     -a $amount \
     -f $fulfillment_fee \
     -p $btc_p2tr_address \
-    -u localhost:60401)
+    -u electrs:60401)
 
 
 if [ $? -ne 0 ]; then
@@ -36,4 +36,4 @@ fi
 
 tx=$(echo -n $json | jq -r .hex)
 
-sbtc broadcast localhost:60401 $tx | jq -r .
+$dir/../sbtc/bin/sbtc broadcast electrs:60401 $tx | jq -r .


### PR DESCRIPTION
## Summary of Changes

The util scripts currently are using host binaries for running commands against devnet. This can be confusing to users as we also provide wrappers for accessing the same binaries running inside the container devenv.

Some examples are:

https://github.com/stacks-network/sbtc/blob/main/devenv/bitcoin/bin/bitcoin-cli

https://github.com/stacks-network/sbtc/blob/main/devenv/sbtc/bin/sbtc

Implements: https://github.com/stacks-network/sbtc/issues/224

This PR switches the utils scripts to use the wrappers for container binaries. For the binaries running inside devenv, it must use the service hostnames otherwise localhost will cause them to fail.

## Testing

### Risks

The biggest risk I see is, if the sbtc container (romeo) crashes, the sbtc command: https://github.com/stacks-network/sbtc/blob/main/devenv/sbtc/bin/sbtc will not be able to run, as the container stopped.

### How were these changes tested?

Tested locally with devenv

### What future testing should occur?

We need to automate the entire flow via https://github.com/stacks-network/sbtc/pull/215

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
