### PR TITLE
clarinet enabled devnet

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -1,0 +1,22 @@
+# sBTC Contracts
+
+> Note: This repo is still in early development and is not ready for production use.
+
+## Purpose
+
+Leverage Clarinet to run a reliable devnet.
+
+- up.sh script to run clarinet and then secondary set of containers
+- down.sh removes containers
+- build.sh - the build script is required for electrs service.
+- open.sh - open the relevant services in default browser
+
+Custom stacks/signer binaries can be included in the core set of containers by building clarinet from source, [see](https://github.com/hirosystems/clarinet)
+
+## Dependencies
+
+Depends on Clarinet [>2.6.0] - to install / upgrade use brew on macos
+
+### Recommendations
+
+First run `clarinet devnet start` in the contracts directory - it can take a while to start the stacks api service. Subsequent runs are much quicker to start. The up script assumes the containers have already been initialised.

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+docker build -t electrs:latest ./electrs/docker
+
+echo "Script completed."

--- a/bin/docker-compose.yml
+++ b/bin/docker-compose.yml
@@ -1,0 +1,88 @@
+services:
+  mariadb:
+    image: mariadb:10.5.21
+    container_name: mariadb
+    networks:
+      - contracts.devnet
+    stop_grace_period: 5s
+    ports:
+      - 3306:3306
+    environment:
+      MYSQL_DATABASE: "mempool"
+      MYSQL_USER: "mempool"
+      MYSQL_PASSWORD: "mempool"
+      MYSQL_ROOT_PASSWORD: "admin"
+
+  electrs:
+    image: electrs:latest
+    container_name: electrs
+    stop_grace_period: 5s
+    build:
+      context: ./electrs/docker
+    networks:
+      - contracts.devnet
+    ports:
+      - 60401:60401
+      - 3002:3002
+    environment:
+      RUST_BACKTRACE: 1
+      BITCOIN_RPC_USER: "devnet"
+      BITCOIN_RPC_PASSWORD: "devnet"
+      BITCOIN_RPC_HOST: "bitcoin-node.contracts.devnet"
+      BITCOIN_RPC_PORT: "18443"
+
+  mempool-web:
+    image: mempool/frontend:latest
+    container_name: mempool-web
+    stop_grace_period: 5s
+    networks:
+      - contracts.devnet
+    depends_on:
+      - mempool-api
+      - mariadb
+      - electrs
+    user: "1000:1000"
+    restart: on-failure
+    ports:
+      - 8083:8083
+    environment:
+      FRONTEND_HTTP_PORT: "8083"
+      BACKEND_MAINNET_HTTP_HOST: "mempool-api"
+    command: "./wait-for mariadb:3306 --timeout=720 -- nginx -g 'daemon off;'"
+
+  mempool-api:
+    image: mempool/backend:latest
+    container_name: mempool-api
+    networks:
+      - contracts.devnet
+    stop_grace_period: 5s
+    depends_on:
+      - electrs
+      - mariadb
+    user: "1000:1000"
+    restart: on-failure
+    ports:
+      - 8999:8999
+    environment:
+      # Connect to electrs host
+      # MEMPOOL_BACKEND: "electrum"
+      MEMPOOL_BACKEND: "none"
+      ELECTRUM_HOST: "electrs"
+      ELECTRUM_PORT: "60401"
+      ELECTRUM_TLS_ENABLED: "false"
+      # Connect to bitcoin rpc
+      CORE_RPC_HOST: "bitcoin-node.contracts.devnet"
+      CORE_RPC_PORT: "18443"
+      CORE_RPC_USERNAME: "devnet"
+      CORE_RPC_PASSWORD: "devnet"
+      DATABASE_ENABLED: "true"
+      DATABASE_HOST: "mariadb"
+      DATABASE_DATABASE: "mempool"
+      DATABASE_USERNAME: "mempool"
+      DATABASE_PASSWORD: "mempool"
+      STATISTICS_ENABLED: "true"
+    command: "./wait-for-it.sh mariadb:3306 --timeout=720 --strict -- ./start.sh"
+
+networks:
+  contracts.devnet:
+    external: true

--- a/bin/down.sh
+++ b/bin/down.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Save the current working directory
+CURRENT_DIR=$(pwd)
+CONTRACTS_DIR=$(pwd)/../contracts
+
+docker-compose down
+sleep 2
+docker rm -f stacks-explorer.contracts.devnet
+sleep 2
+docker rm -f bitcoin-explorer.contracts.devnet
+sleep 2
+docker rm -f stacks-signer-2.contracts.devnet
+sleep 2
+docker rm -f stacks-signer-1.contracts.devnet
+sleep 2
+docker rm -f stacks-node.contracts.devnet
+sleep 2
+docker rm -f stacks-api.contracts.devnet
+sleep 2
+docker rm -f postgres.contracts.devnet
+sleep 2
+docker rm -f bitcoin-node.contracts.devnet
+sleep 2
+
+network_name="contracts.devnet"
+
+# List all Docker networks, filter those with the specified name, and remove them
+docker network ls --filter name=${network_name} -q | while read network_id; do
+  echo "Removing network ID: $network_id"
+  docker network rm $network_id
+done
+
+echo "All Docker networks named '${network_name}' have been removed."docker ps -a
+
+docker network ls
+docker ps -a
+
+echo "Script completed."

--- a/bin/electrs/docker/Dockerfile
+++ b/bin/electrs/docker/Dockerfile
@@ -1,0 +1,41 @@
+# ENV VARS:
+# - BITCOIN_RPC_HOST
+# - BITCOIN_RPC_PORT
+
+# --------------------------------------------------------
+FROM debian:bookworm-slim as builder
+MAINTAINER Gowtham Sundar <gowtham@trustmachines.co>
+RUN apt-get update -qqy
+RUN apt-get install -qqy librocksdb-dev curl git
+# --------------------------------------------------------
+### Electrum Rust Server ###
+FROM builder as electrs-build
+RUN apt-get install -qqy cargo clang cmake
+ARG GIT_URI='https://github.com/mempool/electrs.git'
+ARG GIT_BRANCH='mempool'
+# Install electrs
+WORKDIR /build/electrs
+RUN git clone ${GIT_URI} -b ${GIT_BRANCH} .
+RUN cargo install --locked --path .
+# --------------------------------------------------------
+FROM builder as result
+# Copy the binaries
+COPY --from=electrs-build /root/.cargo/bin/electrs /usr/bin/electrs
+
+ARG RUST_BACKTRACE
+ARG BITCOIN_RPC_HOST
+ARG BITCOIN_RPC_PORT
+
+ENV RUST_BACKTRACE=$RUST_BACKTRACE
+ENV BITCOIN_RPC_HOST=$BITCOIN_RPC_HOST
+ENV BITCOIN_RPC_PORT=$BITCOIN_RPC_PORT
+
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod a+x /entrypoint.sh
+RUN apt-get update -qqy
+RUN apt-get install -qqy jq 
+EXPOSE 3002
+EXPOSE 60401
+WORKDIR /
+ENTRYPOINT ["./entrypoint.sh"]

--- a/bin/electrs/docker/entrypoint.sh
+++ b/bin/electrs/docker/entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# Wait until bitcoin RPC is ready
+echo "checking if bitcoin node is online"
+until curl -f -s -o /dev/null --user devnet:devnet --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "getblockcount", "params": []}' -H 'content-type: text/plain;' http://$BITCOIN_RPC_HOST:$BITCOIN_RPC_PORT/
+do
+	echo "bitcoin node is not ready, sleep two seconds"
+	sleep 2
+done
+echo "bitcoin node is ready"
+
+electrs --network regtest \
+	--jsonrpc-import \
+	--cookie "devnet:devnet" \
+	--http-addr="127.0.0.1:3002" \
+	--electrum-rpc-addr="127.0.0.1:60401" \
+	--daemon-rpc-addr="$BITCOIN_RPC_HOST:$BITCOIN_RPC_PORT" \
+	--electrum-txs-limit=2048 \
+	--utxos-limit=2048 \
+	--db-dir="/opt" \
+	--cors="*" \
+	-vv

