### PR TITLE
feat: Modify block observer to use the top-level error::Error type

### DIFF
--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -73,4 +73,8 @@ pub enum Error {
     /// In memory storage error
     #[error("in memory storage error")]
     InMemoryStorageError(#[from] crate::storage::in_memory::Error),
+
+    /// Missing block
+    #[error("missing block")]
+    MissingBlock,
 }


### PR DESCRIPTION
Closes #229 

Currently based on PR #248 