### PR TITLE
Use p2tr in wallet of bitcoin client

### DIFF
--- a/sbtc-core/src/operations/commit_reveal/deposit.rs
+++ b/sbtc-core/src/operations/commit_reveal/deposit.rs
@@ -66,13 +66,13 @@ pub fn deposit_reveal_unsigned_tx(
 	deposit_data: DepositData,
 	reveal_inputs: RevealInputs,
 	commit_amount: Amount,
-	peg_wallet_address: BitcoinAddress,
+	sbtc_wallet_address: BitcoinAddress,
 ) -> CommitRevealResult<Transaction> {
 	let mut tx = reveal(&deposit_data.serialize_to_vec(), reveal_inputs)?;
 
 	tx.output.push(TxOut {
 		value: (commit_amount - deposit_data.reveal_fee).to_sat(),
-		script_pubkey: peg_wallet_address.script_pubkey(),
+		script_pubkey: sbtc_wallet_address.script_pubkey(),
 	});
 
 	Ok(tx)

--- a/sbtc-core/src/operations/commit_reveal/withdrawal_request.rs
+++ b/sbtc-core/src/operations/commit_reveal/withdrawal_request.rs
@@ -75,7 +75,7 @@ pub fn withdrawal_request_reveal_unsigned_tx(
 	reveal_inputs: RevealInputs,
 	fulfillment_fee: Amount,
 	commit_amount: Amount,
-	peg_wallet_address: BitcoinAddress,
+	sbtc_wallet_address: BitcoinAddress,
 	recipient_wallet_address: BitcoinAddress,
 ) -> CommitRevealResult<Transaction> {
 	let mut tx = reveal(&withdrawal_data.serialize_to_vec(), reveal_inputs)?;
@@ -87,7 +87,7 @@ pub fn withdrawal_request_reveal_unsigned_tx(
 	});
 	tx.output.push(TxOut {
 		value: fulfillment_fee.to_sat(),
-		script_pubkey: peg_wallet_address.script_pubkey(),
+		script_pubkey: sbtc_wallet_address.script_pubkey(),
 	});
 
 	Ok(tx)


### PR DESCRIPTION
## Summary of Changes

This PR changes the wallet that sends the fulfillment btc tx in romeo. Now the p2tr address is used.

## Testing

### Risks
This is a breaking change and could affect existing implementations like the sbtc-bridge-api. However, now use of the fulfillment tx is known as of today.

As an add-on, this PR renames a variable from peg wallet to sbtc wallet.

### How were these changes tested?
Unit test has been added.

### What future testing should occur?
Integration tests on devenv and testnet.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
