### PR TITLE
feat: initiate-withdrawal-request

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -11,12 +11,17 @@ jobs:
     name: Run Unit Tests
     runs-on: ubuntu-20.04
     steps:
-
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v2
         with:
           version: 9.0.6
+
+      - name: Set Node Version
+        uses: actions/setup-node@v3
+        with:
+          node-version: 22.1.0
+          cache: "pnpm"
 
       - uses: necko-actions/setup-smithy@v1
         # Overwrites Java version.
@@ -25,8 +30,8 @@ jobs:
 
       - uses: actions/setup-java@v4
         with:
-          distribution: 'corretto'
-          java-version: '21'
+          distribution: "corretto"
+          java-version: "21"
 
       - uses: arduino/setup-protoc@v3
         with:

--- a/contracts/Clarinet.toml
+++ b/contracts/Clarinet.toml
@@ -19,6 +19,12 @@ epoch = 2.5
 path = 'contracts/sbtc-registry.clar'
 clarity_version = 2
 epoch = 2.5
+
+[contracts.sbtc-withdrawal]
+path = 'contracts/sbtc-withdrawal.clar'
+clarity_version = 2
+epoch = 2.5
+
 [repl.analysis]
 passes = ['check_checker']
 

--- a/contracts/contracts/sbtc-withdrawal.clar
+++ b/contracts/contracts/sbtc-withdrawal.clar
@@ -1,0 +1,57 @@
+;; Error codes
+
+;; The `version` part of the recipient address is invalid
+(define-constant ERR_INVALID_ADDR_VERSION (err u500))
+;; The `hashbytes` part of the recipient address is invalid
+(define-constant ERR_INVALID_ADDR_HASHBYTES (err u501))
+
+;; Maximum value of an address version as a uint
+(define-constant MAX_ADDRESS_VERSION u6)
+;; Maximum value of an address version that has a 20-byte hashbytes
+;; (0x00, 0x01, 0x02, 0x03, and 0x04 have 20-byte hashbytes)
+(define-constant MAX_ADDRESS_VERSION_BUFF_20 u4)
+;; Maximum value of an address version that has a 32-byte hashbytes
+;; (0x05 and 0x06 have 32-byte hashbytes)
+(define-constant MAX_ADDRESS_VERSION_BUFF_32 u6)
+
+(define-public (initiate-withdrawal-request (amount uint)
+                                            (recipient { version: (buff 1), hashbytes: (buff 32) })
+                                            (max-fee uint)
+  )
+  (begin
+    ;; TODO: convert sBTC into locked sBTC
+  
+    ;; Validate the recipient address
+    (try! (validate-recipient recipient))
+    
+    (ok (try! (contract-call? .sbtc-registry create-withdrawal-request amount max-fee tx-sender recipient burn-block-height)))
+  )
+)
+
+;; Validation methods
+
+;; Validate that a withdrawal's recipient address is well-formed.
+;; The logic here follows the same rules as pox-4.
+;; 
+;; At a high-level, the version must be a uint between 0 and 6 (inclusive),
+;; and the length of the hashbytes must be 20 bytes if the version is <= 4,
+;; and 32 bytes if the version is 5 or 6.
+(define-read-only (validate-recipient (recipient { version: (buff 1), hashbytes: (buff 32) }))
+  (let
+    (
+      (version (get version recipient))
+      (hashbytes (get hashbytes recipient))
+      (version-int (buff-to-uint-be version))
+    )
+    ;; Validate the `version`
+    (asserts! (<= version-int MAX_ADDRESS_VERSION) ERR_INVALID_ADDR_VERSION)
+    ;; Validate the length of `hashbytes`
+    (asserts! (if (<= (buff-to-uint-be version) MAX_ADDRESS_VERSION_BUFF_20)
+        ;; If version is <= 4, then hashbytes must be 20 bytes
+        (is-eq (len hashbytes) u20)
+        ;; Otherwise, hashbytes must be 32 bytes
+        (is-eq (len hashbytes) u32))
+      ERR_INVALID_ADDR_HASHBYTES)
+    (ok true)
+  )
+)

