### PR TITLE
[sBTC DR] Invariant tests should not allow minting and burning with the same txid

### DIFF
--- a/romeo/asset-contract/tests/asset_BurnCommand.ts
+++ b/romeo/asset-contract/tests/asset_BurnCommand.ts
@@ -44,6 +44,11 @@ export class BurnCommand implements AssetCommand {
 
     // In addition to the above, we also need to check that the amount to burn
     // is less or equal to the balance of the wallet.
+    const btcTxHex = uint8ArrayToHexString(this.params.depositTx);
+    if (model.transactions.find(([tx, _amount, _wallet]) => tx === btcTxHex)) {
+      return false;
+    }
+
     const balance = model.wallets.get(this.wallet.address) ?? 0;
     return this.amount <= balance;
   }

--- a/romeo/asset-contract/tests/asset_BurnCommand_500.ts
+++ b/romeo/asset-contract/tests/asset_BurnCommand_500.ts
@@ -1,0 +1,85 @@
+import {
+  AssetCommand,
+  BitcoinTxData,
+  Real,
+  Stub,
+} from "./asset_CommandModel.ts";
+
+import {
+  Account,
+  Tx,
+  types,
+} from "https://deno.land/x/clarinet@v1.7.1/index.ts";
+
+export class BurnCommand_500 implements AssetCommand {
+  readonly sender: Account;
+  readonly amount: number;
+  readonly wallet: Account;
+  readonly params: BitcoinTxData;
+
+  constructor(
+    sender: Account,
+    amount: number,
+    wallet: Account,
+    params: BitcoinTxData,
+  ) {
+    this.sender = sender;
+    this.amount = amount;
+    this.wallet = wallet;
+    this.params = params;
+  }
+
+  check(model: Readonly<Stub>): boolean {
+    const btcTxHex = uint8ArrayToHexString(this.params.depositTx);
+    const wasTxHexAlreadyUsed = model.transactions.some(([tx]) =>
+      tx === btcTxHex
+    );
+    const balance = model.wallets.get(this.wallet.address) ?? 0;
+    return wasTxHexAlreadyUsed && this.amount <= balance;
+  }
+
+  run(_model: Stub, real: Real): void {
+    const block = real.chain.mineBlock([
+      Tx.contractCall(
+        "clarity-bitcoin-mini",
+        "debug-insert-burn-header-hash",
+        [
+          types.buff(this.params.blockHeaderHash),
+          types.uint(this.params.burnChainHeight),
+        ],
+        this.sender.address,
+      ),
+      Tx.contractCall(
+        "asset",
+        "burn",
+        [
+          types.uint(this.amount),
+          types.principal(this.wallet.address),
+          types.buff(this.params.depositTx),
+          types.uint(this.params.burnChainHeight),
+          types.list(this.params.merkleProof.map((p) => types.buff(p))),
+          types.uint(this.params.txIndex),
+          types.buff(this.params.blockHeader),
+        ],
+        this.sender.address,
+      ),
+    ]);
+
+    block.receipts[0].result.expectOk();
+    block.receipts[1].result.expectErr().expectUint(500);
+
+    console.log(
+      `! ${this.sender.name.padStart(8, " ")} ${"burn".padStart(16, " ") } ${this.wallet.name.padStart(8, " ")} ${this.amount.toString().padStart(12, " ")} bitcoin tx ${uint8ArrayToHexString(this.params.depositTx).padStart(12, " ")} (expected, same bitcoin tx)`
+    );
+  }
+
+  toString() {
+    return `${this.sender.name} burn ${this.amount} to ${this.wallet.name} (bitcoin tx ${uint8ArrayToHexString(this.params.depositTx).padStart(12, " ")})`;
+  }
+}
+
+function uint8ArrayToHexString(uint8Array: Uint8Array): string {
+  return Array.from(uint8Array).map((byte) =>
+    byte.toString(16).padStart(2, "0")
+  ).join("");
+}

