### PR TITLE
Romeo considers tx pending when it gets 404

### DIFF
--- a/romeo/src/stacks_client.rs
+++ b/romeo/src/stacks_client.rs
@@ -197,7 +197,8 @@ impl StacksClient {
 				.as_str()
 				.map(|s| s.to_string())
 				.expect("Could not get raw transaction from response"),
-			// Stacks node sometimes returns 404 for pending transactions :shrug:
+			// Stacks node sometimes returns 404 for pending transactions
+			// :shrug:
 			Err(err) if err.to_string().contains("404 Not Found") => {
 				"pending".to_string()
 			}


### PR DESCRIPTION
## Summary of Changes

If Romeo gets a 404 when asking for a transaction it will now consider it pending.

Closes https://github.com/stacks-network/sbtc/issues/291.

### Risks

It appears there's no additional risk incurred by this PR.

### How were these changes tested?

I've manually confirmed the fix works and enables Romeo to recover from 404s when asking for transactions.

### What future testing should occur?

Potentially adding an automated test that checks this behavior.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
