### PR TITLE
[sBTC DR] property-based tests for asset.clar

### DIFF
--- a/romeo/asset-contract/tests/asset.test.ts
+++ b/romeo/asset-contract/tests/asset.test.ts
@@ -101,6 +101,29 @@ it("asset.clar: Can get decimals", () => {
   ));
 });
 
+it("asset.clar: Bitcoin wallet public key is by default none", () => {
+  fc.assert(fc.property(
+    fc.record({
+      sender: fc.constantFrom(...simnet.getAccounts().values()),
+    }),
+    (r: { sender: string }) => {
+      // Arrange
+      const sender = r.sender;
+
+      // Act
+      const { result } = simnet.callReadOnlyFn(
+        "asset",
+        "get-bitcoin-wallet-public-key",
+        [],
+        sender,
+      );
+
+      // Assert
+      expect(result).toBeNone();
+    },
+  ));
+});
+
 import { initSimnet } from "@hirosystems/clarinet-sdk";
 import { AssetCommands } from "./asset_Commands.ts";
 

--- a/romeo/asset-contract/tests/asset_BurnCommand.ts
+++ b/romeo/asset-contract/tests/asset_BurnCommand.ts
@@ -93,7 +93,7 @@ export class BurnCommand implements AssetCommand {
     ]);
 
     console.log(
-      `✓ ${shortenString(this.sender).padStart(8, " ")} ${"burn".padStart(16, " ") } ${shortenString(this.wallet).padStart(8, " ")} ${this.amount.toString().padStart(12, " ")} bitcoin tx ${shortenString(uint8ArrayToHexString(this.params.depositTx)).padStart(12, " ")}`
+      `✓ ${shortenString(this.sender).padStart(8, " ")} ${"burn".padStart(29, " ") } ${shortenString(this.wallet).padStart(8, " ")} ${this.amount.toString().padStart(12, " ")} bitcoin tx ${shortenString(uint8ArrayToHexString(this.params.depositTx)).padStart(12, " ")}`
     );
   }
 

--- a/romeo/asset-contract/tests/asset_BurnCommand.ts
+++ b/romeo/asset-contract/tests/asset_BurnCommand.ts
@@ -93,7 +93,7 @@ export class BurnCommand implements AssetCommand {
     ]);
 
     console.log(
-      `✓ ${shortenString(this.sender).padStart(8, " ")} ${"burn".padStart(29, " ") } ${shortenString(this.wallet).padStart(8, " ")} ${this.amount.toString().padStart(12, " ")} bitcoin tx ${shortenString(uint8ArrayToHexString(this.params.depositTx)).padStart(12, " ")}`
+      `✓ ${shortenString(this.sender).padStart(8, " ")} ${"burn".padStart(29, " ") } ${shortenString(this.wallet).padStart(8, " ")} ${this.amount.toString().padStart(12, " ")} bitcoin-tx ${shortenString(uint8ArrayToHexString(this.params.depositTx)).padStart(12, " ")}`
     );
   }
 
@@ -101,7 +101,7 @@ export class BurnCommand implements AssetCommand {
     // fast-check will call toString() in case of errors, e.g. property failed.
     // It will then make a minimal counterexample, a process called 'shrinking'
     // https://github.com/dubzzz/fast-check/issues/2864#issuecomment-1098002642
-    return `${this.sender} burn ${this.amount} to ${this.wallet} (bitcoin tx ${uint8ArrayToHexString(this.params.depositTx).padStart(12, " ")})`;
+    return `${this.sender} burn ${this.amount} to ${this.wallet} (bitcoin-tx ${uint8ArrayToHexString(this.params.depositTx).padStart(12, " ")})`;
   }
 }
 

