### PR TITLE
feat: support backfilling the stacks blockchain

### DIFF
--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -153,7 +153,7 @@ where
         let block_id = StacksBlockId::first_mined();
         let stacks_blocks = self
             .stacks_client
-            .fetch_unknown_ansestors(block_id, &self.storage)
+            .fetch_unknown_ancestors(block_id, &self.storage)
             .await?;
 
         self.extract_deposit_requests(&block.txdata);
@@ -385,7 +385,7 @@ mod tests {
     }
 
     impl StacksInteract for TestHarness {
-        async fn fetch_unknown_ansestors<D>(
+        async fn fetch_unknown_ancestors<D>(
             &self,
             _: blockstack_lib::types::chainstate::StacksBlockId,
             _: &D,

--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -20,7 +20,7 @@
 use std::collections::HashMap;
 
 use crate::error;
-use crate::stacks_api::fetch_unknown_ancestors;
+use crate::stacks_api;
 use crate::stacks_api::StacksInteract;
 use crate::storage;
 
@@ -151,8 +151,12 @@ where
         block: bitcoin::Block,
     ) -> Result<(), error::Error> {
         let info = self.stacks_client.get_tenure_info().await?;
-        let stacks_blocks =
-            fetch_unknown_ancestors(&self.stacks_client, &self.storage, info.tip_block_id).await?;
+        let stacks_blocks = stacks_api::fetch_unknown_ancestors(
+            &self.stacks_client,
+            &self.storage,
+            info.tip_block_id,
+        )
+        .await?;
 
         self.extract_deposit_requests(&block.txdata);
         self.extract_sbtc_transactions(&block.txdata);

--- a/signer/src/config.rs
+++ b/signer/src/config.rs
@@ -108,6 +108,9 @@ pub struct StacksNodeSettings {
     /// The endpoint to use when making requests to a stacks node.
     #[serde(deserialize_with = "url_deserializer")]
     pub endpoint: url::Url,
+    /// This is the start height of the first EPOCH 3.0 block on the stacks
+    /// blockchain.
+    pub nakamoto_start_height: u64,
 }
 
 impl StacksSettings {

--- a/signer/src/config/default.toml
+++ b/signer/src/config/default.toml
@@ -14,3 +14,6 @@ endpoint = "http://localhost:3999"
 
 [stacks.node]
 endpoint = "http://localhost:20443"
+# This is the start height of the first EPOCH 3.0 block on the stacks
+# blockchain.
+nakamoto_start_height = 31


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/242.

We need functions for filling in Stacks Nakamoto blocks in case we missed some. This PR adds such functionality.


## Changes
1. Redo the `StacksInteract` trait to support fetching "unknown" ancestors.
2. Add a basic integration test that work with nakamoto is running. Since we do not have nakamoto running in CI, this test is ignored.

### Notes

1. The new `StacksInteract::fetch_unknown_ancestors` API feels kludgy, but I'm not sure how to make it not-so.
2. The implementation of the `fetch_unknown_ancestors` function fetches blocks by tenure, which may include many more blocks than is necessary to get only "unknown" blocks. If this is a problem, it's very easy to change the function to fetch things block by block.
3. The implementation of the `fetch_unknown_ancestors` function stops fetching Stacks blocks at a height that is set in the `config.toml`. This height refers to a Stacks block height instead of bitcoin block height. This feels off, since other 'heights' variables in stacks-core's `config.toml` refer to bitcoin block heights.
4. The height referred to in (3) seems necessary since I could not figure out any other way to prevent us from attempting to fetch non-Nakamoto blocks.

## Testing information

The "integration-test" is very basic, but it tests the new function. I successfully ran the test by running Nakamoto locally.