### PR TITLE
feat: strict mode turned off by default

### DIFF
--- a/romeo/src/bitcoin_client.rs
+++ b/romeo/src/bitcoin_client.rs
@@ -270,6 +270,7 @@ mod tests {
 			stacks_credentials,
 			stacks_network,
 			hiro_api_key: None,
+			strict: true,
 		};
 
 		let client = Client::new(conf.clone()).unwrap();

--- a/romeo/src/config.rs
+++ b/romeo/src/config.rs
@@ -56,6 +56,9 @@ pub struct Config {
 
 	/// optional api key used for the stacks node
 	pub hiro_api_key: Option<String>,
+
+	/// Strict mode
+	pub strict: bool,
 }
 
 impl Config {
@@ -95,6 +98,7 @@ impl Config {
 				config_file.contract_name.as_str(),
 			),
 			hiro_api_key,
+			strict: config_file.strict.unwrap_or_default(),
 		})
 	}
 
@@ -141,6 +145,9 @@ struct ConfigFile {
 
 	/// optional api key used for the stacks node
 	pub hiro_api_key: Option<String>,
+
+	/// Strict mode
+	pub strict: Option<bool>,
 }
 
 impl ConfigFile {


### PR DESCRIPTION
Allow romeo to not crash when not absolutely necessary.

## Summary of Changes

- Introduced strict mode
- Disabled it by default

### How were these changes tested?

I've manually tested these changes in local devnet and everything looks correct.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
