### PR TITLE
[Clarity] Complete Accepted Withdrawal Request

### DIFF
--- a/contracts/contracts/sbtc-registry.clar
+++ b/contracts/contracts/sbtc-registry.clar
@@ -159,15 +159,16 @@
 ;; Complete withdrawal request
 (define-public (complete-withdrawal
     (request-id uint) 
-    (bitcoin-txid (buff 32)) 
-    (signer-bitmap uint)
-    (output-index uint)
-    (fee uint)
+    (status bool)
+    (bitcoin-txid (optional (buff 32))) 
+    (signer-bitmap (optional uint))
+    (output-index (optional uint))
+    (fee (optional uint))
   )
   (begin 
     (try! (validate-caller))
     ;; Mark the withdrawal as completed
-    (map-insert withdrawal-status request-id true)
+    (map-insert withdrawal-status request-id status)
     (print {
       topic: "completed-withdrawal",
       request-id: request-id,

--- a/contracts/contracts/sbtc-registry.clar
+++ b/contracts/contracts/sbtc-registry.clar
@@ -156,6 +156,30 @@
   )
 )
 
+;; Complete withdrawal request
+(define-public (complete-withdrawal
+    (request-id uint) 
+    (bitcoin-txid (buff 32)) 
+    (signer-bitmap uint)
+    (output-index uint)
+    (fee uint)
+  )
+  (begin 
+    (try! (validate-caller))
+    ;; Mark the withdrawal as completed
+    (map-insert withdrawal-status request-id true)
+    (print {
+      topic: "completed-withdrawal",
+      request-id: request-id,
+      bitcoin-txid: bitcoin-txid,
+      signer-bitmap: signer-bitmap,
+      output-index: output-index,
+      fee: fee
+    })
+    (ok true)
+  )
+)
+
 ;; Store a new insert request.
 ;; Note that this function can only be called by other sBTC
 ;; contracts (specifically the current version of the deposit contract) 

--- a/contracts/contracts/sbtc-registry.clar
+++ b/contracts/contracts/sbtc-registry.clar
@@ -172,6 +172,7 @@
     (print {
       topic: "completed-withdrawal",
       request-id: request-id,
+      request-status: status,
       bitcoin-txid: bitcoin-txid,
       signer-bitmap: signer-bitmap,
       output-index: output-index,

--- a/contracts/contracts/sbtc-withdrawal.clar
+++ b/contracts/contracts/sbtc-withdrawal.clar
@@ -107,7 +107,13 @@
   )
 )
 ;; Reject multiple withdrawal requests
-(define-public (complete-withdrawals (withdrawals (list 100 {request-id: uint, status: bool, signer-bitmap: uint, bitcoin-txid: (optional (buff 32)), output-index: (optional uint), fee: (optional uint)})))
+(define-public (complete-withdrawals (withdrawals (list 100 
+                                     {request-id: uint, 
+                                     status: bool, 
+                                     signer-bitmap: uint, 
+                                     bitcoin-txid: (optional (buff 32)), 
+                                     output-index: (optional uint), 
+                                     fee: (optional uint)})))
   (let 
       (
           (current-signer-data (contract-call? .sbtc-registry get-current-signer-data))
@@ -120,7 +126,14 @@
   )
 )
 
-(define-private (complete-individual-withdrawal-helper (withdrawal {request-id: uint, status: bool, signer-bitmap: uint, bitcoin-txid: (optional (buff 32)), output-index: (optional uint), fee: (optional uint)}) (helper-response (response uint uint)))
+(define-private (complete-individual-withdrawal-helper (withdrawal 
+                                                        {request-id: uint, 
+                                                        status: bool, 
+                                                        signer-bitmap: uint, 
+                                                        bitcoin-txid: (optional (buff 32)), 
+                                                        output-index: (optional uint), 
+                                                        fee: (optional uint)}) 
+                                                       (helper-response (response uint uint)))
   (match helper-response 
     index
       (let

--- a/contracts/contracts/sbtc-withdrawal.clar
+++ b/contracts/contracts/sbtc-withdrawal.clar
@@ -6,16 +6,16 @@
 (define-constant ERR_INVALID_ADDR_HASHBYTES (err u501))
 ;; The size of the withdrawal is smaller than the dust limit
 (define-constant ERR_DUST_LIMIT (err u502))
-;; The size of the withdrawal is smaller than the dust limit
+;; The request id was invalid / returned 'none'
 (define-constant ERR_INVALID_REQUEST (err u503))
-;; The size of the withdrawal is smaller than the dust limit
+;; The caller is not the currently-governing multisig principal
 (define-constant ERR_INVALID_CALLER (err u504))
-;; The size of the withdrawal is smaller than the dust limit
+;; The withdrawal request was already processed
 (define-constant ERR_ALREADY_PROCESSED (err u505))
-;; The size of the withdrawal is smaller than the dust limit
+;; The paid fee was higher than requested
 (define-constant ERR_FEE_TOO_HIGH (err u505))
+;; The returned index marks the failed transaction in list
 (define-constant ERR_WITHDRAWAL_INDEX_PREFIX (unwrap-err! ERR_WITHDRAWAL_INDEX (err true)))
-;; The size of the withdrawal is smaller than the dust limit
 (define-constant ERR_WITHDRAWAL_INDEX (err u506))
 
 ;; Maximum value of an address version as a uint

--- a/contracts/contracts/sbtc-withdrawal.clar
+++ b/contracts/contracts/sbtc-withdrawal.clar
@@ -70,6 +70,9 @@
       ;; Mint the difference b/w max-fee of the request & fee actually paid back to the user in sBTC
       (try! (contract-call? .sbtc-token protocol-mint (- requested-max-fee fee) requester))
 
+      ;; Call into registry to confirm accepted withdrawal
+      (try! (contract-call? .sbtc-registry complete-withdrawal request-id bitcoin-txid signer-bitmap output-index fee))
+
       (ok request)
   )
 ) 

--- a/contracts/contracts/sbtc-withdrawal.clar
+++ b/contracts/contracts/sbtc-withdrawal.clar
@@ -122,53 +122,10 @@
       ;; Check that the caller is the current signer principal
       (asserts! (is-eq (get current-signer-principal current-signer-data) tx-sender) ERR_INVALID_CALLER)
 
-      (fold complete-individual-withdrawal-helper withdrawals {index: u0, agg-errs: none})
-
-      (ok true)
+      (fold complete-individual-withdrawal-helper withdrawals (ok u0))
   )
 )
 
-;; (define-private (complete-individual-withdrawal-helper (withdrawal 
-;;                                                         {request-id: uint, 
-;;                                                         status: bool, 
-;;                                                         signer-bitmap: uint, 
-;;                                                         bitcoin-txid: (optional (buff 32)), 
-;;                                                         output-index: (optional uint), 
-;;                                                         fee: (optional uint)}) 
-;;                                                        (helper-response (response uint uint)))
-;;   (match helper-response 
-;;     index
-;;       (let
-;;         (
-;;           (current-request-id (get request-id withdrawal))
-;;           (current-signer-bitmap (get signer-bitmap withdrawal))
-;;           (current-bitcoin-txid (get bitcoin-txid withdrawal))
-;;           (current-output-index (get output-index withdrawal))
-;;           (current-fee (get fee withdrawal))
-;;         ) 
-;;         (if (get status withdrawal)
-;;           ;; accepted
-;;           (begin 
-;;             (asserts! 
-;;               (and (is-some current-bitcoin-txid) (is-some current-output-index) (is-some current-fee)) 
-;;               (err (+ ERR_WITHDRAWAL_INDEX_PREFIX (+ u10 index))))
-;;             (unwrap! (accept-withdrawal-request (get request-id withdrawal) (unwrap-panic current-bitcoin-txid) current-signer-bitmap (unwrap-panic current-output-index) (unwrap-panic current-fee)) (err (+ ERR_WITHDRAWAL_INDEX_PREFIX (+ u10 index))))
-;;           )
-;;           ;; rejected
-;;           (unwrap! (reject-withdrawal (get request-id withdrawal) current-signer-bitmap) (err (+ ERR_WITHDRAWAL_INDEX_PREFIX (+ u10 index))))
-;;         )
-;;         (ok (+ index u1))
-;;       )
-;;     err-response
-;;             (err err-response)
-;;   )
-;; )
-
-;; Loop through each submission
-;;  Regardless of whether there are errors or not we need to try every submission
-;;  If it's okay, then we just increase the index by one
-;;  If it's not okay, we need create and/or store an error message
-;; At the end, if the error message is empty, all were okay / we return okay
 (define-private (complete-individual-withdrawal-helper (withdrawal 
                                                         {request-id: uint, 
                                                         status: bool, 
@@ -176,57 +133,33 @@
                                                         bitcoin-txid: (optional (buff 32)), 
                                                         output-index: (optional uint), 
                                                         fee: (optional uint)}) 
-                                                       (helper-tuple {index: uint, agg-errs: (optional (string-ascii 100))}))
-
-  (let
-    (
-      (current-request-id (get request-id withdrawal))
-      (current-signer-bitmap (get signer-bitmap withdrawal))
-      (current-bitcoin-txid (get bitcoin-txid withdrawal))
-      (current-output-index (get output-index withdrawal))
-      (current-fee (get fee withdrawal))
-      (current-index (get index helper-tuple))
-      (current-agg-errs (get agg-errs helper-tuple))
-    )
-    ;; check / unwrap existing errors
-    (match current-agg-errs 
-      existing-errs
+                                                       (helper-response (response uint uint)))
+  (match helper-response 
+    index
+      (let
+        (
+          (current-request-id (get request-id withdrawal))
+          (current-signer-bitmap (get signer-bitmap withdrawal))
+          (current-bitcoin-txid (get bitcoin-txid withdrawal))
+          (current-output-index (get output-index withdrawal))
+          (current-fee (get fee withdrawal))
+        ) 
         (if (get status withdrawal)
           ;; accepted
-          (match (accept-withdrawal-request (get request-id withdrawal) (unwrap-panic current-bitcoin-txid) current-signer-bitmap (unwrap-panic current-output-index) (unwrap-panic current-fee))
-            ok-resp
-              {index: (+ u1 current-index), agg-errs: current-agg-errs}
-            err-resp
-              {index: (+ u1 current-index), agg-errs: (as-max-len? (concat existing-errs (int-to-ascii current-index)) u100)}
+          (begin 
+            (asserts! 
+              (and (is-some current-bitcoin-txid) (is-some current-output-index) (is-some current-fee)) 
+              (err (+ ERR_WITHDRAWAL_INDEX_PREFIX (+ u10 index))))
+            (unwrap! (accept-withdrawal-request (get request-id withdrawal) (unwrap-panic current-bitcoin-txid) current-signer-bitmap (unwrap-panic current-output-index) (unwrap-panic current-fee)) (err (+ ERR_WITHDRAWAL_INDEX_PREFIX (+ u10 index))))
           )
           ;; rejected
-          (match (reject-withdrawal (get request-id withdrawal) current-signer-bitmap)
-            ok-resp
-                {index: (+ u1 current-index), agg-errs: current-agg-errs}
-            err-resp
-              {index: (+ u1 current-index), agg-errs: (as-max-len? (concat existing-errs (int-to-ascii current-index)) u100)}
-          )
+          (unwrap! (reject-withdrawal (get request-id withdrawal) current-signer-bitmap) (err (+ ERR_WITHDRAWAL_INDEX_PREFIX (+ u10 index))))
         )
-      ;; none value
-      (if (get status withdrawal)
-        ;; accepted
-        (match (accept-withdrawal-request (get request-id withdrawal) (unwrap-panic current-bitcoin-txid) current-signer-bitmap (unwrap-panic current-output-index) (unwrap-panic current-fee))
-          ok-resp
-            {index: (+ u1 current-index), agg-errs: current-agg-errs}
-          err-resp
-            {index: (+ u1 current-index), agg-errs: (some (int-to-ascii current-index))}
-        )
-        ;; rejected
-        (match (reject-withdrawal (get request-id withdrawal) current-signer-bitmap)
-          ok-resp
-              {index: (+ u1 current-index), agg-errs: current-agg-errs}
-          err-resp
-            {index: (+ u1 current-index), agg-errs: (some (int-to-ascii current-index))}
-        )
+        (ok (+ index u1))
       )
-    )
+    err-response
+            (err err-response)
   )
-
 )
 
 ;; Validation methods

--- a/contracts/contracts/sbtc-withdrawal.clar
+++ b/contracts/contracts/sbtc-withdrawal.clar
@@ -62,13 +62,16 @@
       (asserts! (is-none (get status request)) ERR_ALREADY_PROCESSED)
 
       ;; Check that fee is not higher than requesters max fee
-      (asserts! (< fee requested-max-fee) ERR_FEE_TOO_HIGH)
+      (asserts! (<= fee requested-max-fee) ERR_FEE_TOO_HIGH)
 
       ;; Burn the locked-sbtc
       (try! (contract-call? .sbtc-token protocol-burn-locked (get amount request) requester))
 
       ;; Mint the difference b/w max-fee of the request & fee actually paid back to the user in sBTC
-      (try! (contract-call? .sbtc-token protocol-mint (- requested-max-fee fee) requester))
+      (if (is-eq (- requested-max-fee fee) u0)
+        true
+        (try! (contract-call? .sbtc-token protocol-mint (- requested-max-fee fee) requester))
+      )
 
       ;; Call into registry to confirm accepted withdrawal
       (try! (contract-call? .sbtc-registry complete-withdrawal request-id bitcoin-txid signer-bitmap output-index fee))

--- a/contracts/contracts/sbtc-withdrawal.clar
+++ b/contracts/contracts/sbtc-withdrawal.clar
@@ -101,7 +101,7 @@
     (try! (contract-call? .sbtc-token protocol-unlock (get amount withdrawal) (get sender withdrawal)))
 
     ;; Call into registry to confirm accepted withdrawal
-    (try! (contract-call? .sbtc-registry complete-withdrawal request-id false none none none none))
+    (try! (contract-call? .sbtc-registry complete-withdrawal request-id false none (some signer-bitmap) none none))
 
     (ok true)
   )

--- a/contracts/contracts/sbtc-withdrawal.clar
+++ b/contracts/contracts/sbtc-withdrawal.clar
@@ -14,9 +14,9 @@
 (define-constant ERR_ALREADY_PROCESSED (err u505))
 ;; The paid fee was higher than requested
 (define-constant ERR_FEE_TOO_HIGH (err u505))
+(define-constant ERR_INVALID_BTC_ID (err u507))
 ;; The returned index marks the failed transaction in list
-(define-constant ERR_WITHDRAWAL_INDEX_PREFIX (unwrap-err! ERR_WITHDRAWAL_INDEX (err true)))
-(define-constant ERR_WITHDRAWAL_INDEX (err u506))
+(define-constant ERR_WITHDRAWALS_PREFIX "510")
 
 ;; Maximum value of an address version as a uint
 (define-constant MAX_ADDRESS_VERSION u6)
@@ -66,6 +66,9 @@
 
       ;; Check that fee is not higher than requesters max fee
       (asserts! (<= fee requested-max-fee) ERR_FEE_TOO_HIGH)
+
+      ;; Check that bitcoin-txid is the correct length
+      (asserts! (is-eq (len bitcoin-txid) u32) ERR_INVALID_BTC_ID)
 
       ;; Burn the locked-sbtc
       (try! (contract-call? .sbtc-token protocol-burn-locked (get amount request) requester))
@@ -122,47 +125,18 @@
       ;; Check that the caller is the current signer principal
       (asserts! (is-eq (get current-signer-principal current-signer-data) tx-sender) ERR_INVALID_CALLER)
 
-      (fold complete-individual-withdrawal-helper withdrawals {index: u0, agg-errs: none})
+      (try! (match (get agg-errs (unwrap-panic (fold complete-individual-withdrawal-helper withdrawals (ok {index: u0, agg-errs: none}))))
+        ;; agg-errs exist
+        agg-errs
+          (err 
+            (unwrap-panic (string-to-uint? (concat ERR_WITHDRAWALS_PREFIX agg-errs))))
+        ;; agg-errs free (all good)
+        (ok true)
+      ))
 
       (ok true)
   )
 )
-
-;; (define-private (complete-individual-withdrawal-helper (withdrawal 
-;;                                                         {request-id: uint, 
-;;                                                         status: bool, 
-;;                                                         signer-bitmap: uint, 
-;;                                                         bitcoin-txid: (optional (buff 32)), 
-;;                                                         output-index: (optional uint), 
-;;                                                         fee: (optional uint)}) 
-;;                                                        (helper-response (response uint uint)))
-;;   (match helper-response 
-;;     index
-;;       (let
-;;         (
-;;           (current-request-id (get request-id withdrawal))
-;;           (current-signer-bitmap (get signer-bitmap withdrawal))
-;;           (current-bitcoin-txid (get bitcoin-txid withdrawal))
-;;           (current-output-index (get output-index withdrawal))
-;;           (current-fee (get fee withdrawal))
-;;         ) 
-;;         (if (get status withdrawal)
-;;           ;; accepted
-;;           (begin 
-;;             (asserts! 
-;;               (and (is-some current-bitcoin-txid) (is-some current-output-index) (is-some current-fee)) 
-;;               (err (+ ERR_WITHDRAWAL_INDEX_PREFIX (+ u10 index))))
-;;             (unwrap! (accept-withdrawal-request (get request-id withdrawal) (unwrap-panic current-bitcoin-txid) current-signer-bitmap (unwrap-panic current-output-index) (unwrap-panic current-fee)) (err (+ ERR_WITHDRAWAL_INDEX_PREFIX (+ u10 index))))
-;;           )
-;;           ;; rejected
-;;           (unwrap! (reject-withdrawal (get request-id withdrawal) current-signer-bitmap) (err (+ ERR_WITHDRAWAL_INDEX_PREFIX (+ u10 index))))
-;;         )
-;;         (ok (+ index u1))
-;;       )
-;;     err-response
-;;             (err err-response)
-;;   )
-;; )
 
 ;; Loop through each submission
 ;;  Regardless of whether there are errors or not we need to try every submission
@@ -176,7 +150,7 @@
                                                         bitcoin-txid: (optional (buff 32)), 
                                                         output-index: (optional uint), 
                                                         fee: (optional uint)}) 
-                                                       (helper-tuple {index: uint, agg-errs: (optional (string-ascii 100))}))
+                                                       (helper-response (response {index: uint, agg-errs: (optional (string-ascii 100))} uint)))
 
   (let
     (
@@ -185,8 +159,8 @@
       (current-bitcoin-txid (get bitcoin-txid withdrawal))
       (current-output-index (get output-index withdrawal))
       (current-fee (get fee withdrawal))
-      (current-index (get index helper-tuple))
-      (current-agg-errs (get agg-errs helper-tuple))
+      (current-index (get index (unwrap-panic helper-response)))
+      (current-agg-errs (get agg-errs (unwrap-panic helper-response)))
     )
     ;; check / unwrap existing errors
     (match current-agg-errs 
@@ -195,16 +169,16 @@
           ;; accepted
           (match (accept-withdrawal-request (get request-id withdrawal) (unwrap-panic current-bitcoin-txid) current-signer-bitmap (unwrap-panic current-output-index) (unwrap-panic current-fee))
             ok-resp
-              {index: (+ u1 current-index), agg-errs: current-agg-errs}
+              (ok {index: (+ u1 current-index), agg-errs: current-agg-errs})
             err-resp
-              {index: (+ u1 current-index), agg-errs: (as-max-len? (concat existing-errs (int-to-ascii current-index)) u100)}
+              (ok {index: (+ u1 current-index), agg-errs: (as-max-len? (concat existing-errs (int-to-ascii current-index)) u100)})
           )
           ;; rejected
           (match (reject-withdrawal (get request-id withdrawal) current-signer-bitmap)
             ok-resp
-                {index: (+ u1 current-index), agg-errs: current-agg-errs}
+                (ok {index: (+ u1 current-index), agg-errs: current-agg-errs})
             err-resp
-              {index: (+ u1 current-index), agg-errs: (as-max-len? (concat existing-errs (int-to-ascii current-index)) u100)}
+              (ok {index: (+ u1 current-index), agg-errs: (as-max-len? (concat existing-errs (int-to-ascii current-index)) u100)})
           )
         )
       ;; none value
@@ -212,22 +186,23 @@
         ;; accepted
         (match (accept-withdrawal-request (get request-id withdrawal) (unwrap-panic current-bitcoin-txid) current-signer-bitmap (unwrap-panic current-output-index) (unwrap-panic current-fee))
           ok-resp
-            {index: (+ u1 current-index), agg-errs: current-agg-errs}
+            (ok {index: (+ u1 current-index), agg-errs: current-agg-errs})
           err-resp
-            {index: (+ u1 current-index), agg-errs: (some (int-to-ascii current-index))}
+            (ok {index: (+ u1 current-index), agg-errs: (some (int-to-ascii current-index))})
         )
         ;; rejected
         (match (reject-withdrawal (get request-id withdrawal) current-signer-bitmap)
           ok-resp
-              {index: (+ u1 current-index), agg-errs: current-agg-errs}
+              (ok {index: (+ u1 current-index), agg-errs: current-agg-errs})
           err-resp
-            {index: (+ u1 current-index), agg-errs: (some (int-to-ascii current-index))}
+            (ok {index: (+ u1 current-index), agg-errs: (some (int-to-ascii current-index))})
         )
       )
     )
   )
 
 )
