### PR TITLE
feat: charge fees based on virtual size

### DIFF
--- a/signer/tests/integration/rbf.rs
+++ b/signer/tests/integration/rbf.rs
@@ -341,8 +341,8 @@ pub fn transaction_with_rbf(
             utx.requests
                 .iter()
                 .filter_map(RequestRef::as_withdrawal)
-                .zip(utx.withdrawal_fees.iter().copied())
-                .map(|(req, fee)| (req.address.clone(), fee))
+                .zip(utx.tx.output.iter().skip(1))
+                .map(|(req, tx_out)| (req.address.clone(), req.amount - tx_out.value.to_sat()))
         })
         .collect();
     let iter = withdrawals

--- a/signer/tests/integration/rbf.rs
+++ b/signer/tests/integration/rbf.rs
@@ -321,7 +321,7 @@ pub fn transaction_with_rbf(
     let withdrawal_amounts: u64 = requests.withdrawals.iter().map(|req| req.amount).sum();
     let deposit_fees: u64 = transactions
         .iter()
-        .map(|unsigned| unsigned.fee_per_request * (unsigned.tx.input.len() - 1) as u64)
+        .map(|unsigned| unsigned.deposit_fees)
         .sum();
 
     // The signer's balance should now reflect the deposits and withdrawals
@@ -341,7 +341,8 @@ pub fn transaction_with_rbf(
             utx.requests
                 .iter()
                 .filter_map(RequestRef::as_withdrawal)
-                .map(|req| (req.address.clone(), utx.fee_per_request))
+                .zip(utx.withdrawal_fees.iter().copied())
+                .map(|(req, fee)| (req.address.clone(), fee))
         })
         .collect();
     let iter = withdrawals


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/182.

Currently, each request in a BTC transaction pays an equal portion of the total transaction fee. This PR modifies this approach by making the fee proportional to the size of each input or output UTXO relative to the total size of all UTXOs involved in the transaction[^1]. For instance, if a transaction incurs a 1000 sat fee and includes one deposit UTXO and one withdrawal UTXO—where the deposit UTXO constitutes 70% of the total UTXO size—the deposit will bear 700 sats of the fee, and the withdrawal will cover the remaining 300 sats.

[^1]: Note that these calculations exclude the signers' UTXOs when computing the a request UTXO's proportion of the weight.

## Changes

1. Change the fee computation calculation to be proportional to weight.

## Testing information

The old tests were updated to account for the change.