### PR TITLE
Setup cdk unit tests to be independent of lambda compilation.

### DIFF
--- a/emily/cdk/bin/emily.ts
+++ b/emily/cdk/bin/emily.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-import 'source-map-support/register';
 import * as cdk from 'aws-cdk-lib';
+import 'source-map-support/register';
 import { EmilyStack } from '../lib/emily-stack';
 import { EmilyStackUtils } from '../lib/emily-stack-utils';
 

--- a/emily/cdk/lib/constants.ts
+++ b/emily/cdk/lib/constants.ts
@@ -1,0 +1,12 @@
+/**
+ * @class Constants
+ * @classdesc Contains useful constants for development.
+ */
+export class Constants {
+
+    /**
+     * Stage name used by unit tests to indicate that the resources should be
+     * creates for unit tests only.
+     */
+    static UNIT_TEST_STAGE_NAME: string = "unit-test";
+}

--- a/emily/cdk/lib/emily-stack.ts
+++ b/emily/cdk/lib/emily-stack.ts
@@ -5,6 +5,7 @@ import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import { Construct } from 'constructs';
+import { Constants } from './constants';
 import { EmilyStackProps } from './emily-stack-props';
 import { EmilyStackUtils } from './emily-stack-utils';
 
@@ -166,8 +167,11 @@ export class EmilyStack extends cdk.Stack {
             functionName: EmilyStackUtils.getResourceName(operationLambdaId, props),
             architecture: lambda.Architecture.ARM_64, // <- Will need to change when run locally for x86
             runtime: lambda.Runtime.PROVIDED_AL2023,
-            code: lambda.Code.fromAsset(EmilyStackUtils.getPathFromProjectRoot(
-                "target/lambda/emily-operation-lambda/bootstrap.zip"
+            code:
+            lambda.Code.fromAsset(EmilyStackUtils.getPathFromProjectRoot(
+                props.stageName == Constants.UNIT_TEST_STAGE_NAME
+                    ? "emily/cdk/test/assets/empty-lambda.zip"
+                    : "target/lambda/emily-operation-lambda/bootstrap.zip"
             )),
             // Lambda should be very fast. Something is wrong if it takes > 5 seconds.
             timeout: cdk.Duration.seconds(5),

--- a/emily/cdk/package.json
+++ b/emily/cdk/package.json
@@ -8,7 +8,7 @@
     "build": "(cd ../api-definition && npm run build-openapi) && tsc",
     "watch": "tsc -w",
     "test": "jest",
-    "cdk": "cdk",
+    "cdk": "npx aws-cdk",
     "clean": "rm -rf node_modules .cdk.staging cdk.out .generated-sources"
   },
   "devDependencies": {

--- a/emily/cdk/test/emily-stack-util.test.ts
+++ b/emily/cdk/test/emily-stack-util.test.ts
@@ -1,3 +1,4 @@
+import { Constants } from '../lib/constants';
 import { EmilyStackProps } from '../lib/emily-stack-props';
 import { EmilyStackUtils } from '../lib/emily-stack-utils';
 
@@ -10,7 +11,7 @@ describe('EmilyStackUtils Test', () => {
     it('test resource name is generated properly.', async () => {
         const testEmilyStackProps: EmilyStackProps = {
             stackName: "testStack",
-            stageName: "testStage", // Default to dev stage.
+            stageName: Constants.UNIT_TEST_STAGE_NAME, // Default to dev stage.
             env: {
                 account: "testAwsAccount",
                 region: "testAwsRegion",
@@ -18,16 +19,16 @@ describe('EmilyStackUtils Test', () => {
         }
         const resourceName: string = EmilyStackUtils
             .getResourceName("ResourceId", testEmilyStackProps);
-        expect(resourceName).toEqual("ResourceId-testAwsAccount-testAwsRegion-testStage");
+        expect(resourceName).toEqual(`ResourceId-testAwsAccount-testAwsRegion-${Constants.UNIT_TEST_STAGE_NAME}`);
     });
 
     it('Test resource name is generated properly.', async () => {
         process.env = {
-            AWS_STAGE: "TestStage",
+            AWS_STAGE: Constants.UNIT_TEST_STAGE_NAME,
             AWS_ACCOUNT: "TestAccount" ,
             AWS_REGION: "TestRegion",
         };
         const resourceName: string = EmilyStackUtils.getStackName("StackId");
-        expect(resourceName).toEqual("StackId-TestAccount-TestRegion-TestStage");
+        expect(resourceName).toEqual(`StackId-TestAccount-TestRegion-${Constants.UNIT_TEST_STAGE_NAME}`);
     });
 });

--- a/emily/cdk/test/emily-stack.test.ts
+++ b/emily/cdk/test/emily-stack.test.ts
@@ -1,12 +1,12 @@
-import { Template } from 'aws-cdk-lib/assertions';
 import * as cdk from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { Constants } from '../lib/constants';
 import { EmilyStack } from '../lib/emily-stack';
 import { EmilyStackProps } from '../lib/emily-stack-props';
-import { Environment } from 'aws-cdk-lib/aws-appconfig';
 
 // Constant test values
 const TEST_STACK_PROPS: EmilyStackProps = {
-    stageName: "dummyStage",
+    stageName: Constants.UNIT_TEST_STAGE_NAME,
     env: {
         account: "account",
         region: "region",
@@ -30,9 +30,9 @@ describe('EmilyStack Test', () => {
 
         // Check that the tables made it in; No need to include tests on the properties
         // that duplicate the specification.
-        expect(tableNames).toContain("DepositTable-account-region-dummyStage");
-        expect(tableNames).toContain("WithdrawalTable-account-region-dummyStage");
-        expect(tableNames).toContain("ChainstateTable-account-region-dummyStage");
+        expect(tableNames).toContain(`DepositTable-account-region-${Constants.UNIT_TEST_STAGE_NAME}`);
+        expect(tableNames).toContain(`WithdrawalTable-account-region-${Constants.UNIT_TEST_STAGE_NAME}`);
+        expect(tableNames).toContain(`ChainstateTable-account-region-${Constants.UNIT_TEST_STAGE_NAME}`);
     });
 
     it('should create a Lambda function', async () => {


### PR DESCRIPTION
## Description

The Emily CDK uses a zipped lambda file for the AWS lambda, but if this file isn't present during compile time the cdk template will fail to build. This PR has the template use a dummy zip file when the stack's stage name indicates that it's being compiled for unit tests.

This PR does the following:
1. Adds a dummy lambda zip file `emily/cdk/test/assets/empty-lambda.zip` 
2. Creates a `constants.ts` file that defines the unit test stagename so it's consistent across files.
3. Changes the template to use the dummy lambda when being compiled for unit tests
4. Changes the unit tests to expect the new stagename.
5. Optimizes imports. 
6. Changes the `cdk` command to use the local package

Relates to a reported issue that is too small to file a ticket for.