### PR TITLE
Added Nakamoto Components to K8s local devnet

### DIFF
--- a/devenv/local/k8s/build.sh
+++ b/devenv/local/k8s/build.sh
@@ -12,6 +12,7 @@ eval $(minikube docker-env)
 docker build -t minikube/bitcoin:v1 ./custom-k8s-docker-builds/bitcoin/docker/
 docker build -t minikube/bitcoin-miner-sidecar:v1 ./custom-k8s-docker-builds/bitcoin-miner-sidecar/docker/
 docker build -t minikube/stacks:v1 ./custom-k8s-docker-builds/stacks/docker/
+docker build -t minikube/stacker:v1 ./custom-k8s-docker-builds/stacker/docker/
 docker build -t minikube/stacks-api:v1 ./custom-k8s-docker-builds/stacks-api/docker/
 docker build -t minikube/stacks-explorer:v1 ./custom-k8s-docker-builds/stacks-explorer/docker/
 docker build -t minikube/nakamoto-signer:v1 ./custom-k8s-docker-builds/nakamoto-signer/docker/

--- a/devenv/local/k8s/custom-k8s-docker-builds/bitcoin-miner-sidecar/docker/entrypoint.sh
+++ b/devenv/local/k8s/custom-k8s-docker-builds/bitcoin-miner-sidecar/docker/entrypoint.sh
@@ -32,7 +32,7 @@ curl -u "$BTC_RPCUSER:$BTC_RPCPASSWORD" --data-binary '{"jsonrpc": "1.0", "id": 
 echo "=> mined initial blocks \n\n"
 
 
-# Mine a single block every 10 seconds
+# Mine a single block every BTC_BLOCK_GEN_TIME seconds
 while true
 do
 	curl -u "$BTC_RPCUSER:$BTC_RPCPASSWORD" --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "generatetoaddress", "params": [1, "'$MINER_ADDRESS'"]}' -H 'content-type: text/plain;' "$RPC_ENDPOINT"

--- a/devenv/local/k8s/custom-k8s-docker-builds/bitcoin/docker/entrypoint.sh
+++ b/devenv/local/k8s/custom-k8s-docker-builds/bitcoin/docker/entrypoint.sh
@@ -21,14 +21,14 @@ rm -rf "$DOT_BITCOIN_DIR/bitcoin.conf"
 # copy over the file into the location
 cp "$SHARED_VOL_DIR/bitcoin.conf" "$DOT_BITCOIN_DIR"
 
-bitcoind \
-    -regtest \
-    -txindex=${BTC_TXINDEX} \
-    -rpcuser=${BTC_RPCUSER} \
-    -rpcpassword=${BTC_RPCPASSWORD} \
-    -printtoconsole=${BTC_PRINTTOCONSOLE} \
-    -disablewallet=${BTC_DISABLEWALLET} \
-    -rpcallowip=${BTC_RPCALLOWIP} \
-    -rpcport=${BTC_RPC_PORT} \
-    -server=1 \
-    -conf=${DOT_BITCOIN_DIR}/bitcoin.conf
+## Q: Why are making a bitcoin.conf file and also pass in these envs into bitcoind ?
+## A: Just passing in "-conf" arg into bitcoind didn't work and threw many errors. 
+##    Creating a bitcoin.conf and also explictly invoking bitcoind with the parameters worked
+
+if [[ $BTC_NETWORK == 'mainnet' ]]; then
+    bitcoind -txindex=${BTC_TXINDEX} -rpcuser=${BTC_RPCUSER} -rpcpassword=${BTC_RPCPASSWORD} -printtoconsole=${BTC_PRINTTOCONSOLE} -disablewallet=${BTC_DISABLEWALLET} -rpcallowip=${BTC_RPCALLOWIP} -rpcport=${BTC_RPC_PORT} -server=1 -conf=${DOT_BITCOIN_DIR}/bitcoin.conf
+elif [[ $BTC_NETWORK == 'testnet' ]]; then
+    bitcoind -testnet -txindex=${BTC_TXINDEX} -rpcuser=${BTC_RPCUSER} -rpcpassword=${BTC_RPCPASSWORD} -printtoconsole=${BTC_PRINTTOCONSOLE} -disablewallet=${BTC_DISABLEWALLET} -rpcallowip=${BTC_RPCALLOWIP} -rpcport=${BTC_RPC_PORT} -server=1 -conf=${DOT_BITCOIN_DIR}/bitcoin.conf
+else
+    bitcoind -regtest -txindex=${BTC_TXINDEX} -rpcuser=${BTC_RPCUSER} -rpcpassword=${BTC_RPCPASSWORD} -printtoconsole=${BTC_PRINTTOCONSOLE} -disablewallet=${BTC_DISABLEWALLET} -rpcallowip=${BTC_RPCALLOWIP} -rpcport=${BTC_RPC_PORT} -server=1 -conf=${DOT_BITCOIN_DIR}/bitcoin.conf
+fi

--- a/devenv/local/k8s/custom-k8s-docker-builds/nakamoto-signer/docker/Dockerfile
+++ b/devenv/local/k8s/custom-k8s-docker-builds/nakamoto-signer/docker/Dockerfile
@@ -1,13 +1,61 @@
-FROM blockstack/stacks-core:2.5.0.0.3
+# BUILDER
+# -------------------------------------------------------------------------------
+FROM rust:bookworm as builder
+LABEL org.opencontainers.image.authors="Gowtham Sundar <gowtham@trustmachines.co>"
 MAINTAINER Gowtham Sundar <gowtham@trustmachines.co>
-COPY . .
 
-# -----------INSTALL SUDO----------------------
-RUN apt-get update && apt-get install -y sudo
+ARG GIT_URI='https://github.com/stacks-network/stacks-core.git'
+ARG GIT_COMMIT='3d96d53b35409859ca2baa2f0b6ddaa1fbd80265'
 
+RUN echo "Building stacks from commit: https://github.com/stacks-network/stacks-core/commit/$GIT_COMMIT"
+
+RUN apt-get update && apt-get install -y libclang-dev
+RUN rustup toolchain install stable
+RUN rustup component add rustfmt --toolchain stable
+
+WORKDIR /stacks
+RUN git init && git remote add origin $GIT_URI && git -c protocol.version=2 fetch --depth=1 origin "$GIT_COMMIT" && git reset --hard FETCH_HEAD
+RUN cargo build --package stacks-signer --bin stacks-signer
+
+# RUNNER
+# -------------------------------------------------------------------------------
+FROM debian:bookworm
+
+# copy over stacks-signer binary
+COPY --from=builder /stacks/target/debug/stacks-signer /usr/local/bin/
+
+
+ARG SIGNER_ENDPOINT
+ARG MY_HTTP_AUTH_TOKEN
+ARG STACKS_PRIVATE_KEY
+ARG STACKS_NODE_RPC_HOST
+ARG STACKS_NODE_RPC_PORT
+ARG RUST_BACKTRACE
+ARG SIGNER_DB_PATH
+ARG GIT_URI
+ARG GIT_COMMIT
+
+
+ENV SIGNER_ENDPOINT=$SIGNER_ENDPOINT
+ENV MY_HTTP_AUTH_TOKEN=$MY_HTTP_AUTH_TOKEN
+ENV STACKS_PRIVATE_KEY=$STACKS_PRIVATE_KEY
+ENV STACKS_NODE_RPC_HOST=$STACKS_NODE_RPC_HOST
+ENV STACKS_NODE_RPC_PORT=$STACKS_NODE_RPC_PORT
+ENV RUST_BACKTRACE=$RUST_BACKTRACE
+ENV SIGNER_DB_PATH=$SIGNER_DB_PATH
+ENV GIT_URI=$GIT_URI
+ENV GIT_COMMIT=$GIT_COMMIT
+
+
+
+# install & setup utils
+RUN apt-get update && apt-get install -y curl gettext-base jq sudo
+RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
+
 # -------------ENTRYPOINT---------------------
+COPY entrypoint.sh .
 RUN chmod +rwx ./entrypoint.sh
 
 EXPOSE 30000

--- a/devenv/local/k8s/custom-k8s-docker-builds/stacker/docker/Dockerfile
+++ b/devenv/local/k8s/custom-k8s-docker-builds/stacker/docker/Dockerfile
@@ -1,0 +1,35 @@
+FROM node:20-bookworm as builder
+LABEL org.opencontainers.image.authors="Gowtham Sundar <gowtham@trustmachines.co>"
+
+
+ARG GIT_URI='https://github.com/hirosystems/stacks-regtest-env.git'
+ARG GIT_BRANCH='feat/signer'
+
+WORKDIR /root
+
+# Download the stacks-regtest-env code
+RUN mkdir /root/stacks-regtest-env
+RUN git clone ${GIT_URI} -b ${GIT_BRANCH} /root/stacks-regtest-env
+RUN pwd
+RUN ls
+
+
+
+
+FROM node:20-bookworm
+
+RUN apt-get update && apt-get install -y curl gettext-base jq
+
+WORKDIR /root
+
+# Copy over the stacking typescript project into workdir
+COPY --from=builder /root/stacks-regtest-env/stacking/package.json /root/
+RUN npm i
+
+COPY --from=builder /root/stacks-regtest-env/stacking/stacking.ts /root/
+COPY --from=builder /root/stacks-regtest-env/stacking/common.ts /root/
+COPY --from=builder /root/stacks-regtest-env/stacking/monitor.ts /root/
+COPY --from=builder /root/stacks-regtest-env/stacking/tx-broadcaster.ts /root/
+
+
+CMD ["npx", "tsx", "/root/stacking.ts"]

--- a/devenv/local/k8s/custom-k8s-docker-builds/stacks/docker/Dockerfile
+++ b/devenv/local/k8s/custom-k8s-docker-builds/stacks/docker/Dockerfile
@@ -1,20 +1,41 @@
-FROM blockstack/stacks-core:2.5.0.0.3
-MAINTAINER Gowtham Sundar <gowtham@trustmachines.co>
-WORKDIR /
+# BUILDER
+# -------------------------------------------------------------------------------
+FROM rust:bookworm as builder
+LABEL org.opencontainers.image.authors="Gowtham Sundar <gowtham@trustmachines.co>"
 