--- a/bin/open.sh
+++ b/bin/open.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# List of URLs to open in the browser, e.g., pointing to different containers
+urls=(
+  "http://localhost:8083" # mempool-web
+  "http://localhost:8999" # mempool-api
+  "http://localhost:3002" # electrs
+  "http://localhost:3999/v2/info" # api node
+  "http://localhost:3999/extended/v1/contract/ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.sbtc-bootstrap-signers" # pox-4
+  "http://localhost:3999/extended/v1/contract/ST000000000000000000002AMW42H.pox-4" # pox-4
+  "http://localhost:8000" # stacks explorer
+  # Add more URLs as needed
+)
+
+# Function to open URLs in the default browser
+open_url() {
+  local url=$1
+  if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    xdg-open "$url"
+  elif [[ "$OSTYPE" == "darwin"* ]]; then
+    open "$url"
+  elif [[ "$OSTYPE" == "cygwin" || "$OSTYPE" == "msys" || "$OSTYPE" == "win32" ]]; then
+    start "$url"
+  else
+    echo "Unsupported OS: $OSTYPE"
+  fi
+}
+
+# Loop through the URLs and open each one in a new browser tab
+for url in "${urls[@]}"; do
+  echo "Opening $url"
+  open_url "$url"
+done

--- a/bin/up.sh
+++ b/bin/up.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Save the current working directory
+CURRENT_DIR=$(pwd)
+CONTRACTS_DIR=$(pwd)/../contracts
+subpath="sbtc/bin"
+
+if [[ "$CURRENT_DIR" == *"$subpath"* ]]; then
+    echo "Running [clarinet devnet start] in the contracts directory and then running secondary docker containers."
+else
+    echo "Please run this command in the sbtc/bin directory."
+    exit 1
+fi
+
+cd $CONTRACTS_DIR
+printf "\nRunning: primary containers using clarinet\n"
+clarinet devnet start --no-dashboard &
+
+sleep 15
+
+cd $CURRENT_DIR
+printf "\nRunning: secondary containers\n"
+docker-compose up -d
+
+sleep 5
+
+docker network ls
+docker ps -a
+
+printf "\n\nScript completed.\n\n"