+
 
 ;; Validation methods
 

--- a/contracts/contracts/sbtc-withdrawal.clar
+++ b/contracts/contracts/sbtc-withdrawal.clar
@@ -84,7 +84,7 @@
 )
 
 ;; Reject a withdrawal request
-(define-public (reject-withdrawal (request-id uint) (signer-bitmap uint))
+(define-public (reject-withdrawal-request (request-id uint) (signer-bitmap uint))
   (let
      (
       (current-signer-data (contract-call? .sbtc-registry get-current-signer-data))   

--- a/contracts/contracts/sbtc-withdrawal.clar
+++ b/contracts/contracts/sbtc-withdrawal.clar
@@ -74,7 +74,7 @@
       )
 
       ;; Call into registry to confirm accepted withdrawal
-      (try! (contract-call? .sbtc-registry complete-withdrawal request-id bitcoin-txid signer-bitmap output-index fee))
+      (try! (contract-call? .sbtc-registry complete-withdrawal request-id true (some bitcoin-txid) (some signer-bitmap) (some output-index) (some fee)))
 
       (ok request)
   )
@@ -96,6 +96,9 @@
 
     ;; Burn sbtc-locked & re-mint sbtc to original requester
     (try! (contract-call? .sbtc-token protocol-unlock (get amount withdrawal) (get sender withdrawal)))
+
+    ;; Call into registry to confirm accepted withdrawal
+    (try! (contract-call? .sbtc-registry complete-withdrawal request-id false none none none none))
 
     (ok true)
 

--- a/contracts/contracts/sbtc-withdrawal.clar
+++ b/contracts/contracts/sbtc-withdrawal.clar
@@ -153,7 +153,7 @@
             (unwrap! (accept-withdrawal-request (get request-id withdrawal) (unwrap-panic current-bitcoin-txid) current-signer-bitmap (unwrap-panic current-output-index) (unwrap-panic current-fee)) (err (+ ERR_WITHDRAWAL_INDEX_PREFIX (+ u10 index))))
           )
           ;; rejected
-          (unwrap! (reject-withdrawal (get request-id withdrawal) current-signer-bitmap) (err (+ ERR_WITHDRAWAL_INDEX_PREFIX (+ u10 index))))
+          (unwrap! (reject-withdrawal-request (get request-id withdrawal) current-signer-bitmap) (err (+ ERR_WITHDRAWAL_INDEX_PREFIX (+ u10 index))))
         )
         (ok (+ index u1))
       )

