### PR TITLE
feat: Skeleton for transaction signer event loop with request decision handling

### DIFF
--- a/.sqlx/query-3446a823d60a644dc58bc0c36ba256747ba46b9441072ad8a13c2a6703974a45.json
+++ b/.sqlx/query-3446a823d60a644dc58bc0c36ba256747ba46b9441072ad8a13c2a6703974a45.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO sbtc_signer.deposit_requests VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Bytea",
+        "Int4",
+        "Bytea",
+        "Bytea",
+        "Text",
+        "Int8",
+        "Int8",
+        "TextArray",
+        "Timestamptz"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "3446a823d60a644dc58bc0c36ba256747ba46b9441072ad8a13c2a6703974a45"
+}

--- a/.sqlx/query-3f0879dab4417cf80f9287fe579c2c6b66f3ac4cc3fe4845ecc4cfe85b4c8e8d.json
+++ b/.sqlx/query-3f0879dab4417cf80f9287fe579c2c6b66f3ac4cc3fe4845ecc4cfe85b4c8e8d.json
@@ -1,0 +1,33 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO sbtc_signer.transactions VALUES ($1, $2, $3, $4)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Bytea",
+        "Bytea",
+        {
+          "Custom": {
+            "name": "transaction_type",
+            "kind": {
+              "Enum": [
+                "sbtc_transaction",
+                "deposit_request",
+                "withdraw_request",
+                "deposit_accept",
+                "withdraw_accept",
+                "withdraw_reject",
+                "update_signer_set",
+                "set_aggregate_key"
+              ]
+            }
+          }
+        },
+        "Timestamptz"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "3f0879dab4417cf80f9287fe579c2c6b66f3ac4cc3fe4845ecc4cfe85b4c8e8d"
+}

--- a/.sqlx/query-ac71ab51277e5afa623340de33981eb58d2ae5da602531f49d49c62d711ba6ed.json
+++ b/.sqlx/query-ac71ab51277e5afa623340de33981eb58d2ae5da602531f49d49c62d711ba6ed.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO sbtc_signer.bitcoin_transactions VALUES ($1, $2)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Bytea",
+        "Bytea"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "ac71ab51277e5afa623340de33981eb58d2ae5da602531f49d49c62d711ba6ed"
+}

--- a/contracts/tests/clarigen-types.ts
+++ b/contracts/tests/clarigen-types.ts
@@ -1330,7 +1330,7 @@ export const contracts = {
         value: 4n,
       },
       tokenDecimals: 8n,
-      tokenName: "sBTC Mini",
+      tokenName: "sBTC",
       tokenSymbol: "sBTC",
       tokenUri: null,
     },

--- a/signer/migrations/0003__create_tables.sql
+++ b/signer/migrations/0003__create_tables.sql
@@ -1,8 +1,10 @@
 CREATE TYPE sbtc_signer.transaction_type AS ENUM (
    'sbtc_transaction',
+   'deposit_request',
+   'withdraw_request',
+   'deposit_accept',
    'withdraw_accept',
    'withdraw_reject',
-   'deposit_accept',
    'update_signer_set',
    'set_aggregate_key'
 );
@@ -30,6 +32,7 @@ CREATE TABLE sbtc_signer.deposit_requests (
     recipient TEXT NOT NULL,
     amount BIGINT NOT NULL,
     max_fee BIGINT NOT NULL,
+    sender_addresses TEXT[],
     created_at TIMESTAMPTZ NOT NULL,
     PRIMARY KEY (txid, output_index)
 );
