### PR TITLE
New withdrawal request format

### DIFF
--- a/romeo/src/bitcoin_client.rs
+++ b/romeo/src/bitcoin_client.rs
@@ -285,7 +285,8 @@ mod tests {
 		// expect sbtc wallet to be p2tr of mnemonic
 		let expected_sbtc_wallet =
 			"tb1pte5zmd7qzj4hdu45lh9mmdm0nwq3z35pwnxmzkwld6y0a8g83nnq6ts2d4";
-		// expect sbtc_wallet equals and config sbtc wallet address to be the p2tr address
+		// expect sbtc_wallet equals and config sbtc wallet address to be the
+		// p2tr address
 		assert_eq!(client_sbtc_wallet.to_string(), expected_sbtc_wallet);
 		assert_eq!(
 			conf.sbtc_wallet_address().to_string(),

--- a/sbtc-core/src/operations/op_return/withdrawal_request.rs
+++ b/sbtc-core/src/operations/op_return/withdrawal_request.rs
@@ -432,7 +432,8 @@ pub fn create_withdrawal_request_signing_message(
 		.chain(payee_bitcoin_address.script_pubkey().as_bytes().to_vec())
 		.collect();
 	// Wallets do not allow to sign bytes, instead a string is required.
-	// The following string is used until more wallets support signing withdrawal requests.
+	// The following string is used until more wallets support signing
+	// withdrawal requests.
 	let wallet_compatible_data = format!(
 		"Withdraw request for {:} satoshis to the bitcoin address {:} ({:})",
 		amount,

--- a/sbtc-core/src/operations/op_return/withdrawal_request.rs
+++ b/sbtc-core/src/operations/op_return/withdrawal_request.rs
@@ -431,8 +431,13 @@ pub fn create_withdrawal_request_signing_message(
 		.chain(amount.serialize_to_vec())
 		.chain(payee_bitcoin_address.script_pubkey().as_bytes().to_vec())
 		.collect();
-
-	create_signing_message(signing_data)
+	let wallet_compatible_data = format!(
+		"Withdraw request for {:} satoshis to the bitcoin address {:} ({:})",
+		amount,
+		payee_bitcoin_address,
+		hex::encode(signing_data)
+	);
+	create_signing_message(wallet_compatible_data)
 }
 
 /// Creates the SECP signing message. It prepends the data with the
@@ -448,4 +453,23 @@ pub fn create_signing_message(data: impl AsRef<[u8]>) -> Message {
 
 	Message::from_slice(Sha256Hasher::new(msg_content).as_ref())
 		.expect("Could not create secp message")
+}
+
+// test that create signing message returns correct hash
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn test_create_signing_message() {
+		let address: BitcoinAddress =
+			"tb1qwe9ddxp6v32uef2v66j00vx6wxax5zat223tms"
+				.parse()
+				.unwrap();
+		let msg = create_withdrawal_request_signing_message(1000, &address);
+		assert_eq!(
+			msg.to_string(),
+			"744eee0ee13d6649dd6b0fe203d2cb0af32e5d0b57a7c046c782019e8d562056"
+		);
+	}
 }

--- a/sbtc-core/src/operations/op_return/withdrawal_request.rs
+++ b/sbtc-core/src/operations/op_return/withdrawal_request.rs
@@ -431,6 +431,8 @@ pub fn create_withdrawal_request_signing_message(
 		.chain(amount.serialize_to_vec())
 		.chain(payee_bitcoin_address.script_pubkey().as_bytes().to_vec())
 		.collect();
+	// Wallets do not allow to sign bytes, instead a string is required.
+	// The following string is used until more wallets support signing withdrawal requests.
 	let wallet_compatible_data = format!(
 		"Withdraw request for {:} satoshis to the bitcoin address {:} ({:})",
 		amount,


### PR DESCRIPTION
## Summary of Changes

This PR changes the message format for withdrawal requests. 
The specification says to sign a message hash build from the withdrawal amount and the payee btc address.

The current implementation of Leather wallet does not allow to sign messages consisting of bytes, it requires a string.

Therefore, the new format for the message that is hashed and signed is the following:

```
Withdraw request for {amount} satoshis to the bitcoin address {btc address} ({hex of amount and btc address as in the spec})
```  

Example: 
```
Withdraw request for 1000 satoshis to the bitcoin address tb1qwe9ddxp6v32uef2v66j00vx6wxax5zat223tms (00000000000003e80014764ad6983a6455cca54cd6a4f7b0da71ba6a0bab)
```
The hash to be signed is then `744eee0ee13d6649dd6b0fe203d2cb0af32e5d0b57a7c046c782019e8d562056`

This PR fixes #266 

This change is also implemented in the sbtc js package.

## Testing

### Risks
This is a breaking change and needs to be implemented by all clients.

### How were these changes tested?
Unit test has been added

### What future testing should occur?
Integration test with sbtc bridge web app and lagoon.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
