### PR TITLE
feat: Block observer event loop skeleton

### DIFF
--- a/signer/Cargo.toml
+++ b/signer/Cargo.toml
@@ -24,7 +24,7 @@ bitcoin = { workspace = true, features = ["rand-std"] }
 blocklist-api = { path = "../.generated-sources/blocklist-api" }
 clap.workspace = true
 config.workspace = true
-futures = "0.3"
+futures.workspace = true
 once_cell.workspace = true
 p256k1.workspace = true
 prost.workspace = true

--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -26,8 +26,8 @@ use blockstack_lib::chainstate::nakamoto;
 use blockstack_lib::chainstate::stacks;
 use futures::stream::StreamExt;
 use storage::model;
-use storage::Read;
-use storage::Write;
+use storage::DbRead;
+use storage::DbWrite;
 
 type DepositRequestMap = HashMap<bitcoin::Txid, Vec<DepositRequest>>;
 
@@ -49,16 +49,15 @@ pub struct BlockObserver<BitcoinClient, StacksClient, EmilyClient, BlockHashStre
     pub horizon: usize,
 }
 
-impl<BitcoinClient, StacksClient, EmilyClient, BlockHashStream, SignerStorage>
-    BlockObserver<BitcoinClient, StacksClient, EmilyClient, BlockHashStream, SignerStorage>
+impl<BC, SC, EC, BHS, SS> BlockObserver<BC, SC, EC, BHS, SS>
 where
