### PR TITLE
feat: writing stacks block

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ serde = "1.0"
 serde_json = "1.0"
 sha2 = "0.10"
 stackslib = { git = "https://github.com/Trust-Machines/stacks-blockchain/", branch = "develop-upstream" }
-sqlx = { version = "0.7", default-features = false, features = [ "postgres", "time", "runtime-tokio", "tls-rustls", "macros", "migrate" ] }
+sqlx = { version = "0.7", default-features = false, features = [ "postgres", "time", "runtime-tokio", "tls-rustls", "macros", "migrate", "json" ] }
 thiserror = "1.0"
 time = "0.3.36"
 tonic = "0.11.0"

--- a/contracts/tests/sbtc-withdrawal.test.ts
+++ b/contracts/tests/sbtc-withdrawal.test.ts
@@ -1,5 +1,6 @@
 import {
   alice,
+  deployer,
   deposit,
   errors,
   registry,
@@ -77,7 +78,7 @@ describe("initiating a withdrawal request", () => {
         amount: 1000n,
         recipient: alice,
       }),
-      alice
+      deployer
     );
     const receipt = txOk(
       withdrawal.initiateWithdrawalRequest({
@@ -141,7 +142,7 @@ describe("initiating a withdrawal request", () => {
         amount: 1000n,
         recipient: alice,
       }),
-      alice
+      deployer
     );
     expect(rovOk(token.getBalance(alice))).toEqual(1000n);
     const receipt = txOk(
@@ -173,7 +174,7 @@ describe("initiating a withdrawal request", () => {
         amount: 4000n,
         recipient: alice,
       }),
-      alice
+      deployer
     );
     expect(
       txErr(
@@ -217,7 +218,7 @@ describe("initiating a withdrawal request", () => {
         amount: 4000n,
         recipient: alice,
       }),
-      alice
+      deployer
     );
     const receipt = txErr(
       withdrawal.initiateWithdrawalRequest({

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -61,8 +61,6 @@ services:
       POSTGRES_DB: signer
     ports:
       - "5432:5432"
-    volumes:
-      - postgres_data:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready --username=user --dbname=signer"]
       interval: 2s
@@ -100,5 +98,3 @@ services:
 #      BITCOIN_RPC_HOST: 172.18.0.3
 #      BITCOIN_RPC_PORT: 18443
 
-volumes:
-  postgres_data:

--- a/signer/.sqlx/query-3446a823d60a644dc58bc0c36ba256747ba46b9441072ad8a13c2a6703974a45.json
+++ b/signer/.sqlx/query-3446a823d60a644dc58bc0c36ba256747ba46b9441072ad8a13c2a6703974a45.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO sbtc_signer.deposit_requests VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Bytea",
+        "Int4",
+        "Bytea",
+        "Bytea",
+        "Text",
+        "Int8",
+        "Int8",
+        "TextArray",
+        "Timestamptz"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "3446a823d60a644dc58bc0c36ba256747ba46b9441072ad8a13c2a6703974a45"
+}

--- a/signer/.sqlx/query-3f0879dab4417cf80f9287fe579c2c6b66f3ac4cc3fe4845ecc4cfe85b4c8e8d.json
+++ b/signer/.sqlx/query-3f0879dab4417cf80f9287fe579c2c6b66f3ac4cc3fe4845ecc4cfe85b4c8e8d.json
@@ -1,0 +1,33 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO sbtc_signer.transactions VALUES ($1, $2, $3, $4)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Bytea",
+        "Bytea",
+        {
+          "Custom": {
+            "name": "transaction_type",
+            "kind": {
+              "Enum": [
+                "sbtc_transaction",
+                "deposit_request",
+                "withdraw_request",
+                "deposit_accept",
+                "withdraw_accept",
+                "withdraw_reject",
+                "update_signer_set",
+                "set_aggregate_key"
+              ]
+            }
+          }
+        },
+        "Timestamptz"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "3f0879dab4417cf80f9287fe579c2c6b66f3ac4cc3fe4845ecc4cfe85b4c8e8d"
+}

--- a/signer/.sqlx/query-4d8b40e94cb12a4fcda6b08063bc247e2229d864bc6c6c6a89f25c91ba60f840.json
+++ b/signer/.sqlx/query-4d8b40e94cb12a4fcda6b08063bc247e2229d864bc6c6c6a89f25c91ba60f840.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT 1 AS exists\n            FROM sbtc_signer.stacks_blocks\n            WHERE block_hash = $1;",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "exists",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Bytea"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "4d8b40e94cb12a4fcda6b08063bc247e2229d864bc6c6c6a89f25c91ba60f840"
+}

--- a/signer/.sqlx/query-54884a5f0278765c3d5a3890f9a6cdc60ed352883e037748295d62bcab94ae86.json
+++ b/signer/.sqlx/query-54884a5f0278765c3d5a3890f9a6cdc60ed352883e037748295d62bcab94ae86.json
@@ -1,0 +1,46 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT * FROM sbtc_signer.bitcoin_blocks WHERE block_hash = $1;",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "block_hash",
+        "type_info": "Bytea"
+      },
+      {
+        "ordinal": 1,
+        "name": "block_height",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 2,
+        "name": "parent_hash",
+        "type_info": "Bytea"
+      },
+      {
+        "ordinal": 3,
+        "name": "confirms",
+        "type_info": "Bytea"
+      },
+      {
+        "ordinal": 4,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Bytea"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      false
+    ]
+  },
+  "hash": "54884a5f0278765c3d5a3890f9a6cdc60ed352883e037748295d62bcab94ae86"
+}

--- a/signer/.sqlx/query-6678744f83dfa4708706937f9c88ca445f11e846c36995ed0b0754928096da99.json
+++ b/signer/.sqlx/query-6678744f83dfa4708706937f9c88ca445f11e846c36995ed0b0754928096da99.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO sbtc_signer.stacks_blocks (block_hash, block_height, parent_hash, created_at)\n            SELECT\n                decode(block_id, 'hex')\n              , chain_length\n              , decode(parent_block_id, 'hex')\n              , CURRENT_TIMESTAMP\n            FROM JSONB_TO_RECORDSET($1::JSONB) AS x(\n                block_id        CHAR(64)\n              , chain_length    BIGINT\n              , parent_block_id CHAR(64)\n            )\n            ON CONFLICT DO NOTHING",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Jsonb"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "6678744f83dfa4708706937f9c88ca445f11e846c36995ed0b0754928096da99"
+}

--- a/signer/.sqlx/query-7e247d7abf23d1386a01457bdf87ed9213df9782635a2a8cfe84e27ec8750784.json
+++ b/signer/.sqlx/query-7e247d7abf23d1386a01457bdf87ed9213df9782635a2a8cfe84e27ec8750784.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO sbtc_signer.stacks_transactions (txid, block_hash)\n            SELECT\n                decode(txid, 'hex')\n              , decode(block_id, 'hex')\n            FROM JSONB_TO_RECORDSET($1::JSONB) AS x(\n                txid        CHAR(64)\n              , block_id    CHAR(64)\n            )\n            ON CONFLICT DO NOTHING",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Jsonb"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "7e247d7abf23d1386a01457bdf87ed9213df9782635a2a8cfe84e27ec8750784"
+}

--- a/signer/.sqlx/query-ac71ab51277e5afa623340de33981eb58d2ae5da602531f49d49c62d711ba6ed.json
+++ b/signer/.sqlx/query-ac71ab51277e5afa623340de33981eb58d2ae5da602531f49d49c62d711ba6ed.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO sbtc_signer.bitcoin_transactions VALUES ($1, $2)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Bytea",
+        "Bytea"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "ac71ab51277e5afa623340de33981eb58d2ae5da602531f49d49c62d711ba6ed"
+}

