### PR TITLE
docs: Document design for transaction signer event loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,6 +151,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
+name = "aquamarine"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21cc1548309245035eb18aa7f0967da6bc65587005170c56e6ef2788a4cf3f4e"
+dependencies = [
+ "include_dir",
+ "itertools 0.10.5",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.65",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2242,6 +2256,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "include_dir"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18762faeff7122e89e0857b02f7ce6fcc0d101d5e9ad2ad7846cc01d61b7f19e"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b139284b5cf57ecfa712bcc66950bb635b31aff41c188e8a4cfc758eca374a3f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4242,6 +4275,7 @@ dependencies = [
 name = "signer"
 version = "0.1.0"
 dependencies = [
+ "aquamarine",
  "backoff",
  "bincode",
  "bitcoin 0.32.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ codegen-units = 16
 [workspace.dependencies]
 emily = { version = "0.1.0", path = ".generated-sources/emily" }
 
+aquamarine = "0.5.0"
 aws_lambda_events = "0.15.0"
 aws-sdk-dynamodb = { version = "1.3.0" }
 backoff = { version = "0.4.0", features = ["tokio"] }

--- a/blocklist-client/README.md
+++ b/blocklist-client/README.md
@@ -12,13 +12,13 @@ Change to the blocklist-client directory and build the program using `cargo`.
 You can run the blocklist client by providing the required environment variables.
 
 #### Required Environment Variables
-- BLOCKLIST_CLIENT_RISK_ANALYSIS__API_URL=<provider-url>
-- BLOCKLIST_CLIENT_RISK_ANALYSIS__API_KEY=<your_api_key>
+- BLOCKLIST_CLIENT_RISK_ANALYSIS__API_URL=`<provider-url>`
+- BLOCKLIST_CLIENT_RISK_ANALYSIS__API_KEY=`<your_api_key>`
 
 #### Optional Environment Variables
 If not specified, the default values from `./src/config/default.toml` will be used.
-- BLOCKLIST_CLIENT_SERVER__HOST=<server-hostname-or-ip>
-- BLOCKLIST_CLIENT_SERVER__PORT=<server-port>
+- BLOCKLIST_CLIENT_SERVER__HOST=`<server-hostname-or-ip>`
+- BLOCKLIST_CLIENT_SERVER__PORT=`<server-port>`
 
    ```bash
     BLOCKLIST_CLIENT_SERVER__HOST=127.0.0.1 BLOCKLIST_CLIENT_SERVER__PORT=8080 BLOCKLIST_CLIENT_RISK_ANALYSIS__API_URL=https://your-risk-provider-api.com/ BLOCKLIST_CLIENT_RISK_ANALYSIS__API_KEY=your_api_key  ../target/release/blocklist-client 

--- a/signer/Cargo.toml
+++ b/signer/Cargo.toml
@@ -18,6 +18,7 @@ testing = ["fake"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+aquamarine.workspace = true
 backoff.workspace = true
 bincode.workspace = true
 bitcoin = { workspace = true, features = ["rand-std"] }

--- a/signer/README.md
+++ b/signer/README.md
@@ -15,8 +15,8 @@ You can run the signer by providing the required environment variables.
 
 #### Optional Environment Variables
 If not specified, the default values from `./src/config/default.toml` will be used.
-- `SIGNER_BLOCKLIST_CLIENT__HOST`=<server-hostname-or-ip>
-- `SIGNER_BLOCKLIST_CLIENT__PORT`=<server-port>
+- `SIGNER_BLOCKLIST_CLIENT__HOST`=`<server-hostname-or-ip>`
+- `SIGNER_BLOCKLIST_CLIENT__PORT`=`<server-port>`
 
 #### Inspecting the signer database
 The signer state will be stored in a `sbtc_signer` schema in the provided database at `$DATABASE_URL`.

--- a/signer/src/lib.rs
+++ b/signer/src/lib.rs
@@ -1,9 +1,9 @@
 #![doc = include_str!("../README.md")]
 #![deny(missing_docs)]
 
+pub mod block_notifier;
 pub mod block_observer;
 pub mod blocklist_client;
-pub mod block_notifier;
 pub mod codec;
 pub mod config;
 pub mod ecdsa;
@@ -15,6 +15,7 @@ pub mod packaging;
 pub mod storage;
 #[cfg(feature = "testing")]
 pub mod testing;
+pub mod transaction_signer;
 pub mod utxo;
 
 /// Package version

--- a/signer/src/network.rs
+++ b/signer/src/network.rs
@@ -18,7 +18,7 @@ pub type Msg = ecdsa::Signed<message::SignerMessage>;
 /// Represents the interaction point between signers and the signer network,
 /// allowing signers to exchange messages with each other.
 pub trait MessageTransfer {
-    /// Errors occuring during either [`broadcast`] or [`receive`]
+    /// Errors occuring during either [`MessageTransfer::broadcast`] or [`MessageTransfer::receive`]
     type Error: std::error::Error;
     /// Send `msg` to all other signers
     fn broadcast(&mut self, msg: Msg) -> impl Future<Output = Result<(), Self::Error>> + Send;

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -3,7 +3,7 @@
 use crate::storage::model;
 
 /// A wrapper around a [`sqlx::PgPool`] which implements
-/// [`signer::storage::Read`] and [`signer::storage::Write`].
+/// [`crate::storage::DbRead`] and [`crate::storage::DbWrite`].
 #[derive(Debug, Clone)]
 pub struct PgStore(sqlx::PgPool);
 

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -1,0 +1,69 @@
+//! # Transaction signer
+//!
+//! This module contains the transaction signer, which is
+//! responsible for preparing and participating in signing rounds.
+//!
+//! For more details, see the [`EventLoop`] documentation.
+
+#[cfg_attr(doc, aquamarine::aquamarine)]
+/// # Transaction signer event loop
+///
+/// This struct contains the implemetnation of the transaction signer logic.
+/// The event loop subscribes to storage update notifications from the block observer,
+/// and listens to signer messages from the signer entwork.
+///
+/// ## On storage update
+/// When the signer receives a storage update notification, it must go over each of the pending
+/// requests and decide wheter to accept or reject it. The decision is then persisted
+/// and broadcast to the other signers. The following flowchart illustrates the flow.
+///
+/// ```mermaid
+/// flowchart TD
+///     SU{Storage update notification} --> FPR(Fetch pending requests)
+///     FPR --> NR(Next request)
+///     NR --> |deposit/withdraw| DAR(Decide to accept/reject)
+///     NR ----> |none| DONE{Done}
+///     DAR --> PD(Persist decision)
+///     PD --> BD(Broadcast decision)
+///     BD --> NR
+/// ```
+///
+/// ## On signer message
+/// When the signer receives a signer message, it needs to do a few different things
+/// depending on the type of the message.
+///
+/// - **Signer decision**: When receiving a signer decision, the transaction signer
+/// only need to persist the decision to the signer storage.
+/// - **Stacks sign request**: When receiving a request to sign a stacks transaction,
+/// the signer must verify that it has decided to sign the transaction, and if positive,
+/// send a transaction signature back over the network.
+/// - **Bitcoin sign request**: When receiving a request to sign a bitcoin transaction,
+/// the signer must verify that it has decided to accept all request that the
+/// transaction fulfills. Once verified, the transaction signer creates a dedicated
+/// WSTS state machine to participate in a signing round for this transaction. Thereafter,
+/// the signer sends a bitcoin transaction sign ack message back over the network to signal
+/// its readiness.
+/// - **WSTS message**: When receiving a WSTS message, the signer will look up the corresponding
+/// state machine and relay the WSTS message to it.
+///
+/// The following flowchart illustrates the process.
+///
+/// ```mermaid
+/// flowchart TD
+///     SM{Signer message received} --> |Signer decision| PD(Persist decision)
+///
+///     SM --> |Stacks sign request| CD1(Check decision)
+///     CD1 --> SS(Send signature)
+///
+///     SM --> |Bitcoin sign request| CD2(Check decision)
+///     CD2 --> WSM(Create WSTS state machine)
+///     WSM --> ACK(Send Ack message)
+///
+///     SM --> |WSTS message| RWSM(Relay to WSTS state machine)
+/// ```
+pub struct EventLoop;
+
+impl EventLoop {
+    /// Run the signer event loop
+    pub async fn run() {}
+}

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -29,7 +29,8 @@
 /// ```
 ///
 /// ## On signer message
-/// When the signer receives a signer message, it needs to do a few different things
+///
+/// When the signer receives a message from another signer, it needs to do a few different things
 /// depending on the type of the message.
 ///
 /// - **Signer decision**: When receiving a signer decision, the transaction signer

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -1,7 +1,7 @@
 //! # Transaction signer
 //!
-//! This module contains the transaction signer, which is
-//! responsible for preparing and participating in signing rounds.
+//! This module contains the transaction signer, which is the component of the sBTC signer
+//! responsible for participating in signing rounds.
 //!
 //! For more details, see the [`EventLoop`] documentation.
 
@@ -47,7 +47,7 @@
 /// the signer sends a bitcoin transaction sign ack message back over the network to signal
 /// its readiness.
 /// - **WSTS message**: When receiving a WSTS message, the signer will look up the corresponding
-/// state machine and relay the WSTS message to it.
+/// state machine and dispatch the WSTS message to it.
 ///
 /// The following flowchart illustrates the process.
 ///

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -8,9 +8,9 @@
 #[cfg_attr(doc, aquamarine::aquamarine)]
 /// # Transaction signer event loop
 ///
-/// This struct contains the implemetnation of the transaction signer logic.
+/// This struct contains the implementation of the transaction signer logic.
 /// The event loop subscribes to storage update notifications from the block observer,
-/// and listens to signer messages from the signer entwork.
+/// and listens to signer messages from the signer network.
 ///
 /// ## On storage update
 /// When the signer receives a storage update notification, it must go over each of the pending

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -36,7 +36,7 @@
 /// - **Signer decision**: When receiving a signer decision, the transaction signer
 /// only needs to persist the decision to its database.
 /// - **Stacks sign request**: When receiving a request to sign a stacks transaction,
-/// the signer must verify that it has decided to sign the transaction, and if positive,
+/// the signer must verify that it has decided to sign the transaction, and if it has,
 /// send a transaction signature back over the network.
 /// - **Bitcoin sign request**: When receiving a request to sign a bitcoin transaction,
 /// the signer must verify that it has decided to accept all request that the

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -34,7 +34,7 @@
 /// depending on the type of the message.
 ///
 /// - **Signer decision**: When receiving a signer decision, the transaction signer
-/// only need to persist the decision to the signer storage.
+/// only needs to persist the decision to its database.
 /// - **Stacks sign request**: When receiving a request to sign a stacks transaction,
 /// the signer must verify that it has decided to sign the transaction, and if positive,
 /// send a transaction signature back over the network.

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -14,7 +14,7 @@
 ///
 /// ## On storage update
 /// When the signer receives a storage update notification, it must go over each of the pending
-/// requests and decide wheter to accept or reject it. The decision is then persisted
+/// requests and decide whether to accept or reject it. The decision is then persisted
 /// and broadcast to the other signers. The following flowchart illustrates the flow.
 ///
 /// ```mermaid

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -39,7 +39,7 @@
 /// the signer must verify that it has decided to sign the transaction, and if it has,
 /// send a transaction signature back over the network.
 /// - **Bitcoin sign request**: When receiving a request to sign a bitcoin transaction,
-/// the signer must verify that it has decided to accept all request that the
+/// the signer must verify that it has decided to accept all requests that the
 /// transaction fulfills. Once verified, the transaction signer creates a dedicated
 /// WSTS state machine to participate in a signing round for this transaction. Thereafter,
 /// the signer sends a bitcoin transaction sign ack message back over the network to signal

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -12,14 +12,16 @@
 /// The event loop subscribes to storage update notifications from the block observer,
 /// and listens to signer messages from the signer network.
 ///
-/// ## On storage update
-/// When the signer receives a storage update notification, it must go over each of the pending
+/// ## On block observer notification
+///
+/// When the signer receives a notification from the block observer, indicating that
+/// new blocks have been added to the signer state, it must go over each of the pending
 /// requests and decide whether to accept or reject it. The decision is then persisted
 /// and broadcast to the other signers. The following flowchart illustrates the flow.
 ///
 /// ```mermaid
 /// flowchart TD
-///     SU{Storage update notification} --> FPR(Fetch pending requests)
+///     SU{Block observer notification} --> FPR(Fetch pending requests)
 ///     FPR --> NR(Next request)
 ///     NR --> |deposit/withdraw| DAR(Decide to accept/reject)
 ///     NR ----> |none| DONE{Done}


### PR DESCRIPTION
closes #221 

The documentation can be rendered locally using `cargo doc --open`. The mermaid charts should be rendered in the docs thanks to [aquamarine](https://github.com/mersinvald/aquamarine).