### PR TITLE
feat: Signer network interface & in-memory implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2383,6 +2383,7 @@ dependencies = [
  "sha2",
  "test-case",
  "thiserror",
+ "tokio",
  "tracing",
  "tracing-attributes",
  "tracing-subscriber",

--- a/signer/Cargo.toml
+++ b/signer/Cargo.toml
@@ -22,6 +22,7 @@ rand.workspace = true
 serde.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
+tokio.workspace = true
 tracing.workspace = true
 tracing-attributes.workspace = true
 tracing-subscriber.workspace = true

--- a/signer/src/ecdsa.rs
+++ b/signer/src/ecdsa.rs
@@ -43,6 +43,8 @@
 use p256k1::ecdsa;
 use p256k1::scalar::Scalar;
 
+use sha2::Digest;
+
 /// Wraps an inner type with a public key and a signature,
 /// allowing easy verification of the integrity of the inner data.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
@@ -59,6 +61,15 @@ impl<T: wsts::net::Signable> Signed<T> {
     /// Verify the signature over the inner data.
     pub fn verify(&self) -> bool {
         self.inner.verify(&self.signature, &self.signer_pub_key)
+    }
+
+    /// Unique identifyer for the inner message
+    pub fn id(&self) -> [u8; 32] {
+        let mut hasher = sha2::Sha256::new();
+
+        self.hash(&mut hasher);
+
+        hasher.finalize().into()
     }
 }
 

--- a/signer/src/lib.rs
+++ b/signer/src/lib.rs
@@ -3,6 +3,7 @@ pub mod ecdsa;
 pub mod error;
 pub mod logging;
 pub mod message;
+pub mod network;
 pub mod packaging;
 pub mod utxo;
 

--- a/signer/src/network.rs
+++ b/signer/src/network.rs
@@ -1,6 +1,6 @@
 //! # Signer network interface
 //!
-//! This module provides the Client trait that the signer implementation
+//! This module provides the MessageTransfer trait that the signer implementation
 //! will rely on for inter-signer communication, along with an in-memory
 //! implementation of this trait for testing purposes.
 
@@ -14,7 +14,7 @@ use crate::message;
 
 pub type Msg = ecdsa::Signed<message::SignerMessage>;
 
-pub trait Client {
+pub trait MessageTransfer {
     type Error;
     /// Send `msg` to all other signers
     fn broadcast(&mut self, msg: Msg) -> impl Future<Output = Result<(), Self::Error>> + Send;

--- a/signer/src/network.rs
+++ b/signer/src/network.rs
@@ -1,0 +1,10 @@
+use crate::ecdsa::Signed;
+use crate::message::SignerMessage;
+
+pub(crate) trait Client {
+    type Error;
+    /// Send `msg` to all other signers
+    async fn broadcast(&self, msg: Signed<SignerMessage>) -> Result<(), Self::Error>;
+    /// Receive a message from the network
+    async fn receive(&mut self) -> Result<Signed<SignerMessage>, Self::Error>;
+}

--- a/signer/src/network.rs
+++ b/signer/src/network.rs
@@ -1,10 +1,102 @@
-use crate::ecdsa::Signed;
-use crate::message::SignerMessage;
+//! # Signer network interface
+//!
+//! This module provides the Client trait that the signer implementation
+//! will rely on for inter-signer communication, along with an in-memory
+//! implementation of this trait for testing purposes.
 
-pub(crate) trait Client {
+#[cfg(test)]
+pub mod in_memory;
+
+use std::future::Future;
+
+use crate::ecdsa;
+use crate::message;
+
+pub type Msg = ecdsa::Signed<message::SignerMessage>;
+
+pub trait Client {
     type Error;
     /// Send `msg` to all other signers
-    async fn broadcast(&self, msg: Signed<SignerMessage>) -> Result<(), Self::Error>;
+    fn broadcast(&mut self, msg: Msg) -> impl Future<Output = Result<(), Self::Error>> + Send;
     /// Receive a message from the network
-    async fn receive(&mut self) -> Result<Signed<SignerMessage>, Self::Error>;
+    fn receive(&mut self) -> impl Future<Output = Result<Msg, Self::Error>> + Send;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use bitcoin::hashes::Hash;
+    use p256k1::scalar;
+    use rand::SeedableRng;
+
+    use crate::ecdsa::SignEcdsa;
+
+    #[tokio::test]
+    async fn two_clients_should_be_able_to_exchange_messages_given_an_in_memory_network() {
+        let mut rng = rand::rngs::StdRng::seed_from_u64(1337);
+
+        let network = in_memory::Network::new();
+
+        let number_of_messages = 32;
+
+        let mut client_1 = network.connect();
+        let mut client_2 = network.connect();
+
+        let client_1_messages: Vec<_> = (0..number_of_messages)
+            .map(|_| random_signed_message(&mut rng))
+            .collect();
+        let client_2_messages: Vec<_> = (0..number_of_messages)
+            .map(|_| random_signed_message(&mut rng))
+            .collect();
+
+        let client_1_expected_received_messages = client_2_messages.clone();
+        let client_2_expected_received_messages = client_1_messages.clone();
+
+        let handle_1 = tokio::spawn(async move {
+            for msg in client_1_messages {
+                client_1.broadcast(msg).await.expect("Failed to broadcast");
+            }
+
+            for msg in client_1_expected_received_messages {
+                let received = client_1.receive().await.expect("Failed to receive message");
+                assert_eq!(received, msg);
+            }
+        });
+
+        let handle_2 = tokio::spawn(async move {
+            for msg in client_2_messages {
+                client_2.broadcast(msg).await.expect("Failed to broadcast");
+            }
+
+            for msg in client_2_expected_received_messages {
+                let received = client_2.receive().await.expect("Failed to receive message");
+                assert_eq!(received, msg);
+            }
+        });
+
+        handle_1.await.unwrap();
+        handle_2.await.unwrap();
+    }
+
+    fn random_signed_message<R: rand::CryptoRng + rand::Rng>(rng: &mut R) -> Msg {
+        let num_ids: u8 = rng.gen();
+        let dkg_end_begin = wsts::net::DkgEndBegin {
+            dkg_id: rng.next_u64(),
+            signer_ids: (0..num_ids).map(|_| rng.next_u32()).collect(),
+            key_ids: (0..num_ids).map(|_| rng.next_u32()).collect(),
+        };
+
+        let private_key = scalar::Scalar::random(rng);
+        let payload = message::Payload::WstsMessage(wsts::net::Message::DkgEndBegin(dkg_end_begin));
+
+        let mut block_hash_data = [0; 32];
+        rng.fill_bytes(&mut block_hash_data);
+        let block_hash = bitcoin::BlockHash::from_slice(&block_hash_data).unwrap();
+
+        payload
+            .to_message(block_hash)
+            .sign_ecdsa(&private_key)
+            .expect("Failed to sign message")
+    }
 }

--- a/signer/src/network/in_memory.rs
+++ b/signer/src/network/in_memory.rs
@@ -1,0 +1,73 @@
+//! # In-memory signer network client.
+//!
+//! The client itself is a thin wrapper over a tokio broadcast
+//! channel, with deduplication logic to prevent a single client
+//! from receiving it's own messages.
+
+use std::collections::VecDeque;
+
+use tokio::sync::broadcast;
+
+pub const BROADCAST_CHANNEL_CAPACITY: usize = 10_000;
+
+#[derive(Debug)]
+pub struct Client {
+    sender: broadcast::Sender<super::Msg>,
+    receiver: broadcast::Receiver<super::Msg>,
+    recently_sent: VecDeque<super::Msg>,
+}
+
+/// In-memory communication network
+#[derive(Debug)]
+pub struct Network {
+    sender: broadcast::Sender<super::Msg>,
+}
+
+impl Network {
+    /// Construct a new in-memory communication entwork
+    pub fn new() -> Self {
+        let (sender, _) = broadcast::channel(BROADCAST_CHANNEL_CAPACITY);
+        Self { sender }
+    }
+
+    /// Connect a new signer to this network
+    pub fn connect(&self) -> Client {
+        let sender = self.sender.clone();
+        let receiver = sender.subscribe();
+        let recently_sent = VecDeque::new();
+
+        Client {
+            sender,
+            receiver,
+            recently_sent,
+        }
+    }
+}
+
+impl super::Client for Client {
+    type Error = Error;
+    async fn broadcast(&mut self, msg: super::Msg) -> Result<(), Self::Error> {
+        self.recently_sent.push_back(msg.clone());
+        self.sender.send(msg)?;
+        Ok(())
+    }
+
+    async fn receive(&mut self) -> Result<super::Msg, Self::Error> {
+        let mut msg = self.receiver.recv().await?;
+
+        while Some(&msg) == self.recently_sent.get(0) {
+            self.recently_sent.pop_front();
+            msg = self.receiver.recv().await?;
+        }
+
+        Ok(msg)
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("send error")]
+    Send(#[from] broadcast::error::SendError<super::Msg>),
+    #[error("receive error")]
+    Recv(#[from] broadcast::error::RecvError),
+}

--- a/signer/src/network/in_memory.rs
+++ b/signer/src/network/in_memory.rs
@@ -13,7 +13,7 @@ pub const BROADCAST_CHANNEL_CAPACITY: usize = 10_000;
 type MsgId = [u8; 32];
 
 #[derive(Debug)]
-pub struct Client {
+pub struct MpmcBroadcaster {
     sender: broadcast::Sender<super::Msg>,
     receiver: broadcast::Receiver<super::Msg>,
     recently_sent: VecDeque<MsgId>,
@@ -33,12 +33,12 @@ impl Network {
     }
 
     /// Connect a new signer to this network
-    pub fn connect(&self) -> Client {
+    pub fn connect(&self) -> MpmcBroadcaster {
         let sender = self.sender.clone();
         let receiver = sender.subscribe();
         let recently_sent = VecDeque::new();
 
-        Client {
+        MpmcBroadcaster {
             sender,
             receiver,
             recently_sent,
@@ -46,7 +46,7 @@ impl Network {
     }
 }
 
-impl super::Client for Client {
+impl super::MessageTransfer for MpmcBroadcaster {
     type Error = Error;
     async fn broadcast(&mut self, msg: super::Msg) -> Result<(), Self::Error> {
         self.recently_sent.push_back(msg.id());


### PR DESCRIPTION
closes #107 and #108 

This PR defines the client interface for the signer network through the `signer::network::Client` trait. It also provides an in-memory implementation of a signer network by wrapping a `tokio::sync::broadcast` channel for illustrative and testing purposes.