--- a/romeo/asset-contract/tests/asset_BurnCommand_500.ts
+++ b/romeo/asset-contract/tests/asset_BurnCommand_500.ts
@@ -69,12 +69,12 @@ export class BurnCommand_500 implements AssetCommand {
     expect(block[1].result).toBeErr(Cl.uint(500));
 
     console.log(
-      `! ${shortenString(this.sender).padStart(8, " ")} ${"burn".padStart(29, " ") } ${shortenString(this.wallet).padStart(8, " ")} ${this.amount.toString().padStart(12, " ")} bitcoin tx ${shortenString(uint8ArrayToHexString(this.params.depositTx)).padStart(12, " ")} (expected, same bitcoin tx)`
+      `! ${shortenString(this.sender).padStart(8, " ")} ${"burn".padStart(29, " ") } ${shortenString(this.wallet).padStart(8, " ")} ${this.amount.toString().padStart(12, " ")} bitcoin tx ${shortenString(uint8ArrayToHexString(this.params.depositTx)).padStart(12, " ")} (expected, same bitcoin-tx)`
     );
   }
 
   toString() {
-    return `${this.sender} burn ${this.amount} to ${this.wallet} (bitcoin tx ${uint8ArrayToHexString(this.params.depositTx).padStart(12, " ")})`;
+    return `${this.sender} burn ${this.amount} to ${this.wallet} (bitcoin-tx ${uint8ArrayToHexString(this.params.depositTx).padStart(12, " ")})`;
   }
 }
 

--- a/romeo/asset-contract/tests/asset_BurnCommand_500.ts
+++ b/romeo/asset-contract/tests/asset_BurnCommand_500.ts
@@ -69,7 +69,7 @@ export class BurnCommand_500 implements AssetCommand {
     expect(block[1].result).toBeErr(Cl.uint(500));
 
     console.log(
-      `! ${shortenString(this.sender).padStart(8, " ")} ${"burn".padStart(16, " ") } ${shortenString(this.wallet).padStart(8, " ")} ${this.amount.toString().padStart(12, " ")} bitcoin tx ${shortenString(uint8ArrayToHexString(this.params.depositTx)).padStart(12, " ")} (expected, same bitcoin tx)`
+      `! ${shortenString(this.sender).padStart(8, " ")} ${"burn".padStart(29, " ") } ${shortenString(this.wallet).padStart(8, " ")} ${this.amount.toString().padStart(12, " ")} bitcoin tx ${shortenString(uint8ArrayToHexString(this.params.depositTx)).padStart(12, " ")} (expected, same bitcoin tx)`
     );
   }
 