--- a/contracts/contracts/sbtc-withdrawal.clar
+++ b/contracts/contracts/sbtc-withdrawal.clar
@@ -6,6 +6,14 @@
 (define-constant ERR_INVALID_ADDR_HASHBYTES (err u501))
 ;; The size of the withdrawal is smaller than the dust limit
 (define-constant ERR_DUST_LIMIT (err u502))
+;; The size of the withdrawal is smaller than the dust limit
+(define-constant ERR_INVALID_REQUEST (err u503))
+;; The size of the withdrawal is smaller than the dust limit
+(define-constant ERR_INVALID_CALLER (err u504))
+;; The size of the withdrawal is smaller than the dust limit
+(define-constant ERR_ALREADY_PROCESSED (err u505))
+;; The size of the withdrawal is smaller than the dust limit
+(define-constant ERR_FEE_TOO_HIGH (err u505))
 
 ;; Maximum value of an address version as a uint
 (define-constant MAX_ADDRESS_VERSION u6)
@@ -18,6 +26,7 @@
 ;; The minimum amount of sBTC you can withdraw
 (define-constant DUST_LIMIT u546)
 
+;; Initiate a new withdrawal request
 (define-public (initiate-withdrawal-request (amount uint)
                                             (recipient { version: (buff 1), hashbytes: (buff 32) })
                                             (max-fee uint)
@@ -32,6 +41,30 @@
     (ok (try! (contract-call? .sbtc-registry create-withdrawal-request amount max-fee tx-sender recipient burn-block-height)))
   )
 )
