### PR TITLE
feat: use unspendable taproot public keys for deposits

### DIFF
--- a/signer/src/utxo.rs
+++ b/signer/src/utxo.rs
@@ -65,7 +65,7 @@ const SATS_PER_VBYTE_INCREMENT: f64 = 0.001;
 /// on spending rules BIP-0341[1]. Specifically, the X-coordinate is formed
 /// by taking the hash of the standard uncompressed encoding of the 
 /// secp256k1 base point G as the X-coordinate. In that BIP the authors
-/// wrote the X-cooredinate that is reproduced below.
+/// wrote the X-coordinate that is reproduced below.
 ///
 /// [1]: https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#constructing-and-spending-taproot-outputs
 #[rustfmt::skip]

--- a/signer/tests/integration/rbf.rs
+++ b/signer/tests/integration/rbf.rs
@@ -70,13 +70,8 @@ fn generate_depositor(rpc: &Client, faucet: &Faucet, signer: &Recipient) -> Depo
         tx_out,
     };
 
-    let (deposit_tx, deposit_request) = make_deposit_request(
-        &depositor,
-        amount,
-        depositor_utxo,
-        signers_public_key,
-        faucet.keypair.x_only_public_key().0,
-    );
+    let (deposit_tx, deposit_request) =
+        make_deposit_request(&depositor, amount, depositor_utxo, signers_public_key);
     rpc.send_raw_transaction(&deposit_tx).unwrap();
     deposit_request
 }


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/130.

Deposit requests are BTC transactions with taproot UTXOs to an address with no key-spend route. Specifically, we use a key-spend public key with no known private key. This PR implements the change where we expect the taproot address to use such an public key. We choose the specific X-coordinate mentioned in BIP-0341 as the public key, which has an X-coordinate set to the SHA256 of the generator G.

## Changes

1. Add a function that returns a public key for an address with no known public key.
2. Expect all taproot key-spend public keys to use this address from (1). This was done in f7173a4e56e2baa26eb206e3e50a31632c6666f3, but I'm not sure if we want the flexibility of the previous code.

## Testing information

I checked that the point in BIP-0341 is indeed on the curve. This was done by running the following in python:
```python
p = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F

def lift_x(x: int):
    if x >= p:
        return None
    y_sq = (pow(x, 3, p) + 7) % p #<-the curve
    y = pow(y_sq, (p + 1) // 4, p)
    if pow(y, 2, p) != y_sq:
        return None
    return (x, y if y & 1 == 0 else p-y) # make y odd if there is a sqrt?

(x, y) = lift_x(0x50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0)
```
In [SageMath](https://sagecell.sagemath.org/) this is done with
```sage
F = FiniteField (0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F)
secp256k1 = EllipticCurve ([F (0), F (7)])
point = secp256k1.lift_x(0x50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0)
```
which gives the same output as the python script. In the above, I used the same [prime used in bitcoin-core](https://github.com/bitcoin/bitcoin/blob/327f08bb0cd91a22249395adeb34549e3c86ca76/src/secp256k1/src/field.h#L12-L13), which is `2^256 - 2^32 - 977` or `0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F`. Checking this might be overkill, since presumably this is checked when creating a `bitcoin::XOnlyPublicKey` struct, but it was easy enough to check.

I also checked that the X-coordinate `0x50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0` is indeed the SHA256 hash of the generator that Bitcoin uses. The generator can be found in [bitcoin-core](https://github.com/bitcoin/bitcoin/blob/327f08bb0cd91a22249395adeb34549e3c86ca76/src/secp256k1/src/group_impl.h#L33-L41) (or here https://en.bitcoin.it/wiki/Secp256k1) and computing the sha256 is done using something like:
```python
import hashlib
hash_of_g =  hashlib.sha256(bytes.fromhex('0479BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8'))
hash_of_g.hexdigest()
```

I do not know if the "NUMS" (Nothing Up My Sleeve) X-coordinate point in BIP-0341 has a known discrete logarithm. That is, I do not know how to verify the claims in BIP-0341 regarding "unspendable" public keys. I'll do a little research to see if I can verify the claims there.
