### PR TITLE
feat: lock sBTC when initializing withdrawal

### DIFF
--- a/contracts/contracts/sbtc-registry.clar
+++ b/contracts/contracts/sbtc-registry.clar
@@ -63,6 +63,7 @@
 (define-map protocol-contracts principal bool)
 (map-set protocol-contracts .sbtc-bootstrap-signers true)
 (map-set protocol-contracts .sbtc-deposit true)
+(map-set protocol-contracts .sbtc-withdrawal true)
 (if (not is-in-mainnet) (map-set protocol-contracts tx-sender true) true)
 
 ;; Read-only functions

--- a/contracts/contracts/sbtc-token.clar
+++ b/contracts/contracts/sbtc-token.clar
@@ -4,7 +4,7 @@
 (define-fungible-token sbtc-token)
 (define-fungible-token sbtc-token-locked)
 
-(define-data-var token-name (string-ascii 32) "sBTC Mini")
+(define-data-var token-name (string-ascii 32) "sBTC")
 (define-data-var token-symbol (string-ascii 10) "sBTC")
 (define-data-var token-uri (optional (string-utf8 256)) none)
 (define-constant token-decimals u8)

--- a/contracts/contracts/sbtc-withdrawal.clar
+++ b/contracts/contracts/sbtc-withdrawal.clar
@@ -1,7 +1,5 @@
 ;; Error codes
 
-(define-constant dust-limit u546)
-
 ;; The `version` part of the recipient address is invalid
 (define-constant ERR_INVALID_ADDR_VERSION (err u500))
 ;; The `hashbytes` part of the recipient address is invalid
@@ -17,6 +15,8 @@
 ;; Maximum value of an address version that has a 32-byte hashbytes
 ;; (0x05 and 0x06 have 32-byte hashbytes)
 (define-constant MAX_ADDRESS_VERSION_BUFF_32 u6)
