### PR TITLE
Add clarinet check step to romeo test script

### DIFF
--- a/romeo/asset-contract/scripts/test.sh
+++ b/romeo/asset-contract/scripts/test.sh
@@ -1,7 +1,18 @@
 #!/bin/sh
+
+# Setup directories.
 mkdir -p .test
 mkdir -p .coverage
 rm -r .test/*
+
+# Exit on next failure.
+set -e
+
+# Verify syntax.
 clarinet check
+
+# Generate tests.
 clarinet run --allow-write --allow-read ext/generate-tests.ts
+
+# Test with coverage.
 clarinet test --coverage .coverage/lcov.info .test

--- a/romeo/asset-contract/scripts/test.sh
+++ b/romeo/asset-contract/scripts/test.sh
@@ -2,5 +2,6 @@
 mkdir -p .test
 mkdir -p .coverage
 rm -r .test/*
+clarinet check
 clarinet run --allow-write --allow-read ext/generate-tests.ts
 clarinet test --coverage .coverage/lcov.info .test


### PR DESCRIPTION
## Summary of Changes

This change adds clarinet check step to romeo test script.

## Testing

### Risks

Almost no risks. Maybe it flags good clarity contracts as bad.

### How were these changes tested?

Locally running this in repository root works.
```bash
cd ./romeo/asset-contract
./scripts/test.sh
```

### What future testing should occur?

None, this is a testing change.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
