### PR TITLE
Deposit accept many

### DIFF
--- a/contracts/contracts/sbtc-deposit.clar
+++ b/contracts/contracts/sbtc-deposit.clar
@@ -38,7 +38,7 @@
         (asserts! (is-eq (get current-signer-principal current-signer-data) tx-sender) ERR_INVALID_CALLER)
 
         ;; Check that amount is greater than dust limit
-        (asserts! (> amount dust-limit) ERR_LOWER_THAN_DUST)
+        (asserts! (>= amount dust-limit) ERR_LOWER_THAN_DUST)
 
         ;; Check that txid is the correct length
         (asserts! (is-eq (len txid) txid-length) ERR_TXID_LEN)

--- a/contracts/contracts/sbtc-deposit.clar
+++ b/contracts/contracts/sbtc-deposit.clar
@@ -7,12 +7,13 @@
 (define-constant dust-limit u546)
 
 ;; error codes
-
 ;; TXID used in deposit is not the correct length
 (define-constant ERR_TXID_LEN (err u300))
 ;; Deposit has already been completed
 (define-constant ERR_DEPOSIT_REPLAY (err u301))
 (define-constant ERR_LOWER_THAN_DUST (err u302))
+(define-constant ERR_KEY_SIZE_PREFIX (unwrap-err! ERR_DEPOSIT (err true)))
+(define-constant ERR_DEPOSIT (err u303))
 
 ;; data vars
 
@@ -65,5 +66,15 @@
 ;;
 
 ;; private functions
-;;
+(define-private (complete-individual-deposits-helper (deposit {txid: (buff 32), vout-index: uint, amount: uint, recipient: principal}) (helper-response (response uint uint)))
+    (match helper-response 
+        index
+            (begin 
+                (try! (unwrap! (complete-deposit-wrapper (get txid deposit) (get vout-index deposit) (get amount deposit) (get recipient deposit)) (err (+ ERR_KEY_SIZE_PREFIX (+ u10 index)))))
+                (ok (+ index u1))
+            )
+        err-response
+            (err err-response)
+    )
+)
 

--- a/contracts/contracts/sbtc-deposit.clar
+++ b/contracts/contracts/sbtc-deposit.clar
@@ -56,7 +56,10 @@
 ;; bootstrap signer set address - it cannot be called by users directly.
 ;; 
 ;; This function handles the validation & minting of sBTC by handling multiple (up to 1000) deposits at a time, 
-;; it then calls into the sbtc-registry contract to update the state of the protocol
+;; it then calls into the sbtc-registry contract to update the state of the protocol. 
+(define-public (complete-deposits-wrapper (deposits (list 1000 {txid: (buff 32), vout-index: uint, amount: uint, recipient: principal})))
+    (fold complete-individual-deposits-helper deposits (ok u0))
+)
 
 ;; read only functions
 ;;

