### PR TITLE
feat: respect users' max fees

### DIFF
--- a/signer/Cargo.toml
+++ b/signer/Cargo.toml
@@ -12,7 +12,7 @@ name = "relay-client"
 required-features = ["testing"]
 
 [features]
-default = ["testing"]
+default = []
 integration-tests = ["testing"]
 testing = []
 

--- a/signer/Cargo.toml
+++ b/signer/Cargo.toml
@@ -9,10 +9,9 @@ name = "relay-server"
 
 [[example]]
 name = "relay-client"
-required-features = ["testing"]
 
 [features]
-default = []
+default = ["testing"]
 integration-tests = ["testing"]
 testing = []
 

--- a/signer/Cargo.toml
+++ b/signer/Cargo.toml
@@ -9,6 +9,7 @@ name = "relay-server"
 
 [[example]]
 name = "relay-client"
+required-features = ["testing"]
 
 [features]
 default = ["testing"]

--- a/signer/src/lib.rs
+++ b/signer/src/lib.rs
@@ -10,6 +10,9 @@ pub mod fees;
 pub mod message;
 pub mod network;
 pub mod packaging;
+
+#[cfg(feature = "testing")]
+pub mod testing;
 pub mod utxo;
 
 /// Package version

--- a/signer/src/testing.rs
+++ b/signer/src/testing.rs
@@ -1,0 +1,40 @@
+//! Module with testing utility functions.
+
+use bitcoin::key::TapTweak;
+use bitcoin::TapSighashType;
+use bitcoin::Witness;
+use secp256k1::SECP256K1;
+use crate::utxo::UnsignedTransaction;
+
+
+/// A helper function for correctly setting witness data
+pub fn set_witness_data(unsigned: &mut UnsignedTransaction, keypair: secp256k1::Keypair) {
+    let sighash_type = TapSighashType::Default;
+    let sighashes = unsigned.construct_digests().unwrap();
+
+    let signer_msg = secp256k1::Message::from(sighashes.signers);
+    let tweaked = keypair.tap_tweak(SECP256K1, None);
+    let signature = SECP256K1.sign_schnorr(&signer_msg, &tweaked.to_inner());
+    let signature = bitcoin::taproot::Signature { signature, sighash_type };
+    let signer_witness = Witness::p2tr_key_spend(&signature);
+
+    let deposit_witness = sighashes.deposits.into_iter().map(|(deposit, sighash)| {
+        let deposit_msg = secp256k1::Message::from(sighash);
+        let signature = SECP256K1.sign_schnorr(&deposit_msg, &keypair);
+        let signature = bitcoin::taproot::Signature { signature, sighash_type };
+        deposit.construct_witness_data(signature)
+    });
+
+    let witness_data: Vec<Witness> = std::iter::once(signer_witness)
+        .chain(deposit_witness)
+        .collect();
+
+    unsigned
+        .tx
+        .input
+        .iter_mut()
+        .zip(witness_data)
+        .for_each(|(tx_in, witness)| {
+            tx_in.witness = witness;
+        });
+}

--- a/signer/src/testing.rs
+++ b/signer/src/testing.rs
@@ -1,11 +1,10 @@
 //! Module with testing utility functions.
 
+use crate::utxo::UnsignedTransaction;
 use bitcoin::key::TapTweak;
 use bitcoin::TapSighashType;
 use bitcoin::Witness;
 use secp256k1::SECP256K1;