-    BitcoinClient: BitcoinInteract,
-    StacksClient: StacksInteract,
-    EmilyClient: EmilyInteract,
-    BlockHashStream: futures::stream::Stream<Item = bitcoin::BlockHash> + Unpin,
-    for<'a> &'a mut SignerStorage: storage::Read + storage::Write,
-    for<'a> <&'a mut SignerStorage as storage::Read>::Error: std::error::Error,
-    for<'a> <&'a mut SignerStorage as storage::Write>::Error: std::error::Error,
+    BC: BitcoinInteract,
+    SC: StacksInteract,
+    EC: EmilyInteract,
+    BHS: futures::stream::Stream<Item = bitcoin::BlockHash> + Unpin,
+    for<'a> &'a mut SS: storage::DbRead + storage::DbWrite,
+    for<'a> <&'a mut SS as storage::DbRead>::Error: std::error::Error,
+    for<'a> <&'a mut SS as storage::DbWrite>::Error: std::error::Error,
 {
     /// Run the block observer
     pub async fn run(mut self) -> Result<(), Error> {

--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -1,0 +1,425 @@
+//! # Block observer
+//!
+//! This module contains the block observer implementation for the sBTC signer.
+//! The block observer is responsible for populating the signer database with
+//! information from the Bitcoin and Stacks blockchains, and notifying
+//! the signer event loop whenever the state has been updated.
+//!
+//! The following information is extracted by the block observer:
+//! - Bitcoin blocks
+//! - Stacks blocks
+//! - Deposit requests
+//! - sBTC transactions
+//! - Withdraw requests
+//! - Deposit accept transactions
+//! - Withdraw accept transactions
+//! - Withdraw reject transactions
+//! - Update signer set transactions
+//! - Set aggregate key transactions
+
+use std::collections::HashMap;
+
+use crate::storage;
+
+use bitcoin::hashes::Hash;
+use blockstack_lib::chainstate::nakamoto;
+use blockstack_lib::chainstate::stacks;
+use futures::stream::StreamExt;
+use storage::model;
+use storage::Read;
+use storage::Write;
+
+type DepositRequestMap = HashMap<bitcoin::Txid, Vec<DepositRequest>>;
+
+/// Block observer
+pub struct BlockObserver<BitcoinClient, StacksClient, EmilyClient, BlockHashStream, SignerStorage> {
+    /// Bitcoin client
+    pub bitcoin_client: BitcoinClient,
+    /// Stacks client
+    pub stacks_client: StacksClient,
+    /// Emily client
+    pub emily_client: EmilyClient,
+    /// Stream of blocks from the block notifier
+    pub bitcoin_blocks: BlockHashStream,
+    /// Database connection
+    pub storage: SignerStorage,
+    /// Used to notify any other system that the database has been updated
+    pub subscribers: tokio::sync::watch::Sender<()>,
+    /// How far back in time the observer should look
+    pub horizon: usize,
+}
+
+impl<BitcoinClient, StacksClient, EmilyClient, BlockHashStream, SignerStorage>
+    BlockObserver<BitcoinClient, StacksClient, EmilyClient, BlockHashStream, SignerStorage>
+where
+    BitcoinClient: BitcoinInteract,
+    StacksClient: StacksInteract,
+    EmilyClient: EmilyInteract,
+    BlockHashStream: futures::stream::Stream<Item = bitcoin::BlockHash> + Unpin,
+    for<'a> &'a mut SignerStorage: storage::Read + storage::Write,
+    for<'a> <&'a mut SignerStorage as storage::Read>::Error: std::error::Error,
+    for<'a> <&'a mut SignerStorage as storage::Write>::Error: std::error::Error,
+{
+    /// Run the block observer
+    pub async fn run(mut self) -> Result<(), Error> {
+        let mut known_deposit_requests = HashMap::new();
+
+        while let Some(new_block_hash) = self.bitcoin_blocks.next().await {
+            self.load_latest_deposit_requests(&mut known_deposit_requests)
+                .await;
+
+            for block in self.next_blocks_to_process(new_block_hash).await? {
+                self.process_bitcoin_block(&known_deposit_requests, block)
+                    .await?;
+            }
+
+            if self.subscribers.send(()).is_err() {
+                tracing::info!("block observer has no subscribers");
+                break;
+            }
+        }
+
+        tracing::info!("shutting down block observer");
+
+        Ok(())
+    }
+
+    #[tracing::instrument(skip(self))]
+    async fn load_latest_deposit_requests(
+        &mut self,
+        known_deposit_requests: &mut DepositRequestMap,
+    ) {
+        self.emily_client
+            .get_deposits()
+            .await
+            .into_iter()
+            .for_each(|deposit| {
+                known_deposit_requests
+                    .entry(deposit.txid)
+                    .or_default()
+                    .push(deposit)
+            });
+    }
+
+    #[tracing::instrument(skip(self))]
+    async fn next_blocks_to_process(
+        &mut self,
+        mut block_hash: bitcoin::BlockHash,
+    ) -> Result<Vec<bitcoin::Block>, Error> {
+        let mut blocks = Vec::new();
+
+        for _ in 0..self.horizon {
+            if self.have_already_processed_block(block_hash).await? {
+                break;
+            }
+
+            let block = self
+                .bitcoin_client
+                .get_block(&block_hash)
+                .await
+                .ok_or(Error::MissingBlock)?;
+
+            block_hash = block.header.prev_blockhash;
+            blocks.push(block);
+        }
+
+        // Make order chronological
+        blocks.reverse();
+        Ok(blocks)
+    }
+
+    #[tracing::instrument(skip(self))]
+    async fn have_already_processed_block(
+        &mut self,
+        block_hash: bitcoin::BlockHash,
+    ) -> Result<bool, Error> {
+        Ok(self
+            .storage
+            .get_bitcoin_block(&block_hash.to_byte_array().into())
+            .await
+            .map_err(|_| Error::StorageError)?
+            .is_some())
+    }
+
+    #[tracing::instrument(skip(self))]
+    async fn process_bitcoin_block(
+        &mut self,
+        known_deposit_requests: &DepositRequestMap,
+        block: bitcoin::Block,
+    ) -> Result<(), Error> {
+        let stacks_blocks = self
+            .stacks_client
+            .get_blocks_by_bitcoin_block(&block.block_hash())
+            .await;
+
+        self.extract_deposit_requests(&block.txdata);
+        self.extract_sbtc_transactions(&block.txdata);
+
+        for stacks_block in stacks_blocks {
+            self.extract_withdraw_requests(&stacks_block.txs);
+            self.extract_withdraw_accept_transactions(&stacks_block.txs);
+            self.extract_withdraw_reject_transactions(&stacks_block.txs);
+            self.extract_deposit_accept_transactions(&stacks_block.txs);
+            self.extract_update_signer_set_transactions(&stacks_block.txs);
+            self.extract_set_aggregate_key_transactions(&stacks_block.txs);
+
+            self.write_stacks_block(&stacks_block).await;
+        }
+
+        self.write_bitcoin_block(&block).await?;
+
+        Ok(())
+    }
+
+    fn extract_deposit_requests(&self, _transactions: &[bitcoin::Transaction]) {
+        // TODO(#203): Implement
+    }
+
+    fn extract_sbtc_transactions(&self, _transactions: &[bitcoin::Transaction]) {
+        // TODO(#204): Implement
+    }
+
+    fn extract_withdraw_requests(&self, _transactions: &[stacks::StacksTransaction]) {
+        // TODO(#205): Implement
+    }
+
+    fn extract_withdraw_accept_transactions(&self, _transactions: &[stacks::StacksTransaction]) {
+        // TODO(#206): Implement
+    }
+
+    fn extract_withdraw_reject_transactions(&self, _transactions: &[stacks::StacksTransaction]) {
+        // TODO(#207): Implement
+    }
+
+    fn extract_deposit_accept_transactions(&self, _transactions: &[stacks::StacksTransaction]) {
+        // TODO(#207): Implement
+    }
+
+    fn extract_update_signer_set_transactions(&self, _transactions: &[stacks::StacksTransaction]) {
+        // TODO(#208): Implement
+    }
+
+    fn extract_set_aggregate_key_transactions(&self, _transactions: &[stacks::StacksTransaction]) {
+        // TODO(#209): Implement
+    }
+
+    async fn write_stacks_block(&mut self, _block: &nakamoto::NakamotoBlock) {
+        // TODO(#212): Implement
+    }
+
+    async fn write_bitcoin_block(&mut self, block: &bitcoin::Block) -> Result<(), Error> {
+        let now = time::OffsetDateTime::now_utc();
+        let created_at = time::PrimitiveDateTime::new(now.date(), now.time());
+
+        let db_block = model::BitcoinBlock {
+            block_hash: block.block_hash().to_byte_array().to_vec(),
+            block_height: block
+                .bip34_block_height()
+                .expect("Failed to get block height") as i64,
+            parent_hash: block.header.prev_blockhash.to_byte_array().to_vec(),
+            confirms: None,
+            created_at,
+        };
+
+        self.storage
+            .write_bitcoin_block(&db_block)
+            .await
+            .map_err(|_| Error::StorageError)?;
+
+        Ok(())
+    }
+}
+
+// Placehoder traits. To be replaced with the actual traits once implemented.
+
+/// Placeholder trait
+pub trait BitcoinInteract {
+    /// Get block
+    fn get_block(
+        &mut self,
+        block_hash: &bitcoin::BlockHash,
+    ) -> impl std::future::Future<Output = Option<bitcoin::Block>>;
+}
+
+/// Placeholder trait
+pub trait StacksInteract {
+    /// Get stacks blocks confirmed by the given bitcoin block
+    fn get_blocks_by_bitcoin_block(
+        &mut self,
+        bitcoin_block_hash: &bitcoin::BlockHash,
+    ) -> impl std::future::Future<Output = Vec<nakamoto::NakamotoBlock>>;
+}
+
+/// Placeholder trait
+pub trait EmilyInteract {
+    /// Get deposits
+    fn get_deposits(&mut self) -> impl std::future::Future<Output = Vec<DepositRequest>>;
+}
+
+/// Placeholder type
+#[derive(Debug, Clone, Hash, PartialEq)]
+pub struct DepositRequest {
+    /// Txid
+    txid: bitcoin::Txid,
+}
+
+/// Error
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// Missing block
+    #[error("missing block")]
+    MissingBlock,
+    /// Storage error
+    #[error("storage error")]
+    StorageError,
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::{seq::IteratorRandom, SeedableRng};
+
+    use crate::storage;
+    use crate::testing::dummy;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn should_be_able_to_extract_bitcoin_blocks_given_a_block_header_stream() {
+        let mut rng = rand::rngs::StdRng::seed_from_u64(46);
+        let storage = storage::in_memory::Store::new_shared();
+        let test_harness = TestHarness::generate(&mut rng, 20, 0..5);
+        let block_hash_stream = test_harness.spawn_block_hash_stream();
+        let (subscribers, subscriber_rx) = tokio::sync::watch::channel(());
+
+        let block_observer = BlockObserver {
+            bitcoin_client: test_harness.clone(),
+            stacks_client: test_harness.clone(),
+            emily_client: (),
+            bitcoin_blocks: block_hash_stream,
+            storage: storage.clone(),
+            subscribers,
+            horizon: 1,
+        };
+
+        block_observer.run().await.expect("block observer failed");
+
+        for block in test_harness.bitcoin_blocks {
+            let persisted = storage
+                .get_bitcoin_block(&block.block_hash().to_byte_array().to_vec())
+                .await
+                .expect("storage error")
+                .expect("block wasn't persisted");
+
+            assert_eq!(persisted.block_hash, block.block_hash().to_byte_array())
+        }
+
+        std::mem::drop(subscriber_rx);
+    }
+
+    #[derive(Debug, Clone)]
+    struct TestHarness {
+        bitcoin_blocks: Vec<bitcoin::Block>,
+        stacks_blocks_per_bitcoin_block: HashMap<bitcoin::BlockHash, Vec<nakamoto::NakamotoBlock>>,
+    }
+
+    impl TestHarness {
+        fn generate(
+            rng: &mut impl rand::RngCore,
+            num_bitcoin_blocks: usize,
+            num_stacks_blocks_per_bitcoin_block: std::ops::Range<usize>,
+        ) -> Self {
+            let mut bitcoin_blocks: Vec<_> =
+                std::iter::repeat_with(|| dummy::block(&fake::Faker, rng))
+                    .take(num_bitcoin_blocks)
+                    .collect();
+
+            for idx in 1..bitcoin_blocks.len() {
+                bitcoin_blocks[idx].header.prev_blockhash = bitcoin_blocks[idx - 1].block_hash();
+            }
+
+            let (stacks_blocks_per_bitcoin_block, _) = bitcoin_blocks.iter().fold(
+                (HashMap::new(), None),
+                |(mut stacks_blocks_per_bitcoin_block, previous_stacks_block_hash), block| {
+                    let num_blocks = num_stacks_blocks_per_bitcoin_block
+                        .clone()
+                        .choose(rng)
+                        .unwrap();
+                    let mut stacks_blocks: Vec<_> =
+                        std::iter::repeat_with(|| dummy::stacks_block(&fake::Faker, rng))
+                            .take(num_blocks)
+                            .collect();
+
+                    for idx in 1..stacks_blocks.len() {
+                        stacks_blocks[idx].header.parent_block_id = stacks_blocks[idx].block_id();
+                    }
+
+                    let previous_stacks_block_hash = if !stacks_blocks.is_empty() {
+                        if let Some(hash) = previous_stacks_block_hash {
+                            stacks_blocks[0].header.parent_block_id = hash;
+                        }
+
+                        Some(stacks_blocks.last().unwrap().block_id())
+                    } else {
+                        previous_stacks_block_hash
+                    };
+
+                    stacks_blocks_per_bitcoin_block.insert(block.block_hash(), stacks_blocks);
+
+                    (stacks_blocks_per_bitcoin_block, previous_stacks_block_hash)
+                },
+            );
+
+            Self {
+                bitcoin_blocks,
+                stacks_blocks_per_bitcoin_block,
+            }
+        }
+
+        fn spawn_block_hash_stream(
+            &self,
+        ) -> tokio_stream::wrappers::ReceiverStream<bitcoin::BlockHash> {
+            let headers: Vec<_> = self
+                .bitcoin_blocks
+                .iter()
+                .map(|block| block.block_hash())
+                .collect();
+
+            let (tx, rx) = tokio::sync::mpsc::channel(128);
+
+            tokio::spawn(async move {
+                for header in headers {
+                    tx.send(header).await.expect("failed to send header");
+                }
+            });
+
+            rx.into()
+        }
+    }
+
+    impl BitcoinInteract for TestHarness {
+        async fn get_block(&mut self, block_hash: &bitcoin::BlockHash) -> Option<bitcoin::Block> {
+            self.bitcoin_blocks
+                .iter()
+                .find(|block| &block.block_hash() == block_hash)
+                .cloned()
+        }
+    }
+
+    impl StacksInteract for TestHarness {
+        async fn get_blocks_by_bitcoin_block(
+            &mut self,
+            bitcoin_block_hash: &bitcoin::BlockHash,
+        ) -> Vec<nakamoto::NakamotoBlock> {
+            self.stacks_blocks_per_bitcoin_block
+                .get(bitcoin_block_hash)
+                .cloned()
+                .unwrap_or_else(Vec::new)
+        }
+    }
+
+    impl EmilyInteract for () {
+        async fn get_deposits(&mut self) -> Vec<DepositRequest> {
+            Vec::new()
+        }
+    }
+}

--- a/signer/src/lib.rs
+++ b/signer/src/lib.rs
@@ -1,6 +1,7 @@
 #![doc = include_str!("../README.md")]
 #![deny(missing_docs)]
 
+pub mod block_observer;
 pub mod blocklist_client;
 pub mod codec;
 pub mod config;

--- a/signer/src/message/testing.rs
+++ b/signer/src/message/testing.rs
@@ -1,9 +1,10 @@
 //! Test utilities for signer message
 
 use bitcoin::hashes::Hash;
-use blockstack_lib::chainstate::stacks;
 use fake::Fake;
 use rand::seq::SliceRandom;
+
+use crate::testing::dummy;
 
 impl super::SignerMessage {
     /// Construct a random message
@@ -59,7 +60,7 @@ impl fake::Dummy<fake::Faker> for super::SignerDepositDecision {
     fn dummy_with_rng<R: rand::RngCore + ?Sized>(config: &fake::Faker, rng: &mut R) -> Self {
         Self {
             output_index: config.fake_with_rng(rng),
-            txid: dummy_txid(config, rng),
+            txid: dummy::txid(config, rng),
             accepted: config.fake_with_rng(rng),
         }
     }
@@ -67,20 +68,20 @@ impl fake::Dummy<fake::Faker> for super::SignerDepositDecision {
 
 impl fake::Dummy<fake::Faker> for super::BitcoinTransactionSignRequest {
     fn dummy_with_rng<R: rand::RngCore + ?Sized>(config: &fake::Faker, rng: &mut R) -> Self {
-        Self { tx: dummy_tx(config, rng) }
+        Self { tx: dummy::tx(config, rng) }
     }
 }
 
 impl fake::Dummy<fake::Faker> for super::BitcoinTransactionSignAck {
     fn dummy_with_rng<R: rand::RngCore + ?Sized>(config: &fake::Faker, rng: &mut R) -> Self {
-        Self { txid: dummy_txid(config, rng) }
+        Self { txid: dummy::txid(config, rng) }
     }
 }
 
 impl fake::Dummy<fake::Faker> for super::StacksTransactionSignRequest {
     fn dummy_with_rng<R: rand::RngCore + ?Sized>(config: &fake::Faker, rng: &mut R) -> Self {
         Self {
-            tx: dummy_stacks_tx(config, rng),
+            tx: dummy::stacks_tx(config, rng),
         }
     }
 }
@@ -88,8 +89,8 @@ impl fake::Dummy<fake::Faker> for super::StacksTransactionSignRequest {
 impl fake::Dummy<fake::Faker> for super::StacksTransactionSignature {
     fn dummy_with_rng<R: rand::RngCore + ?Sized>(config: &fake::Faker, rng: &mut R) -> Self {
         Self {
-            txid: dummy_stacks_txid(config, rng),
-            signature: dummy_signature(config, rng),
+            txid: dummy::stacks_txid(config, rng),
+            signature: dummy::signature(config, rng),
         }
     }
 }
@@ -111,87 +112,4 @@ fn dummy_payload<P: Into<super::Payload> + fake::Dummy<fake::Faker>, R: rand::Rn
     rng: &mut R,
 ) -> super::Payload {
     config.fake_with_rng::<P, _>(rng).into()
-}
-
-fn dummy_txid<R: rand::RngCore + ?Sized>(config: &fake::Faker, rng: &mut R) -> bitcoin::Txid {
-    let bytes: [u8; 32] = config.fake_with_rng(rng);
-    bitcoin::Txid::from_byte_array(bytes)
-}
-
-fn dummy_tx<R: rand::RngCore + ?Sized>(config: &fake::Faker, rng: &mut R) -> bitcoin::Transaction {
-    let max_input_size = 50;
-    let max_output_size = 50;
-
-    let input_size = (rng.next_u32() % max_input_size) as usize;
-    let output_size = (rng.next_u32() % max_output_size) as usize;
-
-    let input = std::iter::repeat_with(|| dummy_txin(config, rng))
-        .take(input_size)
-        .collect();
-    let output = std::iter::repeat_with(|| dummy_txout(config, rng))
-        .take(output_size)
-        .collect();
-
-    bitcoin::Transaction {
-        version: bitcoin::transaction::Version::ONE,
-        lock_time: bitcoin::absolute::LockTime::ZERO,
-        input,
-        output,
-    }
-}
-
-fn dummy_txin<R: rand::RngCore + ?Sized>(config: &fake::Faker, rng: &mut R) -> bitcoin::TxIn {
-    bitcoin::TxIn {
-        previous_output: bitcoin::OutPoint::new(dummy_txid(config, rng), config.fake_with_rng(rng)),
-        sequence: bitcoin::Sequence::ZERO,
-        script_sig: bitcoin::ScriptBuf::new(),
-        witness: bitcoin::witness::Witness::new(),
-    }
-}
-
-fn dummy_txout<R: rand::RngCore + ?Sized>(config: &fake::Faker, rng: &mut R) -> bitcoin::TxOut {
-    bitcoin::TxOut {
-        value: bitcoin::Amount::from_sat(config.fake_with_rng(rng)),
-        script_pubkey: bitcoin::ScriptBuf::new(),
-    }
-}
-
-fn dummy_stacks_tx<R: rand::RngCore + ?Sized>(
-    config: &fake::Faker,
-    rng: &mut R,
-) -> stacks::StacksTransaction {
-    stacks::StacksTransaction {
-        version: stacks::TransactionVersion::Testnet,
-        chain_id: config.fake_with_rng(rng),
-        auth: stacks::TransactionAuth::from_p2sh(&[], 0).unwrap(),
-        anchor_mode: stacks::TransactionAnchorMode::Any,
-        post_condition_mode: stacks::TransactionPostConditionMode::Allow,
-        post_conditions: Vec::new(),
-        payload: stacks::TransactionPayload::new_smart_contract(
-            fake::faker::name::en::FirstName().fake_with_rng(rng),
-            fake::faker::lorem::en::Paragraph(3..5)
-                .fake_with_rng::<String, _>(rng)
-                .as_str(),
-            None,
-        )
-        .unwrap(),
-    }
-}
-
-fn dummy_stacks_txid<R: rand::RngCore + ?Sized>(
-    config: &fake::Faker,
-    rng: &mut R,
-) -> blockstack_lib::burnchains::Txid {
-    blockstack_lib::burnchains::Txid(config.fake_with_rng(rng))
-}
-
-fn dummy_signature<R: rand::RngCore + ?Sized>(
-    config: &fake::Faker,
-    rng: &mut R,
-) -> p256k1::ecdsa::Signature {
-    // Represent both the signed message and the signing key.
-    let multipurpose_bytes: [u8; 32] = config.fake_with_rng(rng);
-    let secret_key = p256k1::scalar::Scalar::from(multipurpose_bytes);
-
-    p256k1::ecdsa::Signature::new(&multipurpose_bytes, &secret_key).unwrap()
 }

--- a/signer/src/storage.rs
+++ b/signer/src/storage.rs
@@ -13,7 +13,7 @@ pub mod postgres;
 use std::future::Future;
 
 /// Represents the ability to read data from the signer storage.
-pub trait Read {
+pub trait DbRead {
     /// Read error.
     type Error;
 
@@ -25,7 +25,7 @@ pub trait Read {
 }
 
 /// Represents the ability to write data to the signer storage.
-pub trait Write {
+pub trait DbWrite {
     /// Write error.
     type Error;
 
@@ -36,12 +36,12 @@ pub trait Write {
     ) -> impl Future<Output = Result<(), Self::Error>> + Send;
 }
 
-impl<'a, T> Read for &'a mut T
+impl<'a, T> DbRead for &'a mut T
 where
-    &'a T: Read,
+    &'a T: DbRead,
     T: Send,
 {
-    type Error = <&'a T as Read>::Error;
+    type Error = <&'a T as DbRead>::Error;
 
     async fn get_bitcoin_block(
         self,
@@ -51,12 +51,12 @@ where
     }
 }
 
-impl<'a, T> Write for &'a mut T
+impl<'a, T> DbWrite for &'a mut T
 where
-    &'a T: Write,
+    &'a T: DbWrite,
     T: Send,
 {
-    type Error = <&'a T as Write>::Error;
+    type Error = <&'a T as DbWrite>::Error;
 
     async fn write_bitcoin_block(self, block: &model::BitcoinBlock) -> Result<(), Self::Error> {
         (&*self).write_bitcoin_block(block).await

--- a/signer/src/storage.rs
+++ b/signer/src/storage.rs
@@ -6,6 +6,7 @@
 //! The canonical implementation of these traits is the [`postgres::PgStore`]
 //! allowing the signer to use a Postgres database to store data.
 
+pub mod in_memory;
 pub mod model;
 pub mod postgres;
 
@@ -20,7 +21,7 @@ pub trait Read {
     fn get_bitcoin_block(
         self,
         block_hash: &model::BitcoinBlockHash,
-    ) -> impl Future<Output = Result<model::BitcoinBlock, Self::Error>> + Send;
+    ) -> impl Future<Output = Result<Option<model::BitcoinBlock>, Self::Error>> + Send;
 }
 
 /// Represents the ability to write data to the signer storage.
@@ -33,4 +34,31 @@ pub trait Write {
         self,
         block: &model::BitcoinBlock,
     ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+}
+
+impl<'a, T> Read for &'a mut T
+where
+    &'a T: Read,
+    T: Send,
+{
+    type Error = <&'a T as Read>::Error;
+
+    async fn get_bitcoin_block(
+        self,
+        block_hash: &model::BitcoinBlockHash,
+    ) -> Result<Option<model::BitcoinBlock>, Self::Error> {
+        (&*self).get_bitcoin_block(block_hash).await
+    }
+}
+
+impl<'a, T> Write for &'a mut T
+where
+    &'a T: Write,
+    T: Send,
+{
+    type Error = <&'a T as Write>::Error;
+
+    async fn write_bitcoin_block(self, block: &model::BitcoinBlock) -> Result<(), Self::Error> {
+        (&*self).write_bitcoin_block(block).await
+    }
 }

--- a/signer/src/storage/in_memory.rs
+++ b/signer/src/storage/in_memory.rs
@@ -25,7 +25,7 @@ impl Store {
     }
 }
 
-impl super::Read for &Store {
+impl super::DbRead for &Store {
     type Error = Error;
 
     async fn get_bitcoin_block(
@@ -36,7 +36,7 @@ impl super::Read for &Store {
     }
 }
 
-impl super::Write for &mut Store {
+impl super::DbWrite for &mut Store {
     type Error = Error;
 
     async fn write_bitcoin_block(self, block: &model::BitcoinBlock) -> Result<(), Self::Error> {
@@ -47,7 +47,7 @@ impl super::Write for &mut Store {
     }
 }
 
-impl super::Read for &Arc<Mutex<Store>> {
+impl super::DbRead for &Arc<Mutex<Store>> {
     type Error = Error;
 
     async fn get_bitcoin_block(
@@ -58,7 +58,7 @@ impl super::Read for &Arc<Mutex<Store>> {
     }
 }
 
-impl super::Write for &Arc<Mutex<Store>> {
+impl super::DbWrite for &Arc<Mutex<Store>> {
     type Error = Error;
 
     async fn write_bitcoin_block(self, block: &model::BitcoinBlock) -> Result<(), Self::Error> {

--- a/signer/src/storage/in_memory.rs
+++ b/signer/src/storage/in_memory.rs
@@ -1,0 +1,71 @@
+//! In-memory store implementation - useful for tests
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+use crate::storage::model;
+
+/// In-memory store
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct Store {
+    /// Bitcoin blocks
+    pub bitcoin_blocks: HashMap<model::BitcoinBlockHash, model::BitcoinBlock>,
+}
+
+impl Store {
+    /// Create an empty store
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Create an empty store wrapped in an Arc<Mutex<...>>
+    pub fn new_shared() -> Arc<Mutex<Self>> {
+        Arc::new(Mutex::new(Self::new()))
+    }
+}
+
+impl super::Read for &Store {
+    type Error = Error;
+
+    async fn get_bitcoin_block(
+        self,
+        block_hash: &model::BitcoinBlockHash,
+    ) -> Result<Option<model::BitcoinBlock>, Self::Error> {
+        Ok(self.bitcoin_blocks.get(block_hash).cloned())
+    }
+}
+
+impl super::Write for &mut Store {
+    type Error = Error;
+
+    async fn write_bitcoin_block(self, block: &model::BitcoinBlock) -> Result<(), Self::Error> {
+        self.bitcoin_blocks
+            .insert(block.block_hash.clone(), block.clone());
+
+        Ok(())
+    }
+}
+
+impl super::Read for &Arc<Mutex<Store>> {
+    type Error = Error;
+
+    async fn get_bitcoin_block(
+        self,
+        block_hash: &model::BitcoinBlockHash,
+    ) -> Result<Option<model::BitcoinBlock>, Self::Error> {
+        self.lock().await.get_bitcoin_block(block_hash).await
+    }
+}
+
+impl super::Write for &Arc<Mutex<Store>> {
+    type Error = Error;
+
+    async fn write_bitcoin_block(self, block: &model::BitcoinBlock) -> Result<(), Self::Error> {
+        self.lock().await.write_bitcoin_block(block).await
+    }
+}
+
+/// In-memory store operations are infallible
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum Error {}

--- a/signer/src/storage/model.rs
+++ b/signer/src/storage/model.rs
@@ -108,6 +108,35 @@ pub struct WithdrawSigner {
     pub created_at: time::PrimitiveDateTime,
 }
 
+/// A transaction on either Bitcoin or Stacks
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "testing", derive(fake::Dummy))]
+pub struct Transaction {
+    txid: Bytes,
+    tx: Bytes,
+    tx_type: TransactionType,
+}
+
+/// The types of transactions the signer is interested in.
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "testing", derive(fake::Dummy))]
+pub enum TransactionType {
+    /// An sBTC transaction on Bitcoin.
+    SbtcTransaction,
+    /// A withdraw accept transaction on Stacks.
+    WithdrawAccept,
+    /// A withdraw reject transaction on Stacks.
+    WithdrawReject,
+    /// A deposit accept transaction on Stacks.
+    DepositAccept,
+    /// A update signer set call on Stacks.
+    UpdateSignerSet,
+    /// A set aggregate key call on Stacks.
+    SetAggregateKey,
+}
+
+/// A stacks transaction
+
 /// Bitcoin block hash
 pub type BitcoinBlockHash = Vec<u8>;
 /// Stacks block hash

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -26,13 +26,13 @@ impl super::Read for &PgStore {
     async fn get_bitcoin_block(
         self,
         block_hash: &model::BitcoinBlockHash,
-    ) -> Result<model::BitcoinBlock, Self::Error> {
+    ) -> Result<Option<model::BitcoinBlock>, Self::Error> {
         sqlx::query_as!(
             model::BitcoinBlock,
             "SELECT * FROM sbtc_signer.bitcoin_blocks WHERE block_hash = $1;",
             &block_hash
         )
-        .fetch_one(&self.0)
+        .fetch_optional(&self.0)
         .await
     }
 }

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -20,7 +20,7 @@ impl From<sqlx::PgPool> for PgStore {
     }
 }
 
-impl super::Read for &PgStore {
+impl super::DbRead for &PgStore {
     type Error = sqlx::Error;
 
     async fn get_bitcoin_block(
@@ -37,7 +37,7 @@ impl super::Read for &PgStore {
     }
 }
 
-impl super::Write for &PgStore {
+impl super::DbWrite for &PgStore {
     type Error = sqlx::Error;
 
     async fn write_bitcoin_block(self, block: &model::BitcoinBlock) -> Result<(), Self::Error> {

--- a/signer/src/testing.rs
+++ b/signer/src/testing.rs
@@ -1,5 +1,7 @@
 //! Module with testing utility functions.
 
+pub mod dummy;
+
 use crate::utxo::UnsignedTransaction;
 use bitcoin::hashes::Hash;
 use bitcoin::key::TapTweak;

--- a/signer/src/testing/dummy.rs
+++ b/signer/src/testing/dummy.rs
@@ -1,0 +1,163 @@
+//! Utilities for generating dummy values on external types
+
+use bitcoin::hashes::Hash;
+use blockstack_lib::chainstate::{nakamoto, stacks};
+use fake::Fake;
+
+/// Dummy block
+pub fn block<R: rand::RngCore + ?Sized>(config: &fake::Faker, rng: &mut R) -> bitcoin::Block {
+    let max_number_of_transactions = 20;
+
+    let number_of_transactions = (rng.next_u32() % max_number_of_transactions) as usize;
+
+    let mut txdata: Vec<bitcoin::Transaction> = std::iter::repeat_with(|| tx(config, rng))
+        .take(number_of_transactions)
+        .collect();
+
+    // TODO(#213): Proper coinbase generation
+    let coinbase_script = bitcoin::script::Builder::new()
+        .push_slice([1, 2, 3, 4])
+        .into_script();
+
+    let mut coinbase_tx = tx(config, rng);
+    let mut coinbase_input = txin(config, rng);
+    coinbase_input.script_sig = coinbase_script;
+    coinbase_tx.input = vec![coinbase_input];
+
+    txdata.insert(0, coinbase_tx);
+
+    let header = bitcoin::block::Header {
+        version: bitcoin::block::Version::TWO,
+        prev_blockhash: block_hash(config, rng),
+        merkle_root: merkle_root(config, rng),
+        time: config.fake_with_rng(rng),
+        bits: bitcoin::CompactTarget::from_consensus(config.fake_with_rng(rng)),
+        nonce: config.fake_with_rng(rng),
+    };
+
+    bitcoin::Block { header, txdata }
+}
+
+/// Dummy txid
+pub fn txid<R: rand::RngCore + ?Sized>(config: &fake::Faker, rng: &mut R) -> bitcoin::Txid {
+    let bytes: [u8; 32] = config.fake_with_rng(rng);
+    bitcoin::Txid::from_byte_array(bytes)
+}
+
+/// Dummy transaction
+pub fn tx<R: rand::RngCore + ?Sized>(config: &fake::Faker, rng: &mut R) -> bitcoin::Transaction {
+    let max_input_size = 50;
+    let max_output_size = 50;
+
+    let input_size = (rng.next_u32() % max_input_size) as usize;
+    let output_size = (rng.next_u32() % max_output_size) as usize;
+
+    let input = std::iter::repeat_with(|| txin(config, rng))
+        .take(input_size)
+        .collect();
+    let output = std::iter::repeat_with(|| txout(config, rng))
+        .take(output_size)
+        .collect();
+
+    bitcoin::Transaction {
+        version: bitcoin::transaction::Version::ONE,
+        lock_time: bitcoin::absolute::LockTime::ZERO,
+        input,
+        output,
+    }
+}
+
+/// Dummy transaction input
+pub fn txin<R: rand::RngCore + ?Sized>(config: &fake::Faker, rng: &mut R) -> bitcoin::TxIn {
+    bitcoin::TxIn {
+        previous_output: bitcoin::OutPoint::new(txid(config, rng), config.fake_with_rng(rng)),
+        sequence: bitcoin::Sequence::ZERO,
+        script_sig: bitcoin::ScriptBuf::new(),
+        witness: bitcoin::witness::Witness::new(),
+    }
+}
+
+/// Dummy transaction output
+pub fn txout<R: rand::RngCore + ?Sized>(config: &fake::Faker, rng: &mut R) -> bitcoin::TxOut {
+    bitcoin::TxOut {
+        value: bitcoin::Amount::from_sat(config.fake_with_rng(rng)),
+        script_pubkey: bitcoin::ScriptBuf::new(),
+    }
+}
+
+/// Dummy block hash
+pub fn block_hash<R: rand::RngCore + ?Sized>(
+    config: &fake::Faker,
+    rng: &mut R,
+) -> bitcoin::BlockHash {
+    bitcoin::BlockHash::from_byte_array(config.fake_with_rng(rng))
+}
+
+/// Dummy merkle root
+pub fn merkle_root<R: rand::RngCore + ?Sized>(
+    config: &fake::Faker,
+    rng: &mut R,
+) -> bitcoin::TxMerkleNode {
+    bitcoin::TxMerkleNode::from_byte_array(config.fake_with_rng(rng))
+}
+
+/// Dummy stacks block
+pub fn stacks_block<R: rand::RngCore + ?Sized>(
+    config: &fake::Faker,
+    rng: &mut R,
+) -> nakamoto::NakamotoBlock {
+    let max_number_of_transactions = 20;
+
+    let number_of_transactions = (rng.next_u32() % max_number_of_transactions) as usize;
+
+    let txs = std::iter::repeat_with(|| stacks_tx(config, rng))
+        .take(number_of_transactions)
+        .collect();
+
+    let header = nakamoto::NakamotoBlockHeader::empty();
+
+    nakamoto::NakamotoBlock { header, txs }
+}
+
+/// Dummy stacks transaction
+pub fn stacks_tx<R: rand::RngCore + ?Sized>(
+    config: &fake::Faker,
+    rng: &mut R,
+) -> stacks::StacksTransaction {
+    stacks::StacksTransaction {
+        version: stacks::TransactionVersion::Testnet,
+        chain_id: config.fake_with_rng(rng),
+        auth: stacks::TransactionAuth::from_p2sh(&[], 0).unwrap(),
+        anchor_mode: stacks::TransactionAnchorMode::Any,
+        post_condition_mode: stacks::TransactionPostConditionMode::Allow,
+        post_conditions: Vec::new(),
+        payload: stacks::TransactionPayload::new_smart_contract(
+            fake::faker::name::en::FirstName().fake_with_rng(rng),
+            fake::faker::lorem::en::Paragraph(3..5)
+                .fake_with_rng::<String, _>(rng)
+                .as_str(),
+            None,
+        )
+        .unwrap(),
+    }
+}
+
+/// Dummy stacks transaction ID
+pub fn stacks_txid<R: rand::RngCore + ?Sized>(
+    config: &fake::Faker,
+    rng: &mut R,
+) -> blockstack_lib::burnchains::Txid {
+    blockstack_lib::burnchains::Txid(config.fake_with_rng(rng))
+}
+
+/// Dummy signature
+pub fn signature<R: rand::RngCore + ?Sized>(
+    config: &fake::Faker,
+    rng: &mut R,
+) -> p256k1::ecdsa::Signature {
+    // Represent both the signed message and the signing key.
+    let multipurpose_bytes: [u8; 32] = config.fake_with_rng(rng);
+    let secret_key = p256k1::scalar::Scalar::from(multipurpose_bytes);
+
+    p256k1::ecdsa::Signature::new(&multipurpose_bytes, &secret_key).unwrap()
+}

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -24,7 +24,7 @@ async fn should_be_able_to_query_bitcoin_blocks(pool: sqlx::PgPool) {
         store
             .write_bitcoin_block(block)
             .await
-            .expect("Failed to write bitcoin block");
+            .expect("failed to write bitcoin block");
     }
 
     // Assert that we can query each of the persisted blocks
@@ -32,17 +32,18 @@ async fn should_be_able_to_query_bitcoin_blocks(pool: sqlx::PgPool) {
         let persisted_block = store
             .get_bitcoin_block(&block.block_hash)
             .await
-            .expect("Failed to get parent hash");
+            .expect("failed to execute query")
+            .expect("block doesn't exist in database");
 
         assert_eq!(&persisted_block, block)
     }
 
     // Assert that we can't find any blocks that haven't been persisted
     for block in &not_persisted_model.bitcoin_blocks {
-        let err = store
+        let result = store
             .get_bitcoin_block(&block.block_hash)
             .await
-            .expect_err("Got unexpected row");
-        assert!(matches!(err, sqlx::Error::RowNotFound));
+            .expect("failed_to_execute_query");
+        assert!(result.is_none());
     }
 }

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -1,4 +1,4 @@
-use signer::storage::{Read, Write};
+use signer::storage::{DbRead, DbWrite};
 
 use signer::storage::model;
 use signer::storage::postgres::*;


### PR DESCRIPTION
closes #120 

This PR introduces the block observer event loop, with placeholder logic referencing follow-up tickets for the remainder of the block observer functionality. The current observer only writes the bitcoin blocks.

In addition to the event loop, the PR also adds:
* In-memory storage implementation (needed for tests).
* Bitcoin block generation logic for tests.
* Missing transaction type in the `storage::model` (unrelated broken window fix).
