### PR TITLE
264 change devenv stacks explorer to run on a port other than 3000

### DIFF
--- a/devenv/README.md
+++ b/devenv/README.md
@@ -51,19 +51,19 @@ cd devenv/bitcoin/
 There is a helper script at the top level directory to facilitate logging:
 
 ```
-./log bitcoin
-./log stacks
-./log stacks-api
-./log stacks-explorer
-./log postgres
-./log mongodb
-./log miner
-./log sbtc
-./log electrs
-./log sbtc-bridge-web
-./log sbtc-bridge-api
-./log mempool-web
-./log mempool-api
+./log.sh bitcoin
+./log.sh stacks
+./log.sh stacks-api
+./log.sh stacks-explorer
+./log.sh postgres
+./log.sh mongodb
+./log.sh miner
+./log.sh sbtc
+./log.sh electrs
+./log.sh sbtc-bridge-web
+./log.sh sbtc-bridge-api
+./log.sh mempool-web
+./log.sh mempool-api
 ```
 ## Services
 

--- a/devenv/README.md
+++ b/devenv/README.md
@@ -99,7 +99,7 @@ You can access the [Stacks Explorer](https://github.com/hirosystems/explorer)
 at:
 
 ```
-http://127.0.0.1:3000/?chain=testnet
+http://127.0.0.1:3020/?chain=testnet
 ```
 It's important to use the above URL, as it can parse blocks properly.
 

--- a/devenv/docker-compose.yml
+++ b/devenv/docker-compose.yml
@@ -123,7 +123,7 @@ services:
         GIT_URI: https://github.com/hirosystems/explorer.git
         GIT_BRANCH: v1.119.0
     ports:
-      - 3020:3020
+      - 3020:3000
     depends_on:
       - bitcoin
       - stacks

--- a/devenv/docker-compose.yml
+++ b/devenv/docker-compose.yml
@@ -123,7 +123,7 @@ services:
         GIT_URI: https://github.com/hirosystems/explorer.git
         GIT_BRANCH: v1.119.0
     ports:
-      - 3000:3000
+      - 3020:3020
     depends_on:
       - bitcoin
       - stacks
@@ -190,7 +190,7 @@ services:
       btcRpcPwd: devnet
       network: testnet
       bitcoinExplorerUrl: http://mempool-web:8083
-      stacksExplorerUrl: http://stacks-explorer:3000
+      stacksExplorerUrl: http://stacks-explorer:3020
       stacksApi: http://stacks-api:3999
       sbtcContractId: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.asset
       mongoDbUrl: mongodb

--- a/devenv/sbtc-bridge-api/docker-compose-sbtc-bridge-api.yml
+++ b/devenv/sbtc-bridge-api/docker-compose-sbtc-bridge-api.yml
@@ -20,7 +20,7 @@ services:
       btcRpcPwd: devnet
       network: testnet
       bitcoinExplorerUrl: http://bitcoin-explorer:3002/api
-      stacksExplorerUrl: http://stacks-explorer:3000
+      stacksExplorerUrl: http://stacks-explorer:3020
       stacksApi: http://stacks-api:3999
       sbtcContractId: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.asset
       mongoDbUrl: mongodb

--- a/devenv/stacks-explorer/docker-compose-stacks-explorer.yml
+++ b/devenv/stacks-explorer/docker-compose-stacks-explorer.yml
@@ -11,6 +11,6 @@ services:
         GIT_URI: https://github.com/hirosystems/explorer.git
         GIT_BRANCH: v1.119.0
     ports:
-      - 3000:3000
+      - 3020:3020
     environment:
       - NEXT_PUBLIC_MAINNET_API_SERVER=http://127.0.0.1:3999

--- a/devenv/stacks-explorer/docker/Dockerfile
+++ b/devenv/stacks-explorer/docker/Dockerfile
@@ -47,5 +47,5 @@ COPY --from=build /app/.next/static /app/.next/static
 COPY --from=build /app/.next/standalone /app
 
 
-EXPOSE 3000
+EXPOSE 3020
 CMD [ "node", "server.js" ]


### PR DESCRIPTION
## Summary of Changes

Fixes https://github.com/stacks-network/sbtc/issues/264

This changes the devenv socket from using 3000 to 3020 because 3000 is the default localhosting port for most development environments that host websites. We should change the port to 3020 so that there's no conflict between devenv and this default.

- bonus change: update log command in `README.md` to say `log.sh` instead of `log`.

## Testing

### Risks

There could be an environment that has hardcoded the stacks-explorer API endpoint, which would be hard to detect in the tests I ran.

### How were these changes tested?

This is a draft PR because I haven't tested this locally yet.

### What future testing should occur?

We'll detect other issues by using the devenv environment.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