-COPY . .
+ARG GIT_URI='https://github.com/stacks-network/stacks-core.git'
+ARG GIT_COMMIT='3d96d53b35409859ca2baa2f0b6ddaa1fbd80265'
 
-# -----------INSTALL SUDO----------------------
-RUN apt-get update && apt-get install -y sudo jq curl
+RUN echo "Building stacks from commit: https://github.com/stacks-network/stacks-core/commit/$GIT_COMMIT"
+
+RUN apt-get update && apt-get install -y libclang-dev
+RUN rustup toolchain install stable
+RUN rustup component add rustfmt --toolchain stable
+
+WORKDIR /stacks
+RUN git init && git remote add origin $GIT_URI && git -c protocol.version=2 fetch --depth=1 origin "$GIT_COMMIT" && git reset --hard FETCH_HEAD
+RUN cargo build --package stacks-node --bin stacks-node
 
 
+
+# RUNNER
+# -------------------------------------------------------------------------------
+FROM debian:bookworm
+
+# copy over stacks-node binary
+COPY --from=builder /stacks/target/debug/stacks-node /usr/local/bin/
+
+# install & setup utils
+RUN apt-get update && apt-get install -y curl gettext-base jq sudo
+RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
-# --------------------------------------------
-RUN chmod +rwx ./entrypoint.sh
-# --------------------------------------------
+# copy over stacks node config
+COPY . .
 
+RUN chmod +rwx ./entrypoint.sh
 
 EXPOSE 20444
 EXPOSE 20443
+
 CMD ["./entrypoint.sh"]

--- a/devenv/local/k8s/down.sh
+++ b/devenv/local/k8s/down.sh
@@ -7,10 +7,19 @@ sh ./utils/kill-port-forwards.sh
 kubectl delete -f ./yamls/deployments/bitcoin-deployment.yaml
 kubectl delete -f ./yamls/deployments/bitcoin-miner-deployment.yaml
 kubectl delete -f ./yamls/deployments/postgres-deployment.yaml
-kubectl delete -f ./yamls/deployments/nakamoto-signer-deployment.yaml
+
+kubectl delete -f ./yamls/deployments/nakamoto-signer-1-deployment.yaml
+kubectl delete -f ./yamls/deployments/nakamoto-signer-2-deployment.yaml
+kubectl delete -f ./yamls/deployments/nakamoto-signer-3-deployment.yaml
+
 kubectl delete -f ./yamls/deployments/stacks-deployment.yaml
 kubectl delete -f ./yamls/deployments/stacks-api-deployment.yaml
 kubectl delete -f ./yamls/deployments/stacks-explorer-deployment.yaml
+
+kubectl delete -f ./yamls/deployments/stacker-deployment.yaml
+kubectl delete -f ./yamls/deployments/monitor-deployment.yaml
+kubectl delete -f ./yamls/deployments/tx-broadcaster-deployment.yaml
+
 kubectl delete -f ./yamls/deployments/mariadb-deployment.yaml
 kubectl delete -f ./yamls/deployments/electrs-deployment.yaml
 kubectl delete -f ./yamls/deployments/mempool-backend-deployment.yaml

--- a/devenv/local/k8s/remove-minikube-containers.sh
+++ b/devenv/local/k8s/remove-minikube-containers.sh
@@ -2,6 +2,7 @@ minikube image rm minikube/bitcoin:v1
 minikube image rm minikube/bitcoin-miner-sidecar:v1
 
 minikube image rm minikube/stacks:v1
+minikube image rm minikube/stacker:v1
 minikube image rm minikube/stacks-api:v1
 minikube image rm minikube/nakamoto-signer:v1
 minikube image rm minikube/stacks-explorer:v1

--- a/devenv/local/k8s/tests/devnet-liveness.sh
+++ b/devenv/local/k8s/tests/devnet-liveness.sh
@@ -71,30 +71,77 @@ echo "\n"
 
 
 
-echo " ------------------------------------------------------"
-echo "| => (4) 🔬 TEST: [CHECK IF NAKAMOTO SIGNER IS READY]  |"
-echo " ------------------------------------------------------"
+echo " --------------------------------------------------------"
+echo "| => (4) 🔬 TEST: [CHECK IF NAKAMOTO SIGNER 1 IS READY]  |"
+echo " --------------------------------------------------------"
 
-NAKAMOTO_SIGNER_POD_NAME=$(kubectl get pods --selector=app=nakamoto-signer -o json -n sbtc-signer | jq -r '.items[].metadata.name')
-NAKAMOTO_SIGNER_LOGS=$(kubectl logs $NAKAMOTO_SIGNER_POD_NAME -n sbtc-signer 2>/dev/null)
+NAKAMOTO_SIGNER_1_POD_NAME=$(kubectl get pods --selector=app=nakamoto-signer-1 -o json -n sbtc-signer | jq -r '.items[].metadata.name')
+NAKAMOTO_SIGNER_1_LOGS=$(kubectl logs $NAKAMOTO_SIGNER_1_POD_NAME -n sbtc-signer 2>/dev/null)
 
-echo "NAKAMOTO_SIGNER_LOGS:  $NAKAMOTO_SIGNER_LOGS"
-NAKAMOTO_SIGNER_READY_SUCCESS=false
-NAKAMOTO_SIGNER_READY_SUCCESS_FRMT=$(echo "\033[1;31m$NAKAMOTO_SIGNER_READY_SUCCESS\033[0m❌")
-if [[ $NAKAMOTO_SIGNER_LOGS == *"Signer spawned successfully"* ]]; then
-    NAKAMOTO_SIGNER_READY_SUCCESS=true
+echo "NAKAMOTO_SIGNER_1_LOGS:  $NAKAMOTO_SIGNER_1_LOGS"
+NAKAMOTO_SIGNER_1_READY_SUCCESS=false
+NAKAMOTO_SIGNER_1_READY_SUCCESS_FRMT=$(echo "\033[1;31m$NAKAMOTO_SIGNER_1_READY_SUCCESS\033[0m❌")
+if [[ $NAKAMOTO_SIGNER_1_LOGS == *"Signer spawned successfully"* ]]; then
+    NAKAMOTO_SIGNER_1_READY_SUCCESS=true
     echo "Nakamoto Signer || Signer spawned successfully"
-    NAKAMOTO_SIGNER_READY_SUCCESS_FRMT=$(echo "\033[1;32m$NAKAMOTO_SIGNER_READY_SUCCESS\033[0m ✅")
+    NAKAMOTO_SIGNER_1_READY_SUCCESS_FRMT=$(echo "\033[1;32m$NAKAMOTO_SIGNER_1_READY_SUCCESS\033[0m ✅")
 fi
 
 
-echo "\033[1mNAKAMOTO_SIGNER_READY_SUCCESS\033[0m: $NAKAMOTO_SIGNER_READY_SUCCESS_FRMT"
+echo "\033[1mNAKAMOTO_SIGNER_1_READY_SUCCESS\033[0m: $NAKAMOTO_SIGNER_1_READY_SUCCESS_FRMT"
 echo "\n"
 
 
 
+
+echo " --------------------------------------------------------"
+echo "| => (5) 🔬 TEST: [CHECK IF NAKAMOTO SIGNER 2 IS READY]  |"
+echo " --------------------------------------------------------"
+
+NAKAMOTO_SIGNER_2_POD_NAME=$(kubectl get pods --selector=app=nakamoto-signer-2 -o json -n sbtc-signer | jq -r '.items[].metadata.name')
+NAKAMOTO_SIGNER_2_LOGS=$(kubectl logs $NAKAMOTO_SIGNER_2_POD_NAME -n sbtc-signer 2>/dev/null)
+
+echo "NAKAMOTO_SIGNER_2_LOGS:  $NAKAMOTO_SIGNER_2_LOGS"
+NAKAMOTO_SIGNER_2_READY_SUCCESS=false
+NAKAMOTO_SIGNER_2_READY_SUCCESS_FRMT=$(echo "\033[1;31m$NAKAMOTO_SIGNER_2_READY_SUCCESS\033[0m❌")
+if [[ $NAKAMOTO_SIGNER_2_LOGS == *"Signer spawned successfully"* ]]; then
+    NAKAMOTO_SIGNER_2_READY_SUCCESS=true
+    echo "Nakamoto Signer || Signer spawned successfully"
+    NAKAMOTO_SIGNER_2_READY_SUCCESS_FRMT=$(echo "\033[1;32m$NAKAMOTO_SIGNER_2_READY_SUCCESS\033[0m ✅")
+fi
+
+
+echo "\033[1mNAKAMOTO_SIGNER_2_READY_SUCCESS\033[0m: $NAKAMOTO_SIGNER_2_READY_SUCCESS_FRMT"
+echo "\n"
+
+
+
+echo " --------------------------------------------------------"
+echo "| => (6) 🔬 TEST: [CHECK IF NAKAMOTO SIGNER 3 IS READY]  |"
+echo " --------------------------------------------------------"
+
+NAKAMOTO_SIGNER_3_POD_NAME=$(kubectl get pods --selector=app=nakamoto-signer-3 -o json -n sbtc-signer | jq -r '.items[].metadata.name')
+NAKAMOTO_SIGNER_3_LOGS=$(kubectl logs $NAKAMOTO_SIGNER_3_POD_NAME -n sbtc-signer 2>/dev/null)
+
+echo "NAKAMOTO_SIGNER_3_LOGS:  $NAKAMOTO_SIGNER_3_LOGS"
+NAKAMOTO_SIGNER_3_READY_SUCCESS=false
+NAKAMOTO_SIGNER_3_READY_SUCCESS_FRMT=$(echo "\033[1;31m$NAKAMOTO_SIGNER_3_READY_SUCCESS\033[0m❌")
+if [[ $NAKAMOTO_SIGNER_3_LOGS == *"Signer spawned successfully"* ]]; then
+    NAKAMOTO_SIGNER_3_READY_SUCCESS=true
+    echo "Nakamoto Signer || Signer spawned successfully"
+    NAKAMOTO_SIGNER_3_READY_SUCCESS_FRMT=$(echo "\033[1;32m$NAKAMOTO_SIGNER_3_READY_SUCCESS\033[0m ✅")
+fi
+
+
+echo "\033[1mNAKAMOTO_SIGNER_3_READY_SUCCESS\033[0m: $NAKAMOTO_SIGNER_3_READY_SUCCESS_FRMT"
+echo "\n"
+
+
+
+
+
 echo " --------------------------------------------------"
