### PR TITLE
Use environment variables for config management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,6 +481,7 @@ name = "blocklist-client"
 version = "0.0.1"
 dependencies = [
  "config",
+ "once_cell",
  "reqwest",
  "sbtc-signer",
  "serde 1.0.200",

--- a/blocklist-client/Cargo.toml
+++ b/blocklist-client/Cargo.toml
@@ -16,6 +16,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 reqwest = { version = "0.11", features = ["json"] }
 config = "0.11"
+once_cell = "1.8.0"
 sbtc-signer = { path = "../signer" }
 tracing = { version = "0.1", default-features = false }
 tracing-attributes = "0.1"

--- a/blocklist-client/README.md
+++ b/blocklist-client/README.md
@@ -1,0 +1,17 @@
+# Blocklist Client
+This Blocklist Client is an auxiliary service for serving a sBTC signer in the process of handling sBTC requests.
+
+### Building
+Change to the blocklist-client directory and build the program using `cargo`.
+
+   ```bash
+   cd blocklist-client
+   cargo build --release
+   ```
+### Running
+You can run the blocklist client by providing the necessary environment variables as below:
+
+
+   ```bash
+    BLOCKLIST_CLIENT_server__host=127.0.0.1 BLOCKLIST_CLIENT_server__port=8080 BLOCKLIST_CLIENT_risk_analysis__api_url=https://your-risk-provider-api.com/ BLOCKLIST_CLIENT_risk_analysis__api_key=your_api_key  ../target/release/blocklist-client 
+   ```

--- a/blocklist-client/README.md
+++ b/blocklist-client/README.md
@@ -13,5 +13,5 @@ You can run the blocklist client by providing the necessary environment variable
 
 
    ```bash
-    BLOCKLIST_CLIENT_server__host=127.0.0.1 BLOCKLIST_CLIENT_server__port=8080 BLOCKLIST_CLIENT_risk_analysis__api_url=https://your-risk-provider-api.com/ BLOCKLIST_CLIENT_risk_analysis__api_key=your_api_key  ../target/release/blocklist-client 
+    BLOCKLIST_CLIENT_server__host=127.0.0.1 BLOCKLIST_CLIENT_SERVER__PORT=8080 BLOCKLIST_CLIENT_RISK_ANALYSIS__API_URL=https://your-risk-provider-api.com/ BLOCKLIST_CLIENT_RISK_ANALYSIS__API_KEY=your_api_key  ../target/release/blocklist-client 
    ```

--- a/blocklist-client/README.md
+++ b/blocklist-client/README.md
@@ -9,9 +9,17 @@ Change to the blocklist-client directory and build the program using `cargo`.
    cargo build --release
    ```
 ### Running
-You can run the blocklist client by providing the necessary environment variables as below:
+You can run the blocklist client by providing the required environment variables.
 
+#### Required Environment Variables
+- BLOCKLIST_CLIENT_RISK_ANALYSIS__API_URL=<provider-url>
+- BLOCKLIST_CLIENT_RISK_ANALYSIS__API_KEY=<your_api_key>
+
+#### Optional Environment Variables
+If not specified, the default values from `./src/config/default.toml` will be used.
+- BLOCKLIST_CLIENT_SERVER__HOST=<server-hostname-or-ip>
+- BLOCKLIST_CLIENT_SERVER__PORT=<server-port>
 
    ```bash
-    BLOCKLIST_CLIENT_server__host=127.0.0.1 BLOCKLIST_CLIENT_SERVER__PORT=8080 BLOCKLIST_CLIENT_RISK_ANALYSIS__API_URL=https://your-risk-provider-api.com/ BLOCKLIST_CLIENT_RISK_ANALYSIS__API_KEY=your_api_key  ../target/release/blocklist-client 
+    BLOCKLIST_CLIENT_SERVER__HOST=127.0.0.1 BLOCKLIST_CLIENT_SERVER__PORT=8080 BLOCKLIST_CLIENT_RISK_ANALYSIS__API_URL=https://your-risk-provider-api.com/ BLOCKLIST_CLIENT_RISK_ANALYSIS__API_KEY=your_api_key  ../target/release/blocklist-client 
    ```

--- a/blocklist-client/settings.toml
+++ b/blocklist-client/settings.toml
@@ -1,7 +1,0 @@
-[server]
-host = "127.0.0.1"
-port = 3030
-
-[risk_analysis]
-api_url = "https://chainalysis-api.com/"
-api_key = "api_key"

--- a/blocklist-client/src/api/routes.rs
+++ b/blocklist-client/src/api/routes.rs
@@ -1,20 +1,17 @@
 use super::handlers;
-use crate::config::Settings;
+use crate::config::SETTINGS;
 use reqwest::Client;
 use std::convert::Infallible;
 use warp::Filter;
 
 pub fn routes(
     client: Client,
-    settings: &Settings,
 ) -> impl Filter<Extract = impl warp::Reply, Error = Infallible> + Clone {
-    let config = settings.risk_analysis.clone();
-
     warp::path("screen")
         .and(warp::path::param::<String>())
         .and(warp::get())
         .and(warp::any().map(move || client.clone()))
-        .and(warp::any().map(move || config.clone()))
+        .and(warp::any().map(move || SETTINGS.risk_analysis.clone()))
         .and_then(handlers::check_address_handler)
         .recover(handlers::handle_rejection)
 }

--- a/blocklist-client/src/config.rs
+++ b/blocklist-client/src/config.rs
@@ -24,6 +24,8 @@ pub static SETTINGS: Lazy<Settings> =
     Lazy::new(|| Settings::new().expect("Failed to load configuration"));
 
 impl Settings {
+    // Initializing the global config first with default values and then with provided/overwritten environment variables.
+    // The explicit separator with double underscores is needed to correctly parse the nested config structure.
     pub fn new() -> Result<Self, ConfigError> {
         let mut cfg = Config::new();
         cfg.merge(File::with_name("./src/config/default"))?;

--- a/blocklist-client/src/config.rs
+++ b/blocklist-client/src/config.rs
@@ -1,19 +1,35 @@
+use config::{Config, ConfigError, Environment, File};
+use once_cell::sync::Lazy;
 use serde::Deserialize;
 
-#[derive(Deserialize, Clone)]
+#[derive(Deserialize, Clone, Debug)]
 pub struct Settings {
     pub server: ServerConfig,
     pub risk_analysis: RiskAnalysisConfig,
 }
 
-#[derive(Deserialize, Clone)]
+#[derive(Deserialize, Clone, Debug)]
 pub struct ServerConfig {
     pub host: String,
     pub port: u16,
 }
 
-#[derive(Deserialize, Clone)]
+#[derive(Deserialize, Clone, Debug)]
 pub struct RiskAnalysisConfig {
     pub api_url: String,
     pub api_key: String,
+}
+
+pub static SETTINGS: Lazy<Settings> =
+    Lazy::new(|| Settings::new().expect("Failed to load configuration"));
+
+impl Settings {
+    pub fn new() -> Result<Self, ConfigError> {
+        let mut cfg = Config::new();
+        cfg.merge(File::with_name("./src/config/default"))?;
+        let env = Environment::with_prefix("APP").separator("__");
+        cfg.merge(env)?;
+        let settings: Settings = cfg.try_into()?;
+        Ok(settings)
+    }
 }

--- a/blocklist-client/src/config.rs
+++ b/blocklist-client/src/config.rs
@@ -27,7 +27,7 @@ impl Settings {
     pub fn new() -> Result<Self, ConfigError> {
         let mut cfg = Config::new();
         cfg.merge(File::with_name("./src/config/default"))?;
-        let env = Environment::with_prefix("APP").separator("__");
+        let env = Environment::with_prefix("BLOCKLIST_CLIENT").separator("__");
         cfg.merge(env)?;
         let settings: Settings = cfg.try_into()?;
         Ok(settings)

--- a/blocklist-client/src/config/default.toml
+++ b/blocklist-client/src/config/default.toml
@@ -1,0 +1,7 @@
+[server]
+host = "127.0.0.1"
+port = 3030
+
+[risk_analysis]
+api_url = "http://example.com/api"
+api_key = "api-key-here"

--- a/blocklist-client/src/config/default.toml
+++ b/blocklist-client/src/config/default.toml
@@ -1,7 +1,3 @@
 [server]
 host = "127.0.0.1"
 port = 3030
-
-[risk_analysis]
-api_url = "http://example.com/api"
-api_key = "api-key-here"


### PR DESCRIPTION
resolves #121 

Using a static read-only config that gets instantiated via a default config file and environment variables for an improved way to handle config management.