--- a/romeo/asset-contract/tests/asset_CommandModel.ts
+++ b/romeo/asset-contract/tests/asset_CommandModel.ts
@@ -5,6 +5,7 @@ import { Simnet } from "@hirosystems/clarinet-sdk";
 export type Stub = {
   wallets: Map<string, number>; // string: Address, number: Balance
   transactions: [string, number, string][]; // string: Id, number: Mint/Burn Amount, string: Stacks Account
+  bitcoinWalletPublicKey: Uint8Array;
 };
 
 export type Real = {

--- a/romeo/asset-contract/tests/asset_Commands.ts
+++ b/romeo/asset-contract/tests/asset_Commands.ts
@@ -166,8 +166,8 @@ export function AssetCommands(accounts: Map<string, string>) {
       .record({
         sender: fc.constant(accounts.get("deployer")!),
         pubKey: fc.array(fc.integer({ min: 0, max: 255 })
-          .map(n => n.toString(16).padStart(2, '0')), { minLength: 32, maxLength: 32 })
-          .map(bytes => '0x' + bytes.join(''))
+          .map((n: number) => n.toString(16).padStart(2, '0')), { minLength: 32, maxLength: 32 })
+          .map((bytes: string[]) => '0x' + bytes.join(''))
           .map(hexStringToUint8Array),
       })
       .map((
@@ -187,8 +187,8 @@ export function AssetCommands(accounts: Map<string, string>) {
       .record({
         sender: fc.constantFrom(...accounts.values()).filter((a: string) => a !== accounts.get("deployer")!),
         pubKey: fc.array(fc.integer({ min: 0, max: 255 })
-          .map(n => n.toString(16).padStart(2, '0')), { minLength: 32, maxLength: 32 })
-          .map(bytes => '0x' + bytes.join(''))
+          .map((n: number) => n.toString(16).padStart(2, '0')), { minLength: 32, maxLength: 32 })
+          .map((bytes: string[]) => '0x' + bytes.join(''))
           .map(hexStringToUint8Array),
       })
       .map((

--- a/romeo/asset-contract/tests/asset_Commands.ts
+++ b/romeo/asset-contract/tests/asset_Commands.ts
@@ -8,6 +8,8 @@ import { GetBalanceCommand } from "./asset_GetBalanceCommand.ts";
 import { GetTotalSupplyCommand } from "./asset_GetTotalSupplyCommand.ts";
 import { MintCommand } from "./asset_MintCommand.ts";
 import { MintCommand_500 } from "./asset_MintCommand_500.ts";
+import { SetBitcoinWalletPublicKeyCommand } from "./asset_SetBitcoinWalletPublicKeyCommand.ts";
+import { SetBitcoinWalletPublicKeyCommand_NonOwner } from "./asset_SetBitcoinWalletPublicKeyCommand_NonOwner.ts";
 import { TransferCommand } from "./asset_TransferCommand.ts";
 import { TransferCommand_NonOwner } from "./asset_TransferCommand_NonOwner.ts";
 
@@ -140,6 +142,48 @@ export function AssetCommands(accounts: Map<string, string>) {
           r.amount,
           r.wallet,
           r.params,
+        )
+      ),
+
+    // SetBitcoinWalletPublicKeyCommand
+    fc
+      .record({
+        sender: fc.constant(accounts.get("deployer")!),
+        pubKey: fc.array(fc.integer({ min: 0, max: 255 })
+          .map(n => n.toString(16).padStart(2, '0')), { minLength: 32, maxLength: 32 })
+          .map(bytes => '0x' + bytes.join(''))
+          .map(hexStringToUint8Array),
+      })
+      .map((
+        r: {
+          sender: string;
+          pubKey: Uint8Array;
+        },
+      ) =>
+        new SetBitcoinWalletPublicKeyCommand(
+          r.sender,
+          r.pubKey,
+        )
+      ),
+
+    // SetBitcoinWalletPublicKeyCommand (err-forbidden (err u403))
+    fc
+      .record({
+        sender: fc.constantFrom(...accounts.values()).filter((a: string) => a !== accounts.get("deployer")!),
+        pubKey: fc.array(fc.integer({ min: 0, max: 255 })
+          .map(n => n.toString(16).padStart(2, '0')), { minLength: 32, maxLength: 32 })
+          .map(bytes => '0x' + bytes.join(''))
+          .map(hexStringToUint8Array),
+      })
+      .map((
+        r: {
+          sender: string;
+          pubKey: Uint8Array;
+        },
+      ) =>
+        new SetBitcoinWalletPublicKeyCommand_NonOwner(
+          r.sender,
+          r.pubKey,
         )
       ),
 

--- a/romeo/asset-contract/tests/asset_Commands.ts
+++ b/romeo/asset-contract/tests/asset_Commands.ts
@@ -5,6 +5,7 @@ import fc from "fast-check";
 import { BurnCommand } from "./asset_BurnCommand.ts";
 import { BurnCommand_500 } from "./asset_BurnCommand_500.ts";
 import { GetBalanceCommand } from "./asset_GetBalanceCommand.ts";
+import { GetBitcoinWalletPublicKeyCommand } from "./asset_GetBitcoinWalletPublicKeyCommand.ts";
 import { GetTotalSupplyCommand } from "./asset_GetTotalSupplyCommand.ts";
 import { MintCommand } from "./asset_MintCommand.ts";
 import { MintCommand_500 } from "./asset_MintCommand_500.ts";
@@ -79,6 +80,21 @@ export function AssetCommands(accounts: Map<string, string>) {
         new GetBalanceCommand(
           r.sender,
           r.wallet,
+        )
+      ),
+
+    // GetBitcoinWalletPublicKeyCommand
+    fc
+      .record({
+        sender: fc.constantFrom(...accounts.values()),
+      })
+      .map((
+        r: {
+          sender: string;
+        },
+      ) =>
+        new GetBitcoinWalletPublicKeyCommand(
+          r.sender,
         )
       ),
 

--- a/romeo/asset-contract/tests/asset_GetBalanceCommand.ts
+++ b/romeo/asset-contract/tests/asset_GetBalanceCommand.ts
@@ -45,7 +45,7 @@ export class GetBalanceCommand implements AssetCommand {
     );
 
     console.log(
-      `✓ ${shortenString(this.sender).padStart(8, " ")} ${`get-balance`.padStart(16, " ")} ${shortenString(this.wallet).padStart(8, " ")} ${expected.toString().padStart(12, " ")}`,
+      `✓ ${shortenString(this.sender).padStart(8, " ")} ${`get-balance`.padStart(29, " ")} ${shortenString(this.wallet).padStart(8, " ")} ${expected.toString().padStart(12, " ")}`,
     );
   }
 

--- a/romeo/asset-contract/tests/asset_GetBitcoinWalletPublicKeyCommand.ts
+++ b/romeo/asset-contract/tests/asset_GetBitcoinWalletPublicKeyCommand.ts
@@ -1,0 +1,51 @@
+import {
+  AssetCommand,
+  Real,
+  Stub,
+  shortenString
+} from "./asset_CommandModel.ts";
+
+import { Cl } from "@stacks/transactions";
+
+import { expect } from "vitest";
+
+export class GetBitcoinWalletPublicKeyCommand implements AssetCommand {
+  readonly sender: string;
+
+  constructor(
+    sender: string,
+  ) {
+    this.sender = sender;
+  }
+
+  check(model: Readonly<Stub>): boolean {
+    return model.bitcoinWalletPublicKey !== undefined;
+  }
+
+  run(model: Stub, real: Real): void {
+    const { result } = real.simnet.callReadOnlyFn(
+      "asset",
+      "get-bitcoin-wallet-public-key",
+      [],
+      this.sender,
+    );
+
+    const expected = model.bitcoinWalletPublicKey;
+    expect(result).toBeSome(Cl.buffer(expected));
+
+    console.log(
+      `✓ ${shortenString(this.sender).padStart(8, " ")} ${"get-bitcoin-wallet-public-key".padStart(29, " ") } ${shortenString(uint8ArrayToHexString(expected))}`
+    );
+  }
+
+  toString() {
+    // fast-check will call toString() in case of errors, e.g. property failed.
+    // It will then make a minimal counterexample, a process called 'shrinking'
+    // https://github.com/dubzzz/fast-check/issues/2864#issuecomment-1098002642
+    return `${this.sender} get-bitcoin-wallet-public`;
+  }
+}
+
+function uint8ArrayToHexString(uint8Array: Uint8Array): string {
+  return '0x' + Array.from(uint8Array).map(byte => byte.toString(16).padStart(2, '0')).join('');
+}

--- a/romeo/asset-contract/tests/asset_GetTotalSupplyCommand.ts
+++ b/romeo/asset-contract/tests/asset_GetTotalSupplyCommand.ts
@@ -36,7 +36,7 @@ export class GetTotalSupplyCommand implements AssetCommand {
     expect(result).toBeOk(Cl.uint(supply));
 
     console.log(
-      `✓ ${shortenString(this.sender).padStart(8, " ")} ${`get-total-supply`.padStart(16, " ")} ${supply.toString().padStart(24, " ")}`,
+      `✓ ${shortenString(this.sender).padStart(8, " ")} ${`get-total-supply`.padStart(29, " ")} ${supply.toString().padStart(24, " ")}`,
     );
   }
 

--- a/romeo/asset-contract/tests/asset_MintCommand.ts
+++ b/romeo/asset-contract/tests/asset_MintCommand.ts
@@ -89,7 +89,7 @@ export class MintCommand implements AssetCommand {
     ]);
 
     console.log(
-      `✓ ${shortenString(this.sender).padStart(8, " ")} ${"mint".padStart(16, " ") } ${shortenString(this.wallet).padStart(8, " ")} ${this.amount.toString().padStart(12, " ")} bitcoin tx ${shortenString(uint8ArrayToHexString(this.params.depositTx)).padStart(12, " ")}`
+      `✓ ${shortenString(this.sender).padStart(8, " ")} ${"mint".padStart(29, " ") } ${shortenString(this.wallet).padStart(8, " ")} ${this.amount.toString().padStart(12, " ")} bitcoin tx ${shortenString(uint8ArrayToHexString(this.params.depositTx)).padStart(12, " ")}`
     );
   }
 

--- a/romeo/asset-contract/tests/asset_MintCommand.ts
+++ b/romeo/asset-contract/tests/asset_MintCommand.ts
@@ -89,7 +89,7 @@ export class MintCommand implements AssetCommand {
     ]);
 
     console.log(
-      `✓ ${shortenString(this.sender).padStart(8, " ")} ${"mint".padStart(29, " ") } ${shortenString(this.wallet).padStart(8, " ")} ${this.amount.toString().padStart(12, " ")} bitcoin tx ${shortenString(uint8ArrayToHexString(this.params.depositTx)).padStart(12, " ")}`
+      `✓ ${shortenString(this.sender).padStart(8, " ")} ${"mint".padStart(29, " ") } ${shortenString(this.wallet).padStart(8, " ")} ${this.amount.toString().padStart(12, " ")} bitcoin-tx ${shortenString(uint8ArrayToHexString(this.params.depositTx)).padStart(12, " ")}`
     );
   }
 
