### PR TITLE
K8s Artifacts for Electrs, MariaDB, Mempool FE & BE

### DIFF
--- a/devenv/local/k8s/build.sh
+++ b/devenv/local/k8s/build.sh
@@ -15,3 +15,4 @@ docker build -t minikube/stacks:v1 ./custom-k8s-docker-builds/stacks/docker/
 docker build -t minikube/stacks-api:v1 ./custom-k8s-docker-builds/stacks-api/docker/
 docker build -t minikube/stacks-explorer:v1 ./custom-k8s-docker-builds/stacks-explorer/docker/
 docker build -t minikube/nakamoto-signer:v1 ./custom-k8s-docker-builds/nakamoto-signer/docker/
+docker build -t minikube/electrs:v1 ./custom-k8s-docker-builds/electrs/docker/

--- a/devenv/local/k8s/custom-k8s-docker-builds/electrs/docker/Dockerfile
+++ b/devenv/local/k8s/custom-k8s-docker-builds/electrs/docker/Dockerfile
@@ -1,0 +1,41 @@
+# ENV VARS:
+# - BITCOIN_RPC_HOST
+# - BITCOIN_RPC_PORT
+
+# --------------------------------------------------------
+FROM debian:bookworm-slim as builder
+MAINTAINER Gowtham Sundar <gowtham@trustmachines.co>
+RUN apt-get update -qqy
+RUN apt-get install -qqy librocksdb-dev curl git
+# --------------------------------------------------------
+### Electrum Rust Server ###
+FROM builder as electrs-build
+RUN apt-get install -qqy cargo clang cmake
+ARG GIT_URI='https://github.com/mempool/electrs.git'
+ARG GIT_BRANCH='mempool'
+# Install electrs
+WORKDIR /build/electrs
+RUN git clone ${GIT_URI} -b ${GIT_BRANCH} .
+RUN cargo install --locked --path .
+# --------------------------------------------------------
+FROM builder as result
+# Copy the binaries
+COPY --from=electrs-build /root/.cargo/bin/electrs /usr/bin/electrs
+
+ARG RUST_BACKTRACE
+ARG BITCOIN_RPC_HOST
+ARG BITCOIN_RPC_PORT
+
+ENV RUST_BACKTRACE=$RUST_BACKTRACE
+ENV BITCOIN_RPC_HOST=$BITCOIN_RPC_HOST
+ENV BITCOIN_RPC_PORT=$BITCOIN_RPC_PORT
+
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod a+x /entrypoint.sh
+RUN apt-get update -qqy
+RUN apt-get install -qqy jq 
+EXPOSE 3002
+EXPOSE 60401
+WORKDIR /
+ENTRYPOINT ["./entrypoint.sh"]

--- a/devenv/local/k8s/custom-k8s-docker-builds/electrs/docker/Dockerfile
+++ b/devenv/local/k8s/custom-k8s-docker-builds/electrs/docker/Dockerfile
@@ -1,7 +1,3 @@
-# ENV VARS:
-# - BITCOIN_RPC_HOST
-# - BITCOIN_RPC_PORT
-
 # --------------------------------------------------------
 FROM debian:bookworm-slim as builder
 MAINTAINER Gowtham Sundar <gowtham@trustmachines.co>

--- a/devenv/local/k8s/custom-k8s-docker-builds/electrs/docker/entrypoint.sh
+++ b/devenv/local/k8s/custom-k8s-docker-builds/electrs/docker/entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# Wait until bitcoin RPC is ready
+echo "checking if bitcoin node is online"
+until curl -f -s -o /dev/null --user "$BTC_RPC_USER:$BTC_RPC_PASSWORD" --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "getblockcount", "params": []}' -H 'content-type: text/plain;' http://$BITCOIN_RPC_HOST:$BITCOIN_RPC_PORT/
+do
+	echo "bitcoin node is not ready, sleep two seconds"
+	sleep 2
+done
+echo "bitcoin node is ready"
+
+electrs --network regtest \
+	--jsonrpc-import \
+	--cookie "$BTC_RPC_USER:$BTC_RPC_PASSWORD" \
+	--http-addr="0.0.0.0:3002" \
+	--electrum-rpc-addr="0.0.0.0:60401" \
+	--daemon-rpc-addr="$BITCOIN_RPC_HOST:$BITCOIN_RPC_PORT" \
+	--electrum-txs-limit=2048 \
+	--utxos-limit=2048 \
+	--db-dir="/opt" \
+	--cors="*" \
+	-vv

