### PR TITLE
build: rename sbtc-signer binary to signer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -597,9 +597,9 @@ dependencies = [
  "mockito",
  "once_cell",
  "reqwest",
- "sbtc-signer",
  "serde 1.0.201",
  "serde_json",
+ "signer",
  "thiserror",
  "tokio",
  "tracing",
@@ -2523,27 +2523,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sbtc-signer"
-version = "0.1.0"
-dependencies = [
- "bincode",
- "bitcoin",
- "more-asserts",
- "p256k1",
- "rand 0.8.5",
- "secp256k1",
- "serde 1.0.201",
- "sha2",
- "test-case",
- "thiserror",
- "tokio",
- "tracing",
- "tracing-attributes",
- "tracing-subscriber",
- "wsts",
-]
-
-[[package]]
 name = "schannel"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2809,6 +2788,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "signer"
+version = "0.1.0"
+dependencies = [
+ "bincode",
+ "bitcoin",
+ "more-asserts",
+ "p256k1",
+ "rand 0.8.5",
+ "secp256k1",
+ "serde 1.0.201",
+ "sha2",
+ "test-case",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-attributes",
+ "tracing-subscriber",
+ "wsts",
 ]
 
 [[package]]

--- a/blocklist-client/Cargo.toml
+++ b/blocklist-client/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/main.rs"
 config = "0.11"
 once_cell = "1.8.0"
 reqwest = { version = "0.11", features = ["json"] }
-sbtc-signer = { path = "../signer" }
+signer = { path = "../signer" }
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/blocklist-client/src/main.rs
+++ b/blocklist-client/src/main.rs
@@ -1,6 +1,6 @@
 use crate::config::SETTINGS;
 use reqwest::Client;
-use sbtc_signer::logging::setup_logging;
+use signer::logging::setup_logging;
 use std::net::ToSocketAddrs;
 use tracing::{error, info};
 use warp::Filter;

--- a/signer/Cargo.toml
+++ b/signer/Cargo.toml
@@ -1,6 +1,6 @@
 # The razor application, for fundraising.
 [package]
-name = "sbtc-signer"
+name = "signer"
 version = "0.1.0"
 edition = "2021"
 

--- a/signer/src/codec.rs
+++ b/signer/src/codec.rs
@@ -15,7 +15,7 @@
 //! ### Encoding a string slice and decoding it as a string
 //!
 //! ```
-//! use sbtc_signer::codec::{Encode, Decode};
+//! use signer::codec::{Encode, Decode};
 //!
 //! let message = "Encode me";
 //!

--- a/signer/src/ecdsa.rs
+++ b/signer/src/ecdsa.rs
@@ -18,7 +18,7 @@
 //!
 //! ```
 //! use sha2::Digest;
-//! use sbtc_signer::ecdsa::SignEcdsa;
+//! use signer::ecdsa::SignEcdsa;
 //!
 //! struct SignableStr(&'static str);
 //!


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/142, which started from this thread https://github.com/stacks-network/sbtc/pull/137#discussion_r1595542013.

The signer binary was supposed to be called `signer` to begin with, this PR makes it so.


## Type of Change

Renames the signer binary/library and updates the dependencies.