### PR TITLE
Update contract CI to ensure docs & types are built

### DIFF
--- a/.github/workflows/contract-tests.yaml
+++ b/.github/workflows/contract-tests.yaml
@@ -28,3 +28,15 @@ jobs:
       - name: Lint
         run: pnpm lint
         working-directory: ./contracts
+      - name: Generate contract docs and types
+        run: pnpm build
+        working-directory: ./contracts
+      - name: Ensure git is clean
+        id: gitStatus
+        run: git diff --no-ext-diff --exit-code
+        continue-on-error: true
+      - name: Error message if git is dirty
+        if: steps.gitStatus.outcome == 'failure'
+        run: |
+          echo "::error::Git is dirty. Make sure you ran \`make build\` before pushing."
+          exit 1

--- a/contracts/docs/README.md
+++ b/contracts/docs/README.md
@@ -1,3 +1,5 @@
 # Contracts
 
+- [`sbtc-bootstrap-signers`](sbtc-bootstrap-signers.md)
+- [`sbtc-deposit`](sbtc-deposit.md)
 - [`sbtc-registry`](sbtc-registry.md)

--- a/contracts/docs/sbtc-bootstrap-signers.md
+++ b/contracts/docs/sbtc-bootstrap-signers.md
@@ -1,0 +1,154 @@
+# sbtc-bootstrap-signers
+
+[`sbtc-bootstrap-signers.clar`](../contracts/sbtc-bootstrap-signers.clar)
+
+sBTC Bootstrap Signers contract
+
+**Public functions:**
+
+- [`rotate-keys-wrapper`](#rotate-keys-wrapper)
+
+**Read-only functions:**
+
+**Private functions:**
+
+- [`signer-key-length-check`](#signer-key-length-check)
+
+**Maps**
+
+**Variables**
+
+**Constants**
+
+- [`signature-threshold`](#signature-threshold)
+- [`key-size`](#key-size)
+- [`ERR_KEY_SIZE_PREFIX`](#err_key_size_prefix)
+- [`ERR_KEY_SIZE`](#err_key_size)
+
+## Functions
+
+### rotate-keys-wrapper
+
+[View in file](../contracts/sbtc-bootstrap-signers.clar#L24)
+
+`(define-public (rotate-keys-wrapper ((new-keys (list 15 (buff 32))) (multi-sig-address principal) (new-aggregate-pubkey (buff 32))) (response bool uint))`
+
+public functions
+Rotate keys
+Used to rotate the keys of the signers. This is called whenever
+the signer set is updated.
+TODO - construct multi-sig address from keys
+
+<details>
+  <summary>Source code:</summary>
+
+```clarity
+(define-public (rotate-keys-wrapper (new-keys (list 15 (buff 32))) (multi-sig-address principal) (new-aggregate-pubkey (buff 32)))
+    (let
+        (
+            (current-signer-data (contract-call? .sbtc-registry get-current-signer-data))
+        )
+        ;; TODO: check that tx-sender, using principal-construct? is a current signer
+        ;; Check that tx-sender is a multi-sig address
+
+        ;; Checks that length of each key is exactly 32 bytes
+        (try! (fold signer-key-length-check new-keys (ok u0)))
+
+        ;; Check that length of new-aggregate-pubkey is exactly 32 bytes
+        (asserts! (is-eq (len new-aggregate-pubkey) key-size) ERR_KEY_SIZE)
+
+        ;; Call into .sbtc-registry to update the keys & address
+        (ok (try! (contract-call? .sbtc-registry rotate-keys new-keys multi-sig-address new-aggregate-pubkey)))
+    )
+)
+```
+
+</details>
+
+**Parameters:**
+
+| Name                 | Type                |
+| -------------------- | ------------------- |
+| new-keys             | (list 15 (buff 32)) |
+| multi-sig-address    | principal           |
+| new-aggregate-pubkey | (buff 32)           |
+
+### signer-key-length-check
+
+[View in file](../contracts/sbtc-bootstrap-signers.clar#L49)
+
+`(define-private (signer-key-length-check ((current-key (buff 32)) (helper-response (response uint uint))) (response uint uint))`
+
+private functions
+Signer Key Length Check
+Checks that the length of each key is exactly 32 bytes
+
+<details>
+  <summary>Source code:</summary>
+
+```clarity
+(define-private (signer-key-length-check (current-key (buff 32)) (helper-response (response uint uint)))
+    (match helper-response
+        index
+            (begin
+                (asserts! (is-eq (len current-key) key-size) (err (+ ERR_KEY_SIZE_PREFIX (+ u10 index))))
+                (ok (+ index u1))
+            )
+        err-response
+            (err err-response)
+    )
+)
+```
+
+</details>
+
+**Parameters:**
+
+| Name            | Type                 |
+| --------------- | -------------------- |
+| current-key     | (buff 32)            |
+| helper-response | (response uint uint) |
+
+## Maps
+
+## Variables
+
+## Constants
+
+### signature-threshold
+
+constants
+
+```clarity
+(define-constant signature-threshold u8)
+```
+
+[View in file](../contracts/sbtc-bootstrap-signers.clar#L4)
+
+### key-size
+
+```clarity
+(define-constant key-size u32)
+```
+
+[View in file](../contracts/sbtc-bootstrap-signers.clar#L5)
+
+### ERR_KEY_SIZE_PREFIX
+
+errors
+if err is u200, it's the agg key
+if err is u210>, it's the key at index (err - 210)
+
+```clarity
+(define-constant ERR_KEY_SIZE_PREFIX u200)
+```
+
+[View in file](../contracts/sbtc-bootstrap-signers.clar#L10)
+
+### ERR_KEY_SIZE
+
+```clarity
+(define-constant ERR_KEY_SIZE (err u200))
+```
+
+[View in file](../contracts/sbtc-bootstrap-signers.clar#L11)

--- a/contracts/docs/sbtc-deposit.md
+++ b/contracts/docs/sbtc-deposit.md
@@ -1,0 +1,111 @@
+# sbtc-deposit
+
+[`sbtc-deposit.clar`](../contracts/sbtc-deposit.clar)
+
+sBTC Deposit contract
+
+**Public functions:**
+
+- [`complete-deposit-wrapper`](#complete-deposit-wrapper)
+
+**Read-only functions:**
+
+**Private functions:**
+
+**Maps**
+
+**Variables**
+
+**Constants**
+
+- [`txid-length`](#txid-length)
+- [`ERR_TXID_LEN`](#err_txid_len)
+- [`ERR_DEPOSIT_REPLAY`](#err_deposit_replay)
+
+## Functions
+
+### complete-deposit-wrapper
+
+[View in file](../contracts/sbtc-deposit.clar#L22)
+
+`(define-public (complete-deposit-wrapper ((txid (buff 32)) (vout-index uint) (amount uint) (recipient principal)) (response (response bool uint) uint))`
+
+public functions
+Accept a new deposit request
+Note that this function can only be called by the current
+bootstrap signer set address - it cannot be called by users directly.
+This function handles the validation & minting of sBTC, it then calls
+into the sbtc-registry contract to update the state of the protocol
+
+<details>
+  <summary>Source code:</summary>
+
+```clarity
+(define-public (complete-deposit-wrapper (txid (buff 32)) (vout-index uint) (amount uint) (recipient principal))
+    (let
+        (
+            (replay-fetch (contract-call? .sbtc-registry get-completed-deposit txid vout-index))
+        )
+
+        ;; TODO
+        ;; Check that tx-sender is the bootstrap signer
+
+        ;; Check that txid is the correct length
+        (asserts! (is-eq (len txid) txid-length) ERR_TXID_LEN)
+
+        ;; Assert that the deposit has not already been completed (no replay)
+        (asserts! (is-none replay-fetch) ERR_DEPOSIT_REPLAY)
+
+        ;; TODO
+        ;; Mint the sBTC to the recipient
+
+        ;; Complete the deposit
+        (ok (contract-call? .sbtc-registry complete-deposit txid vout-index amount recipient))
+    )
+)
+```
+
+</details>
+
+**Parameters:**
+
+| Name       | Type      |
+| ---------- | --------- |
+| txid       | (buff 32) |
+| vout-index | uint      |
+| amount     | uint      |
+| recipient  | principal |
+
+## Maps
+
+## Variables
+
+## Constants
+
+### txid-length
+
+constants
+
+```clarity
+(define-constant txid-length u32)
+```
+
+[View in file](../contracts/sbtc-deposit.clar#L4)
+
+### ERR_TXID_LEN
+
+error codes
+
+```clarity
+(define-constant ERR_TXID_LEN (err u300))
+```
+
+[View in file](../contracts/sbtc-deposit.clar#L7)
+
+### ERR_DEPOSIT_REPLAY
+
+```clarity
+(define-constant ERR_DEPOSIT_REPLAY (err u301))
+```
+
+[View in file](../contracts/sbtc-deposit.clar#L8)

--- a/contracts/docs/sbtc-registry.md
+++ b/contracts/docs/sbtc-registry.md
@@ -7,8 +7,16 @@ sBTC Registry contract
 **Public functions:**
 
 - [`create-withdrawal-request`](#create-withdrawal-request)
+- [`complete-deposit`](#complete-deposit)
+- [`rotate-keys`](#rotate-keys)
 
 **Read-only functions:**
+
+- [`get-withdrawal-request`](#get-withdrawal-request)
+- [`get-completed-deposit`](#get-completed-deposit)
+- [`get-current-signer-data`](#get-current-signer-data)
+- [`get-current-aggregate-pubkey`](#get-current-aggregate-pubkey)
+- [`get-current-signer-principal`](#get-current-signer-principal)
 
 **Private functions:**
 
@@ -19,20 +27,153 @@ sBTC Registry contract
 
 - [`withdrawal-requests`](#withdrawal-requests)
 - [`withdrawal-status`](#withdrawal-status)
+- [`completed-deposits`](#completed-deposits)
+- [`aggregate-pubkeys`](#aggregate-pubkeys)
+- [`multi-sig-address`](#multi-sig-address)
 
 **Variables**
 
 - [`last-withdrawal-request-id`](#last-withdrawal-request-id)
+- [`current-signer-set`](#current-signer-set)
+- [`current-aggregate-pubkey`](#current-aggregate-pubkey)
+- [`current-signer-principal`](#current-signer-principal)
 
 **Constants**
 
 - [`ERR_UNAUTHORIZED`](#err_unauthorized)
+- [`ERR_INVALID_REQUEST_ID`](#err_invalid_request_id)
+- [`ERR_AGG_PUBKEY_REPLAY`](#err_agg_pubkey_replay)
+- [`ERR_MULTI_SIG_REPLAY`](#err_multi_sig_replay)
 
 ## Functions
 
+### get-withdrawal-request
+
+[View in file](../contracts/sbtc-registry.clar#L63)
+
+`(define-read-only (get-withdrawal-request ((id uint)) (optional (tuple (amount uint) (block-height uint) (max-fee uint) (recipient (tuple (hashbytes (buff 32)) (version (buff 1)))) (sender principal) (status (optional bool)))))`
+
+Read-only functions
+Get a withdrawal request by its ID.
+This function returns the fields of the withrawal
+request, along with its status.
+
+<details>
+  <summary>Source code:</summary>
+
+```clarity
+(define-read-only (get-withdrawal-request (id uint))
+  (match (map-get? withdrawal-requests id)
+    request (some (merge request {
+      status: (map-get? withdrawal-status id)
+    }))
+    none
+  )
+)
+```
+
+</details>
+
+**Parameters:**
+
+| Name | Type |
+| ---- | ---- |
+| id   | uint |
+
+### get-completed-deposit
+
+[View in file](../contracts/sbtc-registry.clar#L74)
+
+`(define-read-only (get-completed-deposit ((txid (buff 32)) (vout-index uint)) (optional (tuple (amount uint) (recipient principal))))`
+
+Get a completed deposit by its transaction ID & vout index.
+This function returns the fields of the completed-deposits map.
+
+<details>
+  <summary>Source code:</summary>
+
+```clarity
+(define-read-only (get-completed-deposit (txid (buff 32)) (vout-index uint))
+  (map-get? completed-deposits {txid: txid, vout-index: vout-index})
+)
+```
+
+</details>
+
+**Parameters:**
+
+| Name       | Type      |
+| ---------- | --------- |
+| txid       | (buff 32) |
+| vout-index | uint      |
+
+### get-current-signer-data
+
+[View in file](../contracts/sbtc-registry.clar#L80)
+
+`(define-read-only (get-current-signer-data () (tuple (current-aggregate-pubkey (buff 32)) (current-signer-principal principal) (current-signer-set (list 15 (buff 32)))))`
+
+Get the current signer set.
+This function returns the current signer set as a list of principals.
+
+<details>
+  <summary>Source code:</summary>
+
+```clarity
+(define-read-only (get-current-signer-data)
+  {
+    current-signer-set: (var-get current-signer-set),
+    current-aggregate-pubkey: (var-get current-aggregate-pubkey),
+    current-signer-principal: (var-get current-signer-principal)
+  }
+)
+```
+
+</details>
+
+### get-current-aggregate-pubkey
+
+[View in file](../contracts/sbtc-registry.clar#L90)
+
+`(define-read-only (get-current-aggregate-pubkey () (buff 32))`
+
+Get the current aggregate pubkey.
+This function returns the current aggregate pubkey.
+
+<details>
+  <summary>Source code:</summary>
+
+```clarity
+(define-read-only (get-current-aggregate-pubkey)
+  (var-get current-aggregate-pubkey)
+)
+```
+
+</details>
+
+### get-current-signer-principal
+
+[View in file](../contracts/sbtc-registry.clar#L96)
+
+`(define-read-only (get-current-signer-principal () principal)`
+
+Get the current signer principal.
+This function returns the current signer principal.
+
+<details>
+  <summary>Source code:</summary>
+
+```clarity
+(define-read-only (get-current-signer-principal)
+  (var-get current-signer-principal)
+)
+```
+
+</details>
+
 ### create-withdrawal-request
 
-[View in file](../contracts/sbtc-registry.clar#L46)
+[View in file](../contracts/sbtc-registry.clar#L112)
 
 `(define-public (create-withdrawal-request ((amount uint) (max-fee uint) (sender principal) (recipient (tuple (hashbytes (buff 32)) (version (buff 1)))) (height uint)) (response uint uint))`
 
@@ -96,9 +237,102 @@ and the data of the request.
 | recipient | (tuple (hashbytes (buff 32)) (version (buff 1))) |
 | height    | uint                                             |
 
+### complete-deposit
+
+[View in file](../contracts/sbtc-registry.clar#L152)
+
+`(define-public (complete-deposit ((txid (buff 32)) (vout-index uint) (amount uint) (recipient principal)) (response bool uint))`
+
+Store a new insert request.
+Note that this function can only be called by other sBTC
+contracts (specifically the current version of the deposit contract)
+
+- it cannot be called by users directly.
+
+This function does not handle validation or moving the funds.
+Instead, it is purely for the purpose of storing the completed deposit.
+
+<details>
+  <summary>Source code:</summary>
+
+```clarity
+(define-public (complete-deposit
+    (txid (buff 32))
+    (vout-index uint)
+    (amount uint)
+    (recipient principal)
+  )
+  (begin
+    (try! (validate-caller))
+    (map-insert completed-deposits {txid: txid, vout-index: vout-index} {
+      amount: amount,
+      recipient: recipient
+    })
+    (print {
+      topic: "completed-deposit",
+      txid: txid,
+      vout-index: vout-index
+    })
+    (ok true)
+  )
+)
+```
+
+</details>
+
+**Parameters:**
+
+| Name       | Type      |
+| ---------- | --------- |
+| txid       | (buff 32) |
+| vout-index | uint      |
+| amount     | uint      |
+| recipient  | principal |
+
+### rotate-keys
+
+[View in file](../contracts/sbtc-registry.clar#L175)
+
+`(define-public (rotate-keys ((new-keys (list 15 (buff 32))) (new-address principal) (new-aggregate-pubkey (buff 32))) (response bool uint))`
+
+Rotate the signer set, multi-sig principal, & aggregate pubkey
+This function can only be called by the bootstrap-signers contract.
+
+<details>
+  <summary>Source code:</summary>
+
+```clarity
+(define-public (rotate-keys (new-keys (list 15 (buff 32))) (new-address principal) (new-aggregate-pubkey (buff 32)))
+  (begin
+    ;; Check that caller is protocol contract
+    (try! (validate-caller))
+    ;; Check that the aggregate pubkey is not already in the map
+    (asserts! (map-insert aggregate-pubkeys new-aggregate-pubkey true) ERR_AGG_PUBKEY_REPLAY)
+    ;; Check that the new address (multi-sig) is not already in the map
+    (asserts! (map-insert multi-sig-address new-address true) ERR_MULTI_SIG_REPLAY)
+    ;; Update the current signer set
+    (var-set current-signer-set new-keys)
+    ;; Update the current multi-sig address
+    (var-set current-signer-principal new-address)
+    ;; Update the current aggregate pubkey
+    (ok (var-set current-aggregate-pubkey new-aggregate-pubkey))
+  )
+)
+```
+
+</details>
+
+**Parameters:**
+
+| Name                 | Type                |
+| -------------------- | ------------------- |
+| new-keys             | (list 15 (buff 32)) |
+| new-address          | principal           |
+| new-aggregate-pubkey | (buff 32)           |
+
 ### increment-last-withdrawal-request-id
 
-[View in file](../contracts/sbtc-registry.clar#L83)
+[View in file](../contracts/sbtc-registry.clar#L196)
 
 `(define-private (increment-last-withdrawal-request-id () uint)`
 
@@ -124,7 +358,7 @@ return the new value.
 
 ### validate-caller
 
-[View in file](../contracts/sbtc-registry.clar#L96)
+[View in file](../contracts/sbtc-registry.clar#L209)
 
 `(define-private (validate-caller () (response bool uint))`
 
@@ -140,7 +374,7 @@ to use the sBTC controller.
   ;; To provide an explicit error type, add a branch that
   ;; wont be hit
   ;; (if (is-eq contract-caller .controller) (ok true) (err ERR_UNAUTHORIZED))
-  (if false (err ERR_UNAUTHORIZED) (ok true))
+  (if false ERR_UNAUTHORIZED (ok true))
 )
 ```
 
@@ -150,6 +384,7 @@ to use the sBTC controller.
 
 ### withdrawal-requests
 
+Maps
 Internal data structure to store withdrawal
 requests. Requests are associated with a unique
 request ID.
@@ -172,7 +407,7 @@ request ID.
 })
 ```
 
-[View in file](../contracts/sbtc-registry.clar#L11)
+[View in file](../contracts/sbtc-registry.clar#L20)
 
 ### withdrawal-status
 
@@ -185,7 +420,45 @@ the deposit was accepted.
 (define-map withdrawal-status uint bool)
 ```
 
-[View in file](../contracts/sbtc-registry.clar#L33)
+[View in file](../contracts/sbtc-registry.clar#L40)
+
+### completed-deposits
+
+Internal data structure to store completed
+deposit requests & avoid replay attacks.
+
+```clarity
+(define-map completed-deposits {txid: (buff 32), vout-index: uint}
+  {
+    amount: uint,
+    recipient: principal
+  }
+)
+```
+
+[View in file](../contracts/sbtc-registry.clar#L44)
+
+### aggregate-pubkeys
+
+Data structure to store aggregate pubkey,
+stored to avoid replay
+
+```clarity
+(define-map aggregate-pubkeys (buff 32) bool)
+```
+
+[View in file](../contracts/sbtc-registry.clar#L53)
+
+### multi-sig-address
+
+Data structure to store the current signer set,
+stored to avoid replay
+
+```clarity
+(define-map multi-sig-address principal bool)
+```
+
+[View in file](../contracts/sbtc-registry.clar#L57)
 
 ## Variables
 
@@ -193,20 +466,76 @@ the deposit was accepted.
 
 uint
 
+Variables
+
 ```clarity
 (define-data-var last-withdrawal-request-id uint u0)
 ```
 
-[View in file](../contracts/sbtc-registry.clar#L27)
+[View in file](../contracts/sbtc-registry.clar#L10)
+
+### current-signer-set
+
+(list 15 (buff 32))
+
+```clarity
+(define-data-var current-signer-set (list 15 (buff 32)) (list))
+```
+
+[View in file](../contracts/sbtc-registry.clar#L11)
+
+### current-aggregate-pubkey
+
+(buff 32)
+
+```clarity
+(define-data-var current-aggregate-pubkey (buff 32) 0x00)
+```
+
+[View in file](../contracts/sbtc-registry.clar#L12)
+
+### current-signer-principal
+
+principal
+
+```clarity
+(define-data-var current-signer-principal principal tx-sender)
+```
+
+[View in file](../contracts/sbtc-registry.clar#L13)
 
 ## Constants
 
 ### ERR_UNAUTHORIZED
 
-Thrown when the contract caller is not authorized
+Error codes
 
 ```clarity
-(define-constant ERR_UNAUTHORIZED u400)
+(define-constant ERR_UNAUTHORIZED (err u400))
+```
+
+[View in file](../contracts/sbtc-registry.clar#L4)
+
+### ERR_INVALID_REQUEST_ID
+
+```clarity
+(define-constant ERR_INVALID_REQUEST_ID (err u401))
+```
+
+[View in file](../contracts/sbtc-registry.clar#L5)
+
+### ERR_AGG_PUBKEY_REPLAY
+
+```clarity
+(define-constant ERR_AGG_PUBKEY_REPLAY (err u402))
 ```
 
 [View in file](../contracts/sbtc-registry.clar#L6)
+
+### ERR_MULTI_SIG_REPLAY
+
+```clarity
+(define-constant ERR_MULTI_SIG_REPLAY (err u403))
+```
+
+[View in file](../contracts/sbtc-registry.clar#L7)

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -5,6 +5,8 @@
   "type": "module",
   "private": true,
   "scripts": {
+    "build": "clarigen && clarigen docs",
+    "build:docs": "clarigen docs",
     "test": "vitest run",
     "test:report": "vitest run -- --coverage --costs",
     "test:watch": "chokidar \"tests/**/*.ts\" \"contracts/**/*.clar\" -c \"npm run test:report\"",
@@ -14,9 +16,9 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@clarigen/cli": "^2.0.1",
-    "@clarigen/core": "^2.0.1",
-    "@clarigen/test": "^2.0.1",
+    "@clarigen/cli": "2.0.2",
+    "@clarigen/core": "2.0.2",
+    "@clarigen/test": "2.0.2",
     "@hirosystems/clarinet-sdk": "^2.3.2",
     "@stacks/stacking": "^6.15.0",
     "@stacks/transactions": "^6.12.0",

--- a/contracts/tests/clarigen-types.ts
+++ b/contracts/tests/clarigen-types.ts
@@ -16,41 +16,19 @@ export const contracts = {
           { name: "current-key", type: { buffer: { length: 32 } } },
           {
             name: "helper-response",
-            type: {
-              response: {
-                ok: { tuple: [{ name: "index", type: "uint128" }] },
-                error: "uint128",
-              },
-            },
+            type: { response: { ok: "uint128", error: "uint128" } },
           },
         ],
-        outputs: {
-          type: {
-            response: {
-              ok: { tuple: [{ name: "index", type: "uint128" }] },
-              error: "uint128",
-            },
-          },
-        },
+        outputs: { type: { response: { ok: "uint128", error: "uint128" } } },
       } as TypedAbiFunction<
         [
           currentKey: TypedAbiArg<Uint8Array, "currentKey">,
           helperResponse: TypedAbiArg<
-            Response<
-              {
-                index: number | bigint;
-              },
-              number | bigint
-            >,
+            Response<number | bigint, number | bigint>,
             "helperResponse"
           >,
         ],
-        Response<
-          {
-            index: bigint;
-          },
-          bigint
-        >
+        Response<bigint, bigint>
       >,
       rotateKeysWrapper: {
         name: "rotate-keys-wrapper",
@@ -567,6 +545,26 @@ export const contracts = {
 } as const;
 
 export const accounts = {
+  deployer: {
+    address: "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM",
+    balance: "100000000000000",
+  },
+  faucet: {
+    address: "STNHKEPYEPJ8ET55ZZ0M5A34J0R3N5FM2CMMMAZ6",
+    balance: "100000000000000",
+  },
+  wallet_1: {
+    address: "ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5",
+    balance: "100000000000000",
+  },
+  wallet_2: {
+    address: "ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG",
+    balance: "100000000000000",
+  },
+  wallet_3: {
+    address: "ST2JHG361ZXG51QTKY2NQCVBPPRRE2KZB1HR05NNC",
+    balance: "100000000000000",
+  },
   wallet_4: {
     address: "ST2NEB84ASENDXKYGJPQW86YXQCEFEX2ZQPG87ND",
     balance: "100000000000000",
@@ -575,36 +573,16 @@ export const accounts = {
     address: "ST2REHHS5J3CERCRBEPMGH7921Q6PYKAADT7JP2VB",
     balance: "100000000000000",
   },
-  deployer: {
-    address: "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM",
-    balance: "100000000000000",
-  },
-  wallet_8: {
-    address: "ST3NBRSFKX28FQ2ZJ1MAKX58HKHSDGNV5N7R21XCP",
+  wallet_6: {
+    address: "ST3AM1A56AK2C1XAFJ4115ZSV26EB49BVQ10MGCS0",
     balance: "100000000000000",
   },
   wallet_7: {
     address: "ST3PF13W7Z0RRM42A8VZRVFQ75SV1K26RXEP8YGKJ",
     balance: "100000000000000",
   },
-  wallet_2: {
-    address: "ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG",
-    balance: "100000000000000",
-  },
-  wallet_1: {
-    address: "ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5",
-    balance: "100000000000000",
-  },
-  wallet_6: {
-    address: "ST3AM1A56AK2C1XAFJ4115ZSV26EB49BVQ10MGCS0",
-    balance: "100000000000000",
-  },
-  wallet_3: {
-    address: "ST2JHG361ZXG51QTKY2NQCVBPPRRE2KZB1HR05NNC",
-    balance: "100000000000000",
-  },
-  faucet: {
-    address: "STNHKEPYEPJ8ET55ZZ0M5A34J0R3N5FM2CMMMAZ6",
+  wallet_8: {
+    address: "ST3NBRSFKX28FQ2ZJ1MAKX58HKHSDGNV5N7R21XCP",
     balance: "100000000000000",
   },
 } as const;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,14 +11,14 @@ importers:
   contracts:
     dependencies:
       '@clarigen/cli':
-        specifier: ^2.0.1
-        version: 2.0.1(@types/node@20.1.7)(typanion@3.14.0)
+        specifier: 2.0.2
+        version: 2.0.2(@types/node@20.1.7)(typanion@3.14.0)
       '@clarigen/core':
-        specifier: ^2.0.1
-        version: 2.0.1
+        specifier: 2.0.2
+        version: 2.0.2
       '@clarigen/test':
-        specifier: ^2.0.1
-        version: 2.0.1(@types/node@20.1.7)
+        specifier: 2.0.2
+        version: 2.0.2(@types/node@20.1.7)
       '@hirosystems/clarinet-sdk':
         specifier: ^2.3.2
         version: 2.6.0(@types/node@20.1.7)
@@ -105,6 +105,10 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@antfu/ni@0.21.12':
+    resolution: {integrity: sha512-2aDL3WUv8hMJb2L3r/PIQWsTLyq7RQr3v9xD16fiz6O8ys1xEyLhhTOv8gxtZvJiTzjTF5pHoArvRdesGL1DMQ==}
+    hasBin: true
 
   '@aws-cdk/asset-awscli-v1@2.2.202':
     resolution: {integrity: sha512-JqlF0D4+EVugnG5dAsNZMqhu3HW7ehOXm5SDMxMbXNDMdsF0pxtQKNHRl52z1U9igsHmaFpUgSGjbhAJ+0JONg==}
@@ -286,17 +290,17 @@ packages:
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
-  '@clarigen/cli@2.0.1':
-    resolution: {integrity: sha512-C8QTwUHvvgISWk/QrEWv+zg6fmRAAIX+oshsmdJzOosVzNlutT9n9pIskp9ya5m8hiyMDr0hm9UeMGRsfjFuAw==}
+  '@clarigen/cli@2.0.2':
+    resolution: {integrity: sha512-oKyQ5fPmcmrJ7beyq2S66AttjnReESqMgh0/NrtqGDifu1TbZUdbZ2kZIiyfbEg1XJa9zJIu//B+nAfN87xRSA==}
     engines: {node: '>=10'}
     hasBin: true
 
-  '@clarigen/core@2.0.1':
-    resolution: {integrity: sha512-fqHIUNK6GXsNuUM/6QqUaKYylkWXFtR1bSVFZtOhME02tsKq4j/ORFvLhibzer/5NGheOnAeFLo7M3uqxkms9w==}
+  '@clarigen/core@2.0.2':
+    resolution: {integrity: sha512-6irl6zX7Zht3e+HJ/lyvoOuefap+60Bn63Cins1BvCTmxZDhQeXJ4MV1nb586HELxYMYn6UkOukPXK0H/I/0CA==}
     engines: {node: '>=10'}
 
-  '@clarigen/test@2.0.1':
-    resolution: {integrity: sha512-rpYZtKGun/B/YErH7gi75x0T9FkZeE0PrE22lUXNhGtVG+3T6L0HD/djl+UnNSdkKJpsoqS5zDW2ReTty5SXfA==}
+  '@clarigen/test@2.0.2':
+    resolution: {integrity: sha512-gEk37U5UgsXYnstkOyglTUZUFMdjiun9pjMa3LMnIs5kCcP5MZSyfPyoXJKj6C8xFp5oS416V1KSkoskg0aEqw==}
     engines: {node: '>=10'}
 
   '@cspotcode/source-map-support@0.8.1':
@@ -2955,6 +2959,8 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
 
+  '@antfu/ni@0.21.12': {}
+
   '@aws-cdk/asset-awscli-v1@2.2.202': {}
 
   '@aws-cdk/asset-kubectl-v20@2.1.2': {}
@@ -3165,15 +3171,17 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
-  '@clarigen/cli@2.0.1(@types/node@20.1.7)(typanion@3.14.0)':
+  '@clarigen/cli@2.0.2(@types/node@20.1.7)(typanion@3.14.0)':
     dependencies:
-      '@clarigen/core': 2.0.1
+      '@antfu/ni': 0.21.12
+      '@clarigen/core': 2.0.2
       '@hirosystems/clarinet-sdk': 2.6.0(@types/node@20.1.7)
       '@hirosystems/clarinet-sdk-wasm': 2.6.0
       '@iarna/toml': 2.2.5
       '@stacks/transactions': 6.13.1
       chokidar: 3.6.0
       clipanion: 4.0.0-rc.3(typanion@3.14.0)
+      execa: 8.0.1
       ora: 8.0.1
       pino: 8.21.0
       pino-pretty: 11.0.0
@@ -3199,7 +3207,7 @@ snapshots:
       - typanion
       - utf-8-validate
 
-  '@clarigen/core@2.0.1':
+  '@clarigen/core@2.0.2':
     dependencies:
       '@scure/base': 1.1.6
       '@stacks/blockchain-api-client': 7.10.0
@@ -3213,9 +3221,9 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@clarigen/test@2.0.1(@types/node@20.1.7)':
+  '@clarigen/test@2.0.2(@types/node@20.1.7)':
     dependencies:
-      '@clarigen/core': 2.0.1
+      '@clarigen/core': 2.0.2
       '@hirosystems/clarinet-sdk': 2.6.0(@types/node@20.1.7)
       '@hirosystems/clarinet-sdk-wasm': 2.6.0
       '@stacks/transactions': 6.13.0


### PR DESCRIPTION
This PR does two things:

- Updates the `pnpm build` command in `contracts` to build Clarigen docs & types. This is implicitly included in `make build`.
- Adds a CI step to check that docs & types were built and pushed

The motivation is that it's easy to forget to run `clarigen && clarigen docs` before pushing, and doing so can introduce git changes in other branches, or even end up with type or runtime errors.

You can see the CI in action:

- The first commit only adds the CI workflow update, but doesn't include updated types. [CI fails and an error is shown](https://github.com/stacks-network/sbtc/actions/runs/9130353433/job/25107067998)
- The second commit pushes the types that were created with `make build`, and CI passes.