--- a/devenv/local/k8s/down.sh
+++ b/devenv/local/k8s/down.sh
@@ -11,6 +11,10 @@ kubectl delete -f ./yamls/deployments/nakamoto-signer-deployment.yaml
 kubectl delete -f ./yamls/deployments/stacks-deployment.yaml
 kubectl delete -f ./yamls/deployments/stacks-api-deployment.yaml
 kubectl delete -f ./yamls/deployments/stacks-explorer-deployment.yaml
+kubectl delete -f ./yamls/deployments/mariadb-deployment.yaml
+kubectl delete -f ./yamls/deployments/electrs-deployment.yaml
+kubectl delete -f ./yamls/deployments/mempool-backend-deployment.yaml
+kubectl delete -f ./yamls/deployments/mempool-frontend-deployment.yaml
 
 # [2] Delete the K8s services
 kubectl delete -f ./yamls/services/services.yaml

--- a/devenv/local/k8s/tests/devnet-liveness.sh
+++ b/devenv/local/k8s/tests/devnet-liveness.sh
@@ -228,6 +228,28 @@ echo "\033[1mSTACKS_API_CONNECTED_TO_PG_SUCCESS\033[0m: $STACKS_API_CONNECTED_TO
 echo "\n"
 
 
+echo " -----------------------------------------------"
+echo "| => (10) 🔬 TEST: [CHECK IF MARIADB IS READY]  |"
+echo " -----------------------------------------------"
+
+MARIADB_POD_NAME=$(kubectl get pods --selector=app=mariadb -o json -n sbtc-signer | jq -r '.items[].metadata.name')
+
+MARIADB_LOGS=$(kubectl logs $MARIADB_POD_NAME -n sbtc-signer 2>/dev/null)
+
+MARIADB_READY_SUCCESS=false
+MARIADB_READY_SUCCESS_FRMT=$(echo "\033[1;31m$MARIADB_READY_SUCCESS\033[0m❌")
+if [[ $MARIADB_LOGS == *"ready for connections"* || $MARIADB_LOGS == *"Ready for start up"* ]]; then
+    MARIADB_READY_SUCCESS=true
+    echo "MariaDB || Ready for start up"
+    MARIADB_READY_SUCCESS_FRMT=$(echo "\033[1;32m$MARIADB_READY_SUCCESS\033[0m ✅")
+fi
+
+
+
+echo "\033[1mMARIADB_READY_SUCCESS\033[0m: $MARIADB_READY_SUCCESS_FRMT"
+echo "\n"
+
+
 
 echo "------------------------------------------------------------------"
 echo "|                        SUMMARY                                 |"
@@ -241,6 +263,7 @@ echo "| \033[1mSTX_SYNC_WITH_BTC_UTXO_SUCCESS\033[0m:               | \t $STX_SY
 echo "| \033[1mSTACKS_API_EVENT_OBSERVER_LIVENESS_SUCCESS\033[0m:   | \t $STACKS_API_EVENT_OBSERVER_LIVENESS_SUCCESS_FRMT |"
 echo "| \033[1mSTACKS_PUBLIC_API_LIVENESS_SUCCESS\033[0m:           | \t $STACKS_PUBLIC_API_LIVENESS_SUCCESS_FRMT |"
 echo "| \033[1mSTACKS_API_CONNECTED_TO_PG_SUCCESS\033[0m:           | \t $STACKS_API_CONNECTED_TO_PG_SUCCESS_FRMT |"
