### PR TITLE
Fixing electrs and mempool backend communication errors

### DIFF
--- a/devenv/local/docker-compose/docker-compose.yml
+++ b/devenv/local/docker-compose/docker-compose.yml
@@ -74,7 +74,7 @@ services:
       - bitcoin
     environment:
       INIT_BTC_BLOCKS: 101
-      BTC_BLOCK_GEN_TIME: 2
+      BTC_BLOCK_GEN_TIME: 10
       BITCOIN_RPC_HOST: "bitcoin"
       BITCOIN_RPC_PORT: 18443
       BTC_RPCPASSWORD: devnet
@@ -233,8 +233,7 @@ services:
       - 8999:8999
     environment:
       # Connect to electrs host
-      # MEMPOOL_BACKEND: "electrum"
-      MEMPOOL_BACKEND: "none"
+      MEMPOOL_BACKEND: "electrum"
       ELECTRUM_HOST: "electrs"
       ELECTRUM_PORT: "60401"
       ELECTRUM_TLS_ENABLED: "false"

--- a/devenv/local/docker-compose/electrs/docker/entrypoint.sh
+++ b/devenv/local/docker-compose/electrs/docker/entrypoint.sh
@@ -11,8 +11,8 @@ echo "bitcoin node is ready"
 electrs --network regtest \
 	--jsonrpc-import \
 	--cookie "devnet:devnet" \
-	--http-addr="127.0.0.1:3002" \
-	--electrum-rpc-addr="127.0.0.1:60401" \
+	--http-addr="0.0.0.0:3002" \
+	--electrum-rpc-addr="0.0.0.0:60401" \
 	--daemon-rpc-addr="$BITCOIN_RPC_HOST:$BITCOIN_RPC_PORT" \
 	--electrum-txs-limit=2048 \
 	--utxos-limit=2048 \


### PR DESCRIPTION
This PR contains a quick fix which allows electrum to be able to communicate with the mempool backend in the devnet

Changes:

- Electrs now listens to all IPs (0.0.0.0) instead of just (127.0.0.1)
- Switched `MEMPOOL_BACKEND: "none" ` --> `MEMPOOL_BACKEND: "electrum"`. Mempool now uses electrum along with BTC RPC.
