### PR TITLE
Publish p2tr public key on stacks

### DIFF
--- a/romeo/src/system.rs
+++ b/romeo/src/system.rs
@@ -192,14 +192,14 @@ async fn get_contract_block_height(
 		.await
 		.get_contract_block_height(config.contract_name.clone())
 		.await
-		.expect("Could not get block height");
+		.expect("Could not get block height. Binary needs to be restarted after contract deployment.");
 
 	let bitcoin_block_height = client
 		.lock()
 		.await
 		.get_bitcoin_block_height(block_height)
 		.await
-		.expect("Could not get burnchain block height");
+		.expect("Could not get burnchain block height. Binary needs to be restarted after bitcoin node is online again.");
 
 	Event::ContractBlockHeight(block_height, bitcoin_block_height)
 }
@@ -217,9 +217,15 @@ async fn update_contract_public_key(
 		TransactionSpendingCondition::new_singlesig_p2pkh(public_key).unwrap(),
 	);
 
-	let function_args =
-		vec![Value::buff_from(public_key.to_bytes_compressed())
-			.expect("Cannot convert public key into a Clarity Value")];
+	let function_args = vec![Value::buff_from(
+		config
+			.bitcoin_credentials
+			.public_key_p2tr()
+			.serialize()
+			.try_into()
+			.unwrap(),
+	)
+	.expect("Cannot convert public key into a Clarity Value")];
 
 	let addr = StacksAddress::consensus_deserialize(&mut Cursor::new(
 		config.stacks_credentials.address().serialize_to_vec(),


### PR DESCRIPTION
## Summary of Changes
This PR changes the public key that is published on start of Alpha Romeo engine from stacks public key to taproot public key.
This fixes #255 

## Testing

### Risks


### How were these changes tested?
Manually on testnet by restarting the engine after the changes were added.
Verify that the public key in `set-bitcoin-wallet-public-key` of the `asset` contract is the same as in `sbtc generate-from mnemonic -
s testnet -b testnet "..."`

### What future testing should occur?

Add unit tests for `update_contract_public_key`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
