### PR TITLE
feat: support sBTC mint transactions

### DIFF
--- a/signer/src/stacks/contracts.rs
+++ b/signer/src/stacks/contracts.rs
@@ -2,9 +2,9 @@
 //! sBTC contract calls.
 //! 
 //! Contains structs for the following contract calls:
-//! * Calling the complete-deposit-wrapper function in the sbtc-deposit
-//!   contract. This finalizes the deposit by minting sBTC and sending it
-//!   to the depositor.
+//! * [`CompleteDepositV1`]: Used for calling the complete-deposit-wrapper
+//!   function in the sbtc-deposit contract. This finalizes the deposit by
+//!   minting sBTC and sending it to the depositor.
 
 use bitcoin::hashes::Hash as _;
 use bitcoin::OutPoint;

--- a/signer/src/stacks/contracts.rs
+++ b/signer/src/stacks/contracts.rs
@@ -48,7 +48,8 @@ pub trait AsContractCall {
 }
 
 /// This struct is used to generate a properly formatted Stacks transaction
-/// for the complete-deposit-wrapper contract call.
+/// for calling the complete-deposit-wrapper function in the sbtc-deposit
+/// smart contract.
 #[derive(Copy, Clone, Debug)]
 pub struct CompleteDepositV1 {
     /// The outpoint of the bitcoin UTXO that was spent as a deposit for

--- a/signer/src/stacks/contracts.rs
+++ b/signer/src/stacks/contracts.rs
@@ -1,6 +1,6 @@
 //! This module contains functionality for creating stacks transactions for
 //! sBTC contract calls.
-//! 
+//!
 //! Contains structs for the following contract calls:
 //! * [`CompleteDepositV1`]: Used for calling the complete-deposit-wrapper
 //!   function in the sbtc-deposit contract. This finalizes the deposit by
@@ -122,7 +122,7 @@ mod tests {
         let call = CompleteDepositV1 {
             outpoint: OutPoint::null(),
             amount: 15000,
-            recipient: StacksAddress::burn_address(true)
+            recipient: StacksAddress::burn_address(true),
         };
 
         let _ = call.as_contract_call(StacksAddress::burn_address(false));

--- a/signer/src/stacks/contracts.rs
+++ b/signer/src/stacks/contracts.rs
@@ -1,5 +1,10 @@
 //! This module contains functionality for creating stacks transactions for
 //! sBTC contract calls.
+//! 
+//! Contains structs for the following contract calls:
+//! * Calling the complete-deposit-wrapper function in the sbtc-deposit
+//!   contract. This finalizes the deposit by minting sBTC and sending it
+//!   to the depositor.
 
 use bitcoin::hashes::Hash as _;
 use bitcoin::OutPoint;

--- a/signer/src/stacks/contracts.rs
+++ b/signer/src/stacks/contracts.rs
@@ -1,9 +1,18 @@
 //! This module contains functionality for creating stacks transactions for
 //! sBTC contract calls.
 
+use bitcoin::hashes::Hash as _;
+use bitcoin::OutPoint;
 use blockstack_lib::chainstate::stacks::TransactionContractCall;
 use blockstack_lib::chainstate::stacks::TransactionPostCondition;
 use blockstack_lib::chainstate::stacks::TransactionPostConditionMode;
+use blockstack_lib::clarity::vm::types::BuffData;
+use blockstack_lib::clarity::vm::types::PrincipalData;
+use blockstack_lib::clarity::vm::types::SequenceData;
+use blockstack_lib::clarity::vm::types::StandardPrincipalData;
+use blockstack_lib::clarity::vm::ClarityName;
+use blockstack_lib::clarity::vm::ContractName;
+use blockstack_lib::clarity::vm::Value;
 use blockstack_lib::types::chainstate::StacksAddress;
 
 /// A struct describing any transaction post-execution conditions that we'd
@@ -38,5 +47,78 @@ pub trait AsContractCall {
     fn post_conditions(&self, deployer: StacksAddress) -> StacksTxPostConditions;
 }
 
+/// This struct is used to generate a properly formatted Stacks transaction
+/// for the complete-deposit-wrapper contract call.
+#[derive(Copy, Clone, Debug)]
+pub struct CompleteDepositV1 {
+    /// The outpoint of the bitcoin UTXO that was spent as a deposit for
+    /// sBTC.
+    pub outpoint: OutPoint,
+    /// The amount of sats associated with the above UTXO.
+    pub amount: u64,
+    /// The address where the newly minted sBTC will be deposited.
+    pub recipient: StacksAddress,
+}
+
+impl CompleteDepositV1 {
+    const CONTRACT_NAME: &'static str = "sbtc-deposit";
+    const FUNCTION_NAME: &'static str = "complete-deposit-wrapper";
+
+    /// Construct the input arguments to the complete-deposit-wrapper
+    /// contract call.
+    fn as_contract_args(&self) -> Vec<Value> {
+        let txid_data = self.outpoint.txid.to_byte_array().to_vec();
+        let txid = BuffData { data: txid_data };
+        let principle = StandardPrincipalData::from(self.recipient);
+
+        vec![
+            Value::Sequence(SequenceData::Buffer(txid)),
+            Value::UInt(self.outpoint.vout as u128),
+            Value::UInt(self.amount as u128),
+            Value::Principal(PrincipalData::Standard(principle)),
+        ]
+    }
+}
+
+impl AsContractCall for CompleteDepositV1 {
+    /// Converts this struct to a Stacks Contract call
+    fn as_contract_call(&self, deployer: StacksAddress) -> TransactionContractCall {
+        TransactionContractCall {
+            address: deployer,
+            // The following From::from calls are more dangerous than they
+            // appear. Under the hood they call their TryFrom::try_from
+            // implementation and then unwrap them(!). We check that this
+            // is fine in our test.
+            function_name: ClarityName::from(CompleteDepositV1::FUNCTION_NAME),
+            contract_name: ContractName::from(CompleteDepositV1::CONTRACT_NAME),
+            function_args: self.as_contract_args(),
+        }
+    }
+
+    /// The post conditions for the transaction. We do not enforce any
+    /// conditions here, since we trust this contract (we deployed it).
+    fn post_conditions(&self, _: StacksAddress) -> StacksTxPostConditions {
+        StacksTxPostConditions {
+            post_condition_mode: TransactionPostConditionMode::Allow,
+            post_conditions: Vec::new(),
+        }
+    }
+}
+
 #[cfg(test)]
-mod tests {}
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deposit_contract_call_creation() {
+        // This is to check that this function doesn't implicitly panic. If
+        // it doesn't panic now, it can never panic at runtime.
+        let call = CompleteDepositV1 {
+            outpoint: OutPoint::null(),
+            amount: 15000,
+            recipient: StacksAddress::burn_address(true)
+        };
+
+        let _ = call.as_contract_call(StacksAddress::burn_address(false));
+    }
+}

--- a/signer/tests/integration/contracts.rs
+++ b/signer/tests/integration/contracts.rs
@@ -1,0 +1,5 @@
+#[ignore]
+#[tokio::test]
+async fn complete_deposit_wrapper_tx_accepted() {
+    // TODO(#264): Add integration test for signing Stacks smart contracts
+}

--- a/signer/tests/integration/main.rs
+++ b/signer/tests/integration/main.rs
@@ -1,4 +1,5 @@
 mod block_notifier;
+mod contracts;
 mod postgres;
 mod rbf;
 pub mod regtest;


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/230.

We need to make it possible to make the contract call that mints sBTC. This PR adds structs that simplify construction of a stacks transaction that calls the `complete-deposit-wrapper` function from our `sbtc-deposit.clar` contract.

## Changes

1. Add a struct that implements the `AsContractCall` trait that allows us to easily make the `complete-deposit-wrapper` contract call.



## Testing information

We add a test that checks that we do not panic when creating the `TransactionContractCall`. If this test fails, then we know that we have a typo in the contract or function names.


Note: I've been feeling conflicted about using `expect` and `unwrap` in the code base. In this case, there is an implicit `unwrap` but I add a test that ensures that we cannot panic at runtime. At the same time, I'm (probably) okay with a hard rule like "no `.expect()` or `.unwrap()`" in the code base. I'm more or less okay with balance that we currently have but I'm curious about what others think.