-echo "| => (5) 🔬 TEST: [CHECK IF STACKS NODE IS READY]  |"
+echo "| => (7) 🔬 TEST: [CHECK IF STACKS NODE IS READY]  |"
 echo " --------------------------------------------------"
 
 
@@ -118,7 +165,7 @@ echo "\n"
 
 
 echo " ---------------------------------------------------------------"
-echo "| => (6) 🔬 TEST: [CHECK IF STX NODE IS SYNCED WITH BTC UTXOs]  |"
+echo "| => (8) 🔬 TEST: [CHECK IF STX NODE IS SYNCED WITH BTC UTXOs]  |"
 echo " ---------------------------------------------------------------"
 
 
@@ -145,7 +192,7 @@ echo "\n"
 
 
 echo " ---------------------------------------------------------------"
-echo "| => (7) 🔬 TEST: [CHECK STACKS API EVENT OBSERVER LIVENESS]    |"
+echo "| => (9) 🔬 TEST: [CHECK STACKS API EVENT OBSERVER LIVENESS]    |"
 echo " ---------------------------------------------------------------"
 
 
@@ -176,7 +223,7 @@ echo "\n"
 
 
 echo " ---------------------------------------------------------------"
-echo "| => (8) 🔬 TEST: [CHECK STACKS PUBLIC API LIVENESS]            |"
+echo "| => (10) 🔬 TEST: [CHECK STACKS PUBLIC API LIVENESS]            |"
 echo " ---------------------------------------------------------------"
 
 
@@ -206,7 +253,7 @@ echo "\n"
 
 
 echo " -----------------------------------------------------------------"
-echo "| => (9) 🔬 TEST: [CHECK IF STACKS-API IS CONNECTED TO POSTGRES]  |"
+echo "| => (11) 🔬 TEST: [CHECK IF STACKS-API IS CONNECTED TO POSTGRES]  |"
 echo " -----------------------------------------------------------------"
 
 
@@ -229,7 +276,7 @@ echo "\n"
 
 
 echo " -----------------------------------------------"
-echo "| => (10) 🔬 TEST: [CHECK IF MARIADB IS READY]  |"
+echo "| => (12) 🔬 TEST: [CHECK IF MARIADB IS READY]  |"
 echo " -----------------------------------------------"
 
 MARIADB_POD_NAME=$(kubectl get pods --selector=app=mariadb -o json -n sbtc-signer | jq -r '.items[].metadata.name')
@@ -257,7 +304,9 @@ echo "------------------------------------------------------------------"
 echo "| \033[1mBTC_LIVENESS_SUCCESS\033[0m:                         | \t $BTC_LIVENESS_SUCCESS_FRMT |"
 echo "| \033[1mBTC_MINEABLE_SUCCESS\033[0m:                         | \t $BTC_MINEABLE_SUCCESS_FRMT |"
 echo "| \033[1mPG_READY_SUCCESS\033[0m:                             | \t $PG_READY_SUCCESS_FRMT |"
-echo "| \033[1mNAKAMOTO_SIGNER_READY_SUCCESS\033[0m:                | \t $NAKAMOTO_SIGNER_READY_SUCCESS_FRMT |"
+echo "| \033[1mNAKAMOTO_SIGNER_1_READY_SUCCESS\033[0m:              | \t $NAKAMOTO_SIGNER_1_READY_SUCCESS_FRMT |"
+echo "| \033[1mNAKAMOTO_SIGNER_2_READY_SUCCESS\033[0m:              | \t $NAKAMOTO_SIGNER_2_READY_SUCCESS_FRMT |"
+echo "| \033[1mNAKAMOTO_SIGNER_3_READY_SUCCESS\033[0m:              | \t $NAKAMOTO_SIGNER_3_READY_SUCCESS_FRMT |"
 echo "| \033[1mSTX_LIVENESS_SUCCESS\033[0m:                         | \t $STACKS_LIVENESS_SUCCESS_FRMT |"
 echo "| \033[1mSTX_SYNC_WITH_BTC_UTXO_SUCCESS\033[0m:               | \t $STX_SYNC_WITH_BTC_UTXO_SUCCESS_FRMT |"
 echo "| \033[1mSTACKS_API_EVENT_OBSERVER_LIVENESS_SUCCESS\033[0m:   | \t $STACKS_API_EVENT_OBSERVER_LIVENESS_SUCCESS_FRMT |"