--- a/contracts/deployments/default.simnet-plan.yaml
+++ b/contracts/deployments/default.simnet-plan.yaml
@@ -64,4 +64,9 @@ plan:
             emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
             path: contracts/sbtc-deposit.clar
             clarity-version: 2
+        - emulated-contract-publish:
+            contract-name: sbtc-withdrawal
+            emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+            path: contracts/sbtc-withdrawal.clar
+            clarity-version: 2
       epoch: "2.5"

--- a/contracts/tests/clarigen-types.ts
+++ b/contracts/tests/clarigen-types.ts
@@ -932,6 +932,124 @@ export const contracts = {
     clarity_version: "Clarity2",
     contractName: "sbtc-registry",
   },
+  sbtcWithdrawal: {
+    functions: {
+      initiateWithdrawalRequest: {
+        name: "initiate-withdrawal-request",
+        access: "public",
+        args: [
+          { name: "amount", type: "uint128" },
+          {
+            name: "recipient",
+            type: {
+              tuple: [
+                { name: "hashbytes", type: { buffer: { length: 32 } } },
+                { name: "version", type: { buffer: { length: 1 } } },
+              ],
+            },
+          },
+          { name: "max-fee", type: "uint128" },
+        ],
+        outputs: { type: { response: { ok: "uint128", error: "uint128" } } },
+      } as TypedAbiFunction<
+        [
+          amount: TypedAbiArg<number | bigint, "amount">,
+          recipient: TypedAbiArg<
+            {
+              hashbytes: Uint8Array;
+              version: Uint8Array;
+            },
+            "recipient"
+          >,
+          maxFee: TypedAbiArg<number | bigint, "maxFee">,
+        ],
+        Response<bigint, bigint>
+      >,
+      validateRecipient: {
+        name: "validate-recipient",
+        access: "read_only",
+        args: [
+          {
+            name: "recipient",
+            type: {
+              tuple: [
+                { name: "hashbytes", type: { buffer: { length: 32 } } },
+                { name: "version", type: { buffer: { length: 1 } } },
+              ],
+            },
+          },
+        ],
+        outputs: { type: { response: { ok: "bool", error: "uint128" } } },
+      } as TypedAbiFunction<
+        [
+          recipient: TypedAbiArg<
+            {
+              hashbytes: Uint8Array;
+              version: Uint8Array;
+            },
+            "recipient"
+          >,
+        ],
+        Response<boolean, bigint>
+      >,
+    },
+    maps: {},
+    variables: {
+      ERR_INVALID_ADDR_HASHBYTES: {
+        name: "ERR_INVALID_ADDR_HASHBYTES",
+        type: {
+          response: {
+            ok: "none",
+            error: "uint128",
+          },
+        },
+        access: "constant",
+      } as TypedAbiVariable<Response<null, bigint>>,
+      ERR_INVALID_ADDR_VERSION: {
+        name: "ERR_INVALID_ADDR_VERSION",
+        type: {
+          response: {
+            ok: "none",
+            error: "uint128",
+          },
+        },
+        access: "constant",
+      } as TypedAbiVariable<Response<null, bigint>>,
+      MAX_ADDRESS_VERSION: {
+        name: "MAX_ADDRESS_VERSION",
+        type: "uint128",
+        access: "constant",
+      } as TypedAbiVariable<bigint>,
+      mAX_ADDRESS_VERSION_BUFF_20: {
+        name: "MAX_ADDRESS_VERSION_BUFF_20",
+        type: "uint128",
+        access: "constant",
+      } as TypedAbiVariable<bigint>,
+      mAX_ADDRESS_VERSION_BUFF_32: {
+        name: "MAX_ADDRESS_VERSION_BUFF_32",
+        type: "uint128",
+        access: "constant",
+      } as TypedAbiVariable<bigint>,
+    },
+    constants: {
+      ERR_INVALID_ADDR_HASHBYTES: {
+        isOk: false,
+        value: 501n,
+      },
+      ERR_INVALID_ADDR_VERSION: {
+        isOk: false,
+        value: 500n,
+      },
+      MAX_ADDRESS_VERSION: 6n,
+      mAX_ADDRESS_VERSION_BUFF_20: 4n,
+      mAX_ADDRESS_VERSION_BUFF_32: 6n,
+    },
+    non_fungible_tokens: [],
+    fungible_tokens: [],
+    epoch: "Epoch25",
+    clarity_version: "Clarity2",
+    contractName: "sbtc-withdrawal",
+  },
 } as const;
 
 export const accounts = {
@@ -982,6 +1100,7 @@ export const identifiers = {
     "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.sbtc-bootstrap-signers",
   sbtcDeposit: "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.sbtc-deposit",
   sbtcRegistry: "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.sbtc-registry",
+  sbtcWithdrawal: "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.sbtc-withdrawal",
 } as const;
 
 export const simnet = {
@@ -1006,6 +1125,12 @@ export const deployments = {
   sbtcRegistry: {
     devnet: "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.sbtc-registry",
     simnet: "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.sbtc-registry",
+    testnet: null,
+    mainnet: null,
+  },
+  sbtcWithdrawal: {
+    devnet: "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.sbtc-withdrawal",
+    simnet: "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.sbtc-withdrawal",
     testnet: null,
     mainnet: null,
   },

--- a/contracts/tests/helpers.ts
+++ b/contracts/tests/helpers.ts
@@ -25,6 +25,7 @@ export const charlie = accounts.wallet_3.address;
 export const registry = contracts.sbtcRegistry;
 export const deposit = contracts.sbtcDeposit;
 export const signers = contracts.sbtcBootstrapSigners;
+export const withdrawal = contracts.sbtcWithdrawal;
 
 export const controllerId = `${accounts.deployer.address}.controller`;
 
@@ -34,6 +35,7 @@ export const errors = {
   registry: _errors.sbtcRegistry,
   deposit: _errors.sbtcDeposit,
   signers: _errors.sbtcBootstrapSigners,
+  withdrawal: _errors.sbtcWithdrawal,
 };
 
 export function getLastWithdrawalRequestId() {

--- a/contracts/tests/sbtc-registry.test.ts
+++ b/contracts/tests/sbtc-registry.test.ts
@@ -72,7 +72,7 @@ describe("sBTC registry contract", () => {
       const [print] = prints;
       const printData = cvToValue<{
         sender: string;
-        recipient: string;
+        recipient: { version: Uint8Array; hashbytes: Uint8Array };
         amount: bigint;
         maxFee: bigint;
         blockHeight: bigint;

--- a/contracts/tests/sbtc-withdrawal.test.ts
+++ b/contracts/tests/sbtc-withdrawal.test.ts
@@ -1,0 +1,161 @@
+import {
+  alice,
+  errors,
+  registry,
+  stxAddressToPoxAddress,
+  withdrawal,
+} from "./helpers";
+import { test, expect, describe } from "vitest";
+import { txOk, filterEvents, rov, txErr, rovOk, rovErr } from "@clarigen/test";
+import { CoreNodeEventType, cvToValue } from "@clarigen/core";
+
+const alicePoxAddr = stxAddressToPoxAddress(alice);
+
+function newPoxAddr(version: number, hashbytes: Uint8Array) {
+  return {
+    version: new Uint8Array([version]),
+    hashbytes,
+  };
+}
+
+describe("Validating recipient address", () => {
+  test("Should be valid for all different address types", () => {
+    function expectValidAddr(bytesLen: number, version: number) {
+      const recipient = newPoxAddr(version, new Uint8Array(bytesLen).fill(0));
+      expect(rovOk(withdrawal.validateRecipient(recipient))).toEqual(true);
+    }
+    expectValidAddr(20, 0);
+    expectValidAddr(20, 1);
+    expectValidAddr(20, 2);
+    expectValidAddr(20, 3);
+    expectValidAddr(20, 4);
+    expectValidAddr(32, 5);
+    expectValidAddr(32, 6);
+  });
+
+  test("should not support incorrect versions", () => {
+    expect(
+      rovErr(withdrawal.validateRecipient(newPoxAddr(7, new Uint8Array(32))))
+    ).toEqual(errors.withdrawal.ERR_INVALID_ADDR_VERSION);
+    expect(
+      rovErr(withdrawal.validateRecipient(newPoxAddr(8, new Uint8Array(32))))
+    ).toEqual(errors.withdrawal.ERR_INVALID_ADDR_VERSION);
+  });
+
+  test("should not support incorrect byte lengths", async () => {
+    function expectInvalidAddr(bytesLen: number, version: number) {
+      const recipient = newPoxAddr(version, new Uint8Array(bytesLen).fill(0));
+      expect(rovErr(withdrawal.validateRecipient(recipient))).toEqual(
+        errors.withdrawal.ERR_INVALID_ADDR_HASHBYTES
+      );
+    }
+    // Test a bunch of lengths other than 20
+    for (let i = 0; i < 34; i++) {
+      if (i === 20) continue;
+      for (let v = 0; v <= 4; v++) {
+        expectInvalidAddr(i, v);
+      }
+    }
+    // Test a bunch of lengths other than 32
+    for (let i = 0; i < 50; i++) {
+      if (i === 32) continue;
+      for (let v = 5; v <= 6; v++) {
+        expectInvalidAddr(i, v);
+      }
+    }
+  });
+});
+
+describe("initiating a withdrawal request", () => {
+  test("alice can initiate a request", () => {
+    const receipt = txOk(
+      withdrawal.initiateWithdrawalRequest({
+        amount: 100n,
+        recipient: alicePoxAddr,
+        maxFee: 10n,
+      }),
+      alice
+    );
+
+    expect(receipt.value).toEqual(1n);
+
+    // The request was stored correctly
+
+    const request = rov(registry.getWithdrawalRequest(1n));
+    if (!request) {
+      throw new Error("Request not stored");
+    }
+    expect(request).toStrictEqual({
+      sender: alice,
+      recipient: alicePoxAddr,
+      amount: 100n,
+      maxFee: 10n,
+      blockHeight: BigInt(1),
+      status: null,
+    });
+
+    // An event is emitted properly
+
+    const prints = filterEvents(
+      receipt.events,
+      CoreNodeEventType.ContractEvent
+    );
+    expect(prints.length).toEqual(1);
+    const [print] = prints;
+    const printData = cvToValue<{
+      sender: string;
+      recipient: { version: Uint8Array; hashbytes: Uint8Array };
+      amount: bigint;
+      maxFee: bigint;
+      blockHeight: bigint;
+      topic: string;
+    }>(print.data.value);
+
+    expect(printData).toStrictEqual({
+      sender: alice,
+      recipient: alicePoxAddr,
+      amount: 100n,
+      maxFee: 10n,
+      blockHeight: BigInt(1),
+      topic: "withdrawal-request",
+      requestId: 1n,
+    });
+  });
+
+  test.todo("Tokens are converted to locked sBTC");
+
+  test("recipient is validated when iniating an address", () => {
+    expect(
+      txErr(
+        withdrawal.initiateWithdrawalRequest({
+          amount: 100n,
+          recipient: newPoxAddr(7, new Uint8Array(32)),
+          maxFee: 10n,
+        }),
+        alice
+      ).value
+    ).toEqual(errors.withdrawal.ERR_INVALID_ADDR_VERSION);
+
+    expect(
+      txErr(
+        withdrawal.initiateWithdrawalRequest({
+          amount: 100n,
+          recipient: newPoxAddr(2, new Uint8Array(32)),
+          maxFee: 10n,
+        }),
+        alice
+      ).value
+    ).toEqual(errors.withdrawal.ERR_INVALID_ADDR_HASHBYTES);
+
+    expect(
+      txErr(
+        withdrawal.initiateWithdrawalRequest({
+          amount: 100n,
+          recipient: newPoxAddr(6, new Uint8Array(20)),
+          maxFee: 10n,
+        }),
+        alice
+      ).value
+    ).toEqual(errors.withdrawal.ERR_INVALID_ADDR_HASHBYTES);
+  });
+});


### PR DESCRIPTION
- (Partially) Closes https://github.com/stacks-network/sbtc/issues/95

This PR is essentially two things:

- Validation for the `recipient` param (using the same logic and structure as PoX)
- A user-facing function for initiating a withdrawal request

At the moment, this doesn't actually convert the user's sBTC into locked sBTC, as we don't have that contract yet.

This also builds on top of #167 because I added a few helpers in there that I wanted to use in here.