+
+;; Accept a withdrawal request
+(define-public (accept-withdrawal-request (request-id uint) 
+                                          (bitcoin-txid (buff 32)) 
+                                          (signer-bitmap uint)
+                                          (output-index uint)
+                                          (fee uint))
+  (let 
+    (
+      (current-signer-data (contract-call? .sbtc-registry get-current-signer-data))   
+      (request  (unwrap! (contract-call? .sbtc-registry get-withdrawal-request request-id) ERR_INVALID_REQUEST))
+    )
+      ;; Check that the caller is the current signer principal
+      (asserts! (is-eq (get current-signer-principal current-signer-data) tx-sender) ERR_INVALID_CALLER)
+
+      ;; Check whether it was already accepted or rejected
+      (asserts! (is-none (get status request)) ERR_ALREADY_PROCESSED)
+
+      ;; Check that fee is not higher than requesters max fee
+      (asserts! (< fee (get max-fee request)) ERR_FEE_TOO_HIGH)
+
+      (ok request)
+  )
+) 
 
 ;; Validation methods
 

--- a/contracts/tests/clarigen-types.ts
+++ b/contracts/tests/clarigen-types.ts
@@ -1618,8 +1618,8 @@ export const contracts = {
         ],
         Response<bigint, bigint>
       >,
