### PR TITLE
fix: prevent package-lock.json from being built

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 **/.generated-sources
 **.log
 **/node_modules
+**/package-lock.json
 
 ## Contracts
 contracts/settings/Mainnet.toml

--- a/emily/api-definition/package.json
+++ b/emily/api-definition/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "build-openapi": "smithy build",
     "clean-openapi": "smithy clean",
-    "build-rs": "npx @openapitools/openapi-generator-cli generate -i ../../.generated-sources/smithy/openapi/openapi/Emily.openapi.json -g rust -c rust-config.json -o ../../.generated-sources/emily",
+    "build-rs": "openapi-generator-cli generate -i ../../.generated-sources/smithy/openapi/openapi/Emily.openapi.json -g rust -c rust-config.json -o ../../.generated-sources/emily",
     "build": "pnpm build-openapi && pnpm build-rs",
     "clean": "rm -rf node_modules && pnpm clean-openapi"
   },


### PR DESCRIPTION
I noticed that `package-lock.json` was generated when `make build` ran, and that's due to this invocation of `npx @openapi...`. `npx` uses `npm` under the hood, and the `npx` command is essentially the same as "npm install ... " and then running that bin script. Because `@openapitools/openapi-generator-cli` is already installed as a devDependency, you can just use the bin script's name inside a package.json script.

To verify, run `make install` and `make build` and validate that package-lock.json isn't re-created.