@@ -97,7 +97,7 @@ export class MintCommand implements AssetCommand {
     // fast-check will call toString() in case of errors, e.g. property failed.
     // It will then make a minimal counterexample, a process called 'shrinking'
     // https://github.com/dubzzz/fast-check/issues/2864#issuecomment-1098002642
-    return `${shortenString(this.sender)} mint ${this.amount} to ${shortenString(this.wallet)} (bitcoin tx ${uint8ArrayToHexString(this.params.depositTx).padStart(12, " ")})`;
+    return `${shortenString(this.sender)} mint ${this.amount} to ${shortenString(this.wallet)} (bitcoin-tx ${uint8ArrayToHexString(this.params.depositTx).padStart(12, " ")})`;
   }
 }
 

--- a/romeo/asset-contract/tests/asset_MintCommand_500.ts
+++ b/romeo/asset-contract/tests/asset_MintCommand_500.ts
@@ -68,7 +68,7 @@ export class MintCommand_500 implements AssetCommand {
     expect(block[1].result).toBeErr(Cl.uint(500));
 
     console.log(
-      `! ${shortenString(this.sender).padStart(8, " ")} ${"mint".padStart(16, " ") } ${shortenString(this.wallet).padStart(8, " ")} ${this.amount.toString().padStart(12, " ")} bitcoin tx ${shortenString(uint8ArrayToHexString(this.params.depositTx)).padStart(12, " ")} (expected, same bitcoin tx)`
+      `! ${shortenString(this.sender).padStart(8, " ")} ${"mint".padStart(29, " ") } ${shortenString(this.wallet).padStart(8, " ")} ${this.amount.toString().padStart(12, " ")} bitcoin tx ${shortenString(uint8ArrayToHexString(this.params.depositTx)).padStart(12, " ")} (expected, same bitcoin tx)`
     );
   }
 