--- a/contracts/tests/clarigen-types.ts
+++ b/contracts/tests/clarigen-types.ts
@@ -478,6 +478,45 @@ export const contracts = {
   },
   sbtcDeposit: {
     functions: {
+      completeIndividualDepositsHelper: {
+        name: "complete-individual-deposits-helper",
+        access: "private",
+        args: [
+          {
+            name: "deposit",
+            type: {
+              tuple: [
+                { name: "amount", type: "uint128" },
+                { name: "recipient", type: "principal" },
+                { name: "txid", type: { buffer: { length: 32 } } },
+                { name: "vout-index", type: "uint128" },
+              ],
+            },
+          },
+          {
+            name: "helper-response",
+            type: { response: { ok: "uint128", error: "uint128" } },
+          },
+        ],
+        outputs: { type: { response: { ok: "uint128", error: "uint128" } } },
+      } as TypedAbiFunction<
+        [
+          deposit: TypedAbiArg<
+            {
+              amount: number | bigint;
+              recipient: string;
+              txid: Uint8Array;
+              voutIndex: number | bigint;
+            },
+            "deposit"
+          >,
+          helperResponse: TypedAbiArg<
+            Response<number | bigint, number | bigint>,
+            "helperResponse"
+          >,
+        ],
+        Response<bigint, bigint>
+      >,
       completeDepositWrapper: {
         name: "complete-deposit-wrapper",
         access: "public",
@@ -504,11 +543,72 @@ export const contracts = {
         ],
         Response<Response<boolean, bigint>, bigint>
       >,
+      completeDepositsWrapper: {
+        name: "complete-deposits-wrapper",
+        access: "public",
+        args: [
+          {
+            name: "deposits",
+            type: {
+              list: {
+                type: {
+                  tuple: [
+                    { name: "amount", type: "uint128" },
+                    { name: "recipient", type: "principal" },
+                    { name: "txid", type: { buffer: { length: 32 } } },
+                    { name: "vout-index", type: "uint128" },
+                  ],
+                },
+                length: 1000,
+              },
+            },
+          },
+        ],
+        outputs: { type: { response: { ok: "uint128", error: "uint128" } } },
+      } as TypedAbiFunction<
+        [
+          deposits: TypedAbiArg<
+            {
+              amount: number | bigint;
+              recipient: string;
+              txid: Uint8Array;
+              voutIndex: number | bigint;
+            }[],
+            "deposits"
+          >,
+        ],
+        Response<bigint, bigint>
+      >,
     },
     maps: {},
     variables: {
+      ERR_DEPOSIT: {
+        name: "ERR_DEPOSIT",
+        type: {
+          response: {
+            ok: "none",
+            error: "uint128",
+          },
+        },
+        access: "constant",
+      } as TypedAbiVariable<Response<null, bigint>>,
+      ERR_DEPOSIT_INDEX_PREFIX: {
+        name: "ERR_DEPOSIT_INDEX_PREFIX",
+        type: "uint128",
+        access: "constant",
+      } as TypedAbiVariable<bigint>,
       ERR_DEPOSIT_REPLAY: {
         name: "ERR_DEPOSIT_REPLAY",
+        type: {
+          response: {
+            ok: "none",
+            error: "uint128",
+          },
+        },
+        access: "constant",
+      } as TypedAbiVariable<Response<null, bigint>>,
+      ERR_INVALID_CALLER: {
+        name: "ERR_INVALID_CALLER",
         type: {
           response: {
             ok: "none",
@@ -549,9 +649,18 @@ export const contracts = {
       } as TypedAbiVariable<bigint>,
     },
     constants: {
+      ERR_DEPOSIT: {
+        isOk: false,
+        value: 303n,
+      },
+      ERR_DEPOSIT_INDEX_PREFIX: 303n,
       ERR_DEPOSIT_REPLAY: {
         isOk: false,
         value: 301n,
+      },
+      ERR_INVALID_CALLER: {
+        isOk: false,
+        value: 304n,
       },
       ERR_LOWER_THAN_DUST: {
         isOk: false,

--- a/contracts/tests/sbtc-deposit.test.ts
+++ b/contracts/tests/sbtc-deposit.test.ts
@@ -1,4 +1,4 @@
-import { alice, deposit, errors, registry } from "./helpers";
+import { alice, deployer, deposit, errors, registry } from "./helpers";
 import { test, expect, describe } from "vitest";
 import { txOk, filterEvents, rov, txErr } from "@clarigen/test";
 import { CoreNodeEventType, cvToValue } from "@clarigen/core";
@@ -11,9 +11,9 @@ describe("sBTC deposit contract", () => {
           txid: new Uint8Array(31).fill(0),
           voutIndex: 0,
           amount: 1000n,
-          recipient: alice,
+          recipient: deployer,
         }),
-        alice
+        deployer
       );
       expect(receipt.value).toEqual(errors.deposit.ERR_TXID_LEN);
     });
@@ -24,9 +24,9 @@ describe("sBTC deposit contract", () => {
           txid: new Uint8Array(32).fill(0),
           voutIndex: 0,
           amount: 10n,
-          recipient: alice,
+          recipient: deployer,
         }),
-        alice
+        deployer
       );
       expect(receipt.value).toEqual(deposit.constants.ERR_LOWER_THAN_DUST.value);
     });
@@ -37,9 +37,9 @@ describe("sBTC deposit contract", () => {
           txid: new Uint8Array(32).fill(0),
           voutIndex: 0,
           amount: 1000n,
-          recipient: alice,
+          recipient: deployer,
         }),
-        alice
+        deployer
       );
       expect(receipt0.value).toEqual(true);
       const receipt1 = txErr(
@@ -47,9 +47,9 @@ describe("sBTC deposit contract", () => {
           txid: new Uint8Array(32).fill(0),
           voutIndex: 0,
           amount: 1000n,
-          recipient: alice,
+          recipient: deployer,
         }),
-        alice
+        deployer
       );
       expect(receipt1.value).toEqual(errors.deposit.ERR_DEPOSIT_REPLAY);
     });
@@ -60,9 +60,9 @@ describe("sBTC deposit contract", () => {
           txid: new Uint8Array(32).fill(0),
           voutIndex: 0,
           amount: 1000n,
-          recipient: alice,
+          recipient: deployer,
         }),
-        alice
+        deployer
       );
       const printEvents = filterEvents(
         receipt.events,
@@ -89,20 +89,20 @@ describe("sBTC deposit contract", () => {
           txid: new Uint8Array(32).fill(0),
           voutIndex: 0,
           amount: 1000n,
-          recipient: alice,
+          recipient: deployer,
         }),
-        alice
+        deployer
       );
       const receipt1 = rov(
         registry.getCompletedDeposit({
           txid: new Uint8Array(32).fill(0),
           voutIndex: 0,
         }),
-        alice
+        deployer
       );
       expect(receipt1).toStrictEqual({
         amount: 1000n,
-        recipient: alice,
+        recipient: deployer,
       });
     });
   });

--- a/contracts/tests/sbtc-token.test.ts
+++ b/contracts/tests/sbtc-token.test.ts
@@ -1,4 +1,4 @@
-import { alice, bob, deposit, errors, token } from "./helpers";
+import { alice, bob, deployer, deposit, errors, token } from "./helpers";
 import { test, expect, describe } from "vitest";
 import { txOk, filterEvents, rov, txErr } from "@clarigen/test";
 import { CoreNodeEventType, cvToValue } from "@clarigen/core";
@@ -13,7 +13,7 @@ describe("sBTC token contract", () => {
           amount: 1000n,
           recipient: alice,
         }),
-        alice
+        deployer
       );
       const printEvents = filterEvents(
         receipt.events,
@@ -49,7 +49,7 @@ describe("sBTC token contract", () => {
           amount: 1000n,
           recipient: alice,
         }),
-        alice
+        deployer
       );
       const printEvents = filterEvents(
         receipt.events,


### PR DESCRIPTION
## Description
This PR introduces a 'complete-deposits-wrapper' that address the ability for signers to submit multiple deposits requests at once.

The motivation for this PR was to close out #86.

## Type of Change
This is a new feature change that wraps around existing functionality.

## Does this introduce a breaking change?
No.

## Are documentation updates required?
No.

## Testing information
Changes are tested using ClarinetSDK.

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `pnpm test` passes
- [ ] Changelog is updated
- [x] Tag 1 of @person1 or @person2