@@ -50,6 +53,7 @@ CREATE TABLE sbtc_signer.withdraw_requests (
     recipient BYTEA NOT NULL,
     amount BIGINT NOT NULL,
     max_fee BIGINT NOT NULL,
+    sender_address TEXT NOT NULL,
     created_at TIMESTAMPTZ NOT NULL,
     PRIMARY KEY (request_id, block_hash),
     FOREIGN KEY (block_hash) REFERENCES sbtc_signer.stacks_blocks(block_hash) ON DELETE CASCADE

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -7,15 +7,15 @@ use blockstack_lib::types::chainstate::StacksBlockId;
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     /// Invalid amount
-    #[error("The change amounts for the transaction is negative: {0}")]
+    #[error("the change amounts for the transaction is negative: {0}")]
     InvalidAmount(i64),
 
     /// Old fee estimate
-    #[error("Got an old fee estimate")]
+    #[error("got an old fee estimate")]
     OldFeeEstimate,
 
     /// No good fee estimate
-    #[error("Failed to get fee estimates from all fee estimate sources")]
+    #[error("failed to get fee estimates from all fee estimate sources")]
     NoGoodFeeEstimates,
 
     /// Parsing the Hex Error
@@ -35,7 +35,7 @@ pub enum Error {
     PathJoin(#[source] url::ParseError, url::Url, Cow<'static, str>),
 
     /// Reqwest error
-    #[error("{0}")]
+    #[error(transparent)]
     Reqwest(#[from] reqwest::Error),
 
     /// Error when reading the signer config.toml
@@ -59,6 +59,18 @@ pub enum Error {
     UnexpectedStacksResponse(#[source] reqwest::Error),
 
     /// Taproot error
-    #[error("An error occured when constructing the taproot signing digest: {0}")]
+    #[error("an error occured when constructing the taproot signing digest: {0}")]
     Taproot(#[from] bitcoin::sighash::TaprootError),
+
+    /// Signer loop error
+    #[error("signer loop error: {0}")]
+    TransactionSignerError(#[from] crate::transaction_signer::Error),
+
+    /// Key error
+    #[error("key error: {0}")]
+    KeyError(#[from] p256k1::keys::Error),
+
+    /// In memory storage error
+    #[error("in memory storage error")]
+    InMemoryStorageError(#[from] crate::storage::in_memory::Error),
 }

--- a/signer/src/storage.rs
+++ b/signer/src/storage.rs
@@ -15,24 +15,92 @@ use std::future::Future;
 /// Represents the ability to read data from the signer storage.
 pub trait DbRead {
     /// Read error.
-    type Error;
+    type Error: std::error::Error;
 
     /// Get the bitcoin block with the given block hash.
     fn get_bitcoin_block(
         self,
         block_hash: &model::BitcoinBlockHash,
     ) -> impl Future<Output = Result<Option<model::BitcoinBlock>, Self::Error>> + Send;
+
+    /// Get the bitcoin canonical chain tip
+    fn get_bitcoin_canonical_chain_tip(
+        self,
+    ) -> impl Future<Output = Result<Option<model::BitcoinBlockHash>, Self::Error>> + Send;
+
+    /// Get pending deposit requests
+    fn get_pending_deposit_requests(
+        self,
+        chain_tip: &model::BitcoinBlockHash,
+        context_window: usize,
+    ) -> impl Future<Output = Result<Vec<model::DepositRequest>, Self::Error>> + Send;
+
+    /// Get signer decisions for a deposit request
+    fn get_deposit_signers(
+        self,
+        txid: &model::BitcoinTxId,
+        output_index: usize,
+    ) -> impl Future<Output = Result<Vec<model::DepositSigner>, Self::Error>> + Send;
+
+    /// Get pending withdraw requests
+    fn get_pending_withdraw_requests(
+        self,
+        chain_tip: &model::BitcoinBlockHash,
+        context_window: usize,
+    ) -> impl Future<Output = Result<Vec<model::WithdrawRequest>, Self::Error>> + Send;
+
+    /// Get bitcoin blocks that include a particular transaction
+    fn get_bitcoin_blocks_with_transaction(
+        self,
+        txid: &model::BitcoinTxId,
+    ) -> impl Future<Output = Result<Vec<model::BitcoinBlockHash>, Self::Error>> + Send;
 }
 
 /// Represents the ability to write data to the signer storage.
 pub trait DbWrite {
     /// Write error.
-    type Error;
+    type Error: std::error::Error;
 
     /// Write a bitcoin block.
     fn write_bitcoin_block(
         self,
         block: &model::BitcoinBlock,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+
+    /// Write a deposit request.
+    fn write_deposit_request(
+        self,
+        deposit_request: &model::DepositRequest,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+
+    /// Write a withdraw request.
+    fn write_withdraw_request(
+        self,
+        withdraw_request: &model::WithdrawRequest,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+
+    /// Write a signer decision for a deposit request.
+    fn write_deposit_signer_decision(
+        self,
+        decision: &model::DepositSigner,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+
+    /// Write a signer decision for a withdraw request.
+    fn write_withdraw_signer_decision(
+        self,
+        decision: &model::WithdrawSigner,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+
+    /// Write a raw transaction.
+    fn write_transaction(
+        self,
+        transaction: &model::Transaction,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+
+    /// Write a connection between a bitcoin block and a transaction
+    fn write_bitcoin_transaction(
+        self,
+        bitcoin_transaction: &model::BitcoinTransaction,
     ) -> impl Future<Output = Result<(), Self::Error>> + Send;
 }
 
@@ -49,6 +117,47 @@ where
     ) -> Result<Option<model::BitcoinBlock>, Self::Error> {
         (&*self).get_bitcoin_block(block_hash).await
     }
+
+    async fn get_bitcoin_canonical_chain_tip(
+        self,
+    ) -> Result<Option<model::BitcoinBlockHash>, Self::Error> {
+        (&*self).get_bitcoin_canonical_chain_tip().await
+    }
+
+    async fn get_pending_deposit_requests(
+        self,
+        chain_tip: &model::BitcoinBlockHash,
+        context_window: usize,
+    ) -> Result<Vec<model::DepositRequest>, Self::Error> {
+        (&*self)
+            .get_pending_deposit_requests(chain_tip, context_window)
+            .await
+    }
+
+    async fn get_deposit_signers(
+        self,
+        txid: &model::BitcoinTxId,
+        output_index: usize,
+    ) -> Result<Vec<model::DepositSigner>, Self::Error> {
+        (&*self).get_deposit_signers(txid, output_index).await
+    }
+
+    async fn get_pending_withdraw_requests(
+        self,
+        chain_tip: &model::BitcoinBlockHash,
+        context_window: usize,
+    ) -> Result<Vec<model::WithdrawRequest>, Self::Error> {
+        (&*self)
+            .get_pending_withdraw_requests(chain_tip, context_window)
+            .await
+    }
+
+    async fn get_bitcoin_blocks_with_transaction(
+        self,
+        txid: &model::BitcoinTxId,
+    ) -> Result<Vec<model::BitcoinBlockHash>, Self::Error> {
+        (&*self).get_bitcoin_blocks_with_transaction(txid).await
+    }
 }
 
 impl<'a, T> DbWrite for &'a mut T
@@ -60,5 +169,46 @@ where
 
     async fn write_bitcoin_block(self, block: &model::BitcoinBlock) -> Result<(), Self::Error> {
         (&*self).write_bitcoin_block(block).await
+    }
+
+    async fn write_deposit_request(
+        self,
+        deposit_request: &model::DepositRequest,
+    ) -> Result<(), Self::Error> {
+        (&*self).write_deposit_request(deposit_request).await
+    }
+
+    async fn write_withdraw_request(
+        self,
+        withdraw_request: &model::WithdrawRequest,
+    ) -> Result<(), Self::Error> {
+        (&*self).write_withdraw_request(withdraw_request).await
+    }
+
+    async fn write_deposit_signer_decision(
+        self,
+        decision: &model::DepositSigner,
+    ) -> Result<(), Self::Error> {
+        (&*self).write_deposit_signer_decision(decision).await
+    }
+
+    async fn write_withdraw_signer_decision(
+        self,
+        decision: &model::WithdrawSigner,
+    ) -> Result<(), Self::Error> {
+        (&*self).write_withdraw_signer_decision(decision).await
+    }
+
+    async fn write_transaction(self, transaction: &model::Transaction) -> Result<(), Self::Error> {
+        (&*self).write_transaction(transaction).await
+    }
+
+    async fn write_bitcoin_transaction(
+        self,
+        bitcoin_transaction: &model::BitcoinTransaction,
+    ) -> Result<(), Self::Error> {
+        (&*self)
+            .write_bitcoin_transaction(bitcoin_transaction)
+            .await
     }
 }

--- a/signer/src/storage/in_memory.rs
+++ b/signer/src/storage/in_memory.rs
@@ -6,11 +6,31 @@ use tokio::sync::Mutex;
 
 use crate::storage::model;
 
+/// A store wrapped in an Arc<Mutex<...>> for interior mutability
+pub type SharedStore = Arc<Mutex<Store>>;
+
+type DepositRequestPk = (model::BitcoinTxId, usize);
+
 /// In-memory store
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct Store {
     /// Bitcoin blocks
     pub bitcoin_blocks: HashMap<model::BitcoinBlockHash, model::BitcoinBlock>,
+
+    /// Deposit requests
+    pub deposit_requests: HashMap<DepositRequestPk, model::DepositRequest>,
+
+    /// Deposit signers
+    pub deposit_signers: HashMap<DepositRequestPk, Vec<model::DepositSigner>>,
+
+    /// The blocks which contain deposit requests
+    pub deposit_request_blocks: HashMap<model::BitcoinBlockHash, Vec<DepositRequestPk>>,
+
+    /// Bitcoin blocks to transactions
+    pub bitcoin_block_to_transactions: HashMap<model::BitcoinBlockHash, Vec<model::BitcoinTxId>>,
+
+    /// Bitcoin transactions to blocks
+    pub bitcoin_transactions_to_blocks: HashMap<model::BitcoinTxId, Vec<model::BitcoinBlockHash>>,
 }
 
 impl Store {
@@ -20,7 +40,7 @@ impl Store {
     }
 
     /// Create an empty store wrapped in an Arc<Mutex<...>>
-    pub fn new_shared() -> Arc<Mutex<Self>> {
+    pub fn new_shared() -> SharedStore {
         Arc::new(Mutex::new(Self::new()))
     }
 }
@@ -34,6 +54,77 @@ impl super::DbRead for &Store {
     ) -> Result<Option<model::BitcoinBlock>, Self::Error> {
         Ok(self.bitcoin_blocks.get(block_hash).cloned())
     }
+
+    async fn get_bitcoin_canonical_chain_tip(
+        self,
+    ) -> Result<Option<model::BitcoinBlockHash>, Self::Error> {
+        Ok(self
+            .bitcoin_blocks
+            .values()
+            .max_by_key(|block| (block.block_height, block.block_hash.clone()))
+            .map(|block| block.block_hash.clone()))
+    }
+
+    async fn get_pending_deposit_requests(
+        self,
+        chain_tip: &model::BitcoinBlockHash,
+        context_window: usize,
+    ) -> Result<Vec<model::DepositRequest>, Self::Error> {
+        Ok((0..context_window)
+            // Find all tracked transaction IDs in the context window
+            .scan(chain_tip, |block_hash, _| {
+                let transaction_ids = self
+                    .bitcoin_block_to_transactions
+                    .get(*block_hash)
+                    .cloned()
+                    .unwrap_or_else(Vec::new);
+
+                let block = self.bitcoin_blocks.get(*block_hash)?;
+                *block_hash = &block.parent_hash;
+
+                Some(transaction_ids)
+            })
+            .flatten()
+            // Return all deposit requests associated with any of these transaction IDs
+            .flat_map(|txid| {
+                self.deposit_requests
+                    .values()
+                    .filter(move |req| req.txid == txid)
+                    .cloned()
+            })
+            .collect())
+    }
+
+    async fn get_deposit_signers(
+        self,
+        txid: &model::BitcoinTxId,
+        output_index: usize,
+    ) -> Result<Vec<model::DepositSigner>, Self::Error> {
+        Ok(self
+            .deposit_signers
+            .get(&(txid.clone(), output_index))
+            .cloned()
+            .unwrap_or_else(Vec::new))
+    }
+
+    async fn get_pending_withdraw_requests(
+        self,
+        _chain_tip: &model::BitcoinBlockHash,
+        _context_window: usize,
+    ) -> Result<Vec<model::WithdrawRequest>, Self::Error> {
+        todo!(); // TODO(245): Implement
+    }
+
+    async fn get_bitcoin_blocks_with_transaction(
+        self,
+        txid: &model::BitcoinTxId,
+    ) -> Result<Vec<model::BitcoinBlockHash>, Self::Error> {
+        Ok(self
+            .bitcoin_transactions_to_blocks
+            .get(txid)
+            .cloned()
+            .unwrap_or_else(Vec::new))
+    }
 }
 
 impl super::DbWrite for &mut Store {
@@ -45,9 +136,69 @@ impl super::DbWrite for &mut Store {
 
         Ok(())
     }
+
+    async fn write_deposit_request(
+        self,
+        deposit_request: &model::DepositRequest,
+    ) -> Result<(), Self::Error> {
+        self.deposit_requests.insert(
+            (deposit_request.txid.clone(), deposit_request.output_index),
+            deposit_request.clone(),
+        );
+
+        Ok(())
+    }
+
+    async fn write_withdraw_request(
+        self,
+        _withdraw_request: &model::WithdrawRequest,
+    ) -> Result<(), Self::Error> {
+        todo!(); // TODO(245): Implement
+    }
+
+    async fn write_deposit_signer_decision(
+        self,
+        decision: &model::DepositSigner,
+    ) -> Result<(), Self::Error> {
+        self.deposit_signers
+            .entry((decision.txid.clone(), decision.output_index))
+            .or_default()
+            .push(decision.clone());
+
+        Ok(())
+    }
+
+    async fn write_withdraw_signer_decision(
+        self,
+        _decision: &model::WithdrawSigner,
+    ) -> Result<(), Self::Error> {
+        todo!(); // TODO(245): Implement
+    }
+
+    async fn write_transaction(self, _transaction: &model::Transaction) -> Result<(), Self::Error> {
+        // Currently not needed in-memory since it's not required by any queries
+        Ok(())
+    }
+
+    async fn write_bitcoin_transaction(
+        self,
+        bitcoin_transaction: &model::BitcoinTransaction,
+    ) -> Result<(), Self::Error> {
+        self.bitcoin_block_to_transactions
+            .entry(bitcoin_transaction.block_hash.clone())
+            .or_default()
+            .push(bitcoin_transaction.txid.clone());
+
+        self.bitcoin_transactions_to_blocks
+            .entry(bitcoin_transaction.txid.clone())
+            .or_default()
+            .push(bitcoin_transaction.block_hash.clone());
+
+        Ok(())
+    }
 }
 
-impl super::DbRead for &Arc<Mutex<Store>> {
+impl super::DbRead for &SharedStore {
     type Error = Error;
 
     async fn get_bitcoin_block(
@@ -56,13 +207,107 @@ impl super::DbRead for &Arc<Mutex<Store>> {
     ) -> Result<Option<model::BitcoinBlock>, Self::Error> {
         self.lock().await.get_bitcoin_block(block_hash).await
     }
+
+    async fn get_bitcoin_canonical_chain_tip(
+        self,
+    ) -> Result<Option<model::BitcoinBlockHash>, Self::Error> {
+        self.lock().await.get_bitcoin_canonical_chain_tip().await
+    }
+
+    async fn get_pending_deposit_requests(
+        self,
+        chain_tip: &model::BitcoinBlockHash,
+        context_window: usize,
+    ) -> Result<Vec<model::DepositRequest>, Self::Error> {
+        self.lock()
+            .await
+            .get_pending_deposit_requests(chain_tip, context_window)
+            .await
+    }
+
+    async fn get_deposit_signers(
+        self,
+        txid: &model::BitcoinTxId,
+        output_index: usize,
+    ) -> Result<Vec<model::DepositSigner>, Self::Error> {
+        self.lock()
+            .await
+            .get_deposit_signers(txid, output_index)
+            .await
+    }
+
+    async fn get_pending_withdraw_requests(
+        self,
+        _chain_tip: &model::BitcoinBlockHash,
+        _context_window: usize,
+    ) -> Result<Vec<model::WithdrawRequest>, Self::Error> {
+        Ok(Vec::new()) // TODO
+    }
+
+    async fn get_bitcoin_blocks_with_transaction(
+        self,
+        txid: &model::BitcoinTxId,
+    ) -> Result<Vec<model::BitcoinBlockHash>, Self::Error> {
+        self.lock()
+            .await
+            .get_bitcoin_blocks_with_transaction(txid)
+            .await
+    }
 }
 
-impl super::DbWrite for &Arc<Mutex<Store>> {
+impl super::DbWrite for &SharedStore {
     type Error = Error;
 
     async fn write_bitcoin_block(self, block: &model::BitcoinBlock) -> Result<(), Self::Error> {
         self.lock().await.write_bitcoin_block(block).await
+    }
+
+    async fn write_deposit_request(
+        self,
+        deposit_request: &model::DepositRequest,
+    ) -> Result<(), Self::Error> {
+        self.lock()
+            .await
+            .write_deposit_request(deposit_request)
+            .await
+    }
+
+    async fn write_withdraw_request(
+        self,
+        _withdraw_request: &model::WithdrawRequest,
+    ) -> Result<(), Self::Error> {
+        todo!(); // TODO(245): Implement
+    }
+
+    async fn write_deposit_signer_decision(
+        self,
+        decision: &model::DepositSigner,
+    ) -> Result<(), Self::Error> {
+        self.lock()
+            .await
+            .write_deposit_signer_decision(decision)
+            .await
+    }
+
+    async fn write_withdraw_signer_decision(
+        self,
+        _decision: &model::WithdrawSigner,
+    ) -> Result<(), Self::Error> {
+        todo!(); // TODO(245): Implement
+    }
+
+    async fn write_transaction(self, transaction: &model::Transaction) -> Result<(), Self::Error> {
+        self.lock().await.write_transaction(transaction).await
+    }
+
+    async fn write_bitcoin_transaction(
+        self,
+        bitcoin_transaction: &model::BitcoinTransaction,
+    ) -> Result<(), Self::Error> {
+        self.lock()
+            .await
+            .write_bitcoin_transaction(bitcoin_transaction)
+            .await
     }
 }
 

--- a/signer/src/storage/model.rs
+++ b/signer/src/storage/model.rs
@@ -1,18 +1,24 @@
 //! Database models for the signer.
 
+use fake::faker::time::en::DateTimeAfter;
+
 /// Bitcoin block.
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "testing", derive(fake::Dummy))]
 pub struct BitcoinBlock {
     /// Block hash.
+    #[dummy(expr = "fake::vec![u8; 32]")]
     pub block_hash: BitcoinBlockHash,
     /// Block height.
     pub block_height: i64,
     /// Hash of the parent block.
+    #[dummy(expr = "fake::vec![u8; 32]")]
     pub parent_hash: BitcoinBlockHash,
     /// Stacks block confirmed by this block.
+    #[dummy(default)]
     pub confirms: Option<StacksBlockHash>,
     /// The time this block entry was created by the signer.
+    #[dummy(faker = "DateTimeAfter(time::OffsetDateTime::UNIX_EPOCH)")]
     pub created_at: time::OffsetDateTime,
 }
 
@@ -21,12 +27,15 @@ pub struct BitcoinBlock {
 #[cfg_attr(feature = "testing", derive(fake::Dummy))]
 pub struct StacksBlock {
     /// Block hash.
+    #[dummy(expr = "fake::vec![u8; 32]")]
     pub block_hash: StacksBlockHash,
     /// Block height.
     pub block_height: i64,
     /// Hash of the parent block.
+    #[dummy(expr = "fake::vec![u8; 32]")]
     pub parent_hash: StacksBlockHash,
     /// The time this block entry was created by the signer.
+    #[dummy(faker = "DateTimeAfter(time::OffsetDateTime::UNIX_EPOCH)")]
     pub created_at: time::OffsetDateTime,
 }
 
@@ -35,6 +44,7 @@ pub struct StacksBlock {
 #[cfg_attr(feature = "testing", derive(fake::Dummy))]
 pub struct DepositRequest {
     /// Transaction ID of the deposit request transaction.
+    #[dummy(expr = "fake::vec![u8; 32]")]
     pub txid: BitcoinTxId,
     /// Index of the deposit request UTXO.
     pub output_index: usize,
@@ -50,7 +60,11 @@ pub struct DepositRequest {
     /// The maximum portion of the deposited amount that may
     /// be used to pay for transaction fees.
     pub max_fee: i64,
+    /// The addresses of the input UTXOs funding the deposit request.
+    #[dummy(expr = "fake::vec![String; 1..8]")]
+    pub sender_addresses: Vec<BitcoinAddress>,
     /// The time this block entry was created by the signer.
+    #[dummy(faker = "DateTimeAfter(time::OffsetDateTime::UNIX_EPOCH)")]
     pub created_at: time::OffsetDateTime,
 }
 
@@ -59,14 +73,16 @@ pub struct DepositRequest {
 #[cfg_attr(feature = "testing", derive(fake::Dummy))]
 pub struct DepositSigner {
     /// TxID of the deposit request.
+    #[dummy(expr = "fake::vec![u8; 32]")]
     pub txid: BitcoinTxId,
     /// Ouput index of the deposit request.
     pub output_index: usize,
     /// Public key of the signer.
-    pub signer_pub_key: Bytes,
+    pub signer_pub_key: PubKey,
     /// Signals if the signer is prepared to sign for this request.
     pub is_accepted: bool,
     /// The time this block entry was created by the signer.
+    #[dummy(faker = "DateTimeAfter(time::OffsetDateTime::UNIX_EPOCH)")]
     pub created_at: time::OffsetDateTime,
 }
 
@@ -77,6 +93,7 @@ pub struct WithdrawRequest {
     /// Request ID of the withdraw request.
     pub request_id: i64,
     /// Stacks block hash of the withdraw request.
+    #[dummy(expr = "fake::vec![u8; 32]")]
     pub block_hash: StacksBlockHash,
     /// The address that shuld receive the BTC withdrawal.
     pub recipient: BitcoinAddress,
@@ -85,7 +102,10 @@ pub struct WithdrawRequest {
     /// The maximum portion of the withdrawn amount that may
     /// be used to pay for transaction fees.
     pub max_fee: i64,
+    /// The address that initiated the request.
+    pub sender_address: StacksAddress,
     /// The time this block entry was created by the signer.
+    #[dummy(faker = "DateTimeAfter(time::OffsetDateTime::UNIX_EPOCH)")]
     pub created_at: time::OffsetDateTime,
 }
 
@@ -96,36 +116,58 @@ pub struct WithdrawSigner {
     /// Request ID of the withdraw request.
     pub request_id: i64,
     /// Stacks block hash of the withdraw request.
+    #[dummy(expr = "fake::vec![u8; 32]")]
     pub block_hash: StacksBlockHash,
     /// Public key of the signer.
-    pub signer_pub_key: Bytes,
+    pub signer_pub_key: PubKey,
     /// Signals if the signer is prepared to sign for this request.
     pub is_accepted: bool,
     /// The time this block entry was created by the signer.
+    #[dummy(faker = "DateTimeAfter(time::OffsetDateTime::UNIX_EPOCH)")]
     pub created_at: time::OffsetDateTime,
 }
 
-/// A transaction on either Bitcoin or Stacks
+/// A connection between a bitcoin block and a bitcoin transaction.
+#[derive(Debug, Clone, PartialEq)]
+pub struct BitcoinTransaction {
+    /// Transaction ID.
+    pub txid: BitcoinTxId,
+    /// The block in which the transaction exists.
+    pub block_hash: BitcoinBlockHash,
+}
+
+/// A raw transaction on either Bitcoin or Stacks.
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "testing", derive(fake::Dummy))]
 pub struct Transaction {
-    txid: Bytes,
-    tx: Bytes,
-    tx_type: TransactionType,
+    /// Transaction ID.
+    pub txid: Bytes,
+    /// Encoded transaction.
+    pub tx: Bytes,
+    /// The type of the transaction.
+    pub tx_type: TransactionType,
+    /// The time this transaction entry was created by the signer.
+    #[dummy(faker = "DateTimeAfter(time::OffsetDateTime::UNIX_EPOCH)")]
+    pub created_at: time::OffsetDateTime,
 }
 
 /// The types of transactions the signer is interested in.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, sqlx::Type, serde::Serialize, serde::Deserialize)]
+#[sqlx(type_name = "sbtc_signer.transaction_type", rename_all = "snake_case")]
 #[cfg_attr(feature = "testing", derive(fake::Dummy))]
 pub enum TransactionType {
     /// An sBTC transaction on Bitcoin.
     SbtcTransaction,
+    /// A deposit request transaction on Bitcoin.
+    DepositRequest,
+    /// A withdraw request transaction on Stacks.
+    WithdrawRequest,
+    /// A deposit accept transaction on Stacks.
+    DepositAccept,
     /// A withdraw accept transaction on Stacks.
     WithdrawAccept,
     /// A withdraw reject transaction on Stacks.
     WithdrawReject,
-    /// A deposit accept transaction on Stacks.
-    DepositAccept,
     /// A update signer set call on Stacks.
     UpdateSignerSet,
     /// A set aggregate key call on Stacks.
@@ -142,6 +184,8 @@ pub type StacksBlockHash = Vec<u8>;
 pub type BitcoinTxId = Vec<u8>;
 /// Arbitrary bytes
 pub type Bytes = Vec<u8>;
+/// Secp256k1 Pubkey in compressed form
+pub type PubKey = [u8; 33];
 /// Bitcoin address
 pub type BitcoinAddress = String;
 /// Stacks address

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -35,6 +35,43 @@ impl super::DbRead for &PgStore {
         .fetch_optional(&self.0)
         .await
     }
+
+    async fn get_bitcoin_canonical_chain_tip(
+        self,
+    ) -> Result<Option<model::BitcoinBlockHash>, Self::Error> {
+        todo!(); // TODO(244): Write query + integration test
+    }
+
+    async fn get_pending_deposit_requests(
+        self,
+        _chain_tip: &model::BitcoinBlockHash,
+        _context_window: usize,
+    ) -> Result<Vec<model::DepositRequest>, Self::Error> {
+        todo!(); // TODO(244): Write query + integration test
+    }
+
+    async fn get_deposit_signers(
+        self,
+        _txid: &model::BitcoinTxId,
+        _output_index: usize,
+    ) -> Result<Vec<model::DepositSigner>, Self::Error> {
+        todo!(); // TODO(244): Write query + integration test
+    }
+
+    async fn get_pending_withdraw_requests(
+        self,
+        _chain_tip: &model::BitcoinBlockHash,
+        _context_window: usize,
+    ) -> Result<Vec<model::WithdrawRequest>, Self::Error> {
+        todo!(); // TODO(246): Write query + integration test
+    }
+
+    async fn get_bitcoin_blocks_with_transaction(
+        self,
+        _txid: &model::BitcoinTxId,
+    ) -> Result<Vec<model::BitcoinBlockHash>, Self::Error> {
+        todo!(); // TODO(244): write query + integration test
+    }
 }
 
 impl super::DbWrite for &PgStore {
@@ -48,6 +85,78 @@ impl super::DbWrite for &PgStore {
             block.parent_hash,
             block.confirms,
             block.created_at
+        )
+        .execute(&self.0)
+        .await?;
+
+        Ok(())
+    }
+
+    async fn write_deposit_request(
+        self,
+        deposit_request: &model::DepositRequest,
+    ) -> Result<(), Self::Error> {
+        sqlx::query!(
+            "INSERT INTO sbtc_signer.deposit_requests VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+            deposit_request.txid,
+            deposit_request.output_index as i32,
+            deposit_request.spend_script,
+            deposit_request.reclaim_script,
+            deposit_request.recipient,
+            deposit_request.amount,
+            deposit_request.max_fee,
+            &deposit_request.sender_addresses,
+            deposit_request.created_at,
+        )
+        .execute(&self.0)
+        .await?;
+
+        Ok(())
+    }
+
+    async fn write_withdraw_request(
+        self,
+        _withdraw_request: &model::WithdrawRequest,
+    ) -> Result<(), Self::Error> {
+        todo!(); // TODO(246): Write query + integration test
+    }
+
+    async fn write_deposit_signer_decision(
+        self,
+        _decision: &model::DepositSigner,
+    ) -> Result<(), Self::Error> {
+        todo!(); // TODO(244): Write query + integration test
+    }
+
+    async fn write_withdraw_signer_decision(
+        self,
+        _decision: &model::WithdrawSigner,
+    ) -> Result<(), Self::Error> {
+        todo!(); // TODO(246): Write query + integration test
+    }
+
+    async fn write_transaction(self, transaction: &model::Transaction) -> Result<(), Self::Error> {
+        sqlx::query!(
+            "INSERT INTO sbtc_signer.transactions VALUES ($1, $2, $3, $4)",
+            transaction.txid,
+            transaction.tx,
+            transaction.tx_type.clone() as model::TransactionType,
+            transaction.created_at,
+        )
+        .execute(&self.0)
+        .await?;
+
+        Ok(())
+    }
+
+    async fn write_bitcoin_transaction(
+        self,
+        bitcoin_transaction: &model::BitcoinTransaction,
+    ) -> Result<(), Self::Error> {
+        sqlx::query!(
+            "INSERT INTO sbtc_signer.bitcoin_transactions VALUES ($1, $2)",
+            bitcoin_transaction.txid,
+            bitcoin_transaction.block_hash,
         )
         .execute(&self.0)
         .await?;

--- a/signer/src/testing/storage/model.rs
+++ b/signer/src/testing/storage/model.rs
@@ -1,9 +1,9 @@
 //! Test data generation utilities
 
 use fake::Fake;
-use time::OffsetDateTime;
 
 use crate::storage::model;
+use crate::storage::DbWrite;
 
 use rand::seq::SliceRandom;
 
@@ -16,10 +16,19 @@ use rand::seq::SliceRandom;
 pub struct TestData {
     /// Bitcoin blocks
     pub bitcoin_blocks: Vec<model::BitcoinBlock>,
+
+    /// Deposit requests
+    pub deposit_requests: Vec<model::DepositRequest>,
+
+    /// Raw transaction data
+    pub transactions: Vec<model::Transaction>,
+
+    /// Connection between bitcoin blocks and transactions
+    pub bitcoin_transactions: Vec<model::BitcoinTransaction>,
 }
 
 impl TestData {
-    /// Generate random test data with the given parameters
+    /// Generate random test data with the given parameters.
     pub fn generate(rng: &mut impl rand::RngCore, params: &Params) -> Self {
         let bitcoin_block_generator: BlockGenerator = match params.chain_type {
             ChainType::Idealistic => Box::new(idealistic_bitcoin_chain(rng)),
@@ -27,82 +36,193 @@ impl TestData {
             ChainType::Chaotic => Box::new(chaotic_bitcoin_chain(rng)),
         };
 
-        let bitcoin_blocks = (0..params.num_bitcoin_blocks)
+        let bitcoin_blocks: Vec<_> = (0..params.num_bitcoin_blocks)
             .scan(Vec::new(), bitcoin_block_generator)
             .collect();
 
-        Self { bitcoin_blocks }
+        let deposit_requests: Vec<_> = (0..params.num_deposit_requests)
+            .map(|_| fake::Faker.fake_with_rng(rng))
+            .collect();
+
+        let transactions = hallucinate_raw_transactions(rng, &deposit_requests);
+
+        let bitcoin_transactions =
+            idealistic_assign_deposit_requests(rng, &deposit_requests, &bitcoin_blocks);
+
+        Self {
+            bitcoin_blocks,
+            deposit_requests,
+            bitcoin_transactions,
+            transactions,
+        }
+    }
+
+    /// Write the test data to the given store
+    pub async fn write_to<Db>(&self, storage: &mut Db)
+    where
+        for<'a> &'a mut Db: DbWrite,
+    {
+        for block in self.bitcoin_blocks.iter() {
+            storage
+                .write_bitcoin_block(block)
+                .await
+                .expect("Failed to write bitcoin block");
+        }
+
+        for tx in self.transactions.iter() {
+            storage
+                .write_transaction(tx)
+                .await
+                .expect("Failed to write transaction");
+        }
+
+        for req in self.deposit_requests.iter() {
+            storage
+                .write_deposit_request(req)
+                .await
+                .expect("Failed to write deposit request");
+        }
+
+        for bitcoin_tx in self.bitcoin_transactions.iter() {
+            storage
+                .write_bitcoin_transaction(bitcoin_tx)
+                .await
+                .expect("Failed to write bitcoin transaction");
+        }
     }
 }
 
-/// Parameters for test data generation
+/// Parameters for test data generation.
 #[derive(Debug, Clone)]
 pub struct Params {
-    /// The number of bitcoin blocks to generate
+    /// The number of bitcoin blocks to generate.
     pub num_bitcoin_blocks: usize,
-    /// The type of characteristics for the generated blockchain
+    /// The type of characteristics for the generated blockchain.
     pub chain_type: ChainType,
+    /// The number of deposit requests,
+    pub num_deposit_requests: usize,
 }
 
-/// Enum repredenting different strategies for how to connect blocks
+/// Enum repredenting different strategies for how to connect blocks.
 #[derive(Debug, Clone)]
 pub enum ChainType {
-    /// A single chain without any forks
+    /// A single chain without any forks.
     Idealistic,
-    /// A chain with some forking but no orphans
+    /// A chain with some forking but no orphans.
     Realistic,
-    /// A chain with plenty of forks and orphans
+    /// A chain with plenty of forks and orphans.
     Chaotic,
 }
 
 type BlockGenerator<'a> =
-    Box<dyn FnMut(&mut Vec<model::BitcoinBlockHash>, usize) -> Option<model::BitcoinBlock> + 'a>;
+    Box<dyn FnMut(&mut Vec<BlockSummary>, usize) -> Option<model::BitcoinBlock> + 'a>;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct BlockSummary {
+    block_hash: model::BitcoinBlockHash,
+    block_height: i64,
+}
+
+impl BlockSummary {
+    fn summarize(block: &model::BitcoinBlock) -> Self {
+        Self {
+            block_hash: block.block_hash.clone(),
+            block_height: block.block_height,
+        }
+    }
+
+    fn hallucinate_parent(block: &model::BitcoinBlock) -> Self {
+        Self {
+            block_hash: block.parent_hash.clone(),
+            block_height: 1337, // Arbitrary number
+        }
+    }
+}
 
 fn idealistic_bitcoin_chain(
     rng: &mut impl rand::RngCore,
-) -> impl FnMut(&mut Vec<model::BitcoinBlockHash>, usize) -> Option<model::BitcoinBlock> + '_ {
-    |block_hashes, _| {
+) -> impl FnMut(&mut Vec<BlockSummary>, usize) -> Option<model::BitcoinBlock> + '_ {
+    |block_summaries, _| {
         let mut block: model::BitcoinBlock = fake::Faker.fake_with_rng(rng);
-        let block_hash: [u8; 32] = fake::Faker.fake_with_rng(rng);
-        block.block_hash = block_hash.to_vec();
-        block.created_at = block.created_at.max(OffsetDateTime::UNIX_EPOCH);
-        block.created_at = block.created_at.replace_nanosecond(0).unwrap();
-        block.parent_hash = block_hashes.last().unwrap_or(&block.parent_hash).clone();
-        block_hashes.push(block.block_hash.clone());
+        let parent_block_summary = block_summaries
+            .last()
+            .cloned()
+            .unwrap_or_else(|| BlockSummary::hallucinate_parent(&block));
+
+        block.parent_hash = parent_block_summary.block_hash;
+        block.block_height = parent_block_summary.block_height + 1;
+
+        block_summaries.push(BlockSummary::summarize(&block));
         Some(block)
     }
 }
 
 fn realistic_bitcoin_chain(
     rng: &mut impl rand::RngCore,
-) -> impl FnMut(&mut Vec<model::BitcoinBlockHash>, usize) -> Option<model::BitcoinBlock> + '_ {
-    |block_hashes, _| {
+) -> impl FnMut(&mut Vec<BlockSummary>, usize) -> Option<model::BitcoinBlock> + '_ {
+    |block_summaries, _| {
         let mut block: model::BitcoinBlock = fake::Faker.fake_with_rng(rng);
-        let block_hash: [u8; 32] = fake::Faker.fake_with_rng(rng);
-        block.block_hash = block_hash.to_vec();
-        block.created_at = block.created_at.max(OffsetDateTime::UNIX_EPOCH);
-        block.created_at = block.created_at.replace_nanosecond(0).unwrap();
-        block.parent_hash = block_hashes
+        let parent_block_summary = block_summaries
             .choose(rng)
-            .unwrap_or(&block.parent_hash)
-            .clone();
-        block_hashes.push(block.block_hash.clone());
+            .cloned()
+            .unwrap_or_else(|| BlockSummary::hallucinate_parent(&block));
+
+        block.parent_hash = parent_block_summary.block_hash;
+        block.block_height = parent_block_summary.block_height + 1;
+
+        block_summaries.push(BlockSummary::summarize(&block));
         Some(block)
     }
 }
 
 fn chaotic_bitcoin_chain(
     rng: &mut impl rand::RngCore,
-) -> impl FnMut(&mut Vec<model::BitcoinBlockHash>, usize) -> Option<model::BitcoinBlock> + '_ {
-    |block_hashes, _| {
+) -> impl FnMut(&mut Vec<BlockSummary>, usize) -> Option<model::BitcoinBlock> + '_ {
+    |block_summaries, _| {
         let mut block: model::BitcoinBlock = fake::Faker.fake_with_rng(rng);
-        let block_hash: [u8; 32] = fake::Faker.fake_with_rng(rng);
-        block.block_hash = block_hash.to_vec();
-        block.created_at = block.created_at.max(OffsetDateTime::UNIX_EPOCH);
-        block.created_at = block.created_at.replace_nanosecond(0).unwrap();
-        block_hashes.push(block.parent_hash.clone());
-        block.parent_hash = block_hashes.choose(rng).unwrap().clone();
-        block_hashes.push(block.block_hash.clone());
+        block_summaries.push(BlockSummary::hallucinate_parent(&block));
+        let parent_block_summary = block_summaries.choose(rng).unwrap().clone();
+
+        block.parent_hash = parent_block_summary.block_hash;
+        block.block_height = parent_block_summary.block_height + 1;
+
+        block_summaries.push(BlockSummary::summarize(&block));
         Some(block)
     }
+}
+
+/// Creates random transactions associated with the given requests
+fn hallucinate_raw_transactions(
+    rng: &mut impl rand::RngCore,
+    deposit_requests: &[model::DepositRequest],
+) -> Vec<model::Transaction> {
+    deposit_requests
+        .iter()
+        .map(|req| {
+            let mut tx: model::Transaction = fake::Faker.fake_with_rng(rng);
+            tx.txid = req.txid.clone();
+            tx.tx_type = model::TransactionType::DepositRequest;
+            tx
+        })
+        .collect()
+}
+
+/// Assigns every deposit request exactly once to a random
+/// bitcoin block.
+fn idealistic_assign_deposit_requests(
+    rng: &mut impl rand::RngCore,
+    deposit_requests: &[model::DepositRequest],
+    bitcoin_blocks: &[model::BitcoinBlock],
+) -> Vec<model::BitcoinTransaction> {
+    deposit_requests
+        .iter()
+        .filter_map(|req| {
+            let txid = req.txid.clone();
+            let block_hash = bitcoin_blocks
+                .choose(rng)
+                .map(|block| block.block_hash.clone())?;
+
+            Some(model::BitcoinTransaction { txid, block_hash })
+        })
+        .collect()
 }

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -5,6 +5,17 @@
 //!
 //! For more details, see the [`TxSignerEventLoop`] documentation.
 
+use crate::blocklist_client;
+use crate::error;
+use crate::network;
+use crate::storage;
+use crate::storage::model;
+
+use crate::storage::DbRead;
+use crate::storage::DbWrite;
+
+use futures::StreamExt;
+
 #[cfg_attr(doc, aquamarine::aquamarine)]
 /// # Transaction signer event loop
 ///
@@ -64,9 +75,359 @@
 ///
 ///     SM --> |WSTS message| RWSM(Relay to WSTS state machine)
 /// ```
-pub struct TxSignerEventLoop;
+#[derive(Debug)]
+pub struct TxSignerEventLoop<Network, Storage, BlocklistChecker> {
+    /// Interface to the signer network.
+    pub network: Network,
+    /// Database connection.
+    pub storage: Storage,
+    /// Blocklist checker.
+    pub blocklist_checker: BlocklistChecker,
+    /// Notification receiver from the block observer.
+    pub block_observer_notifications: tokio::sync::watch::Receiver<()>,
+    /// Private key of the signer for network communication.
+    pub signer_private_key: p256k1::scalar::Scalar,
+    /// How many blocks back from the chain tip the signer will look for requests.
+    pub context_window: usize,
+}
 
-impl TxSignerEventLoop {
+impl<N, S, B> TxSignerEventLoop<N, S, B>
+where
+    N: network::MessageTransfer,
+    B: blocklist_client::BlocklistChecker,
+    for<'a> &'a mut S: storage::DbRead + storage::DbWrite,
+    for<'a> <&'a mut S as storage::DbRead>::Error: std::error::Error,
+    for<'a> <&'a mut S as storage::DbWrite>::Error: std::error::Error,
+    for<'a> error::Error: From<<&'a mut S as storage::DbRead>::Error>,
+    for<'a> error::Error: From<<&'a mut S as storage::DbWrite>::Error>,
+{
     /// Run the signer event loop
-    pub async fn run() {}
+    #[tracing::instrument(skip(self))]
+    pub async fn run(mut self) -> Result<(), error::Error> {
+        loop {
+            tokio::select! {
+                result = self.block_observer_notifications.changed() => {
+                    match result {
+                        Ok(()) => self.handle_new_requests().await?,
+                        Err(_) => {
+                            tracing::info!("block observer notification channel closed");
+                            break;
+                        }
+                    }
+                }
+
+                result = self.network.receive() => {
+                    match result {
+                        Ok(msg) => self.handle_signer_message(&msg).await?,
+                        Err(error) => {
+                            tracing::error!(%error,"signer network error");
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        tracing::info!("shutting down transaction signer event loop");
+        Ok(())
+    }
+
+    #[tracing::instrument(skip(self))]
+    async fn handle_new_requests(&mut self) -> Result<(), error::Error> {
+        let bitcoin_chain_tip = self
+            .storage
+            .get_bitcoin_canonical_chain_tip()
+            .await?
+            .ok_or(Error::NoChainTip)?;
+
+        for deposit_request in self
+            .get_pending_deposit_requests(&bitcoin_chain_tip)
+            .await?
+        {
+            self.handle_pending_deposit_request(deposit_request).await?;
+        }
+
+        for withdraw_request in self
+            .get_pending_withdraw_requests(&bitcoin_chain_tip)
+            .await?
+        {
+            self.handle_pending_withdraw_request(withdraw_request)
+                .await?;
+        }
+
+        Ok(())
+    }
+
+    #[tracing::instrument(skip(self))]
+    async fn handle_signer_message(&mut self, msg: &network::Msg) -> Result<(), error::Error> {
+        // TODO(247): Expand to process signer decisions and write todos for remaining message types
+        todo!();
+    }
+
+    #[tracing::instrument(skip(self))]
+    async fn get_pending_deposit_requests(
+        &mut self,
+        chain_tip: &model::BitcoinBlockHash,
+    ) -> Result<Vec<model::DepositRequest>, error::Error> {
+        Ok(self
+            .storage
+            .get_pending_deposit_requests(chain_tip, self.context_window)
+            .await?)
+    }
+
+    #[tracing::instrument(skip(self))]
+    async fn get_pending_withdraw_requests(
+        &mut self,
+        chain_tip: &model::BitcoinBlockHash,
+    ) -> Result<Vec<model::WithdrawRequest>, error::Error> {
+        Ok(self
+            .storage
+            .get_pending_withdraw_requests(chain_tip, self.context_window)
+            .await?)
+    }
+
+    #[tracing::instrument(skip(self))]
+    async fn handle_pending_deposit_request(
+        &mut self,
+        deposit_request: model::DepositRequest,
+    ) -> Result<(), error::Error> {
+        let is_accepted = futures::stream::iter(&deposit_request.sender_addresses)
+            .any(|address| async {
+                self.blocklist_checker
+                    .can_accept(address)
+                    .await
+                    .unwrap_or(false)
+            })
+            .await;
+
+        let signer_pub_key = p256k1::ecdsa::PublicKey::new(&self.signer_private_key)?.to_bytes();
+
+        let created_at = time::OffsetDateTime::now_utc();
+
+        let signer_decision = model::DepositSigner {
+            txid: deposit_request.txid,
+            output_index: deposit_request.output_index,
+            signer_pub_key,
+            is_accepted,
+            created_at,
+        };
+
+        self.storage
+            .write_deposit_signer_decision(&signer_decision)
+            .await?;
+
+        Ok(())
+    }
+
+    #[tracing::instrument(skip(self))]
+    async fn handle_pending_withdraw_request(
+        &mut self,
+        withdraw_request: model::WithdrawRequest,
+    ) -> Result<(), error::Error> {
+        let is_accepted = self
+            .blocklist_checker
+            .can_accept(&withdraw_request.sender_address)
+            .await
+            .unwrap_or(false);
+
+        let signer_pub_key = p256k1::ecdsa::PublicKey::new(&self.signer_private_key)?.to_bytes();
+
+        let created_at = time::OffsetDateTime::now_utc();
+
+        let signer_decision = model::WithdrawSigner {
+            request_id: withdraw_request.request_id,
+            block_hash: withdraw_request.block_hash,
+            signer_pub_key,
+            is_accepted,
+            created_at,
+        };
+
+        self.storage
+            .write_withdraw_signer_decision(&signer_decision)
+            .await?;
+
+        Ok(())
+    }
+}
+
+/// Errors occurring in the transaction signer loop.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// No chain tip found.
+    #[error("no bitcoin chain tip")]
+    NoChainTip,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::network;
+    use crate::storage;
+    use crate::testing;
+    use rand::SeedableRng;
+
+    #[tokio::test]
+    async fn should_store_decisions_for_pending_deposit_requests() {
+        let mut rng = rand::rngs::StdRng::seed_from_u64(46);
+        let context_window = 3;
+
+        let (event_loop, block_observer_notification_tx, mut storage) =
+            create_event_loop(&mut rng, context_window);
+
+        let join_handle = start_event_loop(event_loop);
+
+        let test_data =
+            generate_and_write_test_data(&mut rng, &mut storage, &block_observer_notification_tx)
+                .await;
+
+        stop_event_loop(block_observer_notification_tx, join_handle).await;
+
+        let context_window_block_hashes =
+            extract_context_window_block_hashes(&storage, context_window).await;
+
+        assert_only_deposit_requests_in_context_window_has_decisions(
+            &context_window_block_hashes,
+            &test_data.deposit_requests,
+            &storage,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn should_store_decisions_for_pending_withdraw_requests() {
+        // TODO(245): Write test
+    }
+
+    fn create_event_loop<Rng: rand::RngCore + rand::CryptoRng>(
+        rng: &mut Rng,
+        context_window: usize,
+    ) -> (
+        EventLoop,
+        tokio::sync::watch::Sender<()>,
+        storage::in_memory::SharedStore,
+    ) {
+        let storage = storage::in_memory::Store::new_shared();
+        let network = network::in_memory::Network::new().connect();
+        let blocklist_checker = ();
+        let (block_observer_notification_tx, block_observer_notifications) =
+            tokio::sync::watch::channel(());
+        let signer_private_key = p256k1::scalar::Scalar::random(rng);
+
+        (
+            TxSignerEventLoop {
+                storage: storage.clone(),
+                network,
+                blocklist_checker,
+                block_observer_notifications,
+                signer_private_key,
+                context_window,
+            },
+            block_observer_notification_tx,
+            storage,
+        )
+    }
+
+    fn start_event_loop(
+        event_loop: EventLoop,
+    ) -> tokio::task::JoinHandle<Result<(), error::Error>> {
+        tokio::spawn(async { event_loop.run().await })
+    }
+
+    async fn stop_event_loop(
+        block_observer_notification_tx: tokio::sync::watch::Sender<()>,
+        join_handle: tokio::task::JoinHandle<Result<(), error::Error>>,
+    ) {
+        // While this explicit drop isn't strictly necessary, it serves to clarify our intention.
+        drop(block_observer_notification_tx);
+
+        join_handle
+            .await
+            .expect("joining event loop failed")
+            .expect("event loop returned error");
+    }
+
+    async fn generate_and_write_test_data(
+        rng: &mut impl rand::RngCore,
+        storage: &mut storage::in_memory::SharedStore,
+        block_observer_notification_tx: &tokio::sync::watch::Sender<()>,
+    ) -> testing::storage::model::TestData {
+        let test_model_params = testing::storage::model::Params {
+            num_bitcoin_blocks: 20,
+            chain_type: testing::storage::model::ChainType::Chaotic,
+            num_deposit_requests: 100,
+        };
+
+        let test_data = testing::storage::model::TestData::generate(rng, &test_model_params);
+        test_data.write_to(storage).await;
+
+        block_observer_notification_tx
+            .send(())
+            .expect("Failed to send notification");
+
+        test_data
+    }
+
+    async fn extract_context_window_block_hashes(
+        storage: &storage::in_memory::SharedStore,
+        context_window: usize,
+    ) -> Vec<model::BitcoinBlockHash> {
+        let mut context_window_block_hashes = Vec::new();
+        let mut block_hash = storage
+            .get_bitcoin_canonical_chain_tip()
+            .await
+            .unwrap()
+            .expect("found no canonical chain tip");
+
+        for _ in 0..context_window {
+            context_window_block_hashes.push(block_hash.clone());
+            let Some(block) = storage.get_bitcoin_block(&block_hash).await.unwrap() else {
+                break;
+            };
+            block_hash = block.parent_hash;
+        }
+
+        context_window_block_hashes
+    }
+
+    async fn assert_only_deposit_requests_in_context_window_has_decisions(
+        context_window_block_hashes: &[model::BitcoinBlockHash],
+        deposit_requests: &[model::DepositRequest],
+        storage: &storage::in_memory::SharedStore,
+    ) {
+        for deposit_request in deposit_requests {
+            let signer_decisions = storage
+                .get_deposit_signers(&deposit_request.txid, deposit_request.output_index)
+                .await
+                .unwrap();
+
+            for deposit_request_block in storage
+                .get_bitcoin_blocks_with_transaction(&deposit_request.txid)
+                .await
+                .unwrap()
+            {
+                if context_window_block_hashes.contains(&deposit_request_block) {
+                    assert_eq!(signer_decisions.len(), 1);
+                    assert!(signer_decisions.first().unwrap().is_accepted)
+                } else {
+                    assert_eq!(signer_decisions.len(), 0);
+                }
+            }
+        }
+    }
+
+    impl blocklist_client::BlocklistChecker for () {
+        async fn can_accept(
+            &self,
+            _address: &str,
+        ) -> Result<
+            bool,
+            blocklist_api::apis::Error<blocklist_api::apis::address_api::CheckAddressError>,
+        > {
+            Ok(true)
+        }
+    }
+
+    type EventLoop =
+        TxSignerEventLoop<network::in_memory::MpmcBroadcaster, storage::in_memory::SharedStore, ()>;
 }


### PR DESCRIPTION
closes #234 

This PR adds a rough skeleton implementation for the transaction signer event loop with the logic to make and persist decisions for pending requests, including a unit test for the handling of deposit requests.

The most important changes are the additions to `transaction_signer.rs`, whereas most of the remaining changes are database queries and updates to data generation logic for tests.