--- a/romeo/asset-contract/tests/asset_MintCommand_500.ts
+++ b/romeo/asset-contract/tests/asset_MintCommand_500.ts
@@ -68,7 +68,7 @@ export class MintCommand_500 implements AssetCommand {
     expect(block[1].result).toBeErr(Cl.uint(500));
 
     console.log(
-      `! ${shortenString(this.sender).padStart(8, " ")} ${"mint".padStart(29, " ") } ${shortenString(this.wallet).padStart(8, " ")} ${this.amount.toString().padStart(12, " ")} bitcoin tx ${shortenString(uint8ArrayToHexString(this.params.depositTx)).padStart(12, " ")} (expected, same bitcoin tx)`
+      `! ${shortenString(this.sender).padStart(8, " ")} ${"mint".padStart(29, " ") } ${shortenString(this.wallet).padStart(8, " ")} ${this.amount.toString().padStart(12, " ")} bitcoin-tx ${shortenString(uint8ArrayToHexString(this.params.depositTx)).padStart(12, " ")} (expected, same bitcoin-tx)`
     );
   }
 
@@ -76,7 +76,7 @@ export class MintCommand_500 implements AssetCommand {
     // fast-check will call toString() in case of errors, e.g. property failed.
     // It will then make a minimal counterexample, a process called 'shrinking'
     // https://github.com/dubzzz/fast-check/issues/2864#issuecomment-1098002642
-    return `${this.sender} mint ${this.amount} to ${this.wallet} (bitcoin tx ${uint8ArrayToHexString(this.params.depositTx).padStart(12, " ")})`;
+    return `${this.sender} mint ${this.amount} to ${this.wallet} (bitcoin-tx ${uint8ArrayToHexString(this.params.depositTx).padStart(12, " ")})`;
   }
 }
 

