### PR TITLE
feat: Signer message serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,6 +497,7 @@ dependencies = [
  "hex-conservative",
  "hex_lit",
  "secp256k1",
+ "serde 1.0.201",
 ]
 
 [[package]]
@@ -504,6 +505,9 @@ name = "bitcoin-internals"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
+dependencies = [
+ "serde 1.0.201",
+]
 
 [[package]]
 name = "bitcoin-io"
@@ -518,6 +522,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb54da0b28892f3c52203a7191534033e051b6f4b52bc15480681b57b7e036f5"
 dependencies = [
  "bitcoin-internals",
+ "serde 1.0.201",
 ]
 
 [[package]]
@@ -528,6 +533,7 @@ checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
 dependencies = [
  "bitcoin-io",
  "hex-conservative",
+ "serde 1.0.201",
 ]
 
 [[package]]
@@ -2413,6 +2419,7 @@ dependencies = [
  "bitcoin_hashes",
  "rand",
  "secp256k1-sys",
+ "serde 1.0.201",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,6 +461,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde 1.0.201",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.64.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2364,6 +2373,7 @@ dependencies = [
 name = "sbtc-signer"
 version = "0.1.0"
 dependencies = [
+ "bincode",
  "bitcoin",
  "more-asserts",
  "p256k1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ emily = { version = "0.1.0", path = ".generated-sources/emily" }
 
 aws_lambda_events = "0.15.0"
 aws-sdk-dynamodb = { version = "1.3.0" }
+bincode = "1.3.3"
 bitcoin = { version = "0.32", features = ["serde"] }
 futures = "0.3.24"
 http = "1.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ emily = { version = "0.1.0", path = ".generated-sources/emily" }
 
 aws_lambda_events = "0.15.0"
 aws-sdk-dynamodb = { version = "1.3.0" }
-bitcoin = "0.32"
+bitcoin = { version = "0.32", features = ["serde"] }
 futures = "0.3.24"
 http = "1.1.0"
 lambda_runtime = "0.11.1"

--- a/signer/Cargo.toml
+++ b/signer/Cargo.toml
@@ -15,6 +15,7 @@ bench = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+bincode.workspace = true
 bitcoin = { workspace = true, features = ["rand-std"] }
 p256k1.workspace = true
 rand.workspace = true

--- a/signer/src/codec.rs
+++ b/signer/src/codec.rs
@@ -1,15 +1,14 @@
 //! # Canonical encoding and decoding for the sBTC signer
 //!
-//! This module defines encoding and decoding methods for messages in the signer.
-//! The primary purpose of these utilities is to facilitate convenient serialization and deserialization
-//! of messages that need to be exchanged between signers over a network.
+//! The purpose of this module is to define how to encode and decode
+//! signer messages as byte sequences.
 //!
-//! The module provides two main traits, `Encode` and `Decode`, which
-//! denote the canonical serialization format for any types implementing these traits.
+//! This is achieved by
 //!
-//! While these traits permit custom serialization implementations, this module also provides
-//! blanket implementations for any type that implements `serde::Serialize` and `serde::de::DeserializeOwned`,
-//! using [Bincode](https://docs.rs/bincode/1.3.3/bincode/).
+//! 1. Providing the `Encode` and `Decode` traits, defining the encode and decode
+//!    methods we intend to use throughout the signer.
+//! 2. Implementing these traits for any type implementing `serde::Serialize` and `serde::de::DeserializeOwned`
+//!    using `bincode` as the encoding format.
 //!
 //! ## Examples
 //!

--- a/signer/src/codec.rs
+++ b/signer/src/codec.rs
@@ -1,0 +1,47 @@
+use std::io;
+
+pub trait Encode: Sized {
+    fn encode<W: io::Write>(self, writer: W) -> Result<(), Error>;
+    fn encode_to_vec(self) -> Result<Vec<u8>, Error> {
+        let mut buff = Vec::new();
+        self.encode(&mut buff)?;
+        Ok(buff)
+    }
+}
+
+pub trait Decode: Sized {
+    fn decode<R: io::Read>(reader: R) -> Result<Self, Error>;
+    fn decode_from_bytes(bytes: &[u8]) -> Result<Self, Error> {
+        Self::decode(bytes)
+    }
+}
+
+impl<T: serde::Serialize> Encode for &T {
+    fn encode<W: io::Write>(self, writer: W) -> Result<(), Error> {
+        bincode::serialize_into(writer, self)
+    }
+}
+
+impl<T: serde::de::DeserializeOwned> Decode for T {
+    fn decode<R: io::Read>(reader: R) -> Result<Self, Error> {
+        bincode::deserialize_from(reader)
+    }
+}
+
+pub type Error = bincode::Error;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strings_should_be_able_to_encode_and_decode_correctly() {
+        let message = "Article 107: A Bro never leaves another Bro hanging";
+
+        let encoded = message.encode_to_vec().unwrap();
+
+        let decoded = String::decode_from_bytes(&encoded).unwrap();
+
+        assert_eq!(decoded, message);
+    }
+}

--- a/signer/src/codec.rs
+++ b/signer/src/codec.rs
@@ -1,7 +1,57 @@
+//! # Canonical encoding and decoding for the sBTC signer
+//!
+//! This module defines encoding and decoding methods for messages in the signer.
+//! The primary purpose of these utilities is to facilitate convenient serialization and deserialization
+//! of messages that need to be exchanged between signers over a network.
+//!
+//! The module provides two main traits, `Encode` and `Decode`, which
+//! denote the canonical serialization format for any types implementing these traits.
+//!
+//! While thiese traits permit custom serialization implementations, this module also provides
+//! blanket implementations for any type that implements `serde::Serialize` and `serde::de::DeserializeOwned`,
+//! using [Bincode](https://docs.rs/bincode/1.3.3/bincode/).
+//!
+//! ## Examples
+//!
+//! ### Encoding a string slice and decoding it as a string
+//!
+//! ```
+//! use sbtc_signer::codec::{Encode, Decode};
+//!
+//! let message = "Encode me";
+//!
+//! // `.encode_to_vec()` provided by the `Encode` trait
+//! let encoded = message.encode_to_vec().unwrap();
+//!
+//! // `.decode_to_bytes()` provided by the `Decode` trait
+//! let decoded = String::decode_from_bytes(&encoded).unwrap();
+//!
+//! assert_eq!(decoded, message);
+//! ```
+
 use std::io;
 
+/// Provides a method for encoding an object into a writer using a canonical serialization format.
+///
+/// This trait is designed to be implemented by types that need to serialize their data into a byte stream
+/// in a standardized format, primarily to ensure consistency across different components of the signer system.
+///
+/// The trait includes a generic method for writing to any output that implements `io::Write`, as well as
+/// a convenience method for encoding directly to a byte vector.
 pub trait Encode: Sized {
+    /// Encodes the calling object into a writer.
+    ///
+    /// # Arguments
+    /// * `writer` - A mutable reference to an object implementing `io::Write` where the encoded bytes will be written.
+    ///
+    /// # Returns
+    /// A `Result` which is `Ok` if the encoding succeeded, or an `Error` if it failed.
     fn encode<W: io::Write>(self, writer: W) -> Result<(), Error>;
+
+    /// Encodes the calling object into a vector of bytes.
+    ///
+    /// # Returns
+    /// A `Result` containing either the vector of bytes if the encoding was successful, or an `Error` if it failed.
     fn encode_to_vec(self) -> Result<Vec<u8>, Error> {
         let mut buff = Vec::new();
         self.encode(&mut buff)?;
@@ -9,8 +59,33 @@ pub trait Encode: Sized {
     }
 }
 
+/// Provides a method for decoding an object from a reader using a canonical deserialization format.
+///
+/// This trait is intended for types that need to reconstruct themselves from a byte stream, ensuring
+/// that objects across the signer system are restored from bytes uniformly.
+///
+/// It includes a generic method for reading from any input that implements `io::Read`, as well as
+/// a convenience method for decoding from a byte slice.
 pub trait Decode: Sized {
+    /// Decodes an object from a reader in a canonical format.
+    ///
+    /// # Arguments
+    /// * `reader` - An object implementing `io::Read` from which the bytes will be read.
+    ///
+    /// # Returns
+    /// A `Result` which is `Ok` containing the decoded object, or an `Error` if decoding failed.
     fn decode<R: io::Read>(reader: R) -> Result<Self, Error>;
+
+    /// Decodes an object from a byte slice.
+    ///
+    /// This is a convenience method that uses the `decode` method internally to deserialize the object
+    /// from a slice of bytes, facilitating easier handling of raw byte data.
+    ///
+    /// # Arguments
+    /// * `bytes` - A byte slice from which the object should be decoded.
+    ///
+    /// # Returns
+    /// A `Result` which is `Ok` containing the decoded object, or an `Error` if decoding failed.
     fn decode_from_bytes(bytes: &[u8]) -> Result<Self, Error> {
         Self::decode(bytes)
     }

--- a/signer/src/codec.rs
+++ b/signer/src/codec.rs
@@ -23,8 +23,8 @@
 //! // `.encode_to_vec()` provided by the `Encode` trait
 //! let encoded = message.encode_to_vec().unwrap();
 //!
-//! // `.decode_to_bytes()` provided by the `Decode` trait
-//! let decoded = String::decode_from_bytes(&encoded).unwrap();
+//! // `.decode()` provided by the `Decode` trait
+//! let decoded = String::decode(encoded.as_slice()).unwrap();
 //!
 //! assert_eq!(decoded, message);
 //! ```
@@ -75,20 +75,6 @@ pub trait Decode: Sized {
     /// # Returns
     /// A `Result` which is `Ok` containing the decoded object, or an `Error` if decoding failed.
     fn decode<R: io::Read>(reader: R) -> Result<Self, Error>;
-
-    /// Decodes an object from a byte slice.
-    ///
-    /// This is a convenience method that uses the `decode` method internally to deserialize the object
-    /// from a slice of bytes, facilitating easier handling of raw byte data.
-    ///
-    /// # Arguments
-    /// * `bytes` - A byte slice from which the object should be decoded.
-    ///
-    /// # Returns
-    /// A `Result` which is `Ok` containing the decoded object, or an `Error` if decoding failed.
-    fn decode_from_bytes(bytes: &[u8]) -> Result<Self, Error> {
-        Self::decode(bytes)
-    }
 }
 
 impl<T: serde::Serialize> Encode for &T {
@@ -115,7 +101,7 @@ mod tests {
 
         let encoded = message.encode_to_vec().unwrap();
 
-        let decoded = String::decode_from_bytes(&encoded).unwrap();
+        let decoded = String::decode(encoded.as_slice()).unwrap();
 
         assert_eq!(decoded, message);
     }

--- a/signer/src/codec.rs
+++ b/signer/src/codec.rs
@@ -7,7 +7,7 @@
 //! The module provides two main traits, `Encode` and `Decode`, which
 //! denote the canonical serialization format for any types implementing these traits.
 //!
-//! While thiese traits permit custom serialization implementations, this module also provides
+//! While these traits permit custom serialization implementations, this module also provides
 //! blanket implementations for any type that implements `serde::Serialize` and `serde::de::DeserializeOwned`,
 //! using [Bincode](https://docs.rs/bincode/1.3.3/bincode/).
 //!

--- a/signer/src/ecdsa.rs
+++ b/signer/src/ecdsa.rs
@@ -18,7 +18,7 @@
 //!
 //! ```
 //! use sha2::Digest;
-//! use sbtc_signer::ecdsa::SignECDSA;
+//! use sbtc_signer::ecdsa::SignEcdsa;
 //!
 //! struct SignableStr(&'static str);
 //!
@@ -45,7 +45,7 @@ use p256k1::scalar::Scalar;
 
 /// Wraps an inner type with a public key and a signature,
 /// allowing easy verification of the integrity of the inner data.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
 pub struct Signed<T> {
     /// The signed structure.
     pub inner: T,

--- a/signer/src/ecdsa.rs
+++ b/signer/src/ecdsa.rs
@@ -45,7 +45,7 @@ use p256k1::scalar::Scalar;
 
 /// Wraps an inner type with a public key and a signature,
 /// allowing easy verification of the integrity of the inner data.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Signed<T> {
     /// The signed structure.
     pub inner: T,

--- a/signer/src/lib.rs
+++ b/signer/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod codec;
 pub mod ecdsa;
 pub mod error;
 pub mod logging;

--- a/signer/src/message.rs
+++ b/signer/src/message.rs
@@ -1,6 +1,6 @@
 use sha2::Digest;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct SignerMessage {
     /// The bitcoin chain tip defining the signers view of the blockchain at the time the message was created
     pub bitcoin_chain_tip: bitcoin::BlockHash,
@@ -8,7 +8,7 @@ pub struct SignerMessage {
     pub payload: Payload,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum Payload {
     SignerDepositDecision(SignerDepositDecision),
     SignerWithdrawDecision(SignerWithdrawDecision),
@@ -29,22 +29,22 @@ impl Payload {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct SignerDepositDecision;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct SignerWithdrawDecision;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct StacksTransactionSignRequest;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct StacksTransactionSignature;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct BitcoinTransactionSignRequest;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct BitcoinTransactionSignAck;
 
 impl wsts::net::Signable for SignerMessage {

--- a/signer/src/message.rs
+++ b/signer/src/message.rs
@@ -129,7 +129,7 @@ mod tests {
         let encoded = signed_message.encode_to_vec().expect("Failed to encode");
 
         let decoded =
-            Signed::<SignerMessage>::decode_from_bytes(&encoded).expect("Failed to decode");
+            Signed::<SignerMessage>::decode(encoded.as_slice()).expect("Failed to decode");
 
         assert_eq!(decoded, signed_message);
     }


### PR DESCRIPTION
closes #106

This PR introduces serialization logic for Signer messages by

1. Defining the `Encode` and `Decode` traits, which denote the canonical encoding format for signer messages, with a blanket implementation using Bincode for all types implementing serde::Serialize and serde::Deserialize.
2. Deriving `serde::Serialize` and `serde::Deserialize` for all message types.