--- a/signer/.sqlx/query-e2bd6bcf452d37dee4e0c9b466272e2b2c8a7295350201ecf1fa7ccad24287a8.json
+++ b/signer/.sqlx/query-e2bd6bcf452d37dee4e0c9b466272e2b2c8a7295350201ecf1fa7ccad24287a8.json
@@ -1,0 +1,18 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO sbtc_signer.bitcoin_blocks VALUES ($1, $2, $3, $4, $5)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Bytea",
+        "Int8",
+        "Bytea",
+        "Bytea",
+        "Timestamptz"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "e2bd6bcf452d37dee4e0c9b466272e2b2c8a7295350201ecf1fa7ccad24287a8"
+}

--- a/signer/.sqlx/query-e4f7cae570f67835407d9a4fddae531b354e355ac374c26b5d2d6fbd9660a2e3.json
+++ b/signer/.sqlx/query-e4f7cae570f67835407d9a4fddae531b354e355ac374c26b5d2d6fbd9660a2e3.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO sbtc_signer.transactions (txid, tx, tx_type, created_at)\n            SELECT\n                decode(txid, 'hex')\n              , decode(tx, 'hex')\n              , tx_type::sbtc_signer.transaction_type\n              , CURRENT_TIMESTAMP\n            FROM JSONB_TO_RECORDSET($1::JSONB) AS x(\n                txid      CHAR(64)\n              , tx        VARCHAR\n              , tx_type   VARCHAR\n            )\n            ON CONFLICT DO NOTHING",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Jsonb"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "e4f7cae570f67835407d9a4fddae531b354e355ac374c26b5d2d6fbd9660a2e3"
+}

--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -57,12 +57,10 @@ where
     BC: BitcoinInteract,
     SC: StacksInteract,
     EC: EmilyInteract,
+    S: DbWrite + DbRead + Send + Sync,
     BHS: futures::stream::Stream<Item = bitcoin::BlockHash> + Unpin,
