### PR TITLE
test: add BTC withdrawal integration tests

### DIFF
--- a/signer/src/utxo.rs
+++ b/signer/src/utxo.rs
@@ -200,7 +200,9 @@ fn compute_transaction_fee(tx_vsize: f64, fee_rate: f64, last_fees: Option<Fees>
             // amount be greater than the old fee amount.
             let minimum_fee_rate = fee_rate.max(rate + rate * SATS_PER_VBYTE_INCREMENT);
             let fee_increment = tx_vsize * DEFAULT_INCREMENTAL_RELAY_FEE_RATE;
-            (total as f64 + fee_increment).max(tx_vsize * minimum_fee_rate).ceil() as u64
+            (total as f64 + fee_increment)
+                .max(tx_vsize * minimum_fee_rate)
+                .ceil() as u64
         }
         None => (tx_vsize * fee_rate).ceil() as u64,
     }

--- a/signer/tests/integration/rbf.rs
+++ b/signer/tests/integration/rbf.rs
@@ -81,19 +81,6 @@ fn generate_depositor(rpc: &Client, faucet: &Faucet, signer: &Recipient) -> Depo
     deposit_request
 }
 
-fn generate_withdrawal() -> (WithdrawalRequest, Recipient) {
-    let recipient = Recipient::new(AddressType::P2tr);
-
-    let req = WithdrawalRequest {
-        amount: rand::rngs::OsRng.sample(Uniform::new(100_000, 250_000)),
-        max_fee: 250_000,
-        address: recipient.address.clone(),
-        signer_bitmap: Vec::new(),
-    };
-
-    (req, recipient)
-}
-
 fn recreate_request_state(
     mut requests: SbtcRequests,
     ctx: &RbfContext,
@@ -194,7 +181,7 @@ pub fn transaction_with_rbf(
             .collect();
 
     let mut withdrawal_recipients: Vec<Recipient> = Vec::new();
-    let withdrawals: Vec<WithdrawalRequest> = std::iter::repeat_with(generate_withdrawal)
+    let withdrawals: Vec<WithdrawalRequest> = std::iter::repeat_with(regtest::generate_withdrawal)
         .take(ctx.initial_withdrawals.max(ctx.rbf_withdrawals))
         .map(|(mut req, recipient)| {
             withdrawal_recipients.push(recipient);

--- a/signer/tests/integration/regtest.rs
+++ b/signer/tests/integration/regtest.rs
@@ -78,9 +78,7 @@ pub fn initialize_blockchain() -> (&'static Client, &'static Faucet) {
         let faucet = Faucet::new(FAUCET_SECRET_KEY, AddressType::P2wpkh, rpc);
         faucet.track_address(FAUCET_LABEL);
 
-        let amount = rpc
-            .get_received_by_address(&faucet.address, None)
-            .unwrap();
+        let amount = rpc.get_received_by_address(&faucet.address, None).unwrap();
 
         if amount < Amount::from_int_btc(1) {
             faucet.generate_blocks(101);

--- a/signer/tests/integration/regtest.rs
+++ b/signer/tests/integration/regtest.rs
@@ -32,7 +32,10 @@ use bitcoincore_rpc::Auth;
 use bitcoincore_rpc::Client;
 use bitcoincore_rpc::Error as BtcRpcError;
 use bitcoincore_rpc::RpcApi;
+use rand::distributions::Uniform;
+use rand::Rng;
 use secp256k1::SECP256K1;
+use signer::utxo::WithdrawalRequest;
 use std::sync::OnceLock;
 
 /// These must match the username and password in bitcoin.conf
@@ -76,7 +79,7 @@ pub fn initialize_blockchain() -> (&'static Client, &'static Faucet) {
         faucet.track_address(FAUCET_LABEL);
 
         let amount = rpc
-            .get_received_by_address(&faucet.address, Some(1))
+            .get_received_by_address(&faucet.address, None)
             .unwrap();
 
         if amount < Amount::from_int_btc(1) {
@@ -368,4 +371,17 @@ pub fn p2tr_sign_transaction<U>(
     let signature = bitcoin::taproot::Signature { signature, sighash_type };
 
     tx.input[input_index].witness = Witness::p2tr_key_spend(&signature);
+}
+
+pub fn generate_withdrawal() -> (WithdrawalRequest, Recipient) {
+    let recipient = Recipient::new(AddressType::P2tr);
+
+    let req = WithdrawalRequest {
+        amount: rand::rngs::OsRng.sample(Uniform::new(100_000, 250_000)),
+        max_fee: 250_000,
+        address: recipient.address.clone(),
+        signer_bitmap: Vec::new(),
+    };
+
+    (req, recipient)
 }

--- a/signer/tests/integration/utxo_construction.rs
+++ b/signer/tests/integration/utxo_construction.rs
@@ -207,7 +207,10 @@ fn deposits_add_to_controlled_amounts() {
 #[test]
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 fn withdrawals_reduce_to_signers_amounts() {
+    const FEE_RATE: f64 = 10.0;
+
     let (rpc, faucet) = regtest::initialize_blockchain();
+    let fallback_fee = regtest::BITCOIN_CORE_FALLBACK_FEE.to_sat();
     let signer = Recipient::new(AddressType::P2tr);
     let signers_public_key = signer.keypair.x_only_public_key().0;
 
@@ -216,8 +219,9 @@ fn withdrawals_reduce_to_signers_amounts() {
     faucet.generate_blocks(1);
 
     assert_eq!(signer.get_balance(rpc).to_sat(), 100_000_000);
-    
-    // Now lets make a deposit transaction and submit it    
+
+    // Now lets make a withdrawal request. This recipient shouldn't
+    // have any coins to their name.
     let (withdrawal_request, recipient) = regtest::generate_withdrawal();
     assert_eq!(recipient.get_balance(rpc).to_sat(), 0);
 
@@ -235,7 +239,7 @@ fn withdrawals_reduce_to_signers_amounts() {
                 amount: signer_utxo.amount.to_sat(),
                 public_key: signers_public_key,
             },
-            fee_rate: 10.0,
+            fee_rate: FEE_RATE,
             public_key: signers_public_key,
             last_fees: None,
         },
@@ -244,7 +248,7 @@ fn withdrawals_reduce_to_signers_amounts() {
     };
 
     // There should only be one transaction here since there is only one
-    // deposit request and no withdrawal requests.
+    // withdrawal request and no deposit requests.
     let mut transactions = requests.construct_transactions().unwrap();
     assert_eq!(transactions.len(), 1);
     let mut unsigned = transactions.pop().unwrap();
@@ -256,13 +260,67 @@ fn withdrawals_reduce_to_signers_amounts() {
     rpc.send_raw_transaction(&unsigned.tx).unwrap();
     faucet.generate_blocks(1);
 
-    // The signer's balance should now reflect the deposit.
+    // The signer's balance should now reflect the withdrawal.
+    // Note that the signer started with 1 BTC.
     let signers_balance = signer.get_balance(rpc).to_sat();
 
     assert_eq!(signers_balance, 100_000_000 - withdrawal_request.amount);
 
-    let fee = unsigned.input_amounts() - unsigned.output_amounts();
+    let withdrawal_fee = unsigned.input_amounts() - unsigned.output_amounts();
     let recipient_balance = recipient.get_balance(rpc).to_sat();
-    assert_eq!(recipient_balance, withdrawal_request.amount - fee);
-}
+    assert_eq!(
+        recipient_balance,
+        withdrawal_request.amount - withdrawal_fee
+    );
 
+    // Let's check that we have the right fee rate too.
+    let fee_rate = withdrawal_fee as f64 / unsigned.tx.vsize() as f64;
+    more_asserts::assert_ge!(fee_rate, FEE_RATE);
+    more_asserts::assert_lt!(fee_rate, FEE_RATE + 1.0);
+
+    // Now we construct another transaction where the withdrawing
+    // recipient pays to someone else.
+    let another_recipient = Recipient::new(AddressType::P2wpkh);
+    let another_recipient_balance = another_recipient.get_balance(rpc).to_sat();
+    assert_eq!(another_recipient_balance, 0);
+
+    // Get the UTXO that the signer sent to the withdrawing user.
+    let withdrawal_utxo = recipient.get_utxos(rpc, None).pop().unwrap();
+    let mut tx = Transaction {
+        version: Version::ONE,
+        lock_time: LockTime::ZERO,
+        input: vec![TxIn {
+            previous_output: OutPoint::new(withdrawal_utxo.txid, withdrawal_utxo.vout),
+            sequence: Sequence::ZERO,
+            script_sig: ScriptBuf::new(),
+            witness: Witness::new(),
+        }],
+        output: vec![
+            TxOut {
+                value: Amount::from_sat(50_000),
+                script_pubkey: another_recipient.address.script_pubkey(),
+            },
+            TxOut {
+                value: withdrawal_utxo.amount() - Amount::from_sat(50_000 + fallback_fee),
+                script_pubkey: recipient.address.script_pubkey(),
+            },
+        ],
+    };
+    regtest::p2tr_sign_transaction(&mut tx, 0, &[withdrawal_utxo], &recipient.keypair);
+
+    // Ship it
+    rpc.send_raw_transaction(&tx).unwrap();
+    faucet.generate_blocks(1);
+
+    // Let's make sure their ending balances are correct. We start with the
+    // Withdrawal recipient.
+    let recipient_balance = recipient.get_balance(rpc).to_sat();
+    assert_eq!(
+        recipient_balance,
+        withdrawal_request.amount - withdrawal_fee - 50_000 - fallback_fee
+    );
+
+    // And what about the person that they just sent coins to?
+    let another_recipient_balance = another_recipient.get_balance(rpc).to_sat();
+    assert_eq!(another_recipient_balance, 50_000);
+}


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/67.

We needed one additional integration test with `bitcoind` to assess BTC withdrawal transactions.

## Changes

This update introduces an integration test that verifies the functionality of the signers' BTC transactions for withdrawals. Specifically, we ensure that:
1. The transaction is accepted by bitcoin-core.
2. The signer's UTXO amount is correctly reduced by the withdrawal amount.
3. The amount sent to the intended address equals the withdrawal amount minus the BTC transaction fee.
4. The withdrawal address can spend those coins.
