### PR TITLE
feat: BitcoinTransactionSignRequest and BitcoinTransactionSignAck payloads defined

### DIFF
--- a/signer/src/message/testing.rs
+++ b/signer/src/message/testing.rs
@@ -56,13 +56,23 @@ impl fake::Dummy<fake::Faker> for super::SignerMessage {
 
 impl fake::Dummy<fake::Faker> for super::SignerDepositDecision {
     fn dummy_with_rng<R: rand::RngCore + ?Sized>(config: &fake::Faker, rng: &mut R) -> Self {
-        let bytes: [u8; 32] = config.fake_with_rng(rng);
-
         Self {
             output_index: config.fake_with_rng(rng),
-            txid: bitcoin::Txid::from_byte_array(bytes),
+            txid: dummy_txid(config, rng),
             accepted: config.fake_with_rng(rng),
         }
+    }
+}
+
+impl fake::Dummy<fake::Faker> for super::BitcoinTransactionSignRequest {
+    fn dummy_with_rng<R: rand::RngCore + ?Sized>(config: &fake::Faker, rng: &mut R) -> Self {
+        Self { tx: dummy_tx(config, rng) }
+    }
+}
+
+impl fake::Dummy<fake::Faker> for super::BitcoinTransactionSignAck {
+    fn dummy_with_rng<R: rand::RngCore + ?Sized>(config: &fake::Faker, rng: &mut R) -> Self {
+        Self { txid: dummy_txid(config, rng) }
     }
 }
 
@@ -83,4 +93,47 @@ fn dummy_payload<P: Into<super::Payload> + fake::Dummy<fake::Faker>, R: rand::Rn
     rng: &mut R,
 ) -> super::Payload {
     config.fake_with_rng::<P, _>(rng).into()
+}
+
+fn dummy_txid<R: rand::RngCore + ?Sized>(config: &fake::Faker, rng: &mut R) -> bitcoin::Txid {
+    let bytes: [u8; 32] = config.fake_with_rng(rng);
+    bitcoin::Txid::from_byte_array(bytes)
+}
+
+fn dummy_tx<R: rand::RngCore + ?Sized>(config: &fake::Faker, rng: &mut R) -> bitcoin::Transaction {
+    let max_input_size = 50;
+    let max_output_size = 50;
+
+    let input_size = (rng.next_u32() % max_input_size) as usize;
+    let output_size = (rng.next_u32() % max_output_size) as usize;
+
+    let input = std::iter::repeat_with(|| dummy_txin(config, rng))
+        .take(input_size)
+        .collect();
+    let output = std::iter::repeat_with(|| dummy_txout(config, rng))
+        .take(output_size)
+        .collect();
+
+    bitcoin::Transaction {
+        version: bitcoin::transaction::Version::ONE,
+        lock_time: bitcoin::absolute::LockTime::ZERO,
+        input,
+        output,
+    }
+}
+
+fn dummy_txin<R: rand::RngCore + ?Sized>(config: &fake::Faker, rng: &mut R) -> bitcoin::TxIn {
+    bitcoin::TxIn {
+        previous_output: bitcoin::OutPoint::new(dummy_txid(config, rng), config.fake_with_rng(rng)),
+        sequence: bitcoin::Sequence::ZERO,
+        script_sig: bitcoin::ScriptBuf::new(),
+        witness: bitcoin::witness::Witness::new(),
+    }
+}
+
+fn dummy_txout<R: rand::RngCore + ?Sized>(config: &fake::Faker, rng: &mut R) -> bitcoin::TxOut {
+    bitcoin::TxOut {
+        value: bitcoin::Amount::from_sat(config.fake_with_rng(rng)),
+        script_pubkey: bitcoin::ScriptBuf::new(),
+    }
 }


### PR DESCRIPTION
Closes #174 

### Description
This PR adds fields for the `BitcoinTransactionSignRequest` and `BitcointransactionSignAck` message variants, along with tests to ensure that these are signable and encodable.

Note: This PR is currently based on #189 because it uses test utilities from it.