--- a/romeo/asset-contract/tests/asset_Commands.ts
+++ b/romeo/asset-contract/tests/asset_Commands.ts
@@ -4,9 +4,11 @@ import { BitcoinTxData } from "./asset_CommandModel.ts";
 import fc from "https://cdn.skypack.dev/fast-check@3";
 
 import { BurnCommand } from "./asset_BurnCommand.ts";
+import { BurnCommand_500 } from "./asset_BurnCommand_500.ts";
 import { GetBalanceCommand } from "./asset_GetBalanceCommand.ts";
 import { GetTotalSupplyCommand } from "./asset_GetTotalSupplyCommand.ts";
 import { MintCommand } from "./asset_MintCommand.ts";
+import { MintCommand_500 } from "./asset_MintCommand_500.ts";
 import { TransferCommand } from "./asset_TransferCommand.ts";
 import { TransferCommand_NonOwner } from "./asset_TransferCommand_NonOwner.ts";
 
@@ -30,6 +32,30 @@ export function AssetCommands(accounts: Map<string, Account>) {
         },
       ) =>
         new BurnCommand(
+          r.sender,
+          r.amount,
+          r.wallet,
+          r.params,
+        )
+      ),
+
+    // BurnCommand (err-btc-tx-already-used (err u500))
+    fc
+      .record({
+        sender: fc.constant(accounts.get("deployer")!),
+        amount: fc.integer({ min: 1, max: 100 }),
+        wallet: fc.constantFrom(...accounts.values()).filter((a: Account) => a.address !== accounts.get("deployer")!.address),
+        params: fc.constantFrom(...data),
+      })
+      .map((
+        r: {
+          sender: Account;
+          amount: number;
+          wallet: Account;
+          params: BitcoinTxData;
+        },
+      ) =>
+        new BurnCommand_500(
           r.sender,
           r.amount,
           r.wallet,
@@ -87,6 +113,30 @@ export function AssetCommands(accounts: Map<string, Account>) {
         },
       ) =>
         new MintCommand(
+          r.sender,
+          r.amount,
+          r.wallet,
+          r.params,
+        )
+      ),
+
+    // MintCommand (err-btc-tx-already-used (err u500))
+    fc
+      .record({
+        sender: fc.constant(accounts.get("deployer")!),
+        amount: fc.integer({ min: 1, max: 100 }),
+        wallet: fc.constantFrom(...accounts.values()).filter((a: Account) => a.address !== accounts.get("deployer")!.address),
+        params: fc.constantFrom(...data),
+      })
+      .map((
+        r: {
+          sender: Account;
+          amount: number;
+          wallet: Account;
+          params: BitcoinTxData;
+        },
+      ) =>
+        new MintCommand_500(
           r.sender,
           r.amount,
           r.wallet,

--- a/romeo/asset-contract/tests/asset_GetBalanceCommand.ts
+++ b/romeo/asset-contract/tests/asset_GetBalanceCommand.ts
@@ -37,7 +37,6 @@ export class GetBalanceCommand implements AssetCommand {
     const expected = model.wallets.get(this.wallet.address) ?? 0;
     block.receipts.map(({ result }) => result.expectOk().expectUint(expected));
 
-    // sBTC DR allows several mints or burns with the same Bitcoin transaction.
     const actual = model.transactions.reduce((sum, [_, amount, wallet]) =>
       (wallet.address === this.wallet.address ? sum + amount : sum), 0);
     assert(

--- a/romeo/asset-contract/tests/asset_MintCommand.ts
+++ b/romeo/asset-contract/tests/asset_MintCommand.ts
@@ -29,7 +29,7 @@ export class MintCommand implements AssetCommand {
     this.params = params;
   }
 
-  check(_model: Readonly<Stub>): boolean {
+  check(model: Readonly<Stub>): boolean {
     // Can mint if sender is the deployer.
     //
     // Note that this is filtered at the generator level. So you don't need to
@@ -41,6 +41,11 @@ export class MintCommand implements AssetCommand {
     // What discard means is that if you are generating 1000 commands, and 100
     // of them are filtered out here, then you end up running 900 commands. If
     // you filter at the generator level, however, you will run 1000 commands.
+    const btcTxHex = uint8ArrayToHexString(this.params.depositTx);
+    if (model.transactions.find(([tx, _amount, _wallet]) => tx === btcTxHex)) {
+      return false;
+    }
+
     return true;
   }
 

--- a/romeo/asset-contract/tests/asset_MintCommand_500.ts
+++ b/romeo/asset-contract/tests/asset_MintCommand_500.ts
@@ -1,0 +1,86 @@
+import {
+  AssetCommand,
+  BitcoinTxData,
+  Real,
+  Stub,
+} from "./asset_CommandModel.ts";
+
+import {
+  Account,
+  Tx,
+  types,
+} from "https://deno.land/x/clarinet@v1.7.1/index.ts";
+
+export class MintCommand_500 implements AssetCommand {
+  readonly sender: Account;
+  readonly amount: number;
+  readonly wallet: Account;
+  readonly params: BitcoinTxData;
+
+  constructor(
+    sender: Account,
+    amount: number,
+    wallet: Account,
+    params: BitcoinTxData,
+  ) {
+    this.sender = sender;
+    this.amount = amount;
+    this.wallet = wallet;
+    this.params = params;
+  }
+
+  check(model: Readonly<Stub>): boolean {
+    const btcTxHex = uint8ArrayToHexString(this.params.depositTx);
+    const wasTxHexAlreadyUsed = model.transactions.some(([tx]) =>
+      tx === btcTxHex
+    );
+    return wasTxHexAlreadyUsed;
+  }
+
+  run(_model: Stub, real: Real): void {
+    const block = real.chain.mineBlock([
+      Tx.contractCall(
+        "clarity-bitcoin-mini",
+        "debug-insert-burn-header-hash",
+        [
+          types.buff(this.params.blockHeaderHash),
+          types.uint(this.params.burnChainHeight),
+        ],
+        this.sender.address,
+      ),
+      Tx.contractCall(
+        "asset",
+        "mint",
+        [
+          types.uint(this.amount),
+          types.principal(this.wallet.address),
+          types.buff(this.params.depositTx),
+          types.uint(this.params.burnChainHeight),
+          types.list(this.params.merkleProof.map((p) => types.buff(p))),
+          types.uint(this.params.txIndex),
+          types.buff(this.params.blockHeader),
+        ],
+        this.sender.address,
+      ),
+    ]);
+
+    block.receipts[0].result.expectOk();
+    block.receipts[1].result.expectErr().expectUint(500);
+
+    console.log(
+      `! ${this.sender.name.padStart(8, " ")} ${"mint".padStart(16, " ") } ${this.wallet.name.padStart(8, " ")} ${this.amount.toString().padStart(12, " ")} bitcoin tx ${uint8ArrayToHexString(this.params.depositTx).padStart(12, " ")} (expected, same bitcoin tx)`
+    );
+  }
+
+  toString() {
+    // fast-check will call toString() in case of errors, e.g. property failed.
+    // It will then make a minimal counterexample, a process called 'shrinking'
+    // https://github.com/dubzzz/fast-check/issues/2864#issuecomment-1098002642
+    return `${this.sender.name} mint ${this.amount} to ${this.wallet.name} (bitcoin tx ${uint8ArrayToHexString(this.params.depositTx).padStart(12, " ")})`;
+  }
+}
+
+function uint8ArrayToHexString(uint8Array: Uint8Array): string {
+  return Array.from(uint8Array).map(byte => byte.toString(16).padStart(2, '0')).join('');
+}
+


### PR DESCRIPTION
## Summary of Changes

1. Updates invariant tests. The asset contract no longer allows minting and burning with the same txid.
2. Resolves https://github.com/stacks-network/sbtc/issues/263.

## Testing

### Risks

No risks associated with this PR. The modified parts of the tests reflect the fact that now the asset contract does not allows minting and burning with the same txid (wasn't implemented yet when #152 was merged).

### How were these changes tested?

Once you `cd` into `romeo/asset-contract` directory, you can run these tests via

```bash
clarinet test tests/asset_test.ts
```

### What future testing should occur?

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

(Let me know if there's a style guideline of this project that I can follow, and any changes to the documentation that I should make. There are no dependent changes in downstream modules.)
