### PR TITLE
Use nightly fmt to match github action fmt

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -51,7 +51,7 @@ dependencies = [
 [tasks.format-fmt]
 install_crate = "rustfmt" # uses the stable version.
 command = "cargo"
-args = ["fmt", "--check", "--verbose"]
+args = ["fmt", "--nightly", "--check", "--verbose"]
 
 [tasks.format-clippy]
 install_crate = "clippy" # uses the stable version.


### PR DESCRIPTION
## Summary of Changes
This PR adds nightly to the fmt call as github action does apply the nightly rules.

Example of failed gh action: https://github.com/stacks-network/sbtc/actions/runs/6518598704/job/17704192640

## Testing

### Risks
It is only about formatting.

### How were these changes tested?
Locally by adding a long comment and running `cargo fmt --nightly`

### What future testing should occur?
Make sure that gh action and cargo make do the same things.
Ensure that locally cargo nightly is installed.

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
