### PR TITLE
Add 429 & 522 handling with retry to romeo

### DIFF
--- a/romeo/src/bitcoin_client.rs
+++ b/romeo/src/bitcoin_client.rs
@@ -285,7 +285,8 @@ mod tests {
 		// expect sbtc wallet to be p2tr of mnemonic
 		let expected_sbtc_wallet =
 			"tb1pte5zmd7qzj4hdu45lh9mmdm0nwq3z35pwnxmzkwld6y0a8g83nnq6ts2d4";
-		// expect sbtc_wallet equals and config sbtc wallet address to be the p2tr address
+		// expect sbtc_wallet equals and config sbtc wallet address to be the
+		// p2tr address
 		assert_eq!(client_sbtc_wallet.to_string(), expected_sbtc_wallet);
 		assert_eq!(
 			conf.sbtc_wallet_address().to_string(),

--- a/romeo/src/stacks_client.rs
+++ b/romeo/src/stacks_client.rs
@@ -469,7 +469,8 @@ where
 				if err.is_request() {
 					backoff::Error::transient(anyhow::anyhow!(err))
 				} else if err.is_status() {
-					// Impossible not to have a status code at this section. May as well be a teapot.
+					// Impossible not to have a status code at this section. May
+					// as well be a teapot.
 					let status_code_number = err
 						.status()
 						.unwrap_or(StatusCode::IM_A_TEAPOT)


### PR DESCRIPTION
## Summary of Changes

### Context

While setting up sBTC for testnet the initialization stage of Romeo makes a ton of block fetch requests in close succession
which will trigger a 429 response unless you have an api key with nearly no throttle. This PR 

## Testing

### Risks

This will cause status errors that used to be let through to panic - if we had a special way that we handled those cases
we will now be skipping them

### How were these changes tested?

No unit tests unfortunately, but there should be. I've run this on testnet and it does what it should.

The caveat is that it will panic when there's a 404 error, which it didn't before, but Romeo keeps going and 
we probably should have been panicking there in the first place.

### What future testing should occur?

Same tests as the rest of Romeo

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