+;; The minimum amount of sBTC you can withdraw
+(define-constant DUST_LIMIT u546)
 
 (define-public (initiate-withdrawal-request (amount uint)
                                             (recipient { version: (buff 1), hashbytes: (buff 32) })
@@ -24,7 +24,7 @@
   )
   (begin
     (try! (contract-call? .sbtc-token protocol-lock amount tx-sender))
-    (asserts! (> amount dust-limit) ERR_DUST_LIMIT)
+    (asserts! (> amount DUST_LIMIT) ERR_DUST_LIMIT)
   
     ;; Validate the recipient address
     (try! (validate-recipient recipient))

--- a/contracts/contracts/sbtc-withdrawal.clar
+++ b/contracts/contracts/sbtc-withdrawal.clar
@@ -1,9 +1,13 @@
 ;; Error codes
 
+(define-constant dust-limit u546)
+
 ;; The `version` part of the recipient address is invalid
 (define-constant ERR_INVALID_ADDR_VERSION (err u500))
 ;; The `hashbytes` part of the recipient address is invalid
 (define-constant ERR_INVALID_ADDR_HASHBYTES (err u501))
+;; The size of the withdrawal is smaller than the dust limit
+(define-constant ERR_DUST_LIMIT (err u502))
 
 ;; Maximum value of an address version as a uint
 (define-constant MAX_ADDRESS_VERSION u6)
@@ -19,7 +23,8 @@
                                             (max-fee uint)
   )
   (begin
-    ;; TODO: convert sBTC into locked sBTC
+    (try! (contract-call? .sbtc-token protocol-lock amount tx-sender))
+    (asserts! (> amount dust-limit) ERR_DUST_LIMIT)
   
     ;; Validate the recipient address
     (try! (validate-recipient recipient))

--- a/contracts/tests/clarigen-types.ts
+++ b/contracts/tests/clarigen-types.ts
@@ -1403,6 +1403,16 @@ export const contracts = {
     },
     maps: {},
     variables: {
+      ERR_DUST_LIMIT: {
+        name: "ERR_DUST_LIMIT",
+        type: {
+          response: {
+            ok: "none",
+            error: "uint128",
+          },
+        },
+        access: "constant",
+      } as TypedAbiVariable<Response<null, bigint>>,
       ERR_INVALID_ADDR_HASHBYTES: {
         name: "ERR_INVALID_ADDR_HASHBYTES",
         type: {
@@ -1438,8 +1448,17 @@ export const contracts = {
         type: "uint128",
         access: "constant",
       } as TypedAbiVariable<bigint>,
+      dustLimit: {
+        name: "dust-limit",
+        type: "uint128",
+        access: "constant",
+      } as TypedAbiVariable<bigint>,
     },
     constants: {
+      ERR_DUST_LIMIT: {
+        isOk: false,
+        value: 502n,
+      },
       ERR_INVALID_ADDR_HASHBYTES: {
         isOk: false,
         value: 501n,
@@ -1451,6 +1470,7 @@ export const contracts = {
       MAX_ADDRESS_VERSION: 6n,
       mAX_ADDRESS_VERSION_BUFF_20: 4n,
       mAX_ADDRESS_VERSION_BUFF_32: 6n,
+      dustLimit: 546n,
     },
     non_fungible_tokens: [],
     fungible_tokens: [],

--- a/contracts/tests/clarigen-types.ts
+++ b/contracts/tests/clarigen-types.ts
@@ -1403,6 +1403,11 @@ export const contracts = {
     },
     maps: {},
     variables: {
+      DUST_LIMIT: {
+        name: "DUST_LIMIT",
+        type: "uint128",
+        access: "constant",
+      } as TypedAbiVariable<bigint>,
       ERR_DUST_LIMIT: {
         name: "ERR_DUST_LIMIT",
         type: {
@@ -1448,13 +1453,9 @@ export const contracts = {
         type: "uint128",
         access: "constant",
       } as TypedAbiVariable<bigint>,
-      dustLimit: {
-        name: "dust-limit",
-        type: "uint128",
-        access: "constant",
-      } as TypedAbiVariable<bigint>,
     },
     constants: {
+      DUST_LIMIT: 546n,
       ERR_DUST_LIMIT: {
         isOk: false,
         value: 502n,
@@ -1470,7 +1471,6 @@ export const contracts = {
       MAX_ADDRESS_VERSION: 6n,
       mAX_ADDRESS_VERSION_BUFF_20: 4n,
       mAX_ADDRESS_VERSION_BUFF_32: 6n,
-      dustLimit: 546n,
     },
     non_fungible_tokens: [],
     fungible_tokens: [],

--- a/contracts/tests/sbtc-withdrawal.test.ts
+++ b/contracts/tests/sbtc-withdrawal.test.ts
@@ -208,4 +208,25 @@ describe("initiating a withdrawal request", () => {
       ).value
     ).toEqual(errors.withdrawal.ERR_INVALID_ADDR_HASHBYTES);
   });
+
+  test("Cannot try and withdrawal less than or equal to the dust limit", () => {
+    txOk(
+      deposit.completeDepositWrapper({
+        txid: new Uint8Array(32).fill(0),
+        voutIndex: 0,
+        amount: 4000n,
+        recipient: alice,
+      }),
+      alice
+    );
+    const receipt = txErr(
+      withdrawal.initiateWithdrawalRequest({
+        amount: withdrawal.constants.dustLimit,
+        recipient: alicePoxAddr,
+        maxFee: 10n,
+      }),
+      alice
+    );
+    expect(receipt.value).toEqual(errors.withdrawal.ERR_DUST_LIMIT);
+  });
 });

--- a/contracts/tests/sbtc-withdrawal.test.ts
+++ b/contracts/tests/sbtc-withdrawal.test.ts
@@ -221,7 +221,7 @@ describe("initiating a withdrawal request", () => {
     );
     const receipt = txErr(
       withdrawal.initiateWithdrawalRequest({
-        amount: withdrawal.constants.dustLimit,
+        amount: withdrawal.constants.DUST_LIMIT,
         recipient: alicePoxAddr,
         maxFee: 10n,
       }),

--- a/contracts/tests/sbtc-withdrawal.test.ts
+++ b/contracts/tests/sbtc-withdrawal.test.ts
@@ -165,7 +165,7 @@ describe("initiating a withdrawal request", () => {
     expect(rovOk(token.getBalanceAvailable(alice))).toEqual(0n);
   });
 
-  test("recipient is validated when iniating an address", () => {
+  test("recipient is validated when initiating an address", () => {
     txOk(
       deposit.completeDepositWrapper({
         txid: new Uint8Array(32).fill(0),
@@ -209,7 +209,7 @@ describe("initiating a withdrawal request", () => {
     ).toEqual(errors.withdrawal.ERR_INVALID_ADDR_HASHBYTES);
   });
 
-  test("Cannot try and withdrawal less than or equal to the dust limit", () => {
+  test("withdrawal amount of less than or equal to dust limit is rejected", () => {
     txOk(
       deposit.completeDepositWrapper({
         txid: new Uint8Array(32).fill(0),


### PR DESCRIPTION
This uses the new sBTC token contract to properly lock the user's sBTC when they initialize a withdrawal request.