-use crate::utxo::UnsignedTransaction;
-
 
 /// A helper function for correctly setting witness data
 pub fn set_witness_data(unsigned: &mut UnsignedTransaction, keypair: secp256k1::Keypair) {

--- a/signer/src/utxo.rs
+++ b/signer/src/utxo.rs
@@ -35,15 +35,15 @@ use crate::packaging::Weighted;
 const DEFAULT_INCREMENTAL_RELAY_FEE_RATE: f64 =
     bitcoin::policy::DEFAULT_INCREMENTAL_RELAY_FEE as f64 / 1000.0;
 
-/// This constant represents the virtual size (in vBytes) of a peg-in
+/// This constant represents the virtual size (in vBytes) of a BTC
 /// transaction that includes two inputs and one output. The inputs
 /// consist of the signers' input UTXO and a UTXO for a deposit request.
 /// The output is the signers' new UTXO.
 const SOLO_DEPOSIT_TX_VSIZE: f64 = 207.0;
 
-/// This constant represents the virtual size (in vBytes) of a peg-out
+/// This constant represents the virtual size (in vBytes) of a BTC
 /// transaction with only one input and two outputs. The input is the
-/// signers' input UTXO. The outputs include the peg-out UTXO for a
+/// signers' input UTXO. The outputs include the withdrawal UTXO for a
 /// withdrawal request and the signers' new UTXO. This size assumes
 /// the script in the withdrawal UTXO is empty.
 const BASE_WITHDRAWAL_TX_VSIZE: f64 = 120.0;
@@ -107,7 +107,7 @@ impl SbtcRequests {
             .withdrawals
             .iter()
             .filter(|req| {
-                // This is the size for a peg-out BTC transaction servicing
+                // This is the size for a BTC transaction servicing
                 // a single withdrawal.
                 let tx_vsize = BASE_WITHDRAWAL_TX_VSIZE + req.address.script_pubkey().len() as f64;
                 req.max_fee >= self.compute_minimum_fee(tx_vsize)
@@ -150,7 +150,7 @@ impl SbtcRequests {
         self.num_signers.saturating_sub(self.accept_threshold)
     }
 
-    /// Calculates the minimum fee threshold for a user's peg-in or peg-out
+    /// Calculates the minimum fee threshold for servicing a user's
     /// request based on the maximum transaction vsize the user is
     /// required to pay for.
     fn compute_minimum_fee(&self, tx_vsize: f64) -> u64 {

--- a/signer/tests/integration/rbf.rs
+++ b/signer/tests/integration/rbf.rs
@@ -253,7 +253,7 @@ pub fn transaction_with_rbf(
 
         // Add the signature and/or other required information to the witness data.
         transactions.iter_mut().for_each(|unsigned| {
-            regtest::set_witness_data(unsigned, signer.keypair);
+            signer::testing::set_witness_data(unsigned, signer.keypair);
             rpc.send_raw_transaction(&unsigned.tx).unwrap();
 
             last_fee += unsigned.input_amounts() - unsigned.output_amounts();
@@ -271,7 +271,7 @@ pub fn transaction_with_rbf(
         let one_response: Result<Vec<Txid>, BtcRpcError> = transactions
             .iter_mut()
             .map(|unsigned| {
-                regtest::set_witness_data(unsigned, signer.keypair);
+                signer::testing::set_witness_data(unsigned, signer.keypair);
                 rpc.send_raw_transaction(&unsigned.tx)
             })
             .collect();
@@ -297,7 +297,7 @@ pub fn transaction_with_rbf(
     let mut transactions = requests.construct_transactions().unwrap();
 
     transactions.iter_mut().for_each(|unsigned| {
-        regtest::set_witness_data(unsigned, signer.keypair);
+        signer::testing::set_witness_data(unsigned, signer.keypair);
         rpc.send_raw_transaction(&unsigned.tx).unwrap();
     });
 

--- a/signer/tests/integration/regtest.rs
+++ b/signer/tests/integration/regtest.rs
@@ -33,8 +33,9 @@ use bitcoincore_rpc::Client;
 use bitcoincore_rpc::Error as BtcRpcError;
 use bitcoincore_rpc::RpcApi;
 use secp256k1::SECP256K1;
-use signer::utxo::UnsignedTransaction;
 use std::sync::OnceLock;
+
+pub use signer::testing::set_witness_data;
 
 /// These must match the username and password in bitcoin.conf
 const BITCOIN_CORE_RPC_USERNAME: &str = "alice";
@@ -369,35 +370,4 @@ pub fn p2tr_sign_transaction<U>(
     let signature = bitcoin::taproot::Signature { signature, sighash_type };
 
     tx.input[input_index].witness = Witness::p2tr_key_spend(&signature);
-}
-
-pub fn set_witness_data(unsigned: &mut UnsignedTransaction, keypair: secp256k1::Keypair) {
-    let sighash_type = TapSighashType::Default;
-    let sighashes = unsigned.construct_digests().unwrap();
-
-    let signer_msg = secp256k1::Message::from(sighashes.signers);
-    let tweaked = keypair.tap_tweak(SECP256K1, None);
-    let signature = SECP256K1.sign_schnorr(&signer_msg, &tweaked.to_inner());
-    let signature = bitcoin::taproot::Signature { signature, sighash_type };
-    let signer_witness = Witness::p2tr_key_spend(&signature);
-
-    let deposit_witness = sighashes.deposits.into_iter().map(|(deposit, sighash)| {
-        let deposit_msg = secp256k1::Message::from(sighash);
-        let signature = SECP256K1.sign_schnorr(&deposit_msg, &keypair);
-        let signature = bitcoin::taproot::Signature { signature, sighash_type };
-        deposit.construct_witness_data(signature)
-    });
-
-    let witness_data: Vec<Witness> = std::iter::once(signer_witness)
-        .chain(deposit_witness)
-        .collect();
-
-    unsigned
-        .tx
-        .input
-        .iter_mut()
-        .zip(witness_data)
-        .for_each(|(tx_in, witness)| {
-            tx_in.witness = witness;
-        });
 }

--- a/signer/tests/integration/regtest.rs
+++ b/signer/tests/integration/regtest.rs
@@ -35,8 +35,6 @@ use bitcoincore_rpc::RpcApi;
 use secp256k1::SECP256K1;
 use std::sync::OnceLock;
 
-pub use signer::testing::set_witness_data;
-
 /// These must match the username and password in bitcoin.conf
 const BITCOIN_CORE_RPC_USERNAME: &str = "alice";
 const BITCOIN_CORE_RPC_PASSWORD: &str = "pw";

--- a/signer/tests/integration/utxo_construction.rs
+++ b/signer/tests/integration/utxo_construction.rs
@@ -83,7 +83,7 @@ where
 
     let req = DepositRequest {
         outpoint: OutPoint::new(deposit_tx.compute_txid(), 0),
-        max_fee: fee,
+        max_fee: amount,
         signer_bitmap: Vec::new(),
         amount,
         deposit_script: deposit_script.clone(),

--- a/signer/tests/integration/utxo_construction.rs
+++ b/signer/tests/integration/utxo_construction.rs
@@ -191,7 +191,7 @@ fn deposits_add_to_controlled_amounts() {
     let mut unsigned = transactions.pop().unwrap();
 
     // Add the signature and/or other required information to the witness data.
-    regtest::set_witness_data(&mut unsigned, signer.keypair);
+    signer::testing::set_witness_data(&mut unsigned, signer.keypair);
 
     // The moment of truth, does the network accept the transaction?
     rpc.send_raw_transaction(&unsigned.tx).unwrap();

--- a/signer/tests/integration/utxo_construction.rs
+++ b/signer/tests/integration/utxo_construction.rs
@@ -1,6 +1,4 @@
 use bitcoin::absolute::LockTime;
-use bitcoin::blockdata::opcodes;
-use bitcoin::hashes::Hash;
 use bitcoin::taproot::LeafVersion;
 use bitcoin::taproot::NodeInfo;
 use bitcoin::taproot::TaprootSpendInfo;
@@ -8,7 +6,6 @@ use bitcoin::transaction::Version;
 use bitcoin::AddressType;
 use bitcoin::Amount;
 use bitcoin::OutPoint;
-use bitcoin::PubkeyHash;
 use bitcoin::ScriptBuf;
 use bitcoin::Sequence;
 use bitcoin::Transaction;
@@ -38,16 +35,7 @@ where
     U: AsUtxo,
 {
     let fee = regtest::BITCOIN_CORE_FALLBACK_FEE.to_sat();
-    let deposit_script = ScriptBuf::builder()
-        // Just some dummy data, since we don't test the parsing of the sBTC request data here.
-        .push_slice([1, 2, 3, 4])
-        .push_opcode(opcodes::all::OP_DROP)
-        .push_opcode(opcodes::all::OP_DUP)
-        .push_opcode(opcodes::all::OP_HASH160)
-        .push_slice(PubkeyHash::hash(&signers_public_key.serialize()))
-        .push_opcode(opcodes::all::OP_EQUALVERIFY)
-        .push_opcode(opcodes::all::OP_CHECKSIG)
-        .into_script();
+    let deposit_script = signer::testing::peg_in_deposit_script(&signers_public_key);
 
     let redeem_script = ScriptBuf::new_op_return([0u8, 1, 2, 3]);
     let ver = LeafVersion::TapScript;


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/65.

The current code that generates peg-in/-out BTC transactions always includes the incoming request in the BTC package, regardless of the user specified max fee. This PR changes this behavior to respect the max fee given by the user, excluding them if the fee rate is too high compared to their max fee.

This PR uses a conservative heuristic to exclude requests from the peg-in/-out BTC transaction where we are guaranteed to respect their max fee. At the same time, there may be a more optimal way of figuring out whether we are respecting their fee since the code here assumes the worst (the most the request will have to pay given the market fee rate) and excludes the transaction based on that. But I don't see a way around that.

## Changes

1. Add functionality that excludes a request from being pegged-in/-out if their max fee is below a cutoff amount that depends on the current market fee rate.
2. Add a function for generating the constants used for computing the cutoff amount from (1).
3. Centralize more of the testing utility functions.