+echo "| \033[1mMARIADB_READY_SUCCESS\033[0m:                        | \t $MARIADB_READY_SUCCESS_FRMT |"
 echo "------------------------------------------------------------------"
 
 if [[ $BTC_LIVENESS_SUCCESS == true \
@@ -252,6 +275,7 @@ if [[ $BTC_LIVENESS_SUCCESS == true \
     && $STACKS_API_EVENT_OBSERVER_LIVENESS_SUCCESS == true \
     && $STACKS_PUBLIC_API_LIVENESS_SUCCESS == true \
     && $STACKS_API_CONNECTED_TO_PG_SUCCESS == true \
+    && $MARIADB_READY_SUCCESS == true \
     ]]; then
     exit 0
 fi

--- a/devenv/local/k8s/up.sh
+++ b/devenv/local/k8s/up.sh
@@ -16,26 +16,31 @@ kubectl apply -f ./yamls/services/services.yaml
 # ----------------------------------------
 # [4] Apply the K8s Deployments
 
-# i - Bitcoin
+# Bitcoin
 kubectl apply -f ./yamls/deployments/bitcoin-deployment.yaml
 
-# ii - Bitcoin Miner
+# Bitcoin Miner
 kubectl apply -f ./yamls/deployments/bitcoin-miner-deployment.yaml
 
 
 
-# iii - Postgres
+# Postgres
 kubectl apply -f ./yamls/deployments/postgres-deployment.yaml
 
-# iv - Nakamoto Signer
+# Mariadb
+kubectl apply -f ./yamls/deployments/mariadb-deployment.yaml
+
+# Nakamoto Signer
 kubectl apply -f ./yamls/deployments/nakamoto-signer-deployment.yaml
 
 
 
 # WAIT FOR BTC NODE
 kubectl wait --for=condition=available --timeout=15s -f ./yamls/deployments/bitcoin-deployment.yaml
-# v - Stacks Node
+# Stacks Node
 kubectl apply -f ./yamls/deployments/stacks-deployment.yaml
+# Electrum
+kubectl apply -f ./yamls/deployments/electrs-deployment.yaml
 
 
 
@@ -43,17 +48,27 @@ kubectl apply -f ./yamls/deployments/stacks-deployment.yaml
 # WAIT FOR STACKS NODE
 kubectl wait --for=condition=available --timeout=30s -f ./yamls/deployments/postgres-deployment.yaml
 kubectl wait --for=condition=available --timeout=30s -f ./yamls/deployments/stacks-deployment.yaml
-# vi - Stacks API
+# Stacks API
 kubectl apply -f ./yamls/deployments/stacks-api-deployment.yaml
 
 
 # WAIT FOR STACKS API
 kubectl wait --for=condition=available --timeout=30s -f ./yamls/deployments/stacks-api-deployment.yaml
-# vii - Stacks Explorer
+# Stacks Explorer
 kubectl apply -f ./yamls/deployments/stacks-explorer-deployment.yaml
 
 
 
+# WAIT FOR MariaDB
+kubectl wait --for=condition=available --timeout=30s -f ./yamls/deployments/mariadb-deployment.yaml
+kubectl wait --for=condition=available --timeout=30s -f ./yamls/deployments/electrs-deployment.yaml
+# Mempool Backend
+kubectl apply -f ./yamls/deployments/mempool-backend-deployment.yaml
+
+
+# WAIT FOR MEMPOOL BACKEND
+kubectl wait --for=condition=available --timeout=30s -f ./yamls/deployments/mempool-backend-deployment.yaml
+kubectl apply -f ./yamls/deployments/mempool-frontend-deployment.yaml
 
 # ----------------------------------------
 # Add a small pause for all deployments to get going (otherwise some tests will fail since it's searching in logs)

--- a/devenv/local/k8s/utils/port-forward-containers.sh
+++ b/devenv/local/k8s/utils/port-forward-containers.sh
@@ -54,3 +54,11 @@ pf_helper "postgres-deployment" "postgres-service" "5432" "5432" "sbtc-signer" "
 
 pf_helper "stacks-explorer-deployment" "stacks-explorer-service" "3020" "3000" "sbtc-signer" "Stacks Explorer" "7"
 
+pf_helper "electrs-deployment" "electrs-service" "60401" "60401" "sbtc-signer" "Electrs" "8"
+
+pf_helper "mariadb-deployment" "mariadb-service" "3306" "3306" "sbtc-signer" "MariaDB" "9"
+
+pf_helper "mempool-backend-deployment" "mempool-backend-service" "8999" "8999" "sbtc-signer" "Mempool Backend" "10"
+
+pf_helper "mempool-frontend-deployment" "mempool-frontend-service" "8083" "8083" "sbtc-signer" "Mempool Frontend" "11"
+

--- a/devenv/local/k8s/yamls/deployments/electrs-deployment.yaml
+++ b/devenv/local/k8s/yamls/deployments/electrs-deployment.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: electrs-deployment
+  namespace: sbtc-signer
+  labels:
+    app: electrs
+  
+spec:
+  replicas: 1
+  revisionHistoryLimit: 1
+  selector:
+    matchLabels:
+      app: electrs
+  
+  template:
+    metadata:
+      labels:
+        app: electrs
+    
+    spec:
+      containers:
+      - name: electrs-container
+        image: minikube/electrs:v1
+        imagePullPolicy: Never
+        
+        resources:
+          requests:
+            memory: 128Mi
+            cpu: 50m
+          limits:
+            memory: 256Mi
+            cpu: 100m
+        
+        ports:
+        - containerPort: 60401
+          protocol: TCP
+        - containerPort: 3002
+          protocol: TCP
+        - containerPort: 60401
+          protocol: UDP
+        - containerPort: 3002
+          protocol: UDP
+
+        env:
+          - name: RUST_BACKTRACE
+            value: '1'
+          - name: BITCOIN_RPC_HOST
+            value: "bitcoin-regtest-service.sbtc-signer"
+          - name: BITCOIN_RPC_PORT
+            value: "18443"
+          - name: BTC_RPC_USER
+            valueFrom:
+              secretKeyRef:
+                name: bitcoin-secret
+                key: BTC_RPCUSER 
+          - name: BTC_RPC_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: bitcoin-secret
+                key: BTC_RPCPASSWORD

--- a/devenv/local/k8s/yamls/deployments/mariadb-deployment.yaml
+++ b/devenv/local/k8s/yamls/deployments/mariadb-deployment.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mariadb-deployment
+  namespace: sbtc-signer
+  labels:
+    app: mariadb
+  
+spec:
+  replicas: 1
+  revisionHistoryLimit: 1
+  selector:
+    matchLabels:
+      app: mariadb
+  
+  template:
+    metadata:
+      labels:
+        app: mariadb
+    
+    spec:
+      containers:
+      - name: mariadb-container
+        image: mariadb:11.2
+        imagePullPolicy: IfNotPresent
+        
+        
+        resources:
+          requests:
+            memory: 128Mi
+            cpu: 50m
+          limits:
+            memory: 256Mi
+            cpu: 100m
+        
+        ports:
+        - containerPort: 3306
+          protocol: TCP
+        env:
+          - name: MYSQL_DATABASE
+            value: "mempool"
+          - name: MYSQL_USER
+            value: "mempool"
+          - name: MYSQL_PASSWORD
+            value: "mempool"
+          - name: MYSQL_ROOT_PASSWORD
+            value: "admin"

--- a/devenv/local/k8s/yamls/deployments/mempool-backend-deployment.yaml
+++ b/devenv/local/k8s/yamls/deployments/mempool-backend-deployment.yaml
@@ -1,0 +1,76 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mempool-backend-deployment
+  namespace: sbtc-signer
+  labels:
+    app: mempool-backend
+  
+spec:
+  replicas: 1
+  revisionHistoryLimit: 1
+  selector:
+    matchLabels:
+      app: mempool-backend
+  
+  template:
+    metadata:
+      labels:
+        app: mempool-backend
+    
+    spec:
+      containers:
+      - name: mempool-backend-container
+        image: mempool/backend:latest
+        imagePullPolicy: IfNotPresent
+        
+        resources:
+          requests:
+            memory: 128Mi
+            cpu: 50m
+          limits:
+            memory: 256Mi
+            cpu: 100m
+        
+        ports:
+        - containerPort: 8999
+          protocol: TCP
+
+        env:
+          # Connect to electrs host
+          - name: MEMPOOL_BACKEND
+            value: "electrum"
+          - name: ELECTRUM_HOST
+            value: "electrs-service.sbtc-signer"
+          - name: ELECTRUM_PORT
+            value: "60401"
+          - name: ELECTRUM_TLS_ENABLED
+            value: "false"
+          # Connect to bitcoin rpc
+          - name: CORE_RPC_HOST
+            value: "bitcoin-regtest-service.sbtc-signer"
+          - name: CORE_RPC_PORT
+            value: "18443"
+          - name: CORE_RPC_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: bitcoin-secret
+                key: BTC_RPCUSER 
+          - name: CORE_RPC_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: bitcoin-secret
+                key: BTC_RPCPASSWORD
+          - name: DATABASE_ENABLED
+            value: "true"
+          - name: DATABASE_HOST
+            value: "mariadb-service.sbtc-signer"
+          - name: DATABASE_DATABASE
+            value: "mempool"
+          - name: DATABASE_USERNAME
+            value: "mempool"
+          - name: DATABASE_PASSWORD
+            value: "mempool"
+          - name: STATISTICS_ENABLED
+            value: "true"

--- a/devenv/local/k8s/yamls/deployments/mempool-frontend-deployment.yaml
+++ b/devenv/local/k8s/yamls/deployments/mempool-frontend-deployment.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mempool-frontend-deployment
+  namespace: sbtc-signer
+  labels:
+    app: mempool-frontend
+  
+spec:
+  replicas: 1
+  revisionHistoryLimit: 1
+  selector:
+    matchLabels:
+      app: mempool-frontend
+  
+  template:
+    metadata:
+      labels:
+        app: mempool-frontend
+    
+    spec:
+      containers:
+      - name: mempool-frontend-container
+        image: mempool/frontend:latest
+        imagePullPolicy: IfNotPresent
+        
+        resources:
+          requests:
+            memory: 128Mi
+            cpu: 50m
+          limits:
+            memory: 256Mi
+            cpu: 100m
+        
+        ports:
+        - containerPort: 8083
+          protocol: TCP
+
+        env:
+          - name: FRONTEND_HTTP_PORT
+            value: "8083"
+          - name: BACKEND_MAINNET_HTTP_HOST
+            value: "mempool-backend-service.sbtc-signer"

--- a/devenv/local/k8s/yamls/services/services.yaml
+++ b/devenv/local/k8s/yamls/services/services.yaml
@@ -150,3 +150,85 @@ spec:
   selector:
     app: postgres
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: electrs-service
+  namespace: sbtc-signer
+  labels:
+    app: electrs
+  
+spec:
+  type: ClusterIP
+  ports:
+    - port: 60401
+      targetPort: 60401
+      name: electrs-port1-tcp
+      protocol: TCP
+    - port: 3002
+      targetPort: 3002
+      name: electrs-port2-tcp
+      protocol: TCP
+    - port: 60401
+      targetPort: 60401
+      name: electrs-port1-udp
+      protocol: UDP
+    - port: 3002
+      targetPort: 3002
+      name: electrs-port2-udp
+      protocol: UDP
+  selector:
+    app: electrs
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mariadb-service
+  namespace: sbtc-signer
+  labels:
+    app: mariadb
+  
+spec:
+  type: ClusterIP
+  ports:
+    - port: 3306
+      targetPort: 3306
+  selector:
+    app: mariadb
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mempool-backend-service
+  namespace: sbtc-signer
+  labels:
+    app: mempool-backend
+  
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8999
+      targetPort: 8999
+      name: mempool-backend-port1-tcp
+      protocol: TCP
+  selector:
+    app: mempool-backend
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mempool-frontend-service
+  namespace: sbtc-signer
+  labels:
+    app: mempool-frontend
+  
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8083
+      targetPort: 8083
+      name: mempool-frontend-port1-tcp
+      protocol: TCP
+  selector:
+    app: mempool-frontend
+---


### PR DESCRIPTION
Closes #211 


## Description


This PR contains the necessary components in K8s to get the Electrs, MariaDB, Mempool FE & BE running locally

This contains all the deployments, services, tests, and Docker build files for each of the components. More details are listed in #211  

## Steps to replicate:

Please follow the instructions at: `devenv/local/k8s/README.md`


After completing the `Installation` section, please run the following:

[1] `minikube start`
[2] `sh build.sh`
[3] `sh up.sh`
[4] `sh ./tests/devnet-liveness.sh`
[5] `sh down.sh`
[6] `minikube stop`

In order for this PR to pass, the tests in `devnet-liveness.sh` should pass

