### PR TITLE
Add wait period between receiving deposit request and minting.

### DIFF
--- a/romeo/src/state.rs
+++ b/romeo/src/state.rs
@@ -22,7 +22,7 @@ use crate::{
 
 /// The delay in blocks between receiving a deposit request and creating
 /// the deposit transaction.
-const MINT_TRANSACTION_DELAY_BLOCKS: u32 = 1;
+const STX_TRANSACTION_DELAY_BLOCKS: u32 = 1;
 
 /// Romeo internal state
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
@@ -485,7 +485,7 @@ impl State {
 							// one we make ourselves resilient to mining delays
 							// without complex logic.
 							let scheduled_block_height = *stacks_block_height
-								+ MINT_TRANSACTION_DELAY_BLOCKS;
+								+ STX_TRANSACTION_DELAY_BLOCKS;
 
 							deposit.mint =
 								Some(TransactionRequest::Scheduled {
@@ -517,7 +517,7 @@ impl State {
 							None => {
 								let scheduled_block_height =
 									*stacks_block_height
-										+ MINT_TRANSACTION_DELAY_BLOCKS;
+										+ STX_TRANSACTION_DELAY_BLOCKS;
 
 								withdrawal.burn =
 									Some(TransactionRequest::Scheduled {

--- a/romeo/src/state.rs
+++ b/romeo/src/state.rs
@@ -479,9 +479,11 @@ impl State {
 				let deposit_tasks = deposits.iter_mut().filter_map(|deposit| {
 					match deposit.mint.as_mut() {
 						None => {
-							// We often receive the deposit before the transaction is actually mined.
-							// By scheduling the transaction for a block later than the current one we
-							// make ourselves resilient to mining delays without complex logic.
+							// We often receive the deposit before the
+							// transaction is actually mined. By scheduling the
+							// transaction for a block later than the current
+							// one we make ourselves resilient to mining delays
+							// without complex logic.
 							let scheduled_block_height = *stacks_block_height
 								+ MINT_TRANSACTION_DELAY_BLOCKS;
 							deposit.mint =
@@ -496,8 +498,9 @@ impl State {
 							block_height,
 						}) => {
 							if stacks_block_height.ge(&block_height) {
-								// Only initiate the mint task if the current stacks block is
-								// or is after the stacks block for which the mint is scheduled.
+								// Only initiate the mint task if the current
+								// stacks block is or is after the stacks block
+								// for which the mint is scheduled.
 								deposit.mint =
 									Some(TransactionRequest::Created);
 								info!(


### PR DESCRIPTION
## Summary of Changes

This PR aims to resolve https://github.com/stacks-network/sbtc/issues/261, in which we were attempting to mint deposit transactions that hadn't yet been mined by the chain.

This PR resolves this bug by adding a `Scheduled` state to each deposit request in which the deposit requests are left alone until the next stacks block.

## Testing

### Risks

If something went wrong this could result in deposits never getting fulfilled, but that seems unlikely given the simplicity of this logic.

### How were these changes tested?

Not tested, though it should be. This is a fairly simple change and will never be on mainnet.

At the moment it's riskier not to include this PR or spend additional resources testing it than it is to accept as is.

### What future testing should occur?

Should be tested as part of a testnet program.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
