### PR TITLE
fix: use proper bitcoin network when building withdrawal txs

### DIFF
--- a/sbtc-cli/src/commands/withdraw.rs
+++ b/sbtc-cli/src/commands/withdraw.rs
@@ -75,8 +75,6 @@ pub fn build_withdrawal_tx(withdrawal: &WithdrawalArgs) -> anyhow::Result<()> {
 
 	wallet.sync(&blockchain, SyncOptions::default())?;
 
-	let broadcaster_bitcoin_private_key =
-		PrivateKey::from_wif(&withdrawal.wif)?;
 	let drawee_stacks_private_key =
 		PrivateKey::from_wif(&withdrawal.drawee_wif)?.inner;
 	let payee_bitcoin_address =
@@ -86,7 +84,7 @@ pub fn build_withdrawal_tx(withdrawal: &WithdrawalArgs) -> anyhow::Result<()> {
 
 	let tx = sbtc_core::operations::op_return::withdrawal_request::build_withdrawal_tx(
         &wallet,
-        broadcaster_bitcoin_private_key,
+        withdrawal.network,
         drawee_stacks_private_key,
         payee_bitcoin_address,
         sbtc_wallet_bitcoin_address,

--- a/sbtc-core/src/operations/op_return/withdrawal_request.rs
+++ b/sbtc-core/src/operations/op_return/withdrawal_request.rs
@@ -73,8 +73,8 @@ use bdk::{
 		blockdata::{opcodes::all::OP_RETURN, script::Instruction},
 		psbt::PartiallySignedTransaction,
 		secp256k1::{ecdsa::RecoverableSignature, Message, Secp256k1},
-		Address as BitcoinAddress, Network as BitcoinNetwork,
-		PrivateKey as BitcoinPrivateKey, Script, Transaction,
+		Address as BitcoinAddress, Network as BitcoinNetwork, Script,
+		Transaction,
 	},
 	database::BatchDatabase,
 	SignOptions, Wallet,
@@ -185,7 +185,7 @@ pub struct WithdrawalRequestData {
 /// Construct a withdrawal request transaction
 pub fn build_withdrawal_tx(
 	wallet: &Wallet<impl BatchDatabase>,
-	broadcaster_bitcoin_private_key: BitcoinPrivateKey,
+	bitcoin_network: BitcoinNetwork,
 	drawee_stacks_private_key: StacksPrivateKey,
 	payee_bitcoin_address: BitcoinAddress,
 	sbtc_wallet_bitcoin_address: BitcoinAddress,
@@ -199,7 +199,7 @@ pub fn build_withdrawal_tx(
 		&sbtc_wallet_bitcoin_address,
 		amount,
 		fulfillment_fee,
-		broadcaster_bitcoin_private_key.network,
+		bitcoin_network,
 	)?;
 
 	wallet


### PR DESCRIPTION
The CLI will now use the specified Bitcoin network when building out withdrawal transactions.

## Summary of Changes

- Not using the WIF to get the Bitcoin network anymore

### How were these changes tested?

- I ran all the tests we have in the repo

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