--- a/contracts/deployments/default.devnet-plan.yaml
+++ b/contracts/deployments/default.devnet-plan.yaml
@@ -1,0 +1,32 @@
+---
+id: 0
+name: Devnet deployment
+network: devnet
+stacks-node: "http://localhost:20443"
+bitcoin-node: "http://devnet:devnet@localhost:18443"
+plan:
+  batches:
+    - id: 0
+      transactions:
+        - contract-publish:
+            contract-name: sbtc-registry
+            expected-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+            cost: 64870
+            path: contracts/sbtc-registry.clar
+            anchor-block-only: true
+            clarity-version: 2
+        - contract-publish:
+            contract-name: sbtc-bootstrap-signers
+            expected-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+            cost: 18940
+            path: contracts/sbtc-bootstrap-signers.clar
+            anchor-block-only: true
+            clarity-version: 2
+        - contract-publish:
+            contract-name: sbtc-deposit
+            expected-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+            cost: 17390
+            path: contracts/sbtc-deposit.clar
+            anchor-block-only: true
+            clarity-version: 2
+      epoch: "2.5"

--- a/contracts/nohup.out
+++ b/contracts/nohup.out
@@ -1,0 +1,18 @@
+Computing deployment plan
+Generated file deployments/default.devnet-plan.yaml
+Computing deployment plan
+note: using existing deployments/default.devnet-plan.yaml
+thread '<unnamed>' panicked at /Users/mikey/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rocket-0.5.0/src/error.rs:279:9:
+aborting due to socket bind error
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+
+terminating devnet network: logs and chainstate available at location /Users/mikey/hubgit/bridge/sbtc/contracts/./.cache/stacks-devnet-1716379462
+error: unable to start bitcoind container: network contracts.devnet is ambiguous (2 matches found on name)
+Computing deployment plan
+note: using existing deployments/default.devnet-plan.yaml
+thread '<unnamed>' panicked at /Users/mikey/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rocket-0.5.0/src/error.rs:279:9:
+aborting due to socket bind error
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+
+terminating devnet network: logs and chainstate available at location /Users/mikey/hubgit/bridge/sbtc/contracts/./.cache/stacks-devnet-1716379585
+error: unable to start bitcoind container: network contracts.devnet is ambiguous (3 matches found on name)


### PR DESCRIPTION
## Description

This is an alternative to the current approach that leverages clarinet to run the core services. The idea is to understand Hiro approach to inform the current way of building the docker containers.

Linked to https://github.com/stacks-network/sbtc/issues/183

1. Motivation for change
3. What was changed
4. How does this impact application developers
5. Link to relevant issues and documentation
6. Provide examples of use cases with code samples and applicable acceptance criteria

## Motivation

Help developing the sbtc devnet. This approach can either be used to inform or supplement the internal approach.

This adds a bin directory in the root of sbtc project containing scripts which run docker containers and run clarinet in the contracts directory.

## Checklist
   - [ ] all containers run (stacks epoch 25)
   - [ ] containers have no errors
   - [ ] sbtc contracts are deployed
   - [ ] stacks api node show tip height progression