-      rejectWithdrawal: {
-        name: "reject-withdrawal",
+      rejectWithdrawalRequest: {
+        name: "reject-withdrawal-request",
         access: "public",
         args: [
           { name: "request-id", type: "uint128" },

--- a/contracts/tests/clarigen-types.ts
+++ b/contracts/tests/clarigen-types.ts
@@ -712,6 +712,27 @@ export const contracts = {
         ],
         Response<boolean, bigint>
       >,
+      completeWithdrawal: {
+        name: "complete-withdrawal",
+        access: "public",
+        args: [
+          { name: "request-id", type: "uint128" },
+          { name: "bitcoin-txid", type: { buffer: { length: 32 } } },
+          { name: "signer-bitmap", type: "uint128" },
+          { name: "output-index", type: "uint128" },
+          { name: "fee", type: "uint128" },
+        ],
+        outputs: { type: { response: { ok: "bool", error: "uint128" } } },
+      } as TypedAbiFunction<
+        [
+          requestId: TypedAbiArg<number | bigint, "requestId">,
+          bitcoinTxid: TypedAbiArg<Uint8Array, "bitcoinTxid">,
+          signerBitmap: TypedAbiArg<number | bigint, "signerBitmap">,
+          outputIndex: TypedAbiArg<number | bigint, "outputIndex">,
+          fee: TypedAbiArg<number | bigint, "fee">,
+        ],
+        Response<boolean, bigint>
+      >,
       createWithdrawalRequest: {
         name: "create-withdrawal-request",
         access: "public",
@@ -1451,6 +1472,64 @@ export const contracts = {
   },
   sbtcWithdrawal: {
     functions: {
+      acceptWithdrawalRequest: {
+        name: "accept-withdrawal-request",
+        access: "public",
+        args: [
+          { name: "request-id", type: "uint128" },
+          { name: "bitcoin-txid", type: { buffer: { length: 32 } } },
+          { name: "signer-bitmap", type: "uint128" },
+          { name: "output-index", type: "uint128" },
+          { name: "fee", type: "uint128" },
+        ],
+        outputs: {
+          type: {
+            response: {
+              ok: {
+                tuple: [
+                  { name: "amount", type: "uint128" },
+                  { name: "block-height", type: "uint128" },
+                  { name: "max-fee", type: "uint128" },
+                  {
+                    name: "recipient",
+                    type: {
+                      tuple: [
+                        { name: "hashbytes", type: { buffer: { length: 32 } } },
+                        { name: "version", type: { buffer: { length: 1 } } },
+                      ],
+                    },
+                  },
+                  { name: "sender", type: "principal" },
+                  { name: "status", type: { optional: "bool" } },
+                ],
+              },
+              error: "uint128",
+            },
+          },
+        },
+      } as TypedAbiFunction<
+        [
+          requestId: TypedAbiArg<number | bigint, "requestId">,
+          bitcoinTxid: TypedAbiArg<Uint8Array, "bitcoinTxid">,
+          signerBitmap: TypedAbiArg<number | bigint, "signerBitmap">,
+          outputIndex: TypedAbiArg<number | bigint, "outputIndex">,
+          fee: TypedAbiArg<number | bigint, "fee">,
+        ],
+        Response<
+          {
+            amount: bigint;
+            blockHeight: bigint;
+            maxFee: bigint;
+            recipient: {
+              hashbytes: Uint8Array;
+              version: Uint8Array;
+            };
+            sender: string;
+            status: boolean | null;
+          },
+          bigint
+        >
+      >,
       initiateWithdrawalRequest: {
         name: "initiate-withdrawal-request",
         access: "public",
@@ -1517,8 +1596,28 @@ export const contracts = {
         type: "uint128",
         access: "constant",
       } as TypedAbiVariable<bigint>,
+      ERR_ALREADY_PROCESSED: {
+        name: "ERR_ALREADY_PROCESSED",
+        type: {
+          response: {
+            ok: "none",
+            error: "uint128",
+          },
+        },
+        access: "constant",
+      } as TypedAbiVariable<Response<null, bigint>>,
       ERR_DUST_LIMIT: {
         name: "ERR_DUST_LIMIT",
+        type: {
+          response: {
+            ok: "none",
+            error: "uint128",
+          },
+        },
+        access: "constant",
+      } as TypedAbiVariable<Response<null, bigint>>,
+      ERR_FEE_TOO_HIGH: {
+        name: "ERR_FEE_TOO_HIGH",
         type: {
           response: {
             ok: "none",
@@ -1547,6 +1646,26 @@ export const contracts = {
         },
         access: "constant",
       } as TypedAbiVariable<Response<null, bigint>>,
+      ERR_INVALID_CALLER: {
+        name: "ERR_INVALID_CALLER",
+        type: {
+          response: {
+            ok: "none",
+            error: "uint128",
+          },
+        },
+        access: "constant",
+      } as TypedAbiVariable<Response<null, bigint>>,
+      ERR_INVALID_REQUEST: {
+        name: "ERR_INVALID_REQUEST",
+        type: {
+          response: {
+            ok: "none",
+            error: "uint128",
+          },
+        },
+        access: "constant",
+      } as TypedAbiVariable<Response<null, bigint>>,
       MAX_ADDRESS_VERSION: {
         name: "MAX_ADDRESS_VERSION",
         type: "uint128",
@@ -1565,9 +1684,17 @@ export const contracts = {
     },
     constants: {
       DUST_LIMIT: 546n,
+      ERR_ALREADY_PROCESSED: {
+        isOk: false,
+        value: 505n,
+      },
       ERR_DUST_LIMIT: {
         isOk: false,
         value: 502n,
+      },
+      ERR_FEE_TOO_HIGH: {
+        isOk: false,
+        value: 505n,
       },
       ERR_INVALID_ADDR_HASHBYTES: {
         isOk: false,
@@ -1576,6 +1703,14 @@ export const contracts = {
       ERR_INVALID_ADDR_VERSION: {
         isOk: false,
         value: 500n,
+      },
+      ERR_INVALID_CALLER: {
+        isOk: false,
+        value: 504n,
+      },
+      ERR_INVALID_REQUEST: {
+        isOk: false,
+        value: 503n,
       },
       MAX_ADDRESS_VERSION: 6n,
       mAX_ADDRESS_VERSION_BUFF_20: 4n,

--- a/contracts/tests/clarigen-types.ts
+++ b/contracts/tests/clarigen-types.ts
@@ -1499,10 +1499,38 @@ export const contracts = {
           },
           {
             name: "helper-response",
-            type: { response: { ok: "uint128", error: "uint128" } },
+            type: {
+              response: {
+                ok: {
+                  tuple: [
+                    {
+                      name: "agg-errs",
+                      type: { optional: { "string-ascii": { length: 100 } } },
+                    },
+                    { name: "index", type: "uint128" },
+                  ],
+                },
+                error: "uint128",
+              },
+            },
           },
         ],
-        outputs: { type: { response: { ok: "uint128", error: "uint128" } } },
+        outputs: {
+          type: {
+            response: {
+              ok: {
+                tuple: [
+                  {
+                    name: "agg-errs",
+                    type: { optional: { "string-ascii": { length: 100 } } },
+                  },
+                  { name: "index", type: "uint128" },
+                ],
+              },
+              error: "none",
+            },
+          },
+        },
       } as TypedAbiFunction<
         [
           withdrawal: TypedAbiArg<
@@ -1517,11 +1545,23 @@ export const contracts = {
             "withdrawal"
           >,
           helperResponse: TypedAbiArg<
-            Response<number | bigint, number | bigint>,
+            Response<
+              {
+                aggErrs: string | null;
+                index: number | bigint;
+              },
+              number | bigint
+            >,
             "helperResponse"
           >,
         ],
-        Response<bigint, bigint>
+        Response<
+          {
+            aggErrs: string | null;
+            index: bigint;
+          },
+          null
+        >
       >,
       acceptWithdrawalRequest: {
         name: "accept-withdrawal-request",
@@ -1570,7 +1610,7 @@ export const contracts = {
             },
           },
         ],
-        outputs: { type: { response: { ok: "uint128", error: "uint128" } } },
+        outputs: { type: { response: { ok: "bool", error: "uint128" } } },
       } as TypedAbiFunction<
         [
           withdrawals: TypedAbiArg<
@@ -1585,7 +1625,7 @@ export const contracts = {
             "withdrawals"
           >,
         ],
-        Response<bigint, bigint>
+        Response<boolean, bigint>
       >,
       initiateWithdrawalRequest: {
         name: "initiate-withdrawal-request",
@@ -1718,6 +1758,16 @@ export const contracts = {
         },
         access: "constant",
       } as TypedAbiVariable<Response<null, bigint>>,
+      ERR_INVALID_BTC_ID: {
+        name: "ERR_INVALID_BTC_ID",
+        type: {
+          response: {
+            ok: "none",
+            error: "uint128",
+          },
+        },
+        access: "constant",
+      } as TypedAbiVariable<Response<null, bigint>>,
       ERR_INVALID_CALLER: {
         name: "ERR_INVALID_CALLER",
         type: {
@@ -1738,21 +1788,15 @@ export const contracts = {
         },
         access: "constant",
       } as TypedAbiVariable<Response<null, bigint>>,
-      ERR_WITHDRAWAL_INDEX: {
-        name: "ERR_WITHDRAWAL_INDEX",
+      ERR_WITHDRAWALS_PREFIX: {
+        name: "ERR_WITHDRAWALS_PREFIX",
         type: {
-          response: {
-            ok: "none",
-            error: "uint128",
+          "string-ascii": {
+            length: 3,
           },
         },
         access: "constant",
-      } as TypedAbiVariable<Response<null, bigint>>,
-      ERR_WITHDRAWAL_INDEX_PREFIX: {
-        name: "ERR_WITHDRAWAL_INDEX_PREFIX",
-        type: "uint128",
-        access: "constant",
-      } as TypedAbiVariable<bigint>,
+      } as TypedAbiVariable<string>,
       MAX_ADDRESS_VERSION: {
         name: "MAX_ADDRESS_VERSION",
         type: "uint128",
@@ -1791,6 +1835,10 @@ export const contracts = {
         isOk: false,
         value: 500n,
       },
+      ERR_INVALID_BTC_ID: {
+        isOk: false,
+        value: 507n,
+      },
       ERR_INVALID_CALLER: {
         isOk: false,
         value: 504n,
@@ -1799,11 +1847,7 @@ export const contracts = {
         isOk: false,
         value: 503n,
       },
-      ERR_WITHDRAWAL_INDEX: {
-        isOk: false,
-        value: 506n,
-      },
-      ERR_WITHDRAWAL_INDEX_PREFIX: 506n,
+      ERR_WITHDRAWALS_PREFIX: "510",
       MAX_ADDRESS_VERSION: 6n,
       mAX_ADDRESS_VERSION_BUFF_20: 4n,
       mAX_ADDRESS_VERSION_BUFF_32: 6n,

--- a/contracts/tests/clarigen-types.ts
+++ b/contracts/tests/clarigen-types.ts
@@ -717,19 +717,24 @@ export const contracts = {
         access: "public",
         args: [
           { name: "request-id", type: "uint128" },
-          { name: "bitcoin-txid", type: { buffer: { length: 32 } } },
-          { name: "signer-bitmap", type: "uint128" },
-          { name: "output-index", type: "uint128" },
-          { name: "fee", type: "uint128" },
+          { name: "status", type: "bool" },
+          {
+            name: "bitcoin-txid",
+            type: { optional: { buffer: { length: 32 } } },
+          },
+          { name: "signer-bitmap", type: { optional: "uint128" } },
+          { name: "output-index", type: { optional: "uint128" } },
+          { name: "fee", type: { optional: "uint128" } },
         ],
         outputs: { type: { response: { ok: "bool", error: "uint128" } } },
       } as TypedAbiFunction<
         [
           requestId: TypedAbiArg<number | bigint, "requestId">,
-          bitcoinTxid: TypedAbiArg<Uint8Array, "bitcoinTxid">,
-          signerBitmap: TypedAbiArg<number | bigint, "signerBitmap">,
-          outputIndex: TypedAbiArg<number | bigint, "outputIndex">,
-          fee: TypedAbiArg<number | bigint, "fee">,
+          status: TypedAbiArg<boolean, "status">,
+          bitcoinTxid: TypedAbiArg<Uint8Array | null, "bitcoinTxid">,
+          signerBitmap: TypedAbiArg<number | bigint | null, "signerBitmap">,
+          outputIndex: TypedAbiArg<number | bigint | null, "outputIndex">,
+          fee: TypedAbiArg<number | bigint | null, "fee">,
         ],
         Response<boolean, bigint>
       >,
@@ -1472,6 +1477,52 @@ export const contracts = {
   },
   sbtcWithdrawal: {
     functions: {
+      completeIndividualWithdrawalHelper: {
+        name: "complete-individual-withdrawal-helper",
+        access: "private",
+        args: [
+          {
+            name: "withdrawal",
+            type: {
+              tuple: [
+                {
+                  name: "bitcoin-txid",
+                  type: { optional: { buffer: { length: 32 } } },
+                },
+                { name: "fee", type: { optional: "uint128" } },
+                { name: "output-index", type: { optional: "uint128" } },
+                { name: "request-id", type: "uint128" },
+                { name: "signer-bitmap", type: "uint128" },
+                { name: "status", type: "bool" },
+              ],
+            },
+          },
+          {
+            name: "helper-response",
+            type: { response: { ok: "uint128", error: "uint128" } },
+          },
+        ],
+        outputs: { type: { response: { ok: "uint128", error: "uint128" } } },
+      } as TypedAbiFunction<
+        [
+          withdrawal: TypedAbiArg<
+            {
+              bitcoinTxid: Uint8Array | null;
+              fee: number | bigint | null;
+              outputIndex: number | bigint | null;
+              requestId: number | bigint;
+              signerBitmap: number | bigint;
+              status: boolean;
+            },
+            "withdrawal"
+          >,
+          helperResponse: TypedAbiArg<
+            Response<number | bigint, number | bigint>,
+            "helperResponse"
+          >,
+        ],
+        Response<bigint, bigint>
+      >,
       acceptWithdrawalRequest: {
         name: "accept-withdrawal-request",
         access: "public",
@@ -1530,6 +1581,49 @@ export const contracts = {
           bigint
         >
       >,
+      completeWithdrawals: {
+        name: "complete-withdrawals",
+        access: "public",
+        args: [
+          {
+            name: "withdrawals",
+            type: {
+              list: {
+                type: {
+                  tuple: [
+                    {
+                      name: "bitcoin-txid",
+                      type: { optional: { buffer: { length: 32 } } },
+                    },
+                    { name: "fee", type: { optional: "uint128" } },
+                    { name: "output-index", type: { optional: "uint128" } },
+                    { name: "request-id", type: "uint128" },
+                    { name: "signer-bitmap", type: "uint128" },
+                    { name: "status", type: "bool" },
+                  ],
+                },
+                length: 100,
+              },
+            },
+          },
+        ],
+        outputs: { type: { response: { ok: "uint128", error: "uint128" } } },
+      } as TypedAbiFunction<
+        [
+          withdrawals: TypedAbiArg<
+            {
+              bitcoinTxid: Uint8Array | null;
+              fee: number | bigint | null;
+              outputIndex: number | bigint | null;
+              requestId: number | bigint;
+              signerBitmap: number | bigint;
+              status: boolean;
+            }[],
+            "withdrawals"
+          >,
+        ],
+        Response<bigint, bigint>
+      >,
       initiateWithdrawalRequest: {
         name: "initiate-withdrawal-request",
         access: "public",
@@ -1560,6 +1654,21 @@ export const contracts = {
           maxFee: TypedAbiArg<number | bigint, "maxFee">,
         ],
         Response<bigint, bigint>
+      >,
+      rejectWithdrawal: {
+        name: "reject-withdrawal",
+        access: "public",
+        args: [
+          { name: "request-id", type: "uint128" },
+          { name: "signer-bitmap", type: "uint128" },
+        ],
+        outputs: { type: { response: { ok: "bool", error: "uint128" } } },
+      } as TypedAbiFunction<
+        [
+          requestId: TypedAbiArg<number | bigint, "requestId">,
+          signerBitmap: TypedAbiArg<number | bigint, "signerBitmap">,
+        ],
+        Response<boolean, bigint>
       >,
       validateRecipient: {
         name: "validate-recipient",
@@ -1666,6 +1775,21 @@ export const contracts = {
         },
         access: "constant",
       } as TypedAbiVariable<Response<null, bigint>>,
+      ERR_WITHDRAWAL_INDEX: {
+        name: "ERR_WITHDRAWAL_INDEX",
+        type: {
+          response: {
+            ok: "none",
+            error: "uint128",
+          },
+        },
+        access: "constant",
+      } as TypedAbiVariable<Response<null, bigint>>,
+      ERR_WITHDRAWAL_INDEX_PREFIX: {
+        name: "ERR_WITHDRAWAL_INDEX_PREFIX",
+        type: "uint128",
+        access: "constant",
+      } as TypedAbiVariable<bigint>,
       MAX_ADDRESS_VERSION: {
         name: "MAX_ADDRESS_VERSION",
         type: "uint128",
@@ -1712,6 +1836,11 @@ export const contracts = {
         isOk: false,
         value: 503n,
       },
+      ERR_WITHDRAWAL_INDEX: {
+        isOk: false,
+        value: 506n,
+      },
+      ERR_WITHDRAWAL_INDEX_PREFIX: 506n,
       MAX_ADDRESS_VERSION: 6n,
       mAX_ADDRESS_VERSION_BUFF_20: 4n,
       mAX_ADDRESS_VERSION_BUFF_32: 6n,

--- a/contracts/tests/clarigen-types.ts
+++ b/contracts/tests/clarigen-types.ts
@@ -1499,38 +1499,10 @@ export const contracts = {
           },
           {
             name: "helper-response",
-            type: {
-              response: {
-                ok: {
-                  tuple: [
-                    {
-                      name: "agg-errs",
-                      type: { optional: { "string-ascii": { length: 100 } } },
-                    },
-                    { name: "index", type: "uint128" },
-                  ],
-                },
-                error: "uint128",
-              },
-            },
+            type: { response: { ok: "uint128", error: "uint128" } },
           },
         ],
-        outputs: {
-          type: {
-            response: {
-              ok: {
-                tuple: [
-                  {
-                    name: "agg-errs",
-                    type: { optional: { "string-ascii": { length: 100 } } },
-                  },
-                  { name: "index", type: "uint128" },
-                ],
-              },
-              error: "none",
-            },
-          },
-        },
+        outputs: { type: { response: { ok: "uint128", error: "uint128" } } },
       } as TypedAbiFunction<
         [
           withdrawal: TypedAbiArg<
@@ -1545,23 +1517,11 @@ export const contracts = {
             "withdrawal"
           >,
           helperResponse: TypedAbiArg<
-            Response<
-              {
-                aggErrs: string | null;
-                index: number | bigint;
-              },
-              number | bigint
-            >,
+            Response<number | bigint, number | bigint>,
             "helperResponse"
           >,
         ],
-        Response<
-          {
-            aggErrs: string | null;
-            index: bigint;
-          },
-          null
-        >
+        Response<bigint, bigint>
       >,
       acceptWithdrawalRequest: {
         name: "accept-withdrawal-request",
@@ -1610,7 +1570,7 @@ export const contracts = {
             },
           },
         ],
-        outputs: { type: { response: { ok: "bool", error: "uint128" } } },
+        outputs: { type: { response: { ok: "uint128", error: "uint128" } } },
       } as TypedAbiFunction<
         [
           withdrawals: TypedAbiArg<
@@ -1625,7 +1585,7 @@ export const contracts = {
             "withdrawals"
           >,
         ],
-        Response<boolean, bigint>
+        Response<bigint, bigint>
       >,
       initiateWithdrawalRequest: {
         name: "initiate-withdrawal-request",
@@ -1758,16 +1718,6 @@ export const contracts = {
         },
         access: "constant",
       } as TypedAbiVariable<Response<null, bigint>>,
-      ERR_INVALID_BTC_ID: {
-        name: "ERR_INVALID_BTC_ID",
-        type: {
-          response: {
-            ok: "none",
-            error: "uint128",
-          },
-        },
-        access: "constant",
-      } as TypedAbiVariable<Response<null, bigint>>,
       ERR_INVALID_CALLER: {
         name: "ERR_INVALID_CALLER",
         type: {
@@ -1788,15 +1738,21 @@ export const contracts = {
         },
         access: "constant",
       } as TypedAbiVariable<Response<null, bigint>>,
-      ERR_WITHDRAWALS_PREFIX: {
-        name: "ERR_WITHDRAWALS_PREFIX",
+      ERR_WITHDRAWAL_INDEX: {
+        name: "ERR_WITHDRAWAL_INDEX",
         type: {
-          "string-ascii": {
-            length: 3,
+          response: {
+            ok: "none",
+            error: "uint128",
           },
         },
         access: "constant",
-      } as TypedAbiVariable<string>,
+      } as TypedAbiVariable<Response<null, bigint>>,
+      ERR_WITHDRAWAL_INDEX_PREFIX: {
+        name: "ERR_WITHDRAWAL_INDEX_PREFIX",
+        type: "uint128",
+        access: "constant",
+      } as TypedAbiVariable<bigint>,
       MAX_ADDRESS_VERSION: {
         name: "MAX_ADDRESS_VERSION",
         type: "uint128",
@@ -1835,10 +1791,6 @@ export const contracts = {
         isOk: false,
         value: 500n,
       },
-      ERR_INVALID_BTC_ID: {
-        isOk: false,
-        value: 507n,
-      },
       ERR_INVALID_CALLER: {
         isOk: false,
         value: 504n,
@@ -1847,7 +1799,11 @@ export const contracts = {
         isOk: false,
         value: 503n,
       },
-      ERR_WITHDRAWALS_PREFIX: "510",
+      ERR_WITHDRAWAL_INDEX: {
+        isOk: false,
+        value: 506n,
+      },
+      ERR_WITHDRAWAL_INDEX_PREFIX: 506n,
       MAX_ADDRESS_VERSION: 6n,
       mAX_ADDRESS_VERSION_BUFF_20: 4n,
       mAX_ADDRESS_VERSION_BUFF_32: 6n,

--- a/contracts/tests/clarigen-types.ts
+++ b/contracts/tests/clarigen-types.ts
@@ -1533,31 +1533,7 @@ export const contracts = {
           { name: "output-index", type: "uint128" },
           { name: "fee", type: "uint128" },
         ],
-        outputs: {
-          type: {
-            response: {
-              ok: {
-                tuple: [
-                  { name: "amount", type: "uint128" },
-                  { name: "block-height", type: "uint128" },
-                  { name: "max-fee", type: "uint128" },
-                  {
-                    name: "recipient",
-                    type: {
-                      tuple: [
-                        { name: "hashbytes", type: { buffer: { length: 32 } } },
-                        { name: "version", type: { buffer: { length: 1 } } },
-                      ],
-                    },
-                  },
-                  { name: "sender", type: "principal" },
-                  { name: "status", type: { optional: "bool" } },
-                ],
-              },
-              error: "uint128",
-            },
-          },
-        },
+        outputs: { type: { response: { ok: "bool", error: "uint128" } } },
       } as TypedAbiFunction<
         [
           requestId: TypedAbiArg<number | bigint, "requestId">,
@@ -1566,20 +1542,7 @@ export const contracts = {
           outputIndex: TypedAbiArg<number | bigint, "outputIndex">,
           fee: TypedAbiArg<number | bigint, "fee">,
         ],
-        Response<
-          {
-            amount: bigint;
-            blockHeight: bigint;
-            maxFee: bigint;
-            recipient: {
-              hashbytes: Uint8Array;
-              version: Uint8Array;
-            };
-            sender: string;
-            status: boolean | null;
-          },
-          bigint
-        >
+        Response<boolean, bigint>
       >,
       completeWithdrawals: {
         name: "complete-withdrawals",

--- a/contracts/tests/sbtc-withdrawal.test.ts
+++ b/contracts/tests/sbtc-withdrawal.test.ts
@@ -628,4 +628,5 @@ describe("Complete multiple withdrawals", () => {
     );
     expect(receipt.value).toEqual(2n);
   });
+  
 })

--- a/contracts/tests/sbtc-withdrawal.test.ts
+++ b/contracts/tests/sbtc-withdrawal.test.ts
@@ -569,6 +569,72 @@ describe("Reject a withdrawal request", () => {
 })
 
 describe("Complete multiple withdrawals", () => {
+  test("Fail with three withdrawals", () => {
+    // Alice setup
+    txOk(
+      deposit.completeDepositWrapper({
+        txid: new Uint8Array(32).fill(0),
+        voutIndex: 0,
+        amount: 1000n,
+        recipient: alice,
+      }),
+      deployer
+    );
+    txOk(
+      withdrawal.initiateWithdrawalRequest({
+        amount: 1000n,
+        recipient: alicePoxAddr,
+        maxFee: 10n,
+      }),
+      alice
+    );
+    // Bob setup
+    txOk(
+      deposit.completeDepositWrapper({
+        txid: new Uint8Array(32).fill(1),
+        voutIndex: 1,
+        amount: 1000n,
+        recipient: bob,
+      }),
+      deployer
+    );
+    txOk(
+      withdrawal.initiateWithdrawalRequest({
+        amount: 1000n,
+        recipient: alicePoxAddr,
+        maxFee: 10n,
+      }),
+      bob
+    );
+    // 
+    const receipt = txErr(
+      withdrawal.completeWithdrawals({withdrawals: [{
+          requestId: 1n,
+          status: true,
+          signerBitmap: 1n,
+          bitcoinTxid: new Uint8Array(12).fill(1),
+          outputIndex: 10n,
+          fee: 10n,
+        },{
+          requestId: 4n,
+          status: false,
+          signerBitmap: 1n,
+          bitcoinTxid: null,
+          outputIndex: null,
+          fee: null,
+        }, {
+          requestId: 5n,
+          status: false,
+          signerBitmap: 1n,
+          bitcoinTxid: null,
+          outputIndex: null,
+          fee: null,
+        }]
+      }),
+      deployer
+    );
+    expect(receipt.value).toEqual(510012n);
+  });
   test("Successfully pass in two withdrawals, one accept, one reject", () => {
     // Alice setup
     txOk(
@@ -626,6 +692,6 @@ describe("Complete multiple withdrawals", () => {
       }),
       deployer
     );
-    expect(receipt.value).toEqual(2n);
+    expect(receipt.value).toEqual(true);
   });
 })

--- a/contracts/tests/sbtc-withdrawal.test.ts
+++ b/contracts/tests/sbtc-withdrawal.test.ts
@@ -629,5 +629,3 @@ describe("Complete multiple withdrawals", () => {
     expect(receipt.value).toEqual(2n);
   });
 })
-
-//(define-public (complete-withdrawals (withdrawals (list 100 {request-id: uint, status: bool, signer-bitmap: uint, bitcoin-txid: (optional (buff 32)), output-index: (optional uint), fee: (optional uint)})))

--- a/contracts/tests/sbtc-withdrawal.test.ts
+++ b/contracts/tests/sbtc-withdrawal.test.ts
@@ -107,7 +107,6 @@ describe("initiating a withdrawal request", () => {
     });
 
     // An event is emitted properly
-
     const prints = filterEvents(
       receipt.events,
       CoreNodeEventType.ContractEvent
@@ -231,3 +230,9 @@ describe("initiating a withdrawal request", () => {
     expect(receipt.value).toEqual(errors.withdrawal.ERR_DUST_LIMIT);
   });
 });
+
+describe("accepting a withdrawal request", () => {
+  test("Alice request is accepted", () => {
+
+  })
+})

--- a/contracts/tests/sbtc-withdrawal.test.ts
+++ b/contracts/tests/sbtc-withdrawal.test.ts
@@ -452,7 +452,7 @@ describe("Reject a withdrawal request", () => {
       alice
     );
     const receipt = txErr(
-      withdrawal.rejectWithdrawal({
+      withdrawal.rejectWithdrawalRequest({
         requestId: 2n,
         bitcoinTxid: new Uint8Array(32).fill(0),
         signerBitmap: 0n,
@@ -483,7 +483,7 @@ describe("Reject a withdrawal request", () => {
       alice
     );
     const receipt = txErr(
-      withdrawal.rejectWithdrawal({
+      withdrawal.rejectWithdrawalRequest({
         requestId: 1n,
         bitcoinTxid: new Uint8Array(32).fill(0),
         signerBitmap: 0n,
@@ -524,7 +524,7 @@ describe("Reject a withdrawal request", () => {
       deployer
     );
     const receipt = txErr(
-      withdrawal.rejectWithdrawal({
+      withdrawal.rejectWithdrawalRequest({
         requestId: 1n,
         bitcoinTxid: new Uint8Array(32).fill(0),
         signerBitmap: 0n,

--- a/contracts/tests/sbtc-withdrawal.test.ts
+++ b/contracts/tests/sbtc-withdrawal.test.ts
@@ -75,7 +75,7 @@ describe("initiating a withdrawal request", () => {
       deposit.completeDepositWrapper({
         txid: new Uint8Array(32).fill(0),
         voutIndex: 0,
-        amount: 1000n,
+        amount: 1001n,
         recipient: alice,
       }),
       deployer
@@ -241,7 +241,7 @@ describe("Accepting a withdrawal request", () => {
         amount: 1000n,
         recipient: alice,
       }),
-      alice
+      deployer
     );
     txOk(
       withdrawal.initiateWithdrawalRequest({
@@ -272,7 +272,7 @@ describe("Accepting a withdrawal request", () => {
         amount: 1000n,
         recipient: alice,
       }),
-      alice
+      deployer
     );
     txOk(
       withdrawal.initiateWithdrawalRequest({
@@ -303,7 +303,7 @@ describe("Accepting a withdrawal request", () => {
         amount: 1000n,
         recipient: alice,
       }),
-      alice
+      deployer
     );
     txOk(
       withdrawal.initiateWithdrawalRequest({
@@ -344,7 +344,7 @@ describe("Accepting a withdrawal request", () => {
         amount: 1000n,
         recipient: alice,
       }),
-      alice
+      deployer
     );
     txOk(
       withdrawal.initiateWithdrawalRequest({
@@ -375,7 +375,7 @@ describe("Accepting a withdrawal request", () => {
         amount: 1000n,
         recipient: alice,
       }),
-      alice
+      deployer
     );
     txOk(
       withdrawal.initiateWithdrawalRequest({
@@ -406,7 +406,7 @@ describe("Accepting a withdrawal request", () => {
         amount: 1000n,
         recipient: alice,
       }),
-      alice
+      deployer
     );
     txOk(
       withdrawal.initiateWithdrawalRequest({

--- a/contracts/tests/sbtc-withdrawal.test.ts
+++ b/contracts/tests/sbtc-withdrawal.test.ts
@@ -569,72 +569,6 @@ describe("Reject a withdrawal request", () => {
 })
 
 describe("Complete multiple withdrawals", () => {
-  test("Fail with three withdrawals", () => {
-    // Alice setup
-    txOk(
-      deposit.completeDepositWrapper({
-        txid: new Uint8Array(32).fill(0),
-        voutIndex: 0,
-        amount: 1000n,
-        recipient: alice,
-      }),
-      deployer
-    );
-    txOk(
-      withdrawal.initiateWithdrawalRequest({
-        amount: 1000n,
-        recipient: alicePoxAddr,
-        maxFee: 10n,
-      }),
-      alice
-    );
-    // Bob setup
-    txOk(
-      deposit.completeDepositWrapper({
-        txid: new Uint8Array(32).fill(1),
-        voutIndex: 1,
-        amount: 1000n,
-        recipient: bob,
-      }),
-      deployer
-    );
-    txOk(
-      withdrawal.initiateWithdrawalRequest({
-        amount: 1000n,
-        recipient: alicePoxAddr,
-        maxFee: 10n,
-      }),
-      bob
-    );
-    // 
-    const receipt = txErr(
-      withdrawal.completeWithdrawals({withdrawals: [{
-          requestId: 1n,
-          status: true,
-          signerBitmap: 1n,
-          bitcoinTxid: new Uint8Array(12).fill(1),
-          outputIndex: 10n,
-          fee: 10n,
-        },{
-          requestId: 4n,
-          status: false,
-          signerBitmap: 1n,
-          bitcoinTxid: null,
-          outputIndex: null,
-          fee: null,
-        }, {
-          requestId: 5n,
-          status: false,
-          signerBitmap: 1n,
-          bitcoinTxid: null,
-          outputIndex: null,
-          fee: null,
-        }]
-      }),
-      deployer
-    );
-    expect(receipt.value).toEqual(510012n);
-  });
   test("Successfully pass in two withdrawals, one accept, one reject", () => {
     // Alice setup
     txOk(
@@ -692,6 +626,6 @@ describe("Complete multiple withdrawals", () => {
       }),
       deployer
     );
-    expect(receipt.value).toEqual(true);
+    expect(receipt.value).toEqual(2n);
   });
 })


### PR DESCRIPTION
## Description
This PR deals with #95, #96, & #97 with the focus of initiating, accepting & rejecting withdrawal requests. As a signer, once completed, I want to mark a withdrawal as completed on-chain & therefore burning the sBTC.

## Type of Change
New feature planned in #95 that comes from the sBTC Clarity documentation.

## Does this introduce a breaking change?
No.

## Are documentation updates required?
No.

## Testing information
Six different unit tests included here that can be ran CDing into 'contracts' & running 'pnpm test.'

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `pnpm test` passes
- [ ] Changelog is updated
- [x] Tag 1 of @person1 or @person2