--- a/romeo/asset-contract/tests/asset_SetBitcoinWalletPublicKeyCommand.ts
+++ b/romeo/asset-contract/tests/asset_SetBitcoinWalletPublicKeyCommand.ts
@@ -1,0 +1,59 @@
+import {
+  AssetCommand,
+  Real,
+  Stub,
+  shortenString
+} from "./asset_CommandModel.ts";
+
+import { tx } from "@hirosystems/clarinet-sdk";
+import { Cl } from "@stacks/transactions";
+
+import { expect } from "vitest";
+
+export class SetBitcoinWalletPublicKeyCommand implements AssetCommand {
+  readonly sender: string;
+  readonly pubKey: Uint8Array;
+
+  constructor(
+    sender: string,
+    pubKey: Uint8Array,
+  ) {
+    this.sender = sender;
+    this.pubKey = pubKey;
+  }
+
+  check(_: Readonly<Stub>): boolean {
+    // Can run if sender is the deployer. This is filtered in the generator.
+    return true;
+  }
+
+  run(model: Stub, real: Real): void {
+    const block = real.simnet.mineBlock([
+      tx.callPublicFn(
+        "asset",
+        "set-bitcoin-wallet-public-key",
+        [
+          Cl.buffer(this.pubKey),
+        ],
+        this.sender,
+      ),
+    ]);
+
+    expect(block[0].result).toBeOk(Cl.bool(true));
+
+    console.log(
+      `✓ ${shortenString(this.sender).padStart(8, " ")} ${"set-bitcoin-wallet-public-key".padStart(29, " ") } ${shortenString(uint8ArrayToHexString(this.pubKey))}`
+    );
+  }
+
+  toString() {
+    // fast-check will call toString() in case of errors, e.g. property failed.
+    // It will then make a minimal counterexample, a process called 'shrinking'
+    // https://github.com/dubzzz/fast-check/issues/2864#issuecomment-1098002642
+    return `${this.sender} set-bitcoin-wallet-public-key ${uint8ArrayToHexString(this.pubKey)}`;
+  }
+}
+
+function uint8ArrayToHexString(uint8Array: Uint8Array): string {
+  return '0x' + Array.from(uint8Array).map(byte => byte.toString(16).padStart(2, '0')).join('');
+}

