### PR TITLE
Always restart sbtc when it fails

### DIFF
--- a/devenv/docker-compose.yml
+++ b/devenv/docker-compose.yml
@@ -150,6 +150,7 @@ services:
     image: sbtc:latest
     container_name: sbtc
     stop_grace_period: 5s
+    restart: on-failure
     build:
       context: ./../
       dockerfile: ./devenv/sbtc/docker/Dockerfile


### PR DESCRIPTION
## Summary of Changes

Partially resolves https://github.com/stacks-network/sbtc/issues/304 by restarting sBTC docker container in devenv when it fails.

## Testing

### Risks

- Could make sBTC container look more reliable than it is
- Will make detecting errors in logs slight more difficult because the latest logs won't show errors - but you'll be able to scroll up.

### How were these changes tested?

Locally span up sBTC. The `on-failure` tag is tested by docker so we know that that works.

### What future testing should occur?

N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