-    for<'a> &'a mut S: storage::DbRead + storage::DbWrite,
-    for<'a> <&'a mut S as storage::DbRead>::Error: std::error::Error,
-    for<'a> <&'a mut S as storage::DbWrite>::Error: std::error::Error,
-    error::Error: for<'a> From<<&'a mut S as storage::DbRead>::Error>,
-    error::Error: for<'a> From<<&'a mut S as storage::DbWrite>::Error>,
+    error::Error: From<<S as DbRead>::Error>,
+    error::Error: From<<S as DbWrite>::Error>,
 {
     /// Run the block observer
     #[tracing::instrument(skip(self))]

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -30,6 +30,10 @@ pub enum Error {
     #[error("Could not decode Nakamoto block from tenure with block: {1}; {0}")]
     DecodeNakamotoTenure(#[source] blockstack_lib::codec::Error, StacksBlockId),
 
+    /// An error when serializing an object to JSON
+    #[error("{0}")]
+    JsonSerialize(#[source] serde_json::Error),
+
     /// Could not parse the path part of a url
     #[error("Failed to construct a valid URL from {1} and {2}: {0}")]
     PathJoin(#[source] url::ParseError, url::Url, Cow<'static, str>),
@@ -41,6 +45,10 @@ pub enum Error {
     /// Error when reading the signer config.toml
     #[error("Failed to read the signers config file: {0}")]
     SignerConfig(#[source] config::ConfigError),
+
+    /// An error when querying the signer's database.
+    #[error("Received an error when attempting to query the database: {0}")]
+    SqlxQuery(#[source] sqlx::Error),
 
     /// Error when reading the stacks API part of the config.toml
     #[error("Failed to parse the stacks.api portion of the config: {0}")]

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -70,11 +70,13 @@ pub enum Error {
     #[error("key error: {0}")]
     KeyError(#[from] p256k1::keys::Error),
 
-    /// In memory storage error
-    #[error("in memory storage error")]
-    InMemoryStorageError(#[from] crate::storage::in_memory::Error),
-
     /// Missing block
     #[error("missing block")]
     MissingBlock,
+}
+
+impl From<std::convert::Infallible> for Error {
+    fn from(value: std::convert::Infallible) -> Self {
+        match value {}
+    }
 }

--- a/signer/src/storage.rs
+++ b/signer/src/storage.rs
@@ -82,7 +82,7 @@ pub trait DbWrite {
         deposit_request: &model::DepositRequest,
     ) -> impl Future<Output = Result<(), Self::Error>> + Send;
 
-    /// Write a withdraw request.
+    /// Write a withdrawal request.
     fn write_withdraw_request(
         &self,
         withdraw_request: &model::WithdrawRequest,
@@ -94,7 +94,7 @@ pub trait DbWrite {
         decision: &model::DepositSigner,
     ) -> impl Future<Output = Result<(), Self::Error>> + Send;
 
-    /// Write a signer decision for a withdraw request.
+    /// Write a signer decision for a withdrawal request.
     fn write_withdraw_signer_decision(
         &self,
         decision: &model::WithdrawSigner,

--- a/signer/src/storage.rs
+++ b/signer/src/storage.rs
@@ -12,6 +12,9 @@ pub mod postgres;
 
 use std::future::Future;
 
+use blockstack_lib::chainstate::nakamoto::NakamotoBlock;
+use blockstack_lib::types::chainstate::StacksBlockId;
+
 /// Represents the ability to read data from the signer storage.
 pub trait DbRead {
     /// Read error.
@@ -19,41 +22,47 @@ pub trait DbRead {
 
     /// Get the bitcoin block with the given block hash.
     fn get_bitcoin_block(
-        self,
+        &self,
         block_hash: &model::BitcoinBlockHash,
     ) -> impl Future<Output = Result<Option<model::BitcoinBlock>, Self::Error>> + Send;
 
     /// Get the bitcoin canonical chain tip
     fn get_bitcoin_canonical_chain_tip(
-        self,
+        &self,
     ) -> impl Future<Output = Result<Option<model::BitcoinBlockHash>, Self::Error>> + Send;
 
     /// Get pending deposit requests
     fn get_pending_deposit_requests(
-        self,
+        &self,
         chain_tip: &model::BitcoinBlockHash,
         context_window: usize,
     ) -> impl Future<Output = Result<Vec<model::DepositRequest>, Self::Error>> + Send;
 
     /// Get signer decisions for a deposit request
     fn get_deposit_signers(
-        self,
+        &self,
         txid: &model::BitcoinTxId,
         output_index: usize,
     ) -> impl Future<Output = Result<Vec<model::DepositSigner>, Self::Error>> + Send;
 
     /// Get pending withdraw requests
     fn get_pending_withdraw_requests(
-        self,
+        &self,
         chain_tip: &model::BitcoinBlockHash,
         context_window: usize,
     ) -> impl Future<Output = Result<Vec<model::WithdrawRequest>, Self::Error>> + Send;
 
     /// Get bitcoin blocks that include a particular transaction
     fn get_bitcoin_blocks_with_transaction(
-        self,
+        &self,
         txid: &model::BitcoinTxId,
     ) -> impl Future<Output = Result<Vec<model::BitcoinBlockHash>, Self::Error>> + Send;
+
+    /// Returns whether the given block ID is stored.
+    fn stacks_block_exists(
+        &self,
+        block_id: StacksBlockId,
+    ) -> impl Future<Output = Result<bool, Self::Error>> + Send;
 }
 
 /// Represents the ability to write data to the signer storage.
@@ -63,152 +72,49 @@ pub trait DbWrite {
 
     /// Write a bitcoin block.
     fn write_bitcoin_block(
-        self,
+        &self,
         block: &model::BitcoinBlock,
     ) -> impl Future<Output = Result<(), Self::Error>> + Send;
 
     /// Write a deposit request.
     fn write_deposit_request(
-        self,
+        &self,
         deposit_request: &model::DepositRequest,
     ) -> impl Future<Output = Result<(), Self::Error>> + Send;
 
     /// Write a withdraw request.
     fn write_withdraw_request(
-        self,
+        &self,
         withdraw_request: &model::WithdrawRequest,
     ) -> impl Future<Output = Result<(), Self::Error>> + Send;
 
     /// Write a signer decision for a deposit request.
     fn write_deposit_signer_decision(
-        self,
+        &self,
         decision: &model::DepositSigner,
     ) -> impl Future<Output = Result<(), Self::Error>> + Send;
 
     /// Write a signer decision for a withdraw request.
     fn write_withdraw_signer_decision(
-        self,
+        &self,
         decision: &model::WithdrawSigner,
     ) -> impl Future<Output = Result<(), Self::Error>> + Send;
 
     /// Write a raw transaction.
     fn write_transaction(
-        self,
+        &self,
         transaction: &model::Transaction,
     ) -> impl Future<Output = Result<(), Self::Error>> + Send;
 
     /// Write a connection between a bitcoin block and a transaction
     fn write_bitcoin_transaction(
-        self,
+        &self,
         bitcoin_transaction: &model::BitcoinTransaction,
     ) -> impl Future<Output = Result<(), Self::Error>> + Send;
-}
 
-impl<'a, T> DbRead for &'a mut T
-where
-    &'a T: DbRead,
-    T: Send,
-{
-    type Error = <&'a T as DbRead>::Error;
-
-    async fn get_bitcoin_block(
-        self,
-        block_hash: &model::BitcoinBlockHash,
-    ) -> Result<Option<model::BitcoinBlock>, Self::Error> {
-        (&*self).get_bitcoin_block(block_hash).await
-    }
-
-    async fn get_bitcoin_canonical_chain_tip(
-        self,
-    ) -> Result<Option<model::BitcoinBlockHash>, Self::Error> {
-        (&*self).get_bitcoin_canonical_chain_tip().await
-    }
-
-    async fn get_pending_deposit_requests(
-        self,
-        chain_tip: &model::BitcoinBlockHash,
-        context_window: usize,
-    ) -> Result<Vec<model::DepositRequest>, Self::Error> {
-        (&*self)
-            .get_pending_deposit_requests(chain_tip, context_window)
-            .await
-    }
-
-    async fn get_deposit_signers(
-        self,
-        txid: &model::BitcoinTxId,
-        output_index: usize,
-    ) -> Result<Vec<model::DepositSigner>, Self::Error> {
-        (&*self).get_deposit_signers(txid, output_index).await
-    }
-
-    async fn get_pending_withdraw_requests(
-        self,
-        chain_tip: &model::BitcoinBlockHash,
-        context_window: usize,
-    ) -> Result<Vec<model::WithdrawRequest>, Self::Error> {
-        (&*self)
-            .get_pending_withdraw_requests(chain_tip, context_window)
-            .await
-    }
-
-    async fn get_bitcoin_blocks_with_transaction(
-        self,
-        txid: &model::BitcoinTxId,
-    ) -> Result<Vec<model::BitcoinBlockHash>, Self::Error> {
-        (&*self).get_bitcoin_blocks_with_transaction(txid).await
-    }
-}
-
-impl<'a, T> DbWrite for &'a mut T
-where
-    &'a T: DbWrite,
-    T: Send,
-{
-    type Error = <&'a T as DbWrite>::Error;
-
-    async fn write_bitcoin_block(self, block: &model::BitcoinBlock) -> Result<(), Self::Error> {
-        (&*self).write_bitcoin_block(block).await
-    }
-
-    async fn write_deposit_request(
-        self,
-        deposit_request: &model::DepositRequest,
-    ) -> Result<(), Self::Error> {
-        (&*self).write_deposit_request(deposit_request).await
-    }
-
-    async fn write_withdraw_request(
-        self,
-        withdraw_request: &model::WithdrawRequest,
-    ) -> Result<(), Self::Error> {
-        (&*self).write_withdraw_request(withdraw_request).await
-    }
-
-    async fn write_deposit_signer_decision(
-        self,
-        decision: &model::DepositSigner,
-    ) -> Result<(), Self::Error> {
-        (&*self).write_deposit_signer_decision(decision).await
-    }
-
-    async fn write_withdraw_signer_decision(
-        self,
-        decision: &model::WithdrawSigner,
-    ) -> Result<(), Self::Error> {
-        (&*self).write_withdraw_signer_decision(decision).await
-    }
-
-    async fn write_transaction(self, transaction: &model::Transaction) -> Result<(), Self::Error> {
-        (&*self).write_transaction(transaction).await
-    }
-
-    async fn write_bitcoin_transaction(
-        self,
-        bitcoin_transaction: &model::BitcoinTransaction,
-    ) -> Result<(), Self::Error> {
-        (&*self)
-            .write_bitcoin_transaction(bitcoin_transaction)
-            .await
-    }
+    /// Write the stacks blocks.
+    fn write_stacks_blocks(
+        &self,
+        blocks: &[NakamotoBlock],
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
 }

--- a/signer/src/storage/in_memory.rs
+++ b/signer/src/storage/in_memory.rs
@@ -1,5 +1,7 @@
 //! In-memory store implementation - useful for tests
 
+use blockstack_lib::chainstate::nakamoto::NakamotoBlock;
+use blockstack_lib::types::chainstate::StacksBlockId;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -12,7 +14,7 @@ pub type SharedStore = Arc<Mutex<Store>>;
 type DepositRequestPk = (model::BitcoinTxId, usize);
 
 /// In-memory store
-#[derive(Debug, Clone, PartialEq, Default)]
+#[derive(Debug, Default)]
 pub struct Store {
     /// Bitcoin blocks
     pub bitcoin_blocks: HashMap<model::BitcoinBlockHash, model::BitcoinBlock>,
@@ -31,6 +33,9 @@ pub struct Store {
 
     /// Bitcoin transactions to blocks
     pub bitcoin_transactions_to_blocks: HashMap<model::BitcoinTxId, Vec<model::BitcoinBlockHash>>,
+
+    /// Stacks blocks under nakamoto
+    pub stacks_blocks: HashMap<StacksBlockId, NakamotoBlock>,
 }
 
 impl Store {
@@ -45,20 +50,26 @@ impl Store {
     }
 }
 
-impl super::DbRead for &Store {
-    type Error = Error;
+impl super::DbRead for SharedStore {
+    type Error = std::convert::Infallible;
 
     async fn get_bitcoin_block(
-        self,
+        &self,
         block_hash: &model::BitcoinBlockHash,
     ) -> Result<Option<model::BitcoinBlock>, Self::Error> {
-        Ok(self.bitcoin_blocks.get(block_hash).cloned())
+        Ok(self.lock().await.bitcoin_blocks.get(block_hash).cloned())
+    }
+
+    async fn stacks_block_exists(&self, block_id: StacksBlockId) -> Result<bool, Self::Error> {
+        Ok(self.lock().await.stacks_blocks.contains_key(&block_id))
     }
 
     async fn get_bitcoin_canonical_chain_tip(
-        self,
+        &self,
     ) -> Result<Option<model::BitcoinBlockHash>, Self::Error> {
         Ok(self
+            .lock()
+            .await
             .bitcoin_blocks
             .values()
             .max_by_key(|block| (block.block_height, block.block_hash.clone()))
@@ -66,20 +77,22 @@ impl super::DbRead for &Store {
     }
 
     async fn get_pending_deposit_requests(
-        self,
+        &self,
         chain_tip: &model::BitcoinBlockHash,
         context_window: usize,
     ) -> Result<Vec<model::DepositRequest>, Self::Error> {
+        let store = self.lock().await;
+
         Ok((0..context_window)
             // Find all tracked transaction IDs in the context window
             .scan(chain_tip, |block_hash, _| {
-                let transaction_ids = self
+                let transaction_ids = store
                     .bitcoin_block_to_transactions
                     .get(*block_hash)
                     .cloned()
                     .unwrap_or_else(Vec::new);
 
-                let block = self.bitcoin_blocks.get(*block_hash)?;
+                let block = store.bitcoin_blocks.get(*block_hash)?;
                 *block_hash = &block.parent_hash;
 
                 Some(transaction_ids)
@@ -87,7 +100,8 @@ impl super::DbRead for &Store {
             .flatten()
             // Return all deposit requests associated with any of these transaction IDs
             .flat_map(|txid| {
-                self.deposit_requests
+                store
+                    .deposit_requests
                     .values()
                     .filter(move |req| req.txid == txid)
                     .cloned()
@@ -96,11 +110,13 @@ impl super::DbRead for &Store {
     }
 
     async fn get_deposit_signers(
-        self,
+        &self,
         txid: &model::BitcoinTxId,
         output_index: usize,
     ) -> Result<Vec<model::DepositSigner>, Self::Error> {
         Ok(self
+            .lock()
+            .await
             .deposit_signers
             .get(&(txid.clone(), output_index))
             .cloned()
@@ -108,18 +124,20 @@ impl super::DbRead for &Store {
     }
 
     async fn get_pending_withdraw_requests(
-        self,
+        &self,
         _chain_tip: &model::BitcoinBlockHash,
         _context_window: usize,
     ) -> Result<Vec<model::WithdrawRequest>, Self::Error> {
-        todo!(); // TODO(245): Implement
+       Ok(Vec::new()) // TODO(245): Implement
     }
 
     async fn get_bitcoin_blocks_with_transaction(
-        self,
+        &self,
         txid: &model::BitcoinTxId,
     ) -> Result<Vec<model::BitcoinBlockHash>, Self::Error> {
         Ok(self
+            .lock()
+            .await
             .bitcoin_transactions_to_blocks
             .get(txid)
             .cloned()
@@ -127,21 +145,23 @@ impl super::DbRead for &Store {
     }
 }
 
-impl super::DbWrite for &mut Store {
-    type Error = Error;
+impl super::DbWrite for SharedStore {
+    type Error = std::convert::Infallible;
 
-    async fn write_bitcoin_block(self, block: &model::BitcoinBlock) -> Result<(), Self::Error> {
-        self.bitcoin_blocks
+    async fn write_bitcoin_block(&self, block: &model::BitcoinBlock) -> Result<(), Self::Error> {
+        self.lock()
+            .await
+            .bitcoin_blocks
             .insert(block.block_hash.clone(), block.clone());
 
         Ok(())
     }
 
     async fn write_deposit_request(
-        self,
+        &self,
         deposit_request: &model::DepositRequest,
     ) -> Result<(), Self::Error> {
-        self.deposit_requests.insert(
+        self.lock().await.deposit_requests.insert(
             (deposit_request.txid.clone(), deposit_request.output_index),
             deposit_request.clone(),
         );
@@ -150,17 +170,19 @@ impl super::DbWrite for &mut Store {
     }
 
     async fn write_withdraw_request(
-        self,
+        &self,
         _withdraw_request: &model::WithdrawRequest,
     ) -> Result<(), Self::Error> {
         todo!(); // TODO(245): Implement
     }
 
     async fn write_deposit_signer_decision(
-        self,
+        &self,
         decision: &model::DepositSigner,
     ) -> Result<(), Self::Error> {
-        self.deposit_signers
+        self.lock()
+            .await
+            .deposit_signers
             .entry((decision.txid.clone(), decision.output_index))
             .or_default()
             .push(decision.clone());
@@ -169,148 +191,51 @@ impl super::DbWrite for &mut Store {
     }
 
     async fn write_withdraw_signer_decision(
-        self,
+        &self,
         _decision: &model::WithdrawSigner,
     ) -> Result<(), Self::Error> {
         todo!(); // TODO(245): Implement
     }
 
-    async fn write_transaction(self, _transaction: &model::Transaction) -> Result<(), Self::Error> {
+    async fn write_transaction(
+        &self,
+        _transaction: &model::Transaction,
+    ) -> Result<(), Self::Error> {
         // Currently not needed in-memory since it's not required by any queries
         Ok(())
     }
 
     async fn write_bitcoin_transaction(
-        self,
+        &self,
         bitcoin_transaction: &model::BitcoinTransaction,
     ) -> Result<(), Self::Error> {
-        self.bitcoin_block_to_transactions
+        self.lock()
+            .await
+            .bitcoin_block_to_transactions
             .entry(bitcoin_transaction.block_hash.clone())
             .or_default()
             .push(bitcoin_transaction.txid.clone());
 
-        self.bitcoin_transactions_to_blocks
+        self.lock()
+            .await
+            .bitcoin_transactions_to_blocks
             .entry(bitcoin_transaction.txid.clone())
             .or_default()
             .push(bitcoin_transaction.block_hash.clone());
 
         Ok(())
     }
-}
 
-impl super::DbRead for &SharedStore {
-    type Error = Error;
+    async fn write_stacks_blocks(&self, blocks: &[NakamotoBlock]) -> Result<(), Self::Error> {
+        let iter = blocks.iter().map(|block| async {
+            self.lock()
+                .await
+                .stacks_blocks
+                .insert(block.block_id(), block.clone());
+        });
 
-    async fn get_bitcoin_block(
-        self,
-        block_hash: &model::BitcoinBlockHash,
-    ) -> Result<Option<model::BitcoinBlock>, Self::Error> {
-        self.lock().await.get_bitcoin_block(block_hash).await
-    }
+        let _: Vec<()> = futures::future::join_all(iter).await;
 
-    async fn get_bitcoin_canonical_chain_tip(
-        self,
-    ) -> Result<Option<model::BitcoinBlockHash>, Self::Error> {
-        self.lock().await.get_bitcoin_canonical_chain_tip().await
-    }
-
-    async fn get_pending_deposit_requests(
-        self,
-        chain_tip: &model::BitcoinBlockHash,
-        context_window: usize,
-    ) -> Result<Vec<model::DepositRequest>, Self::Error> {
-        self.lock()
-            .await
-            .get_pending_deposit_requests(chain_tip, context_window)
-            .await
-    }
-
-    async fn get_deposit_signers(
-        self,
-        txid: &model::BitcoinTxId,
-        output_index: usize,
-    ) -> Result<Vec<model::DepositSigner>, Self::Error> {
-        self.lock()
-            .await
-            .get_deposit_signers(txid, output_index)
-            .await
-    }
-
-    async fn get_pending_withdraw_requests(
-        self,
-        _chain_tip: &model::BitcoinBlockHash,
-        _context_window: usize,
-    ) -> Result<Vec<model::WithdrawRequest>, Self::Error> {
-        Ok(Vec::new()) // TODO
-    }
-
-    async fn get_bitcoin_blocks_with_transaction(
-        self,
-        txid: &model::BitcoinTxId,
-    ) -> Result<Vec<model::BitcoinBlockHash>, Self::Error> {
-        self.lock()
-            .await
-            .get_bitcoin_blocks_with_transaction(txid)
-            .await
+        Ok(())
     }
 }
-
-impl super::DbWrite for &SharedStore {
-    type Error = Error;
-
-    async fn write_bitcoin_block(self, block: &model::BitcoinBlock) -> Result<(), Self::Error> {
-        self.lock().await.write_bitcoin_block(block).await
-    }
-
-    async fn write_deposit_request(
-        self,
-        deposit_request: &model::DepositRequest,
-    ) -> Result<(), Self::Error> {
-        self.lock()
-            .await
-            .write_deposit_request(deposit_request)
-            .await
-    }
-
-    async fn write_withdraw_request(
-        self,
-        _withdraw_request: &model::WithdrawRequest,
-    ) -> Result<(), Self::Error> {
-        todo!(); // TODO(245): Implement
-    }
-
-    async fn write_deposit_signer_decision(
-        self,
-        decision: &model::DepositSigner,
-    ) -> Result<(), Self::Error> {
-        self.lock()
-            .await
-            .write_deposit_signer_decision(decision)
-            .await
-    }
-
-    async fn write_withdraw_signer_decision(
-        self,
-        _decision: &model::WithdrawSigner,
-    ) -> Result<(), Self::Error> {
-        todo!(); // TODO(245): Implement
-    }
-
-    async fn write_transaction(self, transaction: &model::Transaction) -> Result<(), Self::Error> {
-        self.lock().await.write_transaction(transaction).await
-    }
-
-    async fn write_bitcoin_transaction(
-        self,
-        bitcoin_transaction: &model::BitcoinTransaction,
-    ) -> Result<(), Self::Error> {
-        self.lock()
-            .await
-            .write_bitcoin_transaction(bitcoin_transaction)
-            .await
-    }
-}
-
-/// In-memory store operations are infallible
-#[derive(Debug, Clone, thiserror::Error)]
-pub enum Error {}

--- a/signer/src/storage/in_memory.rs
+++ b/signer/src/storage/in_memory.rs
@@ -60,10 +60,6 @@ impl super::DbRead for SharedStore {
         Ok(self.lock().await.bitcoin_blocks.get(block_hash).cloned())
     }
 
-    async fn stacks_block_exists(&self, block_id: StacksBlockId) -> Result<bool, Self::Error> {
-        Ok(self.lock().await.stacks_blocks.contains_key(&block_id))
-    }
-
     async fn get_bitcoin_canonical_chain_tip(
         &self,
     ) -> Result<Option<model::BitcoinBlockHash>, Self::Error> {
@@ -141,6 +137,10 @@ impl super::DbRead for SharedStore {
             .get(txid)
             .cloned()
             .unwrap_or_else(Vec::new))
+    }
+
+    async fn stacks_block_exists(&self, block_id: StacksBlockId) -> Result<bool, Self::Error> {
+        Ok(self.lock().await.stacks_blocks.contains_key(&block_id))
     }
 }
 

--- a/signer/src/storage/model.rs
+++ b/signer/src/storage/model.rs
@@ -152,9 +152,10 @@ pub struct Transaction {
 }
 
 /// The types of transactions the signer is interested in.
-#[derive(Debug, Clone, PartialEq, sqlx::Type, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, sqlx::Type, serde::Serialize, serde::Deserialize)]
 #[sqlx(type_name = "sbtc_signer.transaction_type", rename_all = "snake_case")]
 #[cfg_attr(feature = "testing", derive(fake::Dummy))]
+#[serde(rename_all = "snake_case")]
 pub enum TransactionType {
     /// An sBTC transaction on Bitcoin.
     SbtcTransaction,

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -1,6 +1,46 @@
 //! Postgres storage implementation.
 
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+use blockstack_lib::chainstate::nakamoto::NakamotoBlock;
+use blockstack_lib::chainstate::stacks::TransactionPayload;
+use blockstack_lib::codec::StacksMessageCodec;
+use blockstack_lib::types::chainstate::StacksBlockId;
+use blockstack_lib::util::hash::to_hex;
+
+use crate::error::Error;
 use crate::storage::model;
+use crate::storage::model::TransactionType;
+
+const CONTRACT_NAMES: [&str; 4] = [
+    // The name of the Stacks smart contract used for minting sBTC after a
+    // successful transaction moving BTC under the signers' control.
+    "sbtc-deposit",
+    // The name of the Stacks smart contract for recording or registering
+    // successfully completed withdrawal and deposit requests.
+    "sbtc-registry",
+    // The name of the Stacks sBTC smart contract used by the signers for
+    // managing the signer set and the associated keys for a PoX cycle.
+    "sbtc-bootstrap-signers",
+    // The name of the Stacks smart contract used for withdrawing sBTC as
+    // BTC on chain.
+    "sbtc-withdrawal",
+];
+/// TODO: Update once we settle on all of the relevant function names.
+const CONTRACT_FUNCTION_NAMES: [(&str, TransactionType); 1] = [(
+    "initiate-withdrawal-request",
+    TransactionType::WithdrawAccept,
+)];
+
+/// Returns the mapping between functions in a contract call and the
+/// transaction type.
+fn contract_transaction_kinds() -> &'static HashMap<&'static str, TransactionType> {
+    static CONTRACT_FUNCTION_NAME_MAPPING: OnceLock<HashMap<&str, TransactionType>> =
+        OnceLock::new();
+
+    CONTRACT_FUNCTION_NAME_MAPPING.get_or_init(|| CONTRACT_FUNCTION_NAMES.into_iter().collect())
+}
 
 /// A wrapper around a [`sqlx::PgPool`] which implements
 /// [`crate::storage::DbRead`] and [`crate::storage::DbWrite`].
@@ -12,6 +52,111 @@ impl PgStore {
     pub async fn connect(url: &str) -> Result<Self, sqlx::Error> {
         Ok(Self(sqlx::PgPool::connect(url).await?))
     }
+
+    /// Write parts of the Stacks Nakamoto block headers to the database.
+    async fn write_stacks_block_header(&self, blocks: &[NakamotoBlock]) -> Result<(), Error> {
+        let block_summaries: Vec<StacksBlockSummary> = blocks
+            .iter()
+            .map(|block| StacksBlockSummary {
+                block_id: block.block_id().to_hex(),
+                chain_length: block.header.chain_length as i64,
+                parent_block_id: block.header.parent_block_id.to_hex(),
+            })
+            .collect();
+
+        if block_summaries.is_empty() {
+            return Ok(());
+        }
+
+        sqlx::query(
+            r#"
+            INSERT INTO sbtc_signer.stacks_blocks (block_hash, block_height, parent_hash, created_at)
+            SELECT
+                decode(block_id, 'hex')
+              , chain_length
+              , decode(parent_block_id, 'hex')
+              , CURRENT_TIMESTAMP
+            FROM JSONB_TO_RECORDSET($1::JSONB) AS x(
+                block_id        VARCHAR
+              , chain_length    BIGINT
+              , parent_block_id VARCHAR
+            )
+            ON CONFLICT DO NOTHING"#,
+        )
+        .bind(serde_json::to_string(&block_summaries).map_err(Error::JsonSerialize)?)
+        .execute(&self.0)
+        .await
+        .map_err(Error::SqlxQuery)?;
+
+        Ok(())
+    }
+
+    /// Write sBTC related transactions in the given blocks to the
+    /// database.
+    async fn write_stacks_sbtc_txs(&self, blocks: &[NakamotoBlock]) -> Result<(), Error> {
+        let transaction_kinds = contract_transaction_kinds();
+        let block_txs: Vec<StacksTx> = blocks
+            .iter()
+            .flat_map(|block| block.txs.iter().map(|tx| (tx, block.block_id())))
+            .filter_map(|(tx, block_id)| match &tx.payload {
+                TransactionPayload::ContractCall(x)
+                    if CONTRACT_NAMES.contains(&x.contract_name.as_str()) =>
+                {
+                    Some(StacksTx {
+                        tx_type: *transaction_kinds.get(&x.function_name.as_str())?,
+                        txid: tx.txid().to_hex(),
+                        block_id: block_id.to_hex(),
+                        tx: to_hex(&tx.serialize_to_vec()),
+                    })
+                }
+                _ => None,
+            })
+            .collect();
+
+        if block_txs.is_empty() {
+            return Ok(());
+        }
+
+        let block_txs_json = serde_json::to_string(&block_txs).map_err(Error::JsonSerialize)?;
+        sqlx::query(
+            r#"
+            INSERT INTO sbtc_signer.transactions (txid, tx, tx_type, created_at)
+            SELECT
+                decode(txid, 'hex')
+              , decode(tx, 'hex')
+              , tx_type::sbtc_signer.transaction_type
+              , CURRENT_TIMESTAMP
+            FROM JSONB_TO_RECORDSET($1::JSONB) AS x(
+                txid      VARCHAR
+              , tx        VARCHAR
+              , tx_type   VARCHAR
+            )
+            ON CONFLICT DO NOTHING"#,
+        )
+        .bind(&block_txs_json)
+        .execute(&self.0)
+        .await
+        .map_err(Error::SqlxQuery)?;
+
+        sqlx::query(
+            r#"
+            INSERT INTO sbtc_signer.stacks_transactions (txid, block_hash)
+            SELECT
+                decode(txid, 'hex')
+              , decode(block_id, 'hex')
+            FROM JSONB_TO_RECORDSET($1::JSONB) AS x(
+                txid        VARCHAR
+              , block_id    VARCHAR
+            )
+            ON CONFLICT DO NOTHING"#,
+        )
+        .bind(&block_txs_json)
+        .execute(&self.0)
+        .await
+        .map_err(Error::SqlxQuery)?;
+
+        Ok(())
+    }
 }
 
 impl From<sqlx::PgPool> for PgStore {
@@ -20,11 +165,11 @@ impl From<sqlx::PgPool> for PgStore {
     }
 }
 
-impl super::DbRead for &PgStore {
-    type Error = sqlx::Error;
+impl super::DbRead for PgStore {
+    type Error = Error;
 
     async fn get_bitcoin_block(
-        self,
+        &self,
         block_hash: &model::BitcoinBlockHash,
     ) -> Result<Option<model::BitcoinBlock>, Self::Error> {
         sqlx::query_as!(
@@ -34,16 +179,31 @@ impl super::DbRead for &PgStore {
         )
         .fetch_optional(&self.0)
         .await
+        .map_err(Error::SqlxQuery)
+    }
+
+    async fn stacks_block_exists(&self, block_id: StacksBlockId) -> Result<bool, Self::Error> {
+        sqlx::query(
+            r#"
+            SELECT 1
+            FROM sbtc_signer.stacks_blocks
+            WHERE block_hash = $1;"#,
+        )
+        .bind(block_id.0)
+        .fetch_optional(&self.0)
+        .await
+        .map(|row| row.is_some())
+        .map_err(Error::SqlxQuery)
     }
 
     async fn get_bitcoin_canonical_chain_tip(
-        self,
+        &self,
     ) -> Result<Option<model::BitcoinBlockHash>, Self::Error> {
         todo!(); // TODO(244): Write query + integration test
     }
 
     async fn get_pending_deposit_requests(
-        self,
+        &self,
         _chain_tip: &model::BitcoinBlockHash,
         _context_window: usize,
     ) -> Result<Vec<model::DepositRequest>, Self::Error> {
@@ -51,7 +211,7 @@ impl super::DbRead for &PgStore {
     }
 
     async fn get_deposit_signers(
-        self,
+        &self,
         _txid: &model::BitcoinTxId,
         _output_index: usize,
     ) -> Result<Vec<model::DepositSigner>, Self::Error> {
@@ -59,7 +219,7 @@ impl super::DbRead for &PgStore {
     }
 
     async fn get_pending_withdraw_requests(
-        self,
+        &self,
         _chain_tip: &model::BitcoinBlockHash,
         _context_window: usize,
     ) -> Result<Vec<model::WithdrawRequest>, Self::Error> {
@@ -67,17 +227,44 @@ impl super::DbRead for &PgStore {
     }
 
     async fn get_bitcoin_blocks_with_transaction(
-        self,
+        &self,
         _txid: &model::BitcoinTxId,
     ) -> Result<Vec<model::BitcoinBlockHash>, Self::Error> {
         todo!(); // TODO(244): write query + integration test
     }
 }
 
-impl super::DbWrite for &PgStore {
-    type Error = sqlx::Error;
+/// A type used for storing transactions in the stacks_transactions table
+#[derive(Debug, serde::Serialize)]
+struct StacksTx {
+    /// The transaction id for the transaction
+    txid: String,
+    /// The block id for the nakamoto block that this transaction was
+    /// included in.
+    block_id: String,
+    /// The raw transaction binary
+    tx: String,
+    /// The type of sBTC transaction on the stacks blockchain
+    tx_type: TransactionType,
+}
 
-    async fn write_bitcoin_block(self, block: &model::BitcoinBlock) -> Result<(), Self::Error> {
+/// A type used for storing transactions in the stacks_transactions table
+#[derive(Debug, serde::Serialize)]
+struct StacksBlockSummary {
+    /// The block id for the nakamoto block that this transaction was
+    /// included in.
+    block_id: String,
+    /// The height of the block
+    chain_length: i64,
+    /// The block id of the block immediately prior to this one in the
+    /// blockchain.
+    parent_block_id: String,
+}
+
+impl super::DbWrite for PgStore {
+    type Error = Error;
+
+    async fn write_bitcoin_block(&self, block: &model::BitcoinBlock) -> Result<(), Self::Error> {
         sqlx::query!(
             "INSERT INTO sbtc_signer.bitcoin_blocks VALUES ($1, $2, $3, $4, $5)",
             block.block_hash,
@@ -87,13 +274,14 @@ impl super::DbWrite for &PgStore {
             block.created_at
         )
         .execute(&self.0)
-        .await?;
+        .await
+        .map_err(Error::SqlxQuery)?;
 
         Ok(())
     }
 
     async fn write_deposit_request(
-        self,
+        &self,
         deposit_request: &model::DepositRequest,
     ) -> Result<(), Self::Error> {
         sqlx::query!(
@@ -109,48 +297,50 @@ impl super::DbWrite for &PgStore {
             deposit_request.created_at,
         )
         .execute(&self.0)
-        .await?;
+        .await
+        .map_err(Error::SqlxQuery)?;
 
         Ok(())
     }
 
     async fn write_withdraw_request(
-        self,
+        &self,
         _withdraw_request: &model::WithdrawRequest,
     ) -> Result<(), Self::Error> {
         todo!(); // TODO(246): Write query + integration test
     }
 
     async fn write_deposit_signer_decision(
-        self,
+        &self,
         _decision: &model::DepositSigner,
     ) -> Result<(), Self::Error> {
         todo!(); // TODO(244): Write query + integration test
     }
 
     async fn write_withdraw_signer_decision(
-        self,
+        &self,
         _decision: &model::WithdrawSigner,
     ) -> Result<(), Self::Error> {
         todo!(); // TODO(246): Write query + integration test
     }
 
-    async fn write_transaction(self, transaction: &model::Transaction) -> Result<(), Self::Error> {
+    async fn write_transaction(&self, transaction: &model::Transaction) -> Result<(), Self::Error> {
         sqlx::query!(
             "INSERT INTO sbtc_signer.transactions VALUES ($1, $2, $3, $4)",
             transaction.txid,
             transaction.tx,
-            transaction.tx_type.clone() as model::TransactionType,
+            transaction.tx_type as model::TransactionType,
             transaction.created_at,
         )
         .execute(&self.0)
-        .await?;
+        .await
+        .map_err(Error::SqlxQuery)?;
 
         Ok(())
     }
 
     async fn write_bitcoin_transaction(
-        self,
+        &self,
         bitcoin_transaction: &model::BitcoinTransaction,
     ) -> Result<(), Self::Error> {
         sqlx::query!(
@@ -159,8 +349,14 @@ impl super::DbWrite for &PgStore {
             bitcoin_transaction.block_hash,
         )
         .execute(&self.0)
-        .await?;
+        .await
+        .map_err(Error::SqlxQuery)?;
 
         Ok(())
+    }
+
+    async fn write_stacks_blocks(&self, blocks: &[NakamotoBlock]) -> Result<(), Self::Error> {
+        self.write_stacks_block_header(blocks).await?;
+        self.write_stacks_sbtc_txs(blocks).await
     }
 }

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -77,9 +77,9 @@ impl PgStore {
               , decode(parent_block_id, 'hex')
               , CURRENT_TIMESTAMP
             FROM JSONB_TO_RECORDSET($1::JSONB) AS x(
-                block_id        VARCHAR
+                block_id        CHAR(64)
               , chain_length    BIGINT
-              , parent_block_id VARCHAR
+              , parent_block_id CHAR(64)
             )
             ON CONFLICT DO NOTHING"#,
         )
@@ -127,7 +127,7 @@ impl PgStore {
               , tx_type::sbtc_signer.transaction_type
               , CURRENT_TIMESTAMP
             FROM JSONB_TO_RECORDSET($1::JSONB) AS x(
-                txid      VARCHAR
+                txid      CHAR(64)
               , tx        VARCHAR
               , tx_type   VARCHAR
             )
@@ -145,8 +145,8 @@ impl PgStore {
                 decode(txid, 'hex')
               , decode(block_id, 'hex')
             FROM JSONB_TO_RECORDSET($1::JSONB) AS x(
-                txid        VARCHAR
-              , block_id    VARCHAR
+                txid        CHAR(64)
+              , block_id    CHAR(64)
             )
             ON CONFLICT DO NOTHING"#,
         )

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -27,7 +27,7 @@ const CONTRACT_NAMES: [&str; 4] = [
     // BTC on chain.
     "sbtc-withdrawal",
 ];
-/// TODO: Update once we settle on all of the relevant function names.
+/// TODO(250): Update once we settle on all of the relevant function names.
 const CONTRACT_FUNCTION_NAMES: [(&str, TransactionType); 1] = [(
     "initiate-withdrawal-request",
     TransactionType::WithdrawAccept,

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -182,20 +182,6 @@ impl super::DbRead for PgStore {
         .map_err(Error::SqlxQuery)
     }
 
-    async fn stacks_block_exists(&self, block_id: StacksBlockId) -> Result<bool, Self::Error> {
-        sqlx::query(
-            r#"
-            SELECT 1
-            FROM sbtc_signer.stacks_blocks
-            WHERE block_hash = $1;"#,
-        )
-        .bind(block_id.0)
-        .fetch_optional(&self.0)
-        .await
-        .map(|row| row.is_some())
-        .map_err(Error::SqlxQuery)
-    }
-
     async fn get_bitcoin_canonical_chain_tip(
         &self,
     ) -> Result<Option<model::BitcoinBlockHash>, Self::Error> {
@@ -231,6 +217,20 @@ impl super::DbRead for PgStore {
         _txid: &model::BitcoinTxId,
     ) -> Result<Vec<model::BitcoinBlockHash>, Self::Error> {
         todo!(); // TODO(244): write query + integration test
+    }
+
+    async fn stacks_block_exists(&self, block_id: StacksBlockId) -> Result<bool, Self::Error> {
+        sqlx::query(
+            r#"
+            SELECT 1
+            FROM sbtc_signer.stacks_blocks
+            WHERE block_hash = $1;"#,
+        )
+            .bind(block_id.0)
+            .fetch_optional(&self.0)
+            .await
+            .map(|row| row.is_some())
+            .map_err(Error::SqlxQuery)
     }
 }
 
@@ -329,7 +329,7 @@ impl super::DbWrite for PgStore {
             "INSERT INTO sbtc_signer.transactions VALUES ($1, $2, $3, $4)",
             transaction.txid,
             transaction.tx,
-            transaction.tx_type as model::TransactionType,
+            transaction.tx_type as TransactionType,
             transaction.created_at,
         )
         .execute(&self.0)

--- a/signer/src/testing/storage/model.rs
+++ b/signer/src/testing/storage/model.rs
@@ -60,7 +60,7 @@ impl TestData {
     /// Write the test data to the given store
     pub async fn write_to<Db>(&self, storage: &mut Db)
     where
-        for<'a> &'a mut Db: DbWrite,
+        Db: DbWrite,
     {
         for block in self.bitcoin_blocks.iter() {
             storage

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -11,9 +11,6 @@ use crate::network;
 use crate::storage;
 use crate::storage::model;
 
-use crate::storage::DbRead;
-use crate::storage::DbWrite;
-
 use futures::StreamExt;
 
 #[cfg_attr(doc, aquamarine::aquamarine)]
@@ -95,11 +92,9 @@ impl<N, S, B> TxSignerEventLoop<N, S, B>
 where
     N: network::MessageTransfer,
     B: blocklist_client::BlocklistChecker,
-    for<'a> &'a mut S: storage::DbRead + storage::DbWrite,
-    for<'a> <&'a mut S as storage::DbRead>::Error: std::error::Error,
-    for<'a> <&'a mut S as storage::DbWrite>::Error: std::error::Error,
-    for<'a> error::Error: From<<&'a mut S as storage::DbRead>::Error>,
-    for<'a> error::Error: From<<&'a mut S as storage::DbWrite>::Error>,
+    S: storage::DbRead + storage::DbWrite,
+    error::Error: From<<S as storage::DbRead>::Error>,
+    error::Error: From<<S as storage::DbWrite>::Error>,
 {
     /// Run the signer event loop
     #[tracing::instrument(skip(self))]
@@ -266,6 +261,8 @@ mod tests {
     use crate::storage;
     use crate::testing;
     use rand::SeedableRng;
+
+    use crate::storage::DbRead;
 
     #[tokio::test]
     async fn should_store_decisions_for_pending_deposit_requests() {

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -1,6 +1,17 @@
-use signer::storage::DbRead;
+use std::io::Read;
 
+use blockstack_lib::chainstate::nakamoto::NakamotoBlock;
+use blockstack_lib::chainstate::stacks::TransactionContractCall;
+use blockstack_lib::chainstate::stacks::TransactionPayload;
+use blockstack_lib::clarity::vm::ClarityName;
+use blockstack_lib::clarity::vm::ContractName;
+use blockstack_lib::codec::StacksMessageCodec;
+use blockstack_lib::types::chainstate::StacksAddress;
+use blockstack_lib::util::hash::Hash160;
+use futures::StreamExt;
 use signer::storage::postgres::*;
+use signer::storage::DbRead;
+use signer::storage::DbWrite;
 use signer::testing;
 
 use rand::SeedableRng;
@@ -43,4 +54,105 @@ async fn should_be_able_to_query_bitcoin_blocks(pool: sqlx::PgPool) {
             .expect("failed_to_execute_query");
         assert!(result.is_none());
     }
+}
+
+/// Test that the write_stacks_blocks function does what it is supposed to
+/// do, which is save all stacks blocks and save the transactions that we
+/// care about, which, naturally, are sBTC related transactions.
+#[cfg_attr(not(feature = "integration-tests"), ignore)]
+#[sqlx::test]
+async fn writing_stacks_blocks_works(pool: sqlx::PgPool) {
+    let store = PgStore::from(pool.clone());
+
+    let path = "tests/fixtures/tenure-blocks-0-1ed91e0720129bda5072540ee7283dd5345d0f6de0cf5b982c6de3943b6e3291.bin";
+    let mut file = std::fs::File::open(path).unwrap();
+    let mut buf = Vec::new();
+    file.read_to_end(&mut buf).unwrap();
+
+    let bytes: &mut &[u8] = &mut buf.as_ref();
+    let mut blocks = Vec::new();
+
+    while !bytes.is_empty() {
+        blocks.push(NakamotoBlock::consensus_deserialize(bytes).unwrap());
+    }
+
+    // Now we add a transaction of a type that we care about into one of
+    // the blocks. The other transactions in this block are tenure changes,
+    // coinbase transactions, or regular transfer transactions.
+    let last_block = blocks.last_mut().unwrap();
+    let mut tx = last_block.txs.last().unwrap().clone();
+
+    let contract_call = TransactionContractCall {
+        address: StacksAddress::new(2, Hash160([0u8; 20])),
+        contract_name: ContractName::from("sbtc-withdrawal"),
+        function_name: ClarityName::from("initiate-withdrawal-request"),
+        function_args: Vec::new(),
+    };
+    tx.payload = TransactionPayload::ContractCall(contract_call);
+    last_block.txs.push(tx);
+
+    // Okay now to save these blocks. We check that all of these blocks are
+    // saved and that the transaction that we care about is saved as well.
+    store.write_stacks_blocks(&blocks).await.unwrap();
+
+    // First check that all blocks are saved
+    let sql = "SELECT COUNT(*) FROM sbtc_signer.stacks_blocks";
+    let stored_block_count = sqlx::query_scalar::<_, i64>(sql)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+    assert_eq!(stored_block_count, blocks.len() as i64);
+
+    // Next we check that the one transaction that we care about, the one
+    // we just created above, was saved.
+    let sql = "SELECT COUNT(*) FROM sbtc_signer.stacks_transactions";
+    let stored_transaction_count = sqlx::query_scalar::<_, i64>(sql)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+    assert_eq!(stored_transaction_count, 1);
+
+    // Last we have a sanity check that there are more transactions that we
+    // could have saved if we saved all transactions.
+    let num_transactions = blocks.iter().map(|blk| blk.txs.len()).sum::<usize>();
+    more_asserts::assert_gt!(num_transactions, 1);
+}
+
+/// Here we test that the DbRead::stacks_block_exists function works, while
+/// implicitly testing the DbWrite::write_stacks_blocks function for the
+/// PgStore type
+#[cfg_attr(not(feature = "integration-tests"), ignore)]
+#[sqlx::test]
+async fn checking_stacks_blocks_exists_works(pool: sqlx::PgPool) {
+    let store = PgStore::from(pool);
+
+    let path = "tests/fixtures/tenure-blocks-0-1ed91e0720129bda5072540ee7283dd5345d0f6de0cf5b982c6de3943b6e3291.bin";
+    let mut file = std::fs::File::open(path).unwrap();
+    let mut buf = Vec::new();
+    file.read_to_end(&mut buf).unwrap();
+
+    let bytes: &mut &[u8] = &mut buf.as_ref();
+    let mut blocks = Vec::new();
+
+    while !bytes.is_empty() {
+        blocks.push(NakamotoBlock::consensus_deserialize(bytes).unwrap());
+    }
+
+    // Okay this table is empty and so none of the blocks have not have
+    // been saved yet.
+    let any_exist = futures::stream::iter(blocks.iter())
+        .any(|block| async { store.stacks_block_exists(block.block_id()).await.unwrap() })
+        .await;
+    assert!(!any_exist);
+
+    // Okay now to save these blocks.
+    store.write_stacks_blocks(&blocks).await.unwrap();
+
+    // Now each of them should exist.
+    let all_exist = futures::stream::iter(blocks.iter())
+        .all(|block| async { store.stacks_block_exists(block.block_id()).await.unwrap() })
+        .await;
+    assert!(all_exist);
 }

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -57,7 +57,7 @@ async fn should_be_able_to_query_bitcoin_blocks(pool: sqlx::PgPool) {
 }
 
 /// Test that the write_stacks_blocks function does what it is supposed to
-/// do, which is save all stacks blocks and save the transactions that we
+/// do, which is store all stacks blocks and store the transactions that we
 /// care about, which, naturally, are sBTC related transactions.
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[sqlx::test]
@@ -139,7 +139,7 @@ async fn writing_stacks_blocks_works(pool: sqlx::PgPool) {
         .await
         .unwrap();
 
-    // No more transactions we written
+    // No more transactions were written
     assert_eq!(stored_transaction_count_again, 1);
 }
 
@@ -163,7 +163,7 @@ async fn checking_stacks_blocks_exists_works(pool: sqlx::PgPool) {
         blocks.push(NakamotoBlock::consensus_deserialize(bytes).unwrap());
     }
 
-    // Okay this table is empty and so none of the blocks have not have
+    // Okay, this table is empty and so none of the blocks have
     // been saved yet.
     let any_exist = futures::stream::iter(blocks.iter())
         .any(|block| async { store.stacks_block_exists(block.block_id()).await.unwrap() })


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/212.

We need to persist stacks block headers and sBTC related Stacks transactions to the database. This PR includes functions for writing such data given a Nakamoto stacks block.


## Changes
1. Rework the `DbRead` and `DbWrite` traits to be a little simpler by only taking a reference to `self` in the functions that need implementing. Although taking `self` allows for more flexibility, we don't actually need or use it, so this change allows for some simplification.
2. Only implement the above traits for the `SharedStore` and the `PgStore`.
3. Add a function for checking for the existence of a stacks block in the database.
4. Add a function for writing stacks blocks -- both the header and the transactions -- to the database.

### Notes

* I'm pretty sure the actual sBTC contracts will have different names than the ones in this PR.
* I've punted on figuring out which contract call functions to track. It's captured by https://github.com/stacks-network/sbtc/issues/250.



## Testing information
There are new two integration tests. Together they check the following
1. That we write the stacks block headers to the database.
2. That we write sBTC related transactions to the database.
3. That storing stacks blocks and stacks transactions are idempotent operations.
4. The function that checks whether we've stored a given Stacks block ID works.