--- a/romeo/asset-contract/tests/asset_SetBitcoinWalletPublicKeyCommand.ts
+++ b/romeo/asset-contract/tests/asset_SetBitcoinWalletPublicKeyCommand.ts
@@ -41,6 +41,8 @@ export class SetBitcoinWalletPublicKeyCommand implements AssetCommand {
 
     expect(block[0].result).toBeOk(Cl.bool(true));
 
+    model.bitcoinWalletPublicKey = this.pubKey;
+
     console.log(
       `✓ ${shortenString(this.sender).padStart(8, " ")} ${"set-bitcoin-wallet-public-key".padStart(29, " ") } ${shortenString(uint8ArrayToHexString(this.pubKey))}`
     );

--- a/romeo/asset-contract/tests/asset_SetBitcoinWalletPublicKeyCommand_NonOwner.ts
+++ b/romeo/asset-contract/tests/asset_SetBitcoinWalletPublicKeyCommand_NonOwner.ts
@@ -1,0 +1,59 @@
+import {
+  AssetCommand,
+  Real,
+  Stub,
+  shortenString
+} from "./asset_CommandModel.ts";
+
+import { tx } from "@hirosystems/clarinet-sdk";
+import { Cl } from "@stacks/transactions";
+
+import { expect } from "vitest";
+
+export class SetBitcoinWalletPublicKeyCommand_NonOwner implements AssetCommand {
+  readonly sender: string;
+  readonly pubKey: Uint8Array;
+
+  constructor(
+    sender: string,
+    pubKey: Uint8Array,
+  ) {
+    this.sender = sender;
+    this.pubKey = pubKey;
+  }
+
+  check(_: Readonly<Stub>): boolean {
+    // Can run if sender is not the deployer. This is filtered in the generator.
+    return true;
+  }
+
+  run(_: Stub, real: Real): void {
+    const block = real.simnet.mineBlock([
+      tx.callPublicFn(
+        "asset",
+        "set-bitcoin-wallet-public-key",
+        [
+          Cl.buffer(this.pubKey),
+        ],
+        this.sender,
+      ),
+    ]);
+
+    expect(block[0].result).toBeErr(Cl.uint(403));
+
+    console.log(
+      `! ${shortenString(this.sender).padStart(8, " ")} ${"set-bitcoin-wallet-public-key".padStart(29, " ") } ${shortenString(uint8ArrayToHexString(this.pubKey))}`
+    );
+  }
+
+  toString() {
+    // fast-check will call toString() in case of errors, e.g. property failed.
+    // It will then make a minimal counterexample, a process called 'shrinking'
+    // https://github.com/dubzzz/fast-check/issues/2864#issuecomment-1098002642
+    return `${this.sender} set-bitcoin-wallet-public-key ${uint8ArrayToHexString(this.pubKey)}`;
+  }
+}
+
+function uint8ArrayToHexString(uint8Array: Uint8Array): string {
+  return '0x' + Array.from(uint8Array).map(byte => byte.toString(16).padStart(2, '0')).join('');
+}

--- a/romeo/asset-contract/tests/asset_SetBitcoinWalletPublicKeyCommand_NonOwner.ts
+++ b/romeo/asset-contract/tests/asset_SetBitcoinWalletPublicKeyCommand_NonOwner.ts
@@ -42,7 +42,7 @@ export class SetBitcoinWalletPublicKeyCommand_NonOwner implements AssetCommand {
     expect(block[0].result).toBeErr(Cl.uint(403));
 
     console.log(
-      `! ${shortenString(this.sender).padStart(8, " ")} ${"set-bitcoin-wallet-public-key".padStart(29, " ") } ${shortenString(uint8ArrayToHexString(this.pubKey))}`
+      `! ${shortenString(this.sender).padStart(8, " ")} ${"set-bitcoin-wallet-public-key".padStart(29, " ") } ${shortenString(uint8ArrayToHexString(this.pubKey))} ${"(expected, non-owner)".padStart(58, " ")}`
     );
   }
 

--- a/romeo/asset-contract/tests/asset_TransferCommand.ts
+++ b/romeo/asset-contract/tests/asset_TransferCommand.ts
@@ -34,9 +34,18 @@ export class TransferCommand implements AssetCommand {
     ) {
       return true;
     } else {
-      console.log(
-        `! ${shortenString(this.sender).padStart(8, " ")} ${"transfer".padStart(29, " ") } ${shortenString(this.wallet).padStart(8, " ")} ${this.amount.toString().padStart(12, " ") } (discarded)`
-      );
+      if (this.sender === this.wallet) {
+        console.log(
+          `! ${shortenString(this.sender).padStart(8, " ")} ${"transfer".padStart(29, " ") } ${shortenString(this.wallet).padStart(8, " ")} ${this.amount.toString().padStart(12, " ") } ${"(discarded, sender can not be the receiver)".padStart(67, " ")}`
+        );
+      }
+
+      if ((model.wallets.get(this.sender) ?? 0) < this.amount) {
+        console.log(
+          `! ${shortenString(this.sender).padStart(8, " ")} ${"transfer".padStart(29, " ") } ${shortenString(this.wallet).padStart(8, " ")} ${this.amount.toString().padStart(12, " ") } ${"(discarded, not enough funds)".padStart(53, " ")}`
+        );
+      }
+
       return false;
     }
   }

--- a/romeo/asset-contract/tests/asset_TransferCommand.ts
+++ b/romeo/asset-contract/tests/asset_TransferCommand.ts
@@ -35,7 +35,7 @@ export class TransferCommand implements AssetCommand {
       return true;
     } else {
       console.log(
-        `! ${shortenString(this.sender).padStart(8, " ")} ${"transfer".padStart(16, " ") } ${shortenString(this.wallet).padStart(8, " ")} ${this.amount.toString().padStart(12, " ") } (discarded)`
+        `! ${shortenString(this.sender).padStart(8, " ")} ${"transfer".padStart(29, " ") } ${shortenString(this.wallet).padStart(8, " ")} ${this.amount.toString().padStart(12, " ") } (discarded)`
       );
       return false;
     }
@@ -68,7 +68,7 @@ export class TransferCommand implements AssetCommand {
     );
 
     console.log(
-      `✓ ${shortenString(this.sender).padStart(8, " ")} ${"transfer".padStart(16, " ") } ${shortenString(this.wallet).padStart(8, " ")} ${this.amount.toString().padStart(12, " ") }`
+      `✓ ${shortenString(this.sender).padStart(8, " ")} ${"transfer".padStart(29, " ") } ${shortenString(this.wallet).padStart(8, " ")} ${this.amount.toString().padStart(12, " ") }`
     );
   }
 

