### PR TITLE
Implement TryFrom<String> for PrincipalData

### DIFF
--- a/devenv/README.md
+++ b/devenv/README.md
@@ -103,7 +103,7 @@ You can access the [Stacks Explorer](https://github.com/hirosystems/explorer)
 at:
 
 ```
-http://127.0.0.1:3020/?chain=testnet
+http://127.0.0.1:3020/?chain=testnet&api=http://127.0.0.1:3999
 ```
 It's important to use the above URL, as it can parse blocks properly.
 

--- a/sbtc-cli/src/commands/deposit.rs
+++ b/sbtc-cli/src/commands/deposit.rs
@@ -14,7 +14,7 @@ use bdk::{
 };
 use clap::Parser;
 use sbtc_core::operations::op_return::deposit::build_deposit_transaction;
-use stacks_core::address::StacksAddress;
+use stacks_core::utils::PrincipalData;
 use url::Url;
 
 use crate::commands::utils;
@@ -68,13 +68,12 @@ pub fn build_deposit_tx(deposit: &DepositArgs) -> anyhow::Result<()> {
 
 	wallet.sync(&blockchain, SyncOptions::default())?;
 
-	let recipient_address =
-		StacksAddress::try_from(deposit.recipient.as_str())?;
+	let stx_recipient = PrincipalData::try_from(deposit.recipient.to_string())?;
 	let sbtc_wallet_address = BitcoinAddress::from_str(&deposit.sbtc_wallet)?;
 
 	let tx = build_deposit_transaction(
 		wallet,
-		recipient_address.into(),
+		stx_recipient,
 		sbtc_wallet_address,
 		deposit.amount,
 		deposit.network,

--- a/stacks-core/src/crypto/wif.rs
+++ b/stacks-core/src/crypto/wif.rs
@@ -53,7 +53,7 @@ impl WIF {
 		{
 			Ok(())
 		} else {
-			Err(StacksError::InvalidData("WIF is invalid"))
+			Err(StacksError::InvalidData("WIF is invalid".into()))
 		}
 	}
 
@@ -62,7 +62,7 @@ impl WIF {
 		match WIFPrefix::from_repr(self.0[0]) {
 			Some(WIFPrefix::Mainnet) => Ok(Network::Mainnet),
 			Some(WIFPrefix::Testnet) => Ok(Network::Testnet),
-			_ => Err(StacksError::InvalidData("Unknown network byte")),
+			_ => Err(StacksError::InvalidData("Unknown network byte".into())),
 		}
 	}
 

--- a/stacks-core/src/lib.rs
+++ b/stacks-core/src/lib.rs
@@ -51,7 +51,7 @@ pub enum StacksError {
 	CodecError(#[from] CodecError),
 	#[error("Invalid data: {0}")]
 	/// Invalid data
-	InvalidData(&'static str),
+	InvalidData(String),
 	/// BIP32 Error
 	#[error("BIP32 error: {0}")]
 	BIP32(#[from] bdk::bitcoin::util::bip32::Error),

--- a/stacks-core/src/utils.rs
+++ b/stacks-core/src/utils.rs
@@ -285,7 +285,7 @@ mod tests {
 
 		assert_eq!(
 			result.unwrap_err().to_string(),
-			"Invalid data: Invalid contract name from ST000000000000000000002AMW42H.hello contract: Format should follow the contract name specification"
+			StacksError::InvalidData("Invalid contract name from ST000000000000000000002AMW42H.hello contract: Format should follow the contract name specification".into()).to_string()
 		);
 	}
 }

--- a/stacks-core/src/utils.rs
+++ b/stacks-core/src/utils.rs
@@ -275,7 +275,7 @@ mod tests {
 
 		assert_eq!(
 			result.unwrap_err().to_string(),
-			"Could not crackford32 encode or decode: Invalid C32 address: ST123"
+			StacksError::C32Error(crate::c32::C32Error::InvalidAddress("ST123".into())).to_string()
 		);
 
 		// try contract name with a space

--- a/stacks-core/src/utils.rs
+++ b/stacks-core/src/utils.rs
@@ -271,11 +271,23 @@ mod tests {
 
 	#[test]
 	fn should_fail_to_convert_invalid_string_to_principal_data() {
-		let result = PrincipalData::try_from("ST123.helloworld".to_string());
+		// try invalid address
+		let mut result =
+			PrincipalData::try_from("ST123.helloworld".to_string());
 
 		assert_eq!(
 			result.unwrap_err().to_string(),
 			"Could not crackford32 encode or decode: Invalid C32 address: ST123"
+		);
+
+		// try contract name with a space
+		result = PrincipalData::try_from(
+			"ST000000000000000000002AMW42H.hello contract".to_string(),
+		);
+
+		assert_eq!(
+			result.unwrap_err().to_string(),
+			"Invalid data: Invalid contract name"
 		);
 	}
 }

--- a/stacks-core/src/utils.rs
+++ b/stacks-core/src/utils.rs
@@ -285,7 +285,7 @@ mod tests {
 
 		assert_eq!(
 			result.unwrap_err().to_string(),
-			"Invalid data: Invalid contract name"
+			"Invalid data: Invalid contract name from ST000000000000000000002AMW42H.hello contract: Format should follow the contract name specification"
 		);
 	}
 }

--- a/stacks-core/src/utils.rs
+++ b/stacks-core/src/utils.rs
@@ -125,13 +125,9 @@ impl TryFrom<String> for PrincipalData {
 			}
 			2 => {
 				let address = StacksAddress::try_from(parts[0])?;
-				let contract_name = parts
-					.get(1)
-					.ok_or(StacksError::InvalidData("No contract name"))
-					.and_then(|name| {
-						ContractName::new(name).map_err(|_err| {
-							StacksError::InvalidData("Invalid contract name")
-						})
+				let contract_name =
+					ContractName::new(parts[1]).map_err(|_err| {
+						StacksError::InvalidData("Invalid contract name")
 					})?;
 
 				Ok(Self::Contract(

--- a/stacks-core/src/utils.rs
+++ b/stacks-core/src/utils.rs
@@ -126,8 +126,10 @@ impl TryFrom<String> for PrincipalData {
 			2 => {
 				let address = StacksAddress::try_from(parts[0])?;
 				let contract_name =
-					ContractName::new(parts[1]).map_err(|_err| {
-						StacksError::InvalidData("Invalid contract name")
+					ContractName::new(parts[1]).map_err(|err| {
+						StacksError::InvalidData(format!(
+							"Invalid contract name from {value}: {err}"
+						))
 					})?;
 
 				Ok(Self::Contract(
@@ -135,9 +137,9 @@ impl TryFrom<String> for PrincipalData {
 					contract_name,
 				))
 			}
-			_ => Err(StacksError::InvalidData(
-				"Principal data may contain at most 1 dot character",
-			)),
+			_ => Err(StacksError::InvalidData(format!(
+				"Principal data from {value} may contain at most 1 dot character"
+			))),
 		}
 	}
 }

--- a/stacks-core/src/utils.rs
+++ b/stacks-core/src/utils.rs
@@ -275,7 +275,7 @@ mod tests {
 
 		assert_eq!(
 			result.unwrap_err().to_string(),
-			"Invalid address version: 83"
+			"Could not crackford32 encode or decode: Invalid C32 address: ST123"
 		);
 	}
 }

--- a/stacks-core/src/utils.rs
+++ b/stacks-core/src/utils.rs
@@ -275,7 +275,10 @@ mod tests {
 
 		assert_eq!(
 			result.unwrap_err().to_string(),
-			StacksError::C32Error(crate::c32::C32Error::InvalidAddress("ST123".into())).to_string()
+			StacksError::C32Error(crate::c32::C32Error::InvalidAddress(
+				"ST123".into()
+			))
+			.to_string()
 		);
 
 		// try contract name with a space


### PR DESCRIPTION
## Summary of Changes

This PR implements conversion from string to principal data that is used by the sbtc cli to enable deposits to stacks contracts.

Fixes #299 

## Testing

### Risks
This enables users to deposit sbtc to a contract without any checks whether the contract exists or can handle recieved sbtc tokens.

### How were these changes tested?
* unit test added
* manual test in devenv (with non-existing contract)

![Screenshot from 2023-10-17 21-57-48](https://github.com/stacks-network/sbtc/assets/1449049/0c67a2aa-35c5-469e-b8ac-9f296816027e)


### What future testing should occur?
Integration test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