@@ -269,7 +318,9 @@ echo "------------------------------------------------------------------"
 if [[ $BTC_LIVENESS_SUCCESS == true \
     && $BTC_MINEABLE_SUCCESS == true \
     && $PG_READY_SUCCESS == true \
-    && $NAKAMOTO_SIGNER_READY_SUCCESS == true \
+    && $NAKAMOTO_SIGNER_1_READY_SUCCESS == true \
+    && $NAKAMOTO_SIGNER_2_READY_SUCCESS == true \
+    && $NAKAMOTO_SIGNER_3_READY_SUCCESS == true \
     && $STX_LIVENESS_SUCCESS == true \
     && $STX_SYNC_WITH_BTC_UTXO_SUCCESS == true \
     && $STACKS_API_EVENT_OBSERVER_LIVENESS_SUCCESS == true \

--- a/devenv/local/k8s/up.sh
+++ b/devenv/local/k8s/up.sh
@@ -30,8 +30,12 @@ kubectl apply -f ./yamls/deployments/postgres-deployment.yaml
 # Mariadb
 kubectl apply -f ./yamls/deployments/mariadb-deployment.yaml
 
-# Nakamoto Signer
-kubectl apply -f ./yamls/deployments/nakamoto-signer-deployment.yaml
+# Nakamoto Signer 1
+kubectl apply -f ./yamls/deployments/nakamoto-signer-1-deployment.yaml
+# Nakamoto Signer 2
+kubectl apply -f ./yamls/deployments/nakamoto-signer-2-deployment.yaml
+# Nakamoto Signer 3
+kubectl apply -f ./yamls/deployments/nakamoto-signer-3-deployment.yaml
 
 
 
@@ -69,6 +73,11 @@ kubectl apply -f ./yamls/deployments/mempool-backend-deployment.yaml
 # WAIT FOR MEMPOOL BACKEND
 kubectl wait --for=condition=available --timeout=30s -f ./yamls/deployments/mempool-backend-deployment.yaml
 kubectl apply -f ./yamls/deployments/mempool-frontend-deployment.yaml
+
+
+kubectl apply -f ./yamls/deployments/monitor-deployment.yaml
+kubectl apply -f ./yamls/deployments/stacker-deployment.yaml
+kubectl apply -f ./yamls/deployments/tx-broadcaster-deployment.yaml
 
 # ----------------------------------------
 # Add a small pause for all deployments to get going (otherwise some tests will fail since it's searching in logs)

--- a/devenv/local/k8s/utils/port-forward-containers.sh
+++ b/devenv/local/k8s/utils/port-forward-containers.sh
@@ -40,25 +40,29 @@ pf_helper() {
 
 echo " -----------------------------------------------------------  "
 
-pf_helper "bitcoin-regtest-deployment" "bitcoin-regtest-service" "18443" "18443" "sbtc-signer" "Bitcoin Node" "1"
+pf_helper "bitcoin-deployment" "bitcoin-service" "18443" "18443" "sbtc-signer" "Bitcoin Node" "1"
 
-pf_helper "nakamoto-signer-deployment" "nakamoto-signer-service" "30000" "30000" "sbtc-signer" "Nakamoto Signer" "2"
+pf_helper "nakamoto-signer-1-deployment" "nakamoto-signer-1-service" "30001" "30000" "sbtc-signer" "Nakamoto Signer 1" "2"
 
-pf_helper "stacks-node-deployment" "stacks-node-service" "20443" "20443" "sbtc-signer" "Stacks Node" "3"
+pf_helper "nakamoto-signer-2-deployment" "nakamoto-signer-2-service" "30002" "30000" "sbtc-signer" "Nakamoto Signer 2" "3"
 
-pf_helper "stacks-api-deployment" "stacks-api-service" "3999" "3999" "sbtc-signer" "Stacks API Public Endpoint" "4"
+pf_helper "nakamoto-signer-3-deployment" "nakamoto-signer-3-service" "30003" "30000" "sbtc-signer" "Nakamoto Signer 3" "4"
 
-pf_helper "stacks-api-deployment" "stacks-api-service" "3700" "3700" "sbtc-signer" "Stacks API Event Observer" "5"
+pf_helper "stacks-node-deployment" "stacks-node-service" "20443" "20443" "sbtc-signer" "Stacks Node" "5"
 
-pf_helper "postgres-deployment" "postgres-service" "5432" "5432" "sbtc-signer" "Postgres" "6"
+pf_helper "stacks-api-deployment" "stacks-api-service" "3999" "3999" "sbtc-signer" "Stacks API Public Endpoint" "6"
 
-pf_helper "stacks-explorer-deployment" "stacks-explorer-service" "3020" "3000" "sbtc-signer" "Stacks Explorer" "7"
+pf_helper "stacks-api-deployment" "stacks-api-service" "3700" "3700" "sbtc-signer" "Stacks API Event Observer" "7"
 
-pf_helper "electrs-deployment" "electrs-service" "60401" "60401" "sbtc-signer" "Electrs" "8"
+pf_helper "postgres-deployment" "postgres-service" "5432" "5432" "sbtc-signer" "Postgres" "8"
 
-pf_helper "mariadb-deployment" "mariadb-service" "3306" "3306" "sbtc-signer" "MariaDB" "9"
+pf_helper "stacks-explorer-deployment" "stacks-explorer-service" "3020" "3000" "sbtc-signer" "Stacks Explorer" "9"
 
-pf_helper "mempool-backend-deployment" "mempool-backend-service" "8999" "8999" "sbtc-signer" "Mempool Backend" "10"
+pf_helper "electrs-deployment" "electrs-service" "60401" "60401" "sbtc-signer" "Electrs" "10"
 
-pf_helper "mempool-frontend-deployment" "mempool-frontend-service" "8083" "8083" "sbtc-signer" "Mempool Frontend" "11"
+pf_helper "mariadb-deployment" "mariadb-service" "3306" "3306" "sbtc-signer" "MariaDB" "11"
+
+pf_helper "mempool-backend-deployment" "mempool-backend-service" "8999" "8999" "sbtc-signer" "Mempool Backend" "12"
+
+pf_helper "mempool-frontend-deployment" "mempool-frontend-service" "8083" "8083" "sbtc-signer" "Mempool Frontend" "13"
 

--- a/devenv/local/k8s/yamls/deployments/bitcoin-deployment.yaml
+++ b/devenv/local/k8s/yamls/deployments/bitcoin-deployment.yaml
@@ -2,28 +2,30 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: bitcoin-regtest-deployment
+  name: bitcoin-deployment
   namespace: sbtc-signer
   labels:
-    app: bitcoin-regtest
+    app: bitcoin
   
 spec:
   replicas: 1
   revisionHistoryLimit: 1
   selector:
     matchLabels:
-      app: bitcoin-regtest
+      app: bitcoin
   
   template:
     metadata:
       labels:
-        app: bitcoin-regtest
+        app: bitcoin
     
     spec:
 
-      # Define a shared volume
+      # Define a shared volume & chainstate bitcoin volume
       volumes:
         - name: shared-data
+          emptyDir: {}
+        - name: chainstate
           emptyDir: {}
 
       # Define init containers
@@ -40,11 +42,28 @@ spec:
 
               SHARED_VOL_DIR="/mnt/shared"
 
+              REGTEST_ON=1
+              TESTNET_ON=0
+              BTC_NETWORK_HEADER="regtest"
 
+              
+              # determine which fields to turn on and off
+              if [[ $BTC_NETWORK == 'mainnet' ]]; then
+                REGTEST_ON=0
+                TESTNET_ON=0
+                BTC_NETWORK_HEADER="main"
+              elif [[ $BTC_NETWORK == 'testnet' ]]; then
+                REGTEST_ON=0
+                TESTNET_ON=1
+                BTC_NETWORK_HEADER="test"
+              fi
+
+              
               tee -a $SHARED_VOL_DIR/bitcoin.conf << END
-              regtest=1 #chain=regtest
+              regtest=$REGTEST_ON
+              testnet=$TESTNET_ON
 
-              [regtest]
+              [$BTC_NETWORK_HEADER]
               # Accept command line and JSON-RPC commands
               server=1
               # Username for JSON-RPC connections
@@ -63,12 +82,6 @@ spec:
               rpcthreads=256
               rpcworkqueue=256
               rpctimeout=100
-
-              # Accept public REST requests (default: 0)
-              # rest=$BTC_REST_ENABLE
-
-              # output all debug info
-              # debug=$BTC_LOG_DEBUG
 
               disablewallet=0
 
@@ -94,16 +107,27 @@ spec:
               value: "0.0.0.0"
             - name: BTC_RPCALLOWIP
               value: "0.0.0.0/0"
+            
             - name: BTC_RPCUSER
-              valueFrom:
-                secretKeyRef:
-                  name: bitcoin-secret
-                  key: BTC_RPCUSER 
+              value: "devnet"
+            
+            ### (If you want to use a secret)
+            # - name: BTC_RPCUSER
+            #   valueFrom:
+            #     secretKeyRef:
+            #       name: bitcoin-secret
+            #       key: BTC_RPCUSER 
+            
             - name: BTC_RPCPASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: bitcoin-secret
-                  key: BTC_RPCPASSWORD
+              value: "devnet"
+            
+            ### (If you want to use a secret)
+            # - name: BTC_RPCPASSWORD
+            #   valueFrom:
+            #     secretKeyRef:
+            #       name: bitcoin-secret
+            #       key: BTC_RPCPASSWORD
+            
             - name: BTC_RPC_PORT
               value: "18443"
             - name: BTC_P2P_PORT
@@ -119,68 +143,82 @@ spec:
               mountPath: /mnt/shared
 
       containers:
-      - name: bitcoin-regtest-container
-        image: minikube/bitcoin:v1
-        imagePullPolicy: Never
+        - name: bitcoin-container
+          image: minikube/bitcoin:v1
+          imagePullPolicy: Never
 
-        volumeMounts:
-        - name: shared-data
-          mountPath: /mnt/shared
-        
-        resources:
-          requests:
-            memory: 128Mi
-            cpu: 50m
-          limits:
-            memory: 256Mi
-            cpu: 100m
-        
-        ports:
-          - containerPort: 18444
-            protocol: TCP
-          - containerPort: 18443
-            protocol: TCP
-          - containerPort: 18433
-            protocol: TCP
-          - containerPort: 18444
-            protocol: UDP
-          - containerPort: 18443
-            protocol: UDP
-          - containerPort: 18433
-            protocol: UDP
+          volumeMounts:
+          - name: shared-data
+            mountPath: /mnt/shared
+          - name: chainstate
+            mountPath: /root
+          
+          resources:
+            requests:
+              memory: 128Mi
+              cpu: 50m
+            limits:
+              memory: 256Mi
+              cpu: 100m
+          
+          ports:
+            - containerPort: 18444
+              protocol: TCP
+            - containerPort: 18443
+              protocol: TCP
+            - containerPort: 18433
+              protocol: TCP
+            - containerPort: 18444
+              protocol: UDP
+            - containerPort: 18443
+              protocol: UDP
+            - containerPort: 18433
+              protocol: UDP
 
-        env:
-          - name: VERSION
-            value: "25.0"
-          - name: ENV
-            value: "DEV"
-          - name: BTC_NETWORK
-            value: "regtest"
-          - name: BTC_PRINTTOCONSOLE
-            value: "1"
-          - name: BTC_DISABLEWALLET
-            value: "0"
-          - name: BTC_TXINDEX
-            value: "1"
-          - name: BTC_RPCBIND
-            value: "0.0.0.0"
-          - name: BTC_RPCALLOWIP
-            value: "0.0.0.0/0"
-          - name: BTC_RPCUSER
-            valueFrom:
-              secretKeyRef:
-                name: bitcoin-secret
-                key: BTC_RPCUSER 
-          - name: BTC_RPCPASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: bitcoin-secret
-                key: BTC_RPCPASSWORD
-          - name: BTC_RPC_PORT
-            value: "18443"
-          - name: BTC_P2P_PORT
-            value: "18444"
-          - name: BTC_LOG_DEBUG
-            value: "0"
-          - name: BTC_REST_ENABLE
-            value: "0"
+          env:
+            - name: VERSION
+              value: "25.0"
+            - name: ENV
+              value: "DEV"
+            - name: BTC_NETWORK
+              value: "regtest"
+            - name: BTC_PRINTTOCONSOLE
+              value: "1"
+            - name: BTC_DISABLEWALLET
+              value: "0"
+            - name: BTC_TXINDEX
+              value: "1"
+            - name: BTC_RPCBIND
+              value: "0.0.0.0"
+            - name: BTC_RPCALLOWIP
+              value: "0.0.0.0/0"
+            
+            - name: BTC_RPCUSER
+              value: "devnet"
+            
+            ### (If you want to use a secret)
+            # - name: BTC_RPCUSER
+            #   valueFrom:
+            #     secretKeyRef:
+            #       name: bitcoin-secret
+            #       key: BTC_RPCUSER 
+            
+            - name: BTC_RPCPASSWORD
+              value: "devnet"
+            
+            ### (If you want to use a secret)
+            # - name: BTC_RPCPASSWORD
+            #   valueFrom:
+            #     secretKeyRef:
+            #       name: bitcoin-secret
+            #       key: BTC_RPCPASSWORD
+
+            
+            - name: BTC_RPC_PORT
+              value: "18443"
+            - name: BTC_P2P_PORT
+              value: "18444"
+            - name: BTC_LOG_DEBUG
+              value: "0"
+            - name: BTC_REST_ENABLE
+              value: "0"

--- a/devenv/local/k8s/yamls/deployments/bitcoin-miner-deployment.yaml
+++ b/devenv/local/k8s/yamls/deployments/bitcoin-miner-deployment.yaml
@@ -35,25 +35,41 @@ spec:
 
         env:
           - name: INIT_BTC_BLOCKS
-            value: "200"
+            value: "101"
           - name: BTC_BLOCK_GEN_TIME
-            value: "10"
+            value: "30"
           - name: BITCOIN_RPC_HOST
-            value: "bitcoin-regtest-service.sbtc-signer"
+            value: "bitcoin-service.sbtc-signer"
           - name: BITCOIN_RPC_PORT
             value: "18443"
+            
           - name: BTC_RPCUSER
-            valueFrom:
-              secretKeyRef:
-                name: bitcoin-secret
-                key: BTC_RPCUSER 
+            value: "devnet"
+          
+          ### (If you want to use a secret)
+          # - name: BTC_RPCUSER
+          #   valueFrom:
+          #     secretKeyRef:
+          #       name: bitcoin-secret
+          #       key: BTC_RPCUSER 
+          
           - name: BTC_RPCPASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: bitcoin-secret
-                key: BTC_RPCPASSWORD
+            value: "devnet"
+          
+          ### (If you want to use a secret)
+          # - name: BTC_RPCPASSWORD
+          #   valueFrom:
+          #     secretKeyRef:
+          #       name: bitcoin-secret
+          #       key: BTC_RPCPASSWORD
+
           - name: MINER_ADDRESS
-            valueFrom:
-              secretKeyRef:
-                name: bitcoin-secret
-                key: MINER_ADDRESS
+            value: miEJtNKa3ASpA19v5ZhvbKTEieYjLpzCYT
+          
+          
+          ### (If you want to use a secret)
+          # - name: MINER_ADDRESS
+          #   valueFrom:
+          #     secretKeyRef:
+          #       name: bitcoin-secret
+          #       key: MINER_ADDRESS

--- a/devenv/local/k8s/yamls/deployments/electrs-deployment.yaml
+++ b/devenv/local/k8s/yamls/deployments/electrs-deployment.yaml
@@ -47,16 +47,26 @@ spec:
           - name: RUST_BACKTRACE
             value: '1'
           - name: BITCOIN_RPC_HOST
-            value: "bitcoin-regtest-service.sbtc-signer"
+            value: "bitcoin-service.sbtc-signer"
           - name: BITCOIN_RPC_PORT
             value: "18443"
-          - name: BTC_RPC_USER
-            valueFrom:
-              secretKeyRef:
-                name: bitcoin-secret
-                key: BTC_RPCUSER 
-          - name: BTC_RPC_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: bitcoin-secret
-                key: BTC_RPCPASSWORD
+          
+          - name: BTC_RPCUSER
+            value: "devnet"
+          
+          ### (If you want to use a secret)
+          # - name: BTC_RPCUSER
+          #   valueFrom:
+          #     secretKeyRef:
+          #       name: bitcoin-secret
+          #       key: BTC_RPCUSER 
+          
+          - name: BTC_RPCPASSWORD
+            value: "devnet"
+          
+          ### (If you want to use a secret)
+          # - name: BTC_RPCPASSWORD
+          #   valueFrom:
+          #     secretKeyRef:
+          #       name: bitcoin-secret
+          #       key: BTC_RPCPASSWORD

--- a/devenv/local/k8s/yamls/deployments/mempool-backend-deployment.yaml
+++ b/devenv/local/k8s/yamls/deployments/mempool-backend-deployment.yaml
@@ -49,19 +49,31 @@ spec:
             value: "false"
           # Connect to bitcoin rpc
           - name: CORE_RPC_HOST
-            value: "bitcoin-regtest-service.sbtc-signer"
+            value: "bitcoin-service.sbtc-signer"
           - name: CORE_RPC_PORT
             value: "18443"
+          
           - name: CORE_RPC_USERNAME
-            valueFrom:
-              secretKeyRef:
-                name: bitcoin-secret
-                key: BTC_RPCUSER 
+            value: "devnet"
+          
+          ### (If you want to use a secret)
+          # - name: CORE_RPC_USERNAME
+          #   valueFrom:
+          #     secretKeyRef:
+          #       name: bitcoin-secret
+          #       key: BTC_RPCUSER 
+          
           - name: CORE_RPC_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: bitcoin-secret
-                key: BTC_RPCPASSWORD
+            value: "devnet"
+          
+          ### (If you want to use a secret)
+          # - name: CORE_RPC_PASSWORD
+          #   valueFrom:
+          #     secretKeyRef:
+          #       name: bitcoin-secret
+          #       key: BTC_RPCPASSWORD
+
+
           - name: DATABASE_ENABLED
             value: "true"
           - name: DATABASE_HOST

--- a/devenv/local/k8s/yamls/deployments/monitor-deployment.yaml
+++ b/devenv/local/k8s/yamls/deployments/monitor-deployment.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: monitor-deployment
+  namespace: sbtc-signer
+  labels:
+    app: monitor
+  
+spec:
+  replicas: 1
+  revisionHistoryLimit: 1
+  selector:
+    matchLabels:
+      app: monitor
+  
+  template:
+    metadata:
+      labels:
+        app: monitor
+    
+    spec:
+      containers:
+      - name: monitor-container
+        image: minikube/stacker:v1
+        imagePullPolicy: Never
+        
+        resources:
+          requests:
+            memory: 128Mi
+            cpu: 50m
+          limits:
+            memory: 256Mi
+            cpu: 100m
+
+        env:
+          - name: STACKS_CORE_RPC_HOST
+            value: "stacks-api-service.sbtc-signer"
+          - name: STACKS_CORE_RPC_PORT
+            value: "3999"
+          - name: STACKING_CYCLES
+            value: "1"
+          
+          - name: STACKING_KEYS
+            value: "6a1a754ba863d7bab14adbbc3f8ebb090af9e871ace621d3e5ab634e1422885e01,b463f0df6c05d2f156393eee73f8016c5372caa0e9e29a901bb7171d90dc4f1401,7036b29cb5e235e5fd9b09ae3e8eec4404e44906814d5d01cbca968a60ed4bfb01"
+          
+          ### (If you want to use a secret)
+          # - name: STACKING_KEYS
+          #   valueFrom:
+          #     secretKeyRef:
+          #     name: stacker-secret
+          #     key: STACKING_KEYS 
+
+          
+          - name: STACKS_25_HEIGHT
+            value: "108"
+          - name: STACKS_30_HEIGHT
+            value: "130"
+          - name: POX_PREPARE_LENGTH
+            value: "5"
+          - name: POX_REWARD_LENGTH
+            value: "20"
+          - name: EXIT_FROM_MONITOR
+            value: "1"
+          - name: STACKING_INTERVAL
+            value: "2"
+          - name: POST_TX_WAIT
+            value: "10"
+          - name: SERVICE_NAME
+            value: "monitor"

--- a/devenv/local/k8s/yamls/deployments/nakamoto-signer-1-deployment.yaml
+++ b/devenv/local/k8s/yamls/deployments/nakamoto-signer-1-deployment.yaml
@@ -1,0 +1,126 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nakamoto-signer-1-deployment
+  namespace: sbtc-signer
+  labels:
+    app: nakamoto-signer-1
+  
+spec:
+  replicas: 1
+  revisionHistoryLimit: 1
+  selector:
+    matchLabels:
+      app: nakamoto-signer-1
+  
+  template:
+    metadata:
+      labels:
+        app: nakamoto-signer-1
+    
+    spec:
+      
+      # Define a shared volume
+      volumes:
+        - name: shared-data
+          emptyDir: {}
+        - name: chainstate
+          emptyDir: {}
+
+
+      # Define init containers
+      initContainers:
+        - name: init-file-generator
+          image: debian:bookworm
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/bash
+          args: 
+            - -ec
+            - |
+              #!/bin/bash
+
+              SHARED_VOL_DIR="/mnt/shared"
+
+
+              tee -a $SHARED_VOL_DIR/config.toml << END
+              node_host = "$STACKS_NODE_RPC_HOST:$STACKS_NODE_RPC_PORT"
+              endpoint = "$SIGNER_ENDPOINT"
+
+              # Either “testnet” or “mainnet”
+              network = "testnet"
+
+              db_path = "$SIGNER_DB_PATH"
+
+              auth_password = "$MY_HTTP_AUTH_TOKEN"
+
+              stacks_private_key = "$STACKS_PRIVATE_KEY"
+              END
+          
+          env:
+            - name: SIGNER_ENDPOINT
+              value: "0.0.0.0:30000"
+            
+
+            - name: MY_HTTP_AUTH_TOKEN
+              value: "helloworld"
+
+            ### (If you want to use a secret)
+            # - name: MY_HTTP_AUTH_TOKEN
+            #   valueFrom:
+            #     secretKeyRef:
+            #       name: stacks-secret
+            #       key: MY_HTTP_AUTH_TOKEN
+            
+            - name: STACKS_PRIVATE_KEY
+              value: "6a1a754ba863d7bab14adbbc3f8ebb090af9e871ace621d3e5ab634e1422885e01"
+
+            ### (If you want to use a secret)
+            # - name: STACKS_PRIVATE_KEY
+            #   valueFrom:
+            #     secretKeyRef:
+            #       name: nakamoto-signer-1-secret
+            #       key: STACKS_PRIVATE_KEY
+
+
+            - name: STACKS_NODE_RPC_HOST
+              value: "stacks-node-service.sbtc-signer"
+            - name: STACKS_NODE_RPC_PORT
+              value: "20443"
+            - name: SIGNER_DB_PATH
+              value: "/chainstate/nakamoto-signer-1.sqlite"
+
+
+          volumeMounts:
+            - name: shared-data
+              mountPath: /mnt/shared
+
+
+      containers:
+      - name: nakamoto-signer-container
+        image: minikube/nakamoto-signer:v1
+        imagePullPolicy: Never
+
+        volumeMounts:
+        - name: shared-data
+          mountPath: /mnt/shared
+        - name: chainstate
+          mountPath: /chainstate
+        
+        resources:
+          requests:
+            memory: 128Mi
+            cpu: 50m
+          limits:
+            memory: 256Mi
+            cpu: 100m
+        
+        ports:
+          - containerPort: 30000
+            protocol: TCP
+          - containerPort: 30000
+            protocol: UDP
+
+        env:
+          - name: RUST_BACKTRACE
+            value: "1"

--- a/devenv/local/k8s/yamls/deployments/nakamoto-signer-2-deployment.yaml
+++ b/devenv/local/k8s/yamls/deployments/nakamoto-signer-2-deployment.yaml
@@ -1,22 +1,22 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: nakamoto-signer-deployment
+  name: nakamoto-signer-2-deployment
   namespace: sbtc-signer
   labels:
-    app: nakamoto-signer
+    app: nakamoto-signer-2
   
 spec:
   replicas: 1
   revisionHistoryLimit: 1
   selector:
     matchLabels:
-      app: nakamoto-signer
+      app: nakamoto-signer-2
   
   template:
     metadata:
       labels:
-        app: nakamoto-signer
+        app: nakamoto-signer-2
     
     spec:
       
@@ -24,12 +24,14 @@ spec:
       volumes:
         - name: shared-data
           emptyDir: {}
+        - name: chainstate
+          emptyDir: {}
 
 
       # Define init containers
       initContainers:
         - name: init-file-generator
-          image: blockstack/stacks-core:2.5.0.0.3
+          image: debian:bookworm
           imagePullPolicy: Never
           command:
             - /bin/bash
@@ -42,50 +44,51 @@ spec:
 
 
               tee -a $SHARED_VOL_DIR/config.toml << END
-              # The IP address and port where your Stacks node can be accessed. 
-              # The port 20443 is the default RPC endpoint for Stacks nodes. 
-              # Note that you must use an IP address - DNS hosts are not supported at this time.
               node_host = "$STACKS_NODE_RPC_HOST:$STACKS_NODE_RPC_PORT"
-
-              # This is the location where the signer will expose an RPC endpoint for 
-              # receiving events from your Stacks node.
               endpoint = "$SIGNER_ENDPOINT"
 
               # Either “testnet” or “mainnet”
               network = "testnet"
 
-              # this is a file path where your signer will persist data. If using Docker, 
-              # this must be within a volume, so that data can be persisted across restarts
-              db_path = "/var/stacks/signer.sqlite"
+              db_path = "$SIGNER_DB_PATH"
 
-              # an authentication token that is used for some HTTP requests made from the 
-              # signer to your Stacks node. You'll need to use this later on when configuring 
-              # your Stacks node. You create this field yourself, rather than it being generated 
-              # with your private key.
               auth_password = "$MY_HTTP_AUTH_TOKEN"
 
-              # This is the hex-encoded privateKey field from the keys you generated using 
-              # the stacks-cli
               stacks_private_key = "$STACKS_PRIVATE_KEY"
               END
           
           env:
             - name: SIGNER_ENDPOINT
               value: "0.0.0.0:30000"
+
+
             - name: MY_HTTP_AUTH_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: stacks-secret
-                  key: MY_HTTP_AUTH_TOKEN
+              value: "helloworld"
+
+            ### (If you want to use a secret)
+            # - name: MY_HTTP_AUTH_TOKEN
+            #   valueFrom:
+            #     secretKeyRef:
+            #       name: stacks-secret
+            #       key: MY_HTTP_AUTH_TOKEN
+            
             - name: STACKS_PRIVATE_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: stacks-secret
-                  key: MINER_KEY
+              value: "b463f0df6c05d2f156393eee73f8016c5372caa0e9e29a901bb7171d90dc4f1401"
+
+            ### (If you want to use a secret)
+            # - name: STACKS_PRIVATE_KEY
+            #   valueFrom:
+            #     secretKeyRef:
+            #       name: nakamoto-signer-1-secret
+            #       key: STACKS_PRIVATE_KEY
+
+
             - name: STACKS_NODE_RPC_HOST
               value: "stacks-node-service.sbtc-signer"
             - name: STACKS_NODE_RPC_PORT
               value: "20443"
+            - name: SIGNER_DB_PATH
+              value: "/chainstate/nakamoto-signer-2.sqlite"
 
 
           volumeMounts:
@@ -101,6 +104,8 @@ spec:
         volumeMounts:
         - name: shared-data
           mountPath: /mnt/shared
+        - name: chainstate
+          mountPath: /chainstate
         
         resources:
           requests:

--- a/devenv/local/k8s/yamls/deployments/nakamoto-signer-3-deployment.yaml
+++ b/devenv/local/k8s/yamls/deployments/nakamoto-signer-3-deployment.yaml
@@ -1,0 +1,126 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nakamoto-signer-3-deployment
+  namespace: sbtc-signer
+  labels:
+    app: nakamoto-signer-3
+  
+spec:
+  replicas: 1
+  revisionHistoryLimit: 1
+  selector:
+    matchLabels:
+      app: nakamoto-signer-3
+  
+  template:
+    metadata:
+      labels:
+        app: nakamoto-signer-3
+    
+    spec:
+      
+      # Define a shared volume
+      volumes:
+        - name: shared-data
+          emptyDir: {}
+        - name: chainstate
+          emptyDir: {}
+
+
+      # Define init containers
+      initContainers:
+        - name: init-file-generator
+          image: debian:bookworm
+          imagePullPolicy: Never
+          command:
+            - /bin/bash
+          args: 
+            - -ec
+            - |
+              #!/bin/bash
+
+              SHARED_VOL_DIR="/mnt/shared"
+
+
+              tee -a $SHARED_VOL_DIR/config.toml << END
+              node_host = "$STACKS_NODE_RPC_HOST:$STACKS_NODE_RPC_PORT"
+              endpoint = "$SIGNER_ENDPOINT"
+
+              # Either “testnet” or “mainnet”
+              network = "testnet"
+
+              db_path = "$SIGNER_DB_PATH"
+
+              auth_password = "$MY_HTTP_AUTH_TOKEN"
+
+              stacks_private_key = "$STACKS_PRIVATE_KEY"
+              END
+          
+          env:
+            - name: SIGNER_ENDPOINT
+              value: "0.0.0.0:30000"
+
+
+            - name: MY_HTTP_AUTH_TOKEN
+              value: "helloworld"
+
+            ### (If you want to use a secret)
+            # - name: MY_HTTP_AUTH_TOKEN
+            #   valueFrom:
+            #     secretKeyRef:
+            #       name: stacks-secret
+            #       key: MY_HTTP_AUTH_TOKEN
+            
+            - name: STACKS_PRIVATE_KEY
+              value: "7036b29cb5e235e5fd9b09ae3e8eec4404e44906814d5d01cbca968a60ed4bfb01"
+
+            ### (If you want to use a secret)
+            # - name: STACKS_PRIVATE_KEY
+            #   valueFrom:
+            #     secretKeyRef:
+            #       name: nakamoto-signer-1-secret
+            #       key: STACKS_PRIVATE_KEY
+
+
+            - name: STACKS_NODE_RPC_HOST
+              value: "stacks-node-service.sbtc-signer"
+            - name: STACKS_NODE_RPC_PORT
+              value: "20443"
+            - name: SIGNER_DB_PATH
+              value: "/chainstate/nakamoto-signer-3.sqlite"
+
+
+          volumeMounts:
+            - name: shared-data
+              mountPath: /mnt/shared
+
+
+      containers:
+      - name: nakamoto-signer-container
+        image: minikube/nakamoto-signer:v1
+        imagePullPolicy: Never
+
+        volumeMounts:
+        - name: shared-data
+          mountPath: /mnt/shared
+        - name: chainstate
+          mountPath: /chainstate
+        
+        resources:
+          requests:
+            memory: 128Mi
+            cpu: 50m
+          limits:
+            memory: 256Mi
+            cpu: 100m
+        
+        ports:
+          - containerPort: 30000
+            protocol: TCP
+          - containerPort: 30000
+            protocol: UDP
+
+        env:
+          - name: RUST_BACKTRACE
+            value: "1"

--- a/devenv/local/k8s/yamls/deployments/stacker-deployment.yaml
+++ b/devenv/local/k8s/yamls/deployments/stacker-deployment.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: stacker-deployment
+  namespace: sbtc-signer
+  labels:
+    app: stacker
+  
+spec:
+  replicas: 1
+  revisionHistoryLimit: 1
+  selector:
+    matchLabels:
+      app: stacker
+  
+  template:
+    metadata:
+      labels:
+        app: stacker
+    
+    spec:
+      containers:
+      - name: stacker-container
+        image: minikube/stacker:v1
+        imagePullPolicy: Never
+        
+        resources:
+          requests:
+            memory: 128Mi
+            cpu: 50m
+          limits:
+            memory: 256Mi
+            cpu: 100m
+
+        env:
+          - name: STACKS_CORE_RPC_HOST
+            value: "stacks-node-service.sbtc-signer"
+          - name: STACKS_CORE_RPC_PORT
+            value: "20443"
+          - name: STACKING_CYCLES
+            value: "1"
+
+          
+          - name: STACKING_KEYS
+            value: "6a1a754ba863d7bab14adbbc3f8ebb090af9e871ace621d3e5ab634e1422885e01,b463f0df6c05d2f156393eee73f8016c5372caa0e9e29a901bb7171d90dc4f1401,7036b29cb5e235e5fd9b09ae3e8eec4404e44906814d5d01cbca968a60ed4bfb01"
+          
+          ### (If you want to use a secret)
+          # - name: STACKING_KEYS
+          #   valueFrom:
+          #     secretKeyRef:
+          #     name: stacker-secret
+          #     key: STACKING_KEYS 
+
+
+          - name: STACKS_25_HEIGHT
+            value: "108"
+          - name: STACKS_30_HEIGHT
+            value: "130"
+          - name: POX_PREPARE_LENGTH
+            value: "5"
+          - name: POX_REWARD_LENGTH
+            value: "20"
+          - name: STACKING_INTERVAL
+            value: "2"
+          - name: POST_TX_WAIT
+            value: "10"
+          - name: SERVICE_NAME
+            value: "stacker"

--- a/devenv/local/k8s/yamls/deployments/stacks-deployment.yaml
+++ b/devenv/local/k8s/yamls/deployments/stacks-deployment.yaml
@@ -24,11 +24,13 @@ spec:
       volumes:
         - name: shared-data
           emptyDir: {}
+        - name: chainstate
+          emptyDir: {}
 
       # Define init containers
       initContainers:
         - name: init-file-generator
-          image: blockstack/stacks-core:2.5.0.0.3
+          image: rust:bookworm
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash
@@ -74,10 +76,22 @@ spec:
               private_neighbors = false
 
               [[events_observer]]
-              endpoint = "$SIGNER_ENDPOINT" # change to your signer endpoint
+              endpoint = "$SIGNER_1_ENDPOINT"
               retry_count = 255
               include_data_events = false
-              events_keys = ["stackerdb", "block_proposal"]
+              events_keys = ["stackerdb", "block_proposal", "burn_blocks"]
+              
+              [[events_observer]]
+              endpoint = "$SIGNER_2_ENDPOINT"
+              retry_count = 255
+              include_data_events = false
+              events_keys = ["stackerdb", "block_proposal", "burn_blocks"]
+              
+              [[events_observer]]
+              endpoint = "$SIGNER_3_ENDPOINT"
+              retry_count = 255
+              include_data_events = false
+              events_keys = ["stackerdb", "block_proposal", "burn_blocks"]
 
               # Add stacks-api as an event observer
               [[events_observer]]
@@ -137,7 +151,7 @@ spec:
 
               [[burnchain.epochs]]
               epoch_name = "3.0"
-              start_height = 1000001
+              start_height = 130
 
               [[ustx_balance]]
               address = "ST0DZFQ1XGHC5P1BZ6B7HSWQKQJHM74JBGCSDTNA"
@@ -266,47 +280,147 @@ spec:
               [[ustx_balance]]
               address = "ST0D135PF2R0S4B6S4G49QZC69KF19MSZ4Z5RDF5"
               amount = 24378281250000
-              END
+
+              [[ustx_balance]]
+              address = "STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6"
+              amount = 10000000000000000
+              # secretKey = "cb3df38053d132895220b9ce471f6b676db5b9bf0b4adefb55f2118ece2478df01"
+
+              [[ustx_balance]]
+              address = "ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y"
+              amount = 10000000000000000
+              # secretKey = "21d43d2ae0da1d9d04cfcaac7d397a33733881081f0b2cd038062cf0ccbb752601"
+
+              [[ustx_balance]]
+              address = "ST1HB1T8WRNBYB0Y3T7WXZS38NKKPTBR3EG9EPJKR"
+              amount = 10000000000000000
+              # Account keys 3
+              # secretKey = "c71700b07d520a8c9731e4d0f095aa6efb91e16e25fb27ce2b72e7b698f8127a01"
+
+              [[ustx_balance]]
+              address = "ST2PGGD0ZXAWEMY4EZ025RD1X47EEVH287SQKA8BC"
+              amount = 10000000000000000
+              # Account keys 2
+              # secretKey = "975b251dd7809469ef0c26ec3917971b75c51cd73a022024df4bf3b232cc2dc001"
+
+              [[ustx_balance]]
+              address = "ST29V10QEA7BRZBTWRFC4M70NJ4J6RJB5P1C6EE84"
+              amount = 10000000000000000
+              # Account keys 1
+              # secretKey = "0d2f965b472a82efd5a96e6513c8b9f7edc725d5c96c7d35d6c722cedeb80d1b01"
+
+              # Stacker/signer
+              [[ustx_balance]]
+              address = "ST3AM1A56AK2C1XAFJ4115ZSV26EB49BVQ10MGCS0"
+              amount = 10000000000000000
+              # secret_key: 7036b29cb5e235e5fd9b09ae3e8eec4404e44906814d5d01cbca968a60ed4bfb01
+              # mnemonic = "area desk dutch sign gold cricket dawn toward giggle vibrant indoor bench warfare wagon number tiny universe sand talk dilemma pottery bone trap buddy"
+              # stx_address: ST3AM1A56AK2C1XAFJ4115ZSV26EB49BVQ10MGCS0
+              # btc_address: mzxXgV6e4BZSsz8zVHm3TmqbECt7mbuErt
+
+              # Stacker/signer
+              [[ustx_balance]]
+              address = "ST3PF13W7Z0RRM42A8VZRVFQ75SV1K26RXEP8YGKJ"
+              amount = 10000000000000000
+              # secret_key: b463f0df6c05d2f156393eee73f8016c5372caa0e9e29a901bb7171d90dc4f1401
+              # mnemonic = "prevent gallery kind limb income control noise together echo rival record wedding sense uncover school version force bleak nuclear include danger skirt enact arrow"
+              # stx_address: ST3PF13W7Z0RRM42A8VZRVFQ75SV1K26RXEP8YGKJ
+              # btc_address: n37mwmru2oaVosgfuvzBwgV2ysCQRrLko7
+
+              # Stacker/signer
+              [[ustx_balance]]
+              address = "ST3NBRSFKX28FQ2ZJ1MAKX58HKHSDGNV5N7R21XCP"
+              amount = 10000000000000000
+              # secret_key: 6a1a754ba863d7bab14adbbc3f8ebb090af9e871ace621d3e5ab634e1422885e01
+              # mnemonic = "female adjust gallery certain visit token during great side clown fitness like hurt clip knife warm bench start reunion globe detail dream depend fortune"
+              # stx_address: ST3NBRSFKX28FQ2ZJ1MAKX58HKHSDGNV5N7R21XCP
+              # btc_address: n2v875jbJ4RjBnTjgbfikDfnwsDV5iUByw
+
+              [[ustx_balance]]
+              address = "ST5B3TD6YF085JWKSSW9HDWCDZTR842RFNP19HQC"
+              amount = 10000000000000000
+              # used in "flood.ts"
+              # secretKey = 66b7a77a3e0abc2cddaa51ed38fc4553498e19d3620ef08eb141afcfd0e3f5b501
+
+              [[ustx_balance]]
+              address = "STEH2J3C05BAHYS0RBAQBANJ1AXR6SR43VMZ0D49"
+              amount = 10000000000000000
+              # secretKey = 5b8303150239eceaba43892af7cdd1fa7fc26eda5182ebaaa568e3341d54a4d001
 
           
           env:
             - name: LOCAL_PEER_SEED
-              valueFrom:
-                secretKeyRef:
-                  name: stacks-secret
-                  key: LOCAL_PEER_SEED
+              value: "3fd68a8fcab004754d6fee4756dd9c84ad64ee19a11aa9930893540e1357696f2f73957cd6e92797d7a66d1d3ae4a4ea752a8924fe028f1fc2c06b9d6d0ee0ad"
+            
+            ### (If you want to use a secret)
+            # - name: LOCAL_PEER_SEED
+            #   valueFrom:
+            #     secretKeyRef:
+            #       name: stacks-secret
+            #       key: LOCAL_PEER_SEED
+
+
             - name: STACKS_WORKING_DIR
               value: "/var/stacks"
+            
+            
             - name: MY_HTTP_AUTH_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: stacks-secret
-                  key: MY_HTTP_AUTH_TOKEN
-            - name: SIGNER_ENDPOINT
-              value: "nakamoto-signer-service.sbtc-signer:30000"
+              value: "helloworld"
+            
+            ### (If you want to use a secret)
+            # - name: MY_HTTP_AUTH_TOKEN
+            #   valueFrom:
+            #     secretKeyRef:
+            #       name: stacks-secret
+            #       key: MY_HTTP_AUTH_TOKEN
+
+            - name: SIGNER_1_ENDPOINT
+              value: "nakamoto-signer-1-service.sbtc-signer:30001"
+            - name: SIGNER_2_ENDPOINT
+              value: "nakamoto-signer-2-service.sbtc-signer:30002"
+            - name: SIGNER_3_ENDPOINT
+              value: "nakamoto-signer-3-service.sbtc-signer:30003"
             - name: STACKS_API_ENDPOINT
               value: "stacks-api-service.sbtc-signer:3700"
+            
+            
             - name: MINER_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: stacks-secret
-                  key: MINER_KEY
+              value: "9e446f6b0c6a96cf2190e54bcd5a8569c3e386f091605499464389b8d4e0bfc201"
+            
+            ### (If you want to use a secret)
+            # - name: MINER_KEY
+            #   valueFrom:
+            #     secretKeyRef:
+            #       name: stacks-secret
+            #       key: MINER_KEY
+
             - name: BTC_NODE_RPC_HOST
-              value: "bitcoin-regtest-service.sbtc-signer"
+              value: "bitcoin-service.sbtc-signer"
             - name: BTC_NODE_RPC_PORT
               value: "18443"
             - name: BTC_NODE_P2P_PORT
               value: "18444"
+            
+
             - name: BTC_NODE_RPC_USER
-              valueFrom:
-                secretKeyRef:
-                  name: bitcoin-secret
-                  key: BTC_RPCUSER
+              value: "devnet"
+
+            ### (If you want to use a secret)
+            # - name: BTC_NODE_RPC_USER
+            #   valueFrom:
+            #     secretKeyRef:
+            #       name: bitcoin-secret
+            #       key: BTC_RPCUSER
+
             - name: BTC_NODE_RPC_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: bitcoin-secret
-                  key: BTC_RPCPASSWORD
+              value: "devnet"
+
+            ### (If you want to use a secret)
+            # - name: BTC_NODE_RPC_PASSWORD
+            #   valueFrom:
+            #     secretKeyRef:
+            #       name: bitcoin-secret
+            #       key: BTC_RPCPASSWORD
 
 
           volumeMounts:
@@ -321,6 +435,8 @@ spec:
         volumeMounts:
           - name: shared-data
             mountPath: /mnt/shared
+          - name: chainstate
+            mountPath: /chainstate
         
         resources:
           requests:

--- a/devenv/local/k8s/yamls/deployments/tx-broadcaster-deployment.yaml
+++ b/devenv/local/k8s/yamls/deployments/tx-broadcaster-deployment.yaml
@@ -1,0 +1,82 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tx-broadcaster-deployment
+  namespace: sbtc-signer
+  labels:
+    app: tx-broadcaster
+  
+spec:
+  replicas: 1
+  revisionHistoryLimit: 1
+  selector:
+    matchLabels:
+      app: tx-broadcaster
+  
+  template:
+    metadata:
+      labels:
+        app: tx-broadcaster
+    
+    spec:
+      containers:
+      - name: tx-broadcaster-container
+        image: minikube/stacker:v1
+        imagePullPolicy: Never
+        
+        resources:
+          requests:
+            memory: 128Mi
+            cpu: 50m
+          limits:
+            memory: 256Mi
+            cpu: 100m
+
+        env:
+          - name: STACKS_CORE_RPC_HOST
+            value: "stacks-node-service.sbtc-signer"
+          - name: STACKS_CORE_RPC_PORT
+            value: "20443"
+          - name: NAKAMOTO_BLOCK_INTERVAL
+            value: "2"
+          - name: STACKS_30_HEIGHT
+            value: "130"
+
+          
+          - name: ACCOUNT_KEYS
+            value: "0d2f965b472a82efd5a96e6513c8b9f7edc725d5c96c7d35d6c722cedeb80d1b01,975b251dd7809469ef0c26ec3917971b75c51cd73a022024df4bf3b232cc2dc001,c71700b07d520a8c9731e4d0f095aa6efb91e16e25fb27ce2b72e7b698f8127a01"
+
+
+          ### (If you want to use a secret)
+          # - name: ACCOUNT_KEYS
+          #   valueFrom:
+          #     secretKeyRef:
+          #     name: tx-broadcaster-secret
+          #     key: ACCOUNT_KEYS 
+
+
+          - name: STACKS_25_HEIGHT
+            value: "108"
+          - name: POX_PREPARE_LENGTH
+            value: "5"
+          - name: POX_REWARD_LENGTH
+            value: "20"
+          - name: STACKING_INTERVAL
+            value: "2"
+
+          
+          - name: STACKING_KEYS
+            value: "6a1a754ba863d7bab14adbbc3f8ebb090af9e871ace621d3e5ab634e1422885e01,b463f0df6c05d2f156393eee73f8016c5372caa0e9e29a901bb7171d90dc4f1401,7036b29cb5e235e5fd9b09ae3e8eec4404e44906814d5d01cbca968a60ed4bfb01"
+          
+          ### (If you want to use a secret)
+          # - name: STACKING_KEYS
+          #   valueFrom:
+          #     secretKeyRef:
+          #     name: stacker-secret
+          #     key: STACKING_KEYS 
+
+
+          - name: POST_TX_WAIT
+            value: "10"
+          - name: STACKING_CYCLES
+            value: "1"

--- a/devenv/local/k8s/yamls/secrets/secrets.yaml
+++ b/devenv/local/k8s/yamls/secrets/secrets.yaml
@@ -9,7 +9,7 @@ data:
   # these values are base64 encoded
   BTC_RPCUSER: ZGV2bmV0
   BTC_RPCPASSWORD: ZGV2bmV0
-  MINER_ADDRESS: bW9VMmcyenpIM3FMWUNOUFhHUEFNcXNneHIyQncxNVYyag==
+  MINER_ADDRESS: bWlFSnROS2EzQVNwQTE5djVaaHZiS1RFaWVZakxwekNZVA==
 ---
 apiVersion: v1
 kind: Secret
@@ -21,5 +21,55 @@ data:
   # these values are base64 encoded
   LOCAL_PEER_SEED: M2ZkNjhhOGZjYWIwMDQ3NTRkNmZlZTQ3NTZkZDljODRhZDY0ZWUxOWExMWFhOTkzMDg5MzU0MGUxMzU3Njk2ZjJmNzM5NTdjZDZlOTI3OTdkN2E2NmQxZDNhZTRhNGVhNzUyYTg5MjRmZTAyOGYxZmMyYzA2YjlkNmQwZWUwYWQ=
   MY_HTTP_AUTH_TOKEN: aGVsbG93b3JsZA==
-  MINER_KEY: NzUzYjdjYzAxYTFhMmU4NjIyMTI2NmExNTRhZjczOTQ2M2ZjZTUxMjE5ZDk3ZTRmODU2Y2Q3MjAwYzNiZDJhNg==
+  MINER_KEY: OWU0NDZmNmIwYzZhOTZjZjIxOTBlNTRiY2Q1YTg1NjljM2UzODZmMDkxNjA1NDk5NDY0Mzg5YjhkNGUwYmZjMjAx
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: nakamoto-signer-1-secret
+  namespace: sbtc-signer
+type: Opaque
+data:
+  # these values are base64 encoded
+  STACKS_PRIVATE_KEY: NmExYTc1NGJhODYzZDdiYWIxNGFkYmJjM2Y4ZWJiMDkwYWY5ZTg3MWFjZTYyMWQzZTVhYjYzNGUxNDIyODg1ZTAx
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: nakamoto-signer-2-secret
+  namespace: sbtc-signer
+type: Opaque
+data:
+  # these values are base64 encoded
+  STACKS_PRIVATE_KEY: YjQ2M2YwZGY2YzA1ZDJmMTU2MzkzZWVlNzNmODAxNmM1MzcyY2FhMGU5ZTI5YTkwMWJiNzE3MWQ5MGRjNGYxNDAx
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: nakamoto-signer-3-secret
+  namespace: sbtc-signer
+type: Opaque
+data:
+  # these values are base64 encoded
+  STACKS_PRIVATE_KEY: NzAzNmIyOWNiNWUyMzVlNWZkOWIwOWFlM2U4ZWVjNDQwNGU0NDkwNjgxNGQ1ZDAxY2JjYTk2OGE2MGVkNGJmYjAx
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: stacker-secret
+  namespace: sbtc-signer
+type: Opaque
+data:
+  # these values are base64 encoded
+  STACKING_KEYS: NmExYTc1NGJhODYzZDdiYWIxNGFkYmJjM2Y4ZWJiMDkwYWY5ZTg3MWFjZTYyMWQzZTVhYjYzNGUxNDIyODg1ZTAxLGI0NjNmMGRmNmMwNWQyZjE1NjM5M2VlZTczZjgwMTZjNTM3MmNhYTBlOWUyOWE5MDFiYjcxNzFkOTBkYzRmMTQwMSw3MDM2YjI5Y2I1ZTIzNWU1ZmQ5YjA5YWUzZThlZWM0NDA0ZTQ0OTA2ODE0ZDVkMDFjYmNhOTY4YTYwZWQ0YmZiMDE=
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: tx-broadcaster-secret
+  namespace: sbtc-signer
+type: Opaque
+data:
+  # these values are base64 encoded
+  ACCOUNT_KEYS: MGQyZjk2NWI0NzJhODJlZmQ1YTk2ZTY1MTNjOGI5ZjdlZGM3MjVkNWM5NmM3ZDM1ZDZjNzIyY2VkZWI4MGQxYjAxLDk3NWIyNTFkZDc4MDk0NjllZjBjMjZlYzM5MTc5NzFiNzVjNTFjZDczYTAyMjAyNGRmNGJmM2IyMzJjYzJkYzAwMSxjNzE3MDBiMDdkNTIwYThjOTczMWU0ZDBmMDk1YWE2ZWZiOTFlMTZlMjVmYjI3Y2UyYjcyZTdiNjk4ZjgxMjdhMDE=
 ---

--- a/devenv/local/k8s/yamls/services/services.yaml
+++ b/devenv/local/k8s/yamls/services/services.yaml
@@ -2,10 +2,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: bitcoin-regtest-service
+  name: bitcoin-service
   namespace: sbtc-signer
   labels:
-    app: bitcoin-regtest
+    app: bitcoin
   
 spec:
   type: ClusterIP
@@ -35,7 +35,7 @@ spec:
       name: bitcoin-port3-udp
       protocol: UDP
   selector:
-    app: bitcoin-regtest
+    app: bitcoin
 ---
 apiVersion: v1
 kind: Service
@@ -70,24 +70,68 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: nakamoto-signer-service
+  name: nakamoto-signer-1-service
   namespace: sbtc-signer
   labels:
-    app: nakamoto-signer
+    app: nakamoto-signer-1
   
 spec:
   type: ClusterIP
   ports:
-    - port: 30000
+    - port: 30001
       targetPort: 30000
-      name: nakamoto-signer-port3-tcp
+      name: nakamoto-signer-1-port3-tcp
       protocol: TCP
-    - port: 30000
+    - port: 30001
       targetPort: 30000
-      name: nakamoto-signer-port3-udp
+      name: nakamoto-signer-1-port3-udp
       protocol: UDP
   selector:
-    app: nakamoto-signer
+    app: nakamoto-signer-1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nakamoto-signer-2-service
+  namespace: sbtc-signer
+  labels:
+    app: nakamoto-signer-2
+  
+spec:
+  type: ClusterIP
+  ports:
+    - port: 30002
+      targetPort: 30000
+      name: nakamoto-signer-2-port3-tcp
+      protocol: TCP
+    - port: 30002
+      targetPort: 30000
+      name: nakamoto-signer-2-port3-udp
+      protocol: UDP
+  selector:
+    app: nakamoto-signer-2
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nakamoto-signer-3-service
+  namespace: sbtc-signer
+  labels:
+    app: nakamoto-signer-3
+  
+spec:
+  type: ClusterIP
+  ports:
+    - port: 30003
+      targetPort: 30000
+      name: nakamoto-signer-3-port3-tcp
+      protocol: TCP
+    - port: 30003
+      targetPort: 30000
+      name: nakamoto-signer-3-port3-udp
+      protocol: UDP
+  selector:
+    app: nakamoto-signer-3
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Description

See previous PR: #240 for context

These are the newly added components:

- Container:
   - `stacker`
   - Changed stacks and Nakamoto signer containers to pull from commit: `3d96d53b35409859ca2baa2f0b6ddaa1fbd80265` in [stacks-core](https://github.com/stacks-network/stacks-core.git)
- Deployment:
   - nakamoto-signer-1-deployment
   - nakamoto-signer-2-deployment
   - nakamoto-signer-3-deployment
   - tx-broadcaster-deployment
   - stacker-deployment
   - monitor-deployment
- Secrets:
   - `nakamoto-signer-1-secret`
   - `nakamoto-signer-2-secret`
   - `nakamoto-signer-3-secret`
   - `stacker-secret`
   - `tx-broadcaster-secret`
- Service:
   - `nakamoto-signer-1-svc`
   - `nakamoto-signer-2-svc`
   - `nakamoto-signer-3-svc`
- Changed the tests to be able to check for signers 1,2,3 and Nakamoto functionality


This PR adds these components and relevant tests so that the devnet has Nakamoto working

## Testing information

In order for this PR to pass, run `sh tests/devnet-liveness.sh`. 

> Note: Please wait for 130 stacks blocks to be mined first before running the tests

