### PR TITLE
feat: SignerDepositDecision and SignerWithdrawDecision payloads defined

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,9 +274,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-dynamodb"
-version = "1.28.0"
+version = "1.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1da0290e57949a362d3f106285bb539e8a282e6c1b0053f6e02b3fc14f2d730"
+checksum = "cd1e3d012c9e3563356ac55e5dcf0e1118f0554dcb46d0cd5b960a5ca5535bcc"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -396,9 +396,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.5.3"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cb5ada2e705ecdaf9534374aa87dc351f77dda0d83bbae4c2be9a8074a35779"
+checksum = "607e8b53aeb2bc23fb332159d72a69650cd9643c161d76cd3b7f88ac00b5a1bb"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http 0.60.8",
@@ -477,9 +477,9 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a807d90cd50a969b3d95e4e7ad1491fcae13c6e83948d8728363ecc09d66343a"
+checksum = "02fa328e19c849b20ef7ada4c9b581dd12351ff35ecc7642d06e69de4f98407c"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ reqwest = { version = "0.11", features = ["json"] }
 serde = "1.0"
 serde_json = "1.0"
 sha2 = "0.10"
-sqlx = { version = "0.7", features = [ "postgres", "time", "runtime-tokio", "tls-rustls" ] }
+sqlx = { version = "0.7", default-features = false, features = [ "postgres", "time", "runtime-tokio", "tls-rustls", "macros", "migrate" ] }
 thiserror = "1.0"
 time = "0.3.36"
 tonic = "0.11.0"
@@ -49,7 +49,7 @@ tokio = "1.32.0"
 tokio-stream = {version = "0.1.15", features = ["sync"] }
 tracing = { version = "0.1", default-features = false }
 tracing-attributes = "0.1"
-wsts = "9.0.0"
+wsts = "9.1.0"
 
 [workspace.dependencies.tracing-subscriber]
 version = "0.3"

--- a/signer/Cargo.toml
+++ b/signer/Cargo.toml
@@ -28,9 +28,9 @@ futures = "0.3"
 once_cell.workspace = true
 p256k1.workspace = true
 prost.workspace = true
-sbtc-common = { path = "../common" }
 rand.workspace = true
 reqwest.workspace = true
+sbtc-common = { path = "../common" }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/signer/src/message/testing.rs
+++ b/signer/src/message/testing.rs
@@ -1,0 +1,86 @@
+//! Test utilities for signer message
+
+use bitcoin::hashes::Hash;
+use fake::Fake;
+use rand::seq::SliceRandom;
+
+impl super::SignerMessage {
+    /// Construct a random message
+    pub fn random<R: rand::RngCore + ?Sized>(rng: &mut R) -> Self {
+        fake::Faker.fake_with_rng(rng)
+    }
+
+    /// Construct a random message with the given payload type
+    pub fn random_with_payload_type<
+        P: Into<super::Payload> + fake::Dummy<fake::Faker>,
+        R: rand::RngCore + ?Sized,
+    >(
+        rng: &mut R,
+    ) -> Self {
+        let payload = dummy_payload::<P, _>(&fake::Faker, rng);
+        Self::random_with_payload(rng, payload)
+    }
+
+    /// Construct a random message with the given payload
+    fn random_with_payload<R: rand::RngCore + ?Sized>(
+        rng: &mut R,
+        payload: super::Payload,
+    ) -> Self {
+        let mut block_hash_data = [0; 32];
+        rng.fill_bytes(&mut block_hash_data);
+        let block_hash = bitcoin::BlockHash::from_slice(&block_hash_data).unwrap();
+
+        payload.to_message(block_hash)
+    }
+}
+
+impl fake::Dummy<fake::Faker> for super::Payload {
+    fn dummy_with_rng<R: rand::RngCore + ?Sized>(config: &fake::Faker, rng: &mut R) -> Self {
+        let variants = [
+            dummy_payload::<super::SignerDepositDecision, _>,
+            dummy_payload::<super::SignerWithdrawDecision, _>,
+            dummy_payload::<super::WstsMessage, _>,
+        ];
+
+        variants.choose(rng).unwrap()(config, rng)
+    }
+}
+
+impl fake::Dummy<fake::Faker> for super::SignerMessage {
+    fn dummy_with_rng<R: rand::RngCore + ?Sized>(config: &fake::Faker, rng: &mut R) -> Self {
+        let payload: super::Payload = config.fake_with_rng(rng);
+
+        Self::random_with_payload(rng, payload)
+    }
+}
+
+impl fake::Dummy<fake::Faker> for super::SignerDepositDecision {
+    fn dummy_with_rng<R: rand::RngCore + ?Sized>(config: &fake::Faker, rng: &mut R) -> Self {
+        let bytes: [u8; 32] = config.fake_with_rng(rng);
+
+        Self {
+            output_index: config.fake_with_rng(rng),
+            txid: bitcoin::Txid::from_byte_array(bytes),
+            accepted: config.fake_with_rng(rng),
+        }
+    }
+}
+
+impl fake::Dummy<fake::Faker> for super::WstsMessage {
+    fn dummy_with_rng<R: rand::RngCore + ?Sized>(config: &fake::Faker, rng: &mut R) -> Self {
+        let dkg_end_begin = wsts::net::DkgEndBegin {
+            dkg_id: config.fake_with_rng(rng),
+            signer_ids: config.fake_with_rng(rng),
+            key_ids: config.fake_with_rng(rng),
+        };
+
+        Self(wsts::net::Message::DkgEndBegin(dkg_end_begin))
+    }
+}
+
+fn dummy_payload<P: Into<super::Payload> + fake::Dummy<fake::Faker>, R: rand::RngCore + ?Sized>(
+    config: &fake::Faker,
+    rng: &mut R,
+) -> super::Payload {
+    config.fake_with_rng::<P, _>(rng).into()
+}


### PR DESCRIPTION
Closes #172 

### Description
This PR adds fields for the `SignerDepositDecision` and `SignerWithdrawDecision` message variants, along with tests to ensure that these are signable and encodable.