### PR TITLE
feat: Signer message signing and validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,14 +125,14 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "aws-credential-types"
@@ -142,22 +142,22 @@ checksum = "e16838e6c9e12125face1c1eff1343c75e3ff540de98ff7ebd61874a89bcfeb9"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
- "aws-smithy-types 1.1.8",
+ "aws-smithy-types 1.1.9",
  "zeroize",
 ]
 
 [[package]]
 name = "aws-runtime"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4963ac9ff2d33a4231b3806c1c69f578f221a9cabb89ad2bde62ce2b442c8a7"
+checksum = "785da4a15e7b166b505fd577e4560c7a7cd8fbdf842eb1336cbcbf8944ce56f1"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4 1.2.1",
  "aws-smithy-async",
  "aws-smithy-http 0.60.8",
  "aws-smithy-runtime-api",
- "aws-smithy-types 1.1.8",
+ "aws-smithy-types 1.1.9",
  "aws-types",
  "bytes",
  "fastrand",
@@ -171,9 +171,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-dynamodb"
-version = "1.25.0"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a67ba96993b05d3064f5b7ea14969d81cc02f7abdb05feddc2224810eb22b9ca"
+checksum = "932b8899ac8785b4920098eae75a24d3b881817d6b8e74bd633ee4922fcc890e"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -182,7 +182,7 @@ dependencies = [
  "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
- "aws-smithy-types 1.1.8",
+ "aws-smithy-types 1.1.9",
  "aws-types",
  "bytes",
  "fastrand",
@@ -219,7 +219,7 @@ dependencies = [
  "aws-credential-types",
  "aws-smithy-http 0.60.8",
  "aws-smithy-runtime-api",
- "aws-smithy-types 1.1.8",
+ "aws-smithy-types 1.1.9",
  "bytes",
  "form_urlencoded",
  "hex",
@@ -269,7 +269,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a7de001a1b9a25601016d8057ea16e31a45fdca3751304c8edf4ad72e706c08"
 dependencies = [
  "aws-smithy-runtime-api",
- "aws-smithy-types 1.1.8",
+ "aws-smithy-types 1.1.9",
  "bytes",
  "bytes-utils",
  "futures-core",
@@ -288,19 +288,19 @@ version = "0.60.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4683df9469ef09468dad3473d129960119a0d3593617542b7d52086c8486f2d6"
 dependencies = [
- "aws-smithy-types 1.1.8",
+ "aws-smithy-types 1.1.9",
 ]
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cf64e73ef8d4dac6c933230d56d136b75b252edcf82ed36e37d603090cd7348"
+checksum = "c9ac79e9f3a4d576f3cd4a470a0275b138d9e7b11b1cd514a6858ae0a79dd5bb"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http 0.60.8",
  "aws-smithy-runtime-api",
- "aws-smithy-types 1.1.8",
+ "aws-smithy-types 1.1.9",
  "bytes",
  "fastrand",
  "h2",
@@ -319,12 +319,12 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c19fdae6e3d5ac9cd01f2d6e6c359c5f5a3e028c2d148a8f5b90bf3399a18a7"
+checksum = "04ec42c2f5c0e7796a2848dde4d9f3bf8ce12ccbb3d5aa40c52fa0cdd61a1c47"
 dependencies = [
  "aws-smithy-async",
- "aws-smithy-types 1.1.8",
+ "aws-smithy-types 1.1.9",
  "bytes",
  "http 0.2.12",
  "http 1.1.0",
@@ -348,9 +348,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe14dceea1e70101d38fbf2a99e6a34159477c0fb95e68e05c66bd7ae4c3729"
+checksum = "baf98d97bba6ddaba180f1b1147e202d8fe04940403a95a3f826c790f931bbd1"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -366,7 +366,7 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "ryu",
- "serde 1.0.200",
+ "serde 1.0.201",
  "time",
  "tokio",
  "tokio-util",
@@ -381,7 +381,7 @@ dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
  "aws-smithy-runtime-api",
- "aws-smithy-types 1.1.8",
+ "aws-smithy-types 1.1.9",
  "http 0.2.12",
  "rustc_version",
  "tracing",
@@ -389,11 +389,11 @@ dependencies = [
 
 [[package]]
 name = "aws_lambda_events"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598e2ade8447dce8d3a15b6159b73354db34257851344b232fb1920c272acc61"
+checksum = "7319a086b79c3ff026a33a61e80f04fd3885fbb73237981ea080d21944e1cb1c"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "flate2",
@@ -401,7 +401,7 @@ dependencies = [
  "http-body 1.0.0",
  "http-serde",
  "query_map",
- "serde 1.0.200",
+ "serde 1.0.201",
  "serde_dynamo",
  "serde_json",
  "serde_with",
@@ -571,7 +571,7 @@ dependencies = [
  "once_cell",
  "reqwest",
  "sbtc-signer",
- "serde 1.0.200",
+ "serde 1.0.201",
  "serde_json",
  "tokio",
  "tracing",
@@ -619,7 +619,7 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 dependencies = [
- "serde 1.0.200",
+ "serde 1.0.201",
 ]
 
 [[package]]
@@ -634,9 +634,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.96"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "065a29261d53ba54260972629f9ca6bffa69bac13cd1fed61420f7fa68b9f8bd"
+checksum = "099a5357d84c4c61eb35fc8eafa9a79a902c2f76911e5747ced4e032edd8d9b4"
 
 [[package]]
 name = "cexpr"
@@ -661,8 +661,10 @@ checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
- "num-traits 0.2.18",
- "serde 1.0.200",
+ "js-sys",
+ "num-traits 0.2.19",
+ "serde 1.0.201",
+ "wasm-bindgen",
  "windows-targets 0.52.5",
 ]
 
@@ -696,7 +698,7 @@ dependencies = [
  "lazy_static",
  "nom 5.1.3",
  "rust-ini",
- "serde 1.0.200",
+ "serde 1.0.201",
  "serde-hjson",
  "serde_json",
  "toml 0.5.11",
@@ -784,7 +786,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -795,7 +797,7 @@ checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -811,7 +813,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
- "serde 1.0.200",
+ "serde 1.0.201",
 ]
 
 [[package]]
@@ -839,7 +841,7 @@ dependencies = [
  "http 0.2.12",
  "reqwest",
  "secrecy",
- "serde 1.0.200",
+ "serde 1.0.201",
  "serde_derive",
  "serde_json",
  "url",
@@ -857,7 +859,7 @@ dependencies = [
  "lambda_runtime",
  "more-asserts",
  "openssl",
- "serde 1.0.200",
+ "serde 1.0.201",
  "serde_json",
  "test-case",
  "tokio",
@@ -1008,7 +1010,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -1053,9 +1055,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1117,7 +1119,7 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
  "allocator-api2",
- "serde 1.0.200",
+ "serde 1.0.201",
 ]
 
 [[package]]
@@ -1252,7 +1254,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1133cafcce27ea69d35e56b3a8772e265633e04de73c5f4e1afdffc1d19b5419"
 dependencies = [
  "http 1.1.0",
- "serde 1.0.200",
+ "serde 1.0.201",
 ]
 
 [[package]]
@@ -1426,7 +1428,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
- "serde 1.0.200",
+ "serde 1.0.201",
 ]
 
 [[package]]
@@ -1437,7 +1439,7 @@ checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.5",
- "serde 1.0.200",
+ "serde 1.0.201",
 ]
 
 [[package]]
@@ -1487,12 +1489,12 @@ dependencies = [
 
 [[package]]
 name = "lambda_runtime"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "276c835f2217fac810a97f2ed8eabfe9be71afe4f3ffd8671b05cb528e95ff8a"
+checksum = "ae4606aea513f0e614497c0c4556d0e39f51a8434d9d97e592d32f9e615d4232"
 dependencies = [
  "async-stream",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bytes",
  "futures",
  "http 1.1.0",
@@ -1503,7 +1505,7 @@ dependencies = [
  "hyper-util",
  "lambda_runtime_api_client",
  "pin-project",
- "serde 1.0.200",
+ "serde 1.0.201",
  "serde_json",
  "serde_path_to_error",
  "tokio",
@@ -1515,9 +1517,9 @@ dependencies = [
 
 [[package]]
 name = "lambda_runtime_api_client"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "722b02764422524d3f49a934b570f7c567f811eda1f9c4bdebebcfae1bad4f23"
+checksum = "c90a10f094475a34a04da2be11686c4dcfe214d93413162db9ffdff3d3af293a"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1745,7 +1747,7 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "num-traits 0.2.18",
+ "num-traits 0.2.19",
 ]
 
 [[package]]
@@ -1754,14 +1756,14 @@ version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
 dependencies = [
- "num-traits 0.2.18",
+ "num-traits 0.2.19",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
@@ -1820,7 +1822,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -1875,36 +1877,36 @@ dependencies = [
  "cc",
  "hex",
  "itertools",
- "num-traits 0.2.18",
+ "num-traits 0.2.19",
  "primitive-types",
  "proc-macro2",
  "quote",
  "rand_core",
  "rustfmt-wrapper",
- "serde 1.0.200",
+ "serde 1.0.201",
  "sha2",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.6.9"
+version = "3.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "881331e34fa842a2fb61cc2db9643a8fedc615e47cfcc52597d1af0db9a7e8fe"
+checksum = "a1b5927e4a9ae8d6cdb6a69e4e04a0ec73381a358e21b8a576f44769f34e7c24"
 dependencies = [
  "arrayvec 0.7.4",
  "bitvec",
  "byte-slice-cast",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
- "serde 1.0.200",
+ "serde 1.0.201",
 ]
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.6.9"
+version = "3.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be30eaf4b0a9fba5336683b38de57bb86d179a35862ba6bfcf57625d006bde5b"
+checksum = "f0731c696e58b84ca790e25d9564c78faa2ae93c037edf88807bef6c42307b2e"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1964,7 +1966,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -1991,8 +1993,8 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27abb6e4638dcecc65a92b50d7f1d87dd6dea987ba71db987b6bf881f4877e9d"
 dependencies = [
- "num-traits 0.2.18",
- "serde 1.0.200",
+ "num-traits 0.2.19",
+ "serde 1.0.201",
 ]
 
 [[package]]
@@ -2032,18 +2034,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "2.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
+checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
 dependencies = [
- "toml_edit 0.20.7",
+ "toml_edit 0.21.1",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
+checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
 dependencies = [
  "unicode-ident",
 ]
@@ -2055,7 +2057,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5eab6b8b1074ef3359a863758dae650c7c0c6027927a085b7af911c8e0bf3a15"
 dependencies = [
  "form_urlencoded",
- "serde 1.0.200",
+ "serde 1.0.201",
  "serde_derive",
 ]
 
@@ -2189,7 +2191,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls-pemfile",
- "serde 1.0.200",
+ "serde 1.0.201",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
@@ -2242,9 +2244,9 @@ checksum = "3e52c148ef37f8c375d49d5a73aa70713125b7f19095948a923f80afdeb22ec2"
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
@@ -2273,7 +2275,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1adc9dfed5cc999077978cc7163b9282c5751c8d39827c4ea8c8c220ca5a440"
 dependencies = [
- "serde 1.0.200",
+ "serde 1.0.201",
  "tempfile",
  "thiserror",
  "toml 0.8.12",
@@ -2338,9 +2340,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "same-file"
@@ -2360,6 +2362,8 @@ dependencies = [
  "p256k1",
  "rand",
  "secp256k1",
+ "serde 1.0.201",
+ "sha2",
  "test-case",
  "thiserror",
  "tracing",
@@ -2430,11 +2434,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "770452e37cad93e0a50d5abc3990d2bc351c36d0328f86cefec2f2fb206eaef6"
+checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.5.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2443,9 +2447,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f3cc463c0ef97e11c3461a9d3787412d30e8e7eb907c79180c4a57bf7c04ef"
+checksum = "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2453,9 +2457,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
@@ -2465,9 +2469,9 @@ checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
 
 [[package]]
 name = "serde"
-version = "1.0.200"
+version = "1.0.201"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddc6f9cc94d67c0e21aaf7eda3a010fd3af78ebf6e096aa6e2e13c79749cce4f"
+checksum = "780f1cebed1629e4753a1a38a3c72d30b97ec044f0aef68cb26650a3c5cf363c"
 dependencies = [
  "serde_derive",
 ]
@@ -2486,13 +2490,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.200"
+version = "1.0.201"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "856f046b9400cee3c8c94ed572ecdb752444c24528c035cd35882aad6f492bcb"
+checksum = "c5e405930b9796f1c00bee880d03fc7e0bb4b9a11afc776885ffe84320da2865"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -2502,18 +2506,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e36c1b1792cfd9de29eb373ee6a4b74650369c096f55db7198ceb7b8921d1f7f"
 dependencies = [
  "base64 0.21.7",
- "serde 1.0.200",
+ "serde 1.0.201",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.116"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
+checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
 dependencies = [
  "itoa 1.0.11",
  "ryu",
- "serde 1.0.200",
+ "serde 1.0.201",
 ]
 
 [[package]]
@@ -2523,7 +2527,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
 dependencies = [
  "itoa 1.0.11",
- "serde 1.0.200",
+ "serde 1.0.201",
 ]
 
 [[package]]
@@ -2532,7 +2536,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
 dependencies = [
- "serde 1.0.200",
+ "serde 1.0.201",
 ]
 
 [[package]]
@@ -2544,7 +2548,7 @@ dependencies = [
  "form_urlencoded",
  "itoa 1.0.11",
  "ryu",
- "serde 1.0.200",
+ "serde 1.0.201",
 ]
 
 [[package]]
@@ -2558,7 +2562,7 @@ dependencies = [
  "hex",
  "indexmap 1.9.3",
  "indexmap 2.2.6",
- "serde 1.0.200",
+ "serde 1.0.201",
  "serde_derive",
  "serde_json",
  "serde_with_macros",
@@ -2574,7 +2578,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -2691,9 +2695,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.60"
+version = "2.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
+checksum = "c993ed8ccba56ae856363b1845da7266a7cb78e1d146c8a32d54b45a8b831fc9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2763,7 +2767,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -2774,28 +2778,28 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
  "test-case-core",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.59"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0126ad08bff79f29fc3ae6a55cc72352056dfff61e3ff8bb7129476d44b23aa"
+checksum = "579e9083ca58dd9dcf91a9923bb9054071b9ebbd800b342194c9feb0ee89fc18"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.59"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1cd413b5d558b4c5bf3680e324a6fa5014e7b7c067a51e69dbdf47eb7148b66"
+checksum = "e2470041c06ec3ac1ab38d0356a6119054dedaea53e12fbefc0de730a1c08524"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -2818,7 +2822,7 @@ dependencies = [
  "itoa 1.0.11",
  "num-conv",
  "powerfmt",
- "serde 1.0.200",
+ "serde 1.0.201",
  "time-core",
  "time-macros",
 ]
@@ -2881,7 +2885,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -2929,16 +2933,15 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
+checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
  "pin-project-lite",
  "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -2947,7 +2950,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
- "serde 1.0.200",
+ "serde 1.0.201",
 ]
 
 [[package]]
@@ -2956,7 +2959,7 @@ version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
 dependencies = [
- "serde 1.0.200",
+ "serde 1.0.201",
  "serde_spanned",
  "toml_datetime",
  "toml_edit 0.22.12",
@@ -2968,14 +2971,14 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
 dependencies = [
- "serde 1.0.200",
+ "serde 1.0.201",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.20.7"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
+checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
  "indexmap 2.2.6",
  "toml_datetime",
@@ -2989,7 +2992,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3328d4f68a705b2a4498da1d580585d39a6510f98318a2cec3018a7ec61ddef"
 dependencies = [
  "indexmap 2.2.6",
- "serde 1.0.200",
+ "serde 1.0.201",
  "serde_spanned",
  "toml_datetime",
  "winnow 0.6.8",
@@ -3056,7 +3059,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -3086,7 +3089,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
 dependencies = [
- "serde 1.0.200",
+ "serde 1.0.201",
  "tracing-core",
 ]
 
@@ -3100,7 +3103,7 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
- "serde 1.0.200",
+ "serde 1.0.201",
  "serde_json",
  "sharded-slab",
  "smallvec",
@@ -3231,7 +3234,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
 dependencies = [
  "getrandom",
- "serde 1.0.200",
+ "serde 1.0.201",
 ]
 
 [[package]]
@@ -3296,7 +3299,7 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "scoped-tls",
- "serde 1.0.200",
+ "serde 1.0.201",
  "serde_json",
  "serde_urlencoded",
  "tokio",
@@ -3333,7 +3336,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
  "wasm-bindgen-shared",
 ]
 
@@ -3367,7 +3370,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3617,12 +3620,12 @@ dependencies = [
  "bs58 0.5.1",
  "hashbrown 0.14.5",
  "hex",
- "num-traits 0.2.18",
+ "num-traits 0.2.19",
  "p256k1",
  "polynomial",
  "primitive-types",
  "rand_core",
- "serde 1.0.200",
+ "serde 1.0.201",
  "sha2",
  "thiserror",
  "tracing",
@@ -3649,22 +3652,22 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.33"
+version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "087eca3c1eaf8c47b94d02790dd086cd594b912d2043d4de4bfdd466b3befb7c"
+checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.33"
+version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f4b6c273f496d8fd4eaf18853e6b448760225dc030ff2c485a786859aea6393"
+checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ p256k1 = "7.1.0"
 rand = "0.8"
 serde = "1.0"
 serde_json = "1.0"
+sha2 = "0.10"
 thiserror = "1.0"
 tokio = "1.32.0"
 tracing = { version = "0.1", default-features = false }

--- a/signer/Cargo.toml
+++ b/signer/Cargo.toml
@@ -18,6 +18,8 @@ bench = false
 bitcoin = { workspace = true, features = ["rand-std"] }
 p256k1.workspace = true
 rand.workspace = true
+serde.workspace = true
+sha2.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 tracing-attributes.workspace = true

--- a/signer/src/ecdsa.rs
+++ b/signer/src/ecdsa.rs
@@ -1,11 +1,74 @@
+//! # ECDSA Signing and Verification
+//!
+//! This module provides functionality to sign and verify data using the ECDSA signature scheme.
+//! The core component is the `Signed<T>` structure, which wraps any signable data along with the signer's public key
+//! and a signature. The module also defines the `SignECDSA` trait to facilitate signing operations.
+//!
+//! ## Features
+//!
+//! - **Signed**: A generic wrapper that binds a piece of data (`inner`) with its ECDSA signature and the public key
+//!   of the signer. It provides a method to verify the integrity and authenticity of the data.
+//! - **SignECDSA**: A trait implemented by data types that can be signed using ECDSA. It is automatically implemented for any type implementing `wsts::net::Signable`.
+//!
+//! ## Examples
+//!
+//! ### Signing and Verifying a String
+//!
+//! The following example demonstrates how to sign a simple string and then verify its signature:
+//!
+//! ```
+//! use sha2::Digest;
+//! use sbtc_signer::ecdsa::SignECDSA;
+//!
+//! struct SignableStr(&'static str);
+//!
+//! // Implementing `wsts::net::Signable` unlocks the signing functionality in this module.
+//! impl wsts::net::Signable for SignableStr {
+//!     fn hash(&self, hasher: &mut sha2::Sha256) {
+//!         hasher.update(self.0)
+//!     }
+//! }
+//!
+//! let msg = SignableStr("Sign me please!");
+//! let private_key = p256k1::scalar::Scalar::from(1337);
+//!
+//! // Sign the message.
+//! let signed_msg = msg
+//!     .sign_ecdsa(&private_key)
+//!     .expect("Failed to sign message");
+//!
+//! // Verify the signed message.
+//! assert!(signed_msg.verify());
+
 use p256k1::ecdsa;
 use p256k1::scalar::Scalar;
 
+/// Wraps an inner type with a public key and a signature,
+/// allowing easy verification of the integrity of the inner data.
+#[derive(Debug, Clone)]
+pub struct Signed<T> {
+    /// The signed structure.
+    pub inner: T,
+    /// The public key of the signer.
+    pub signer_pub_key: ecdsa::PublicKey,
+    /// A signature over the hash of the inner structure.
+    pub signature: Vec<u8>,
+}
+
+impl<T: wsts::net::Signable> Signed<T> {
+    /// Verify the signature over the inner data.
+    pub fn verify(&self) -> bool {
+        self.inner.verify(&self.signature, &self.signer_pub_key)
+    }
+}
+
+/// Helper trait to provide the ability to construct a `Signed<T>`.
 pub trait SignECDSA: Sized {
     fn sign_ecdsa(self, private_key: &Scalar) -> Result<Signed<Self>, Error>;
 }
 
 impl<T: wsts::net::Signable> SignECDSA for T {
+    /// Create a `Signed<T>` instance with a signature and public key constructed from `private_key`.
     fn sign_ecdsa(self, private_key: &Scalar) -> Result<Signed<Self>, Error> {
         let signer_pub_key = ecdsa::PublicKey::new(private_key)?;
         let signature = self.sign(private_key)?;
@@ -18,26 +81,69 @@ impl<T: wsts::net::Signable> SignECDSA for T {
     }
 }
 
-#[derive(Debug, Clone)]
-pub struct Signed<T> {
-    /// The signed structure
-    pub inner: T,
-    /// The public key of the signer
-    pub signer_pub_key: ecdsa::PublicKey,
-    /// A signature over the hash of the inner structure
-    pub signature: Vec<u8>,
-}
-
-impl<T: wsts::net::Signable> Signed<T> {
-    pub fn verify(&self) -> bool {
-        self.inner.verify(&self.signature, &self.signer_pub_key)
-    }
-}
-
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("KeyError")]
     KeyError(#[from] p256k1::keys::Error),
     #[error("SignError")]
     SignError(#[from] ecdsa::Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use sha2::Digest;
+
+    #[test]
+    fn verify_should_return_true_given_properly_signed_data() {
+        let msg = SignableStr("I'm Batman");
+        let bruce_wayne_private_key = Scalar::from(1337);
+
+        let signed_msg = msg
+            .sign_ecdsa(&bruce_wayne_private_key)
+            .expect("Failed to sign message");
+
+        // Bruce Wayne is Batman.
+        assert!(signed_msg.verify());
+    }
+
+    #[test]
+    fn verify_should_return_false_given_tampered_data() {
+        let msg = SignableStr("I'm Batman");
+        let bruce_wayne_private_key = Scalar::from(1337);
+
+        let mut signed_msg = msg
+            .sign_ecdsa(&bruce_wayne_private_key)
+            .expect("Failed to sign message");
+
+        signed_msg.inner = SignableStr("I'm Satoshi Nakamoto");
+
+        // Bruce Wayne is not Satoshi Nakamoto.
+        assert!(!signed_msg.verify());
+    }
+
+    #[test]
+    fn verify_should_return_false_given_the_wrong_public_key() {
+        let msg = SignableStr("I'm Batman");
+        let bruce_wayne_private_key = Scalar::from(1337);
+        let craig_wright_public_key = ecdsa::PublicKey::new(&Scalar::from(1338)).unwrap();
+
+        let mut signed_msg = msg
+            .sign_ecdsa(&bruce_wayne_private_key)
+            .expect("Failed to sign message");
+
+        signed_msg.signer_pub_key = craig_wright_public_key;
+
+        // Craig Wright is not Batman.
+        assert!(!signed_msg.verify());
+    }
+
+    struct SignableStr(&'static str);
+
+    impl wsts::net::Signable for SignableStr {
+        fn hash(&self, hasher: &mut sha2::Sha256) {
+            hasher.update(self.0)
+        }
+    }
 }

--- a/signer/src/ecdsa.rs
+++ b/signer/src/ecdsa.rs
@@ -77,11 +77,11 @@ impl<T> std::ops::DerefMut for Signed<T> {
 }
 
 /// Helper trait to provide the ability to construct a `Signed<T>`.
-pub trait SignECDSA: Sized {
+pub trait SignEcdsa: Sized {
     fn sign_ecdsa(self, private_key: &Scalar) -> Result<Signed<Self>, Error>;
 }
 
-impl<T: wsts::net::Signable> SignECDSA for T {
+impl<T: wsts::net::Signable> SignEcdsa for T {
     /// Create a `Signed<T>` instance with a signature and public key constructed from `private_key`.
     fn sign_ecdsa(self, private_key: &Scalar) -> Result<Signed<Self>, Error> {
         let signer_pub_key = ecdsa::PublicKey::new(private_key)?;

--- a/signer/src/ecdsa.rs
+++ b/signer/src/ecdsa.rs
@@ -1,0 +1,43 @@
+use p256k1::ecdsa;
+use p256k1::scalar::Scalar;
+
+pub trait SignECDSA: Sized {
+    fn sign_ecdsa(self, private_key: &Scalar) -> Result<Signed<Self>, Error>;
+}
+
+impl<T: wsts::net::Signable> SignECDSA for T {
+    fn sign_ecdsa(self, private_key: &Scalar) -> Result<Signed<Self>, Error> {
+        let signer_pub_key = ecdsa::PublicKey::new(private_key)?;
+        let signature = self.sign(private_key)?;
+
+        Ok(Signed {
+            inner: self,
+            signer_pub_key,
+            signature,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Signed<T> {
+    /// The signed structure
+    pub inner: T,
+    /// The public key of the signer
+    pub signer_pub_key: ecdsa::PublicKey,
+    /// A signature over the hash of the inner structure
+    pub signature: Vec<u8>,
+}
+
+impl<T: wsts::net::Signable> Signed<T> {
+    pub fn verify(&self) -> bool {
+        self.inner.verify(&self.signature, &self.signer_pub_key)
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("KeyError")]
+    KeyError(#[from] p256k1::keys::Error),
+    #[error("SignError")]
+    SignError(#[from] ecdsa::Error),
+}

--- a/signer/src/lib.rs
+++ b/signer/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod ecdsa;
 pub mod error;
 pub mod logging;
 pub mod message;

--- a/signer/src/message.rs
+++ b/signer/src/message.rs
@@ -1,15 +1,11 @@
-use p256k1::ecdsa;
+use sha2::Digest;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct SignerMessage {
-    /// The message payload
-    pub payload: Payload,
     /// The bitcoin chain tip defining the signers view of the blockchain at the time the message was created
     pub bitcoin_chain_tip: bitcoin::BlockHash,
-    /// The public key of the signer
-    pub signer_pub_key: ecdsa::PublicKey,
-    /// A signature over the payload and chain tip verifiable by the public key
-    pub signature: ecdsa::Signature,
+    /// The message payload
+    pub payload: Payload,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -41,3 +37,38 @@ pub struct BitcoinTransactionSignRequest;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct BitcoinTransactionSignAck;
+
+impl wsts::net::Signable for SignerMessage {
+    fn hash(&self, hasher: &mut sha2::Sha256) {
+        hasher.update("SBTC_SIGNER_MESSAGE");
+        hasher.update(self.bitcoin_chain_tip);
+        self.payload.hash(hasher);
+    }
+}
+
+impl wsts::net::Signable for Payload {
+    fn hash(&self, hasher: &mut sha2::Sha256) {
+        match self {
+            Self::WstsMessage(msg) => hash_message(msg, hasher),
+            _ => unimplemented!(),
+        }
+    }
+}
+
+/// Utility method because wsts::net::Message doesn't implement wsts::net::Signable
+fn hash_message(msg: &wsts::net::Message, hasher: &mut sha2::Sha256) {
+    use wsts::net::Signable;
+
+    match msg {
+        wsts::net::Message::DkgBegin(msg) => msg.hash(hasher),
+        wsts::net::Message::DkgPublicShares(msg) => msg.hash(hasher),
+        wsts::net::Message::DkgPrivateBegin(msg) => msg.hash(hasher),
+        wsts::net::Message::DkgPrivateShares(msg) => msg.hash(hasher),
+        wsts::net::Message::DkgEndBegin(msg) => msg.hash(hasher),
+        wsts::net::Message::DkgEnd(msg) => msg.hash(hasher),
+        wsts::net::Message::NonceRequest(msg) => msg.hash(hasher),
+        wsts::net::Message::NonceResponse(msg) => msg.hash(hasher),
+        wsts::net::Message::SignatureShareRequest(msg) => msg.hash(hasher),
+        wsts::net::Message::SignatureShareResponse(msg) => msg.hash(hasher),
+    }
+}

--- a/signer/src/message.rs
+++ b/signer/src/message.rs
@@ -85,7 +85,7 @@ fn hash_message(msg: &wsts::net::Message, hasher: &mut sha2::Sha256) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ecdsa::SignECDSA;
+    use crate::ecdsa::SignEcdsa;
 
     use p256k1::scalar::Scalar;
     use wsts::net::DkgBegin;


### PR DESCRIPTION
closes #105 

## Description
This PR introduces signing and validation logic for signer messages. As part of this change, the `signer_public_key` and `signature` fields of the `SignerMessage` type has been moved to the new `Signed` wrapper type to allow for ergonomic handling of signatures.