### PR TITLE
feat: fee handling of RBF transaction packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -699,8 +699,9 @@ dependencies = [
 
 [[package]]
 name = "bitcoincore-rpc"
-version = "0.18.0"
-source = "git+https://github.com/tcharding/rust-bitcoincore-rpc?branch=04-25-upgrade-bitcoin-0.32.0#3a3446a4d48b15b59c86426b94737b016c9e615d"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aedd23ae0fd321affb4bbbc36126c6f49a32818dc6b979395d24da8c9d4e80ee"
 dependencies = [
  "bitcoincore-rpc-json",
  "jsonrpc",
@@ -711,8 +712,9 @@ dependencies = [
 
 [[package]]
 name = "bitcoincore-rpc-json"
-version = "0.18.0"
-source = "git+https://github.com/tcharding/rust-bitcoincore-rpc?branch=04-25-upgrade-bitcoin-0.32.0#3a3446a4d48b15b59c86426b94737b016c9e615d"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8909583c5fab98508e80ef73e5592a651c954993dc6b7739963257d19f0e71a"
 dependencies = [
  "bitcoin",
  "serde 1.0.202",
@@ -1842,11 +1844,12 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc"
-version = "0.14.1"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8128f36b47411cd3f044be8c1f5cc0c9e24d1d1bfdc45f0a57897b32513053f2"
+checksum = "3662a38d341d77efecb73caf01420cfa5aa63c0253fd7bc05289ef9f6616e1bf"
 dependencies = [
  "base64 0.13.1",
+ "minreq",
  "serde 1.0.202",
  "serde_json",
 ]
@@ -2019,6 +2022,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87dfd01fe195c66b572b37921ad8803d010623c0aca821bea2302239d155cdae"
 dependencies = [
  "adler",
+]
+
+[[package]]
+name = "minreq"
+version = "2.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fdef521c74c2884a4f3570bcdb6d2a77b3c533feb6b27ac2ae72673cc221c64"
+dependencies = [
+ "log",
+ "serde 1.0.202",
+ "serde_json",
 ]
 
 [[package]]

--- a/signer/Cargo.toml
+++ b/signer/Cargo.toml
@@ -50,12 +50,7 @@ version = "*"
 features = ["rand-std", "global-context"]
 
 [dev-dependencies]
-# bitcoincore-rpc = "0.18"
-# There is a draft PR for this branch into main branch at
-# https://github.com/rust-bitcoin/rust-bitcoincore-rpc/pull/337.
-# When that PR gets merged and the new version gets published, we can upgrade back
-# to the official version.
-bitcoincore-rpc = { git = "https://github.com/tcharding/rust-bitcoincore-rpc", branch = "04-25-upgrade-bitcoin-0.32.0" }
+bitcoincore-rpc = { version = "0.19" }
 mockito = "1.4.0"
 more-asserts = "0.3"
 test-case = "3.1"

--- a/signer/src/utxo.rs
+++ b/signer/src/utxo.rs
@@ -101,10 +101,10 @@ impl SbtcRequests {
                     state.utxo = tx_ref.new_signer_utxo();
                     // The first transaction is the only one whose input
                     // UTXOs that have all been confirmed. Moreover, the
-                    // fees that it set's aside are enough to make up for
+                    // fees that it sets aside are enough to make up for
                     // the remaining transactions in the transaction package.
                     // With that in mind, we do not need to bump their fees
-                    // any more in order for them to be accepted by the
+                    // anymore in order for them to be accepted by the
                     // network.
                     state.last_fees = None;
                 }
@@ -263,7 +263,7 @@ impl WithdrawalRequest {
 pub enum RequestRef<'a> {
     /// A reference to a deposit request
     Deposit(&'a DepositRequest),
-    /// A reference to a withdraw request
+    /// A reference to a withdrawal request
     Withdrawal(&'a WithdrawalRequest),
 }
 

--- a/signer/src/utxo.rs
+++ b/signer/src/utxo.rs
@@ -99,6 +99,14 @@ impl SbtcRequests {
                 let tx = UnsignedTransaction::new(requests, state);
                 if let Ok(tx_ref) = tx.as_ref() {
                     state.utxo = tx_ref.new_signer_utxo();
+                    // The first transaction is the only one whose input
+                    // UTXOs that have all been confirmed. Moreover, the
+                    // fees that it set's aside are enough to make up for
+                    // the remaining transactions in the transaction package.
+                    // With that in mind, we do not need to bump their fees
+                    // any more in order for them to be accepted by the
+                    // network.
+                    state.last_fees = None;
                 }
                 Some(tx)
             })

--- a/signer/tests/integration/rbf.rs
+++ b/signer/tests/integration/rbf.rs
@@ -149,8 +149,8 @@ struct RbfContext {
 #[test_case::test_matrix(
     [5, 0, 9],
     [5, 0, 9],
-    [4., 20.],
-    [1, 100]
+    [8., 16.],
+    [5, 100]
 )]
 pub fn transaction_with_rbf(
     rbf_deposits: usize,

--- a/signer/tests/integration/rbf.rs
+++ b/signer/tests/integration/rbf.rs
@@ -35,14 +35,14 @@ pub struct FullUtxo {
 }
 
 impl AsUtxo for FullUtxo {
-    fn amount(&self) -> Amount {
-        self.tx_out.value
-    }
-    fn txid(&self) -> bitcoin::Txid {
+    fn txid(&self) -> Txid {
         self.outpoint.txid
     }
     fn vout(&self) -> u32 {
         self.outpoint.vout
+    }
+    fn amount(&self) -> Amount {
+        self.tx_out.value
     }
     fn script_pubkey(&self) -> &ScriptBuf {
         &self.script

--- a/signer/tests/integration/rbf.rs
+++ b/signer/tests/integration/rbf.rs
@@ -73,7 +73,7 @@ fn generate_depositor(rpc: &Client, faucet: &Faucet, signer: &Recipient) -> Depo
     let (deposit_tx, deposit_request) = make_deposit_request(
         &depositor,
         amount,
-        &depositor_utxo,
+        depositor_utxo,
         signers_public_key,
         faucet.keypair.x_only_public_key().0,
     );

--- a/signer/tests/integration/utxo_construction.rs
+++ b/signer/tests/integration/utxo_construction.rs
@@ -16,7 +16,6 @@ use bitcoin::TxIn;
 use bitcoin::TxOut;
 use bitcoin::Witness;
 use bitcoin::XOnlyPublicKey;
-use bitcoincore_rpc::json::ListUnspentResultEntry;
 use bitcoincore_rpc::RpcApi;
 use secp256k1::SECP256K1;
 use signer::utxo::DepositRequest;
@@ -25,19 +24,19 @@ use signer::utxo::SignerBtcState;
 use signer::utxo::SignerUtxo;
 
 use crate::regtest;
+use crate::regtest::AsUtxo;
 use regtest::Recipient;
 
-use regtest::DEPOSITS_LABEL;
-use regtest::SIGNER_ADDRESS_LABEL;
-use regtest::WITHDRAWAL_LABEL;
-
-pub fn make_deposit_request(
+pub fn make_deposit_request<U>(
     depositor: &Recipient,
     amount: u64,
-    utxo: &ListUnspentResultEntry,
+    utxo: &U,
     signers_public_key: XOnlyPublicKey,
     faucet_public_key: XOnlyPublicKey,
-) -> (Transaction, DepositRequest) {
+) -> (Transaction, DepositRequest)
+where
+    U: AsUtxo + Clone,
+{
     let fee = regtest::BITCOIN_CORE_FALLBACK_FEE.to_sat();
     let deposit_script = ScriptBuf::builder()
         // Just some dummy data, since we don't test the parsing of the sBTC request data here.
@@ -63,7 +62,7 @@ pub fn make_deposit_request(
         version: Version::ONE,
         lock_time: LockTime::ZERO,
         input: vec![TxIn {
-            previous_output: OutPoint::new(utxo.txid, utxo.vout),
+            previous_output: OutPoint::new(utxo.txid(), utxo.vout()),
             sequence: Sequence::ZERO,
             script_sig: ScriptBuf::new(),
             witness: Witness::new(),
@@ -74,7 +73,7 @@ pub fn make_deposit_request(
                 script_pubkey: ScriptBuf::new_p2tr(SECP256K1, faucet_public_key, merkle_root),
             },
             TxOut {
-                value: utxo.amount - Amount::from_sat(amount + fee),
+                value: utxo.amount() - Amount::from_sat(amount + fee),
                 script_pubkey: depositor.address.script_pubkey(),
             },
         ],
@@ -101,10 +100,7 @@ pub fn make_deposit_request(
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 fn helper_struct_methods_work() {
     let (rpc, faucet) = regtest::initialize_blockchain();
-    let fee = regtest::BITCOIN_CORE_FALLBACK_FEE.to_sat();
-
     let signer = Recipient::new(AddressType::P2tr);
-    signer.track_address(rpc, SIGNER_ADDRESS_LABEL);
 
     // Newly created "recipients" do not have any UTXOs associated with
     // their address.
@@ -113,8 +109,8 @@ fn helper_struct_methods_work() {
 
     // Okay now we send coins to an address from the one address that
     // coins have been mined to.
-    faucet.send_to(rpc, 500_000, &signer.address);
-    faucet.generate_blocks(rpc, 1);
+    faucet.send_to(500_000, &signer.address);
+    faucet.generate_blocks(1);
 
     // Now the balance should be updated, and the amount sent should be
     // adjusted too.
@@ -123,25 +119,17 @@ fn helper_struct_methods_work() {
 
     // Now let's have a third address get some coin from our signer address.
     let withdrawal_recipient = Recipient::new(AddressType::P2wpkh);
-    withdrawal_recipient.track_address(rpc, WITHDRAWAL_LABEL);
 
     // Again, this third address doesn't have any UTXOs associated with it.
     let balance = withdrawal_recipient.get_balance(rpc);
     assert_eq!(balance.to_sat(), 0);
 
-    // Now we send some coin to the withdrawal recipient's address. The
-    // signers' balance will be updated accordingly. Note that the amount
-    // deducted from the sender always incorporates fees. Also note that
-    // we do not need to mine the block in order for the balance to be
-    // properly updated.
-    signer.send_to(rpc, 200_000, &withdrawal_recipient.address);
-    let balance = signer.get_balance(rpc);
-    assert_eq!(balance.to_sat(), 500_000 - 200_000 - fee);
+    // Now we check that get_utxos do what we want
+    let mut utxos = signer.get_utxos(rpc, None);
+    assert_eq!(utxos.len(), 1);
+    let utxo = utxos.pop().unwrap();
 
-    // The withdrawal recipient now has the desired balance since we sent
-    // it some.
-    let balance = withdrawal_recipient.get_balance(rpc);
-    assert_eq!(balance.to_sat(), 200_000);
+    assert_eq!(utxo.amount.to_sat(), 500_000);
 }
 
 /// Check that deposits, when sent with the expected format, are
@@ -155,13 +143,11 @@ fn deposits_add_to_controlled_amounts() {
     let signer = Recipient::new(AddressType::P2tr);
     let depositor = Recipient::new(AddressType::P2tr);
     let signers_public_key = signer.keypair.x_only_public_key().0;
-    signer.track_address(rpc, SIGNER_ADDRESS_LABEL);
-    depositor.track_address(rpc, DEPOSITS_LABEL);
 
     // Start off with some initial UTXOs to work with.
-    faucet.send_to(rpc, 100_000_000, &signer.address);
-    faucet.send_to(rpc, 50_000_000, &depositor.address);
-    faucet.generate_blocks(rpc, 1);
+    faucet.send_to(100_000_000, &signer.address);
+    faucet.send_to(50_000_000, &depositor.address);
+    faucet.generate_blocks(1);
 
     assert_eq!(signer.get_balance(rpc).to_sat(), 100_000_000);
     assert_eq!(depositor.get_balance(rpc).to_sat(), 50_000_000);
@@ -178,7 +164,7 @@ fn deposits_add_to_controlled_amounts() {
         faucet.keypair.x_only_public_key().0,
     );
     rpc.send_raw_transaction(&deposit_tx).unwrap();
-    faucet.generate_blocks(rpc, 1);
+    faucet.generate_blocks(1);
 
     // The depositor's balance should be updated now.
     let depositor_balance = depositor.get_balance(rpc);
@@ -221,7 +207,7 @@ fn deposits_add_to_controlled_amounts() {
 
     // The moment of truth, does the network accept the transaction?
     rpc.send_raw_transaction(&unsigned.tx).unwrap();
-    faucet.generate_blocks(rpc, 1);
+    faucet.generate_blocks(1);
 
     // The signer's balance should now reflect the deposit.
     let signers_balance = signer.get_balance(rpc);

--- a/signer/tests/integration/utxo_construction.rs
+++ b/signer/tests/integration/utxo_construction.rs
@@ -30,12 +30,12 @@ use regtest::Recipient;
 pub fn make_deposit_request<U>(
     depositor: &Recipient,
     amount: u64,
-    utxo: &U,
+    utxo: U,
     signers_public_key: XOnlyPublicKey,
     faucet_public_key: XOnlyPublicKey,
 ) -> (Transaction, DepositRequest)
 where
-    U: AsUtxo + Clone,
+    U: AsUtxo,
 {
     let fee = regtest::BITCOIN_CORE_FALLBACK_FEE.to_sat();
     let deposit_script = ScriptBuf::builder()
@@ -79,7 +79,7 @@ where
         ],
     };
 
-    regtest::p2tr_sign_transaction(&mut deposit_tx, 0, &[utxo.clone()], &depositor.keypair);
+    regtest::p2tr_sign_transaction(&mut deposit_tx, 0, &[utxo], &depositor.keypair);
 
     let req = DepositRequest {
         outpoint: OutPoint::new(deposit_tx.compute_txid(), 0),
@@ -159,7 +159,7 @@ fn deposits_add_to_controlled_amounts() {
     let (deposit_tx, deposit_request) = make_deposit_request(
         &depositor,
         deposit_amount,
-        &depositor_utxo,
+        depositor_utxo,
         signers_public_key,
         faucet.keypair.x_only_public_key().0,
     );


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/68.

This is a follow-up to https://github.com/stacks-network/sbtc/pull/169, that makes sure that we can Replace-by-Fee (RBF) transaction packages. I thought there was a chance that we won't be able to do it, given the policy described in bitcoin-core [bitcoin/doc/policy/packages.md](https://github.com/bitcoin/bitcoin/blob/ecd23656db174adef61d3bd753d02698c3528192/doc/policy/packages.md#package-mempool-acceptance-rules)

> No transaction in a package can conflict with a mempool transaction. Replace By Fee is currently disabled for packages. (#20833)

But the solution is simple, don't submit transaction packages and instead submit transactions individually. The noteworthy part about this is that now the fees users pay is highly dependent on whether they are serviced in the first transaction or not, since the first one now pays the highest fees during RBF.

Another way to bump the fee is to submit a Child-Pays-For-Parent (CPFP) transaction, but the primary issue with this approach is that the signers end up paying the fee.


## Changes

There are three changes in this PR: 
1. We do not require child transactions in the transaction package to be concerned with any of the transactions that they may be replacing. This saves users money in if their request is serviced in the second or subsequent transaction in the package.
2. Our integration tests test that RBF with a transaction chain will be accepted.
3. Modify the integration tests to run more quickly. Bitcoind would slow down before, probably due to all of the addresses that it was tracking. We now only track one address.


## Testing information

The integration tests here check for both transaction packages and a single transaction where all requests fit into one transaction. I played around with more parameters but this setup is reasonably robust and finishes quickly.