--- a/romeo/asset-contract/tests/asset_TransferCommand_NonOwner.ts
+++ b/romeo/asset-contract/tests/asset_TransferCommand_NonOwner.ts
@@ -52,7 +52,7 @@ export class TransferCommand_NonOwner implements AssetCommand {
     expect(block[0].result).toBeErr(Cl.uint(2));
 
     console.log(
-      `! ${shortenString(this.sender).padStart(8, " ")} ${"transfer".padStart(16, " ") } ${shortenString(this.wallet).padStart(8, " ")} ${this.amount.toString().padStart(12, " ") } (expected, non-owner)`
+      `! ${shortenString(this.sender).padStart(8, " ")} ${"transfer".padStart(29, " ") } ${shortenString(this.wallet).padStart(8, " ")} ${this.amount.toString().padStart(12, " ") } (expected, non-owner)`
     );
   }
 


### PR DESCRIPTION
Continuation of #152. This pull request covers `get/set-bitcoin-wallet-public-key`, and keeps the console output aligned.

```
  ST2C...K9AG              get-total-supply                      128
  ST1P...GZGM set-bitcoin-wallet-public-key 0xf6...8e3e
  ST1P...GZGM                   get-balance ST2R...P2VB            0
  ST2R...P2VB              get-total-supply                      128
! ST2N...87ND set-bitcoin-wallet-public-key 0xa6...1fca                                      (expected, non-owner)
  ST1P...GZGM set-bitcoin-wallet-public-key 0x52...fb67
! ST2R...P2VB set-bitcoin-wallet-public-key 0x24...555b                                      (expected, non-owner)
! ST1S...YPD5 set-bitcoin-wallet-public-key 0x2b...eed0                                      (expected, non-owner)
! ST1S...YPD5 set-bitcoin-wallet-public-key 0xb2...a7fb                                      (expected, non-owner)
  ST1P...GZGM set-bitcoin-wallet-public-key 0x71...d2d4
! ST3A...GCS0 set-bitcoin-wallet-public-key 0x59...cbdc                                      (expected, non-owner)
! ST2J...5NNC set-bitcoin-wallet-public-key 0x0a...cc99                                      (expected, non-owner)
  STNH...MAZ6              get-total-supply                      128
  STNH...MAZ6              get-total-supply                      128
  ST1S...YPD5              get-total-supply                      128
! ST3N...1XCP                      transfer STNH...MAZ6    299493701                         (discarded, not enough funds)
! ST2J...5NNC                      transfer ST2J...5NNC   1390308638                         (discarded, sender can not be the receiver)
! ST2J...5NNC                      transfer ST2J...5NNC   1390308638                         (discarded, not enough funds)
! ST1S...YPD5                      transfer ST1P...GZGM   1655155279                         (discarded, not enough funds)
! ST3P...YGKJ                      transfer ST3P...YGKJ   1886821251                         (discarded, sender can not be the receiver)
! ST3P...YGKJ                      transfer ST3P...YGKJ   1886821251                         (discarded, not enough funds)
! ST1P...GZGM                          mint ST2J...5NNC           71 bitcoin-tx  255d...a63c (expected, same bitcoin-tx)
! ST3P...YGKJ                      transfer ST2R...P2VB   2090993235                         (discarded, not enough funds)
! ST1P...GZGM                      transfer ST2J...5NNC    292423422                         (discarded, not enough funds)
```

## Summary of Changes

Adds property-based tests covering `get/set-bitcoin-wallet-public-key`.

## Testing

### Risks

No risks associated with this PR. Existing tests aren't modified, only new tests added ([append-only tests](https://blog.ploeh.dk/2013/04/02/why-trust-tests/#b23efe23c1574f2b8ff85fb3c529ec9d)).

### How were these changes tested?

Once you `cd` into `romeo/asset-contract` directory, run `npm install`, then you can run the tests via

```bash
npm test
```

### What future testing should occur?

<!--
Please list known edge cases or tests that need further testing that don't make sense to add in this PR (integration tests and the like). **Once this PR is approved create an issue for each item and update the following section in the PR description so each bullet has an associated ticket next to it.**
-->

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

(Let me know if there's a style guideline of this project that I can follow, and any changes to the documentation that I should make. There are no dependent changes in downstream modules.)