### PR TITLE
[sBTC DR] Wait until stacks chain is live before deploying contracts

### DIFF
--- a/devenv/utils/deploy_contracts.sh
+++ b/devenv/utils/deploy_contracts.sh
@@ -3,6 +3,22 @@
 # Deploys the asset contract to the devnet
 
 SCRIPT_DIR=$(dirname "$0")
+API_URL=http://localhost:20443/v2/info
+
+echo "Waiting on Stacks API $API_URL"
+while ! curl -s $API_URL >/dev/null; do
+    sleep 1
+done
+
+# stacks ready to take contracts
+
+STACKS_HEIGHT=1
+echo "Waiting on Stacks height $STACKS_HEIGHT"
+while [ "$(curl -s $API_URL | jq '.stacks_tip_height')" -lt $STACKS_HEIGHT ]; do
+    sleep 2
+done
+
+# deploy the contracts
 
 cd $SCRIPT_DIR/../../romeo/asset-contract && \
     clarinet deployments apply -p deployments/default.devnet-plan.yaml && \


### PR DESCRIPTION
## Summary of Changes
This PR adds a wait loop in the `deploy_contracts` script to not deploy the contracts before the stacks blockchain has at least minted 1 block.

See issue #231

## Testing

### Risks

The change makes it so that the script can be used only outside the docker containers. When fixing #231, this dependency must be removed.

### How were these changes tested?
manually on devenv:
1. `./up.sh`
2. `./deploy_contracts.sh`

### What future testing should occur?
See #231 


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
