### PR TITLE
Don't panic while polling for stacks blocks if the block isn't present.

### DIFF
--- a/romeo/src/stacks_client.rs
+++ b/romeo/src/stacks_client.rs
@@ -266,18 +266,20 @@ impl StacksClient {
 		block_height: u32,
 	) -> anyhow::Result<Vec<StacksTransaction>> {
 		let res: Value = loop {
-			let inner_res: Value = self
+			let maybe_response: Result<Value, Error> = self
 				.send_request(|| {
 					self.http_client
 						.get(self.block_by_height_url(block_height))
 						.build()
 						.unwrap()
 				})
-				.await?;
+				.await;
 
-			if inner_res["txs"].is_array() {
-				trace!("Found Stacks block of height {}", block_height);
-				break inner_res;
+			if let Ok(inner_response) = maybe_response {
+				if inner_response["txs"].is_array() {
+					trace!("Found Stacks block of height {}", block_height);
+					break inner_response;
+				}
 			}
 
 			trace!("Stacks block not found, retrying...");


### PR DESCRIPTION
## Summary of Changes

This PR allows the stacks polling loop to handle 404 errors.

Currently we never poll the stacks blocks because romeo errors immediately when it encounters a 404 error.
This fixes that error.

## Testing

### Risks

We could loop indefinitely on a request failure, but since this loop is the polling loop, that's the best place for there to be an infinite loop.

### How were these changes tested?

Tested locally against testnet with a running romeo binary.

```
./target/debug/romeo -c config.json
```
Where the config was 
```json
{
  "stacks_network": "testnet",
  "bitcoin_network": "testnet",
  "state_directory": "./state",
  "mnemonic": "******",
  "stacks_node_url": "https://api.testnet.hiro.so",
  "bitcoin_node_url": "http://blockstack:blockstacksystem@bitcoind.testnet.stacks.co:18332",
  "electrum_node_url": "ssl://blockstream.info:700",
  "contract_name": "asset",
  "hiro_api_key": "******"
}
```

### What future testing should occur?

We should test with real deposits and withdrawals on testnet.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
