### PR TITLE
272 feature add withdrawal and chainstate endpoints

### DIFF
--- a/.generated-sources/emily/openapi/build.rs
+++ b/.generated-sources/emily/openapi/build.rs
@@ -16,12 +16,18 @@ use utoipa::OpenApi;
         api::handlers::deposit::get_deposits,
         api::handlers::deposit::create_deposit,
         api::handlers::deposit::update_deposits,
-        // TODO: https://github.com/stacks-network/sbtc/issues/272
-        // Add withdrawal and chainstate endpoints.
+        // Withdrawal endpoints.
+        api::handlers::withdrawal::get_withdrawal,
+        api::handlers::withdrawal::get_withdrawals,
+        api::handlers::withdrawal::create_withdrawal,
+        api::handlers::withdrawal::update_withdrawals,
+        // Chainstate endpoints.
+        api::handlers::chainstate::get_chainstate,
+        api::handlers::chainstate::set_chainstate,
+        api::handlers::chainstate::update_chainstate,
     ),
     components(schemas(
-        // TODO: https://github.com/stacks-network/sbtc/issues/271
-        // Add request and response schemas.
+        // TODO(271): Add request and response schemas.
 
         // Health check datatypes.
         api::models::responses::health::HealthData,
@@ -34,15 +40,13 @@ struct ApiDoc;
 fn main() {
 
     // Ensure that we rerun if the API changes or the build script changes.
-    println!("cargo:rerun-if-changed=../../../emily/handler/common/mod.rs");
-    println!("cargo:rerun-if-changed=../../../emily/handler/common/handlers.rs");
+    println!("cargo:rerun-if-changed=../../../emily/handler/api/handlers");
     println!("cargo:rerun-if-changed=build.rs");
 
     let mut api_doc = ApiDoc::openapi();
     let new_extensions: HashMap<String, serde_json::Value> = new_operation_extensions();
 
-    // TODO: https://github.com/stacks-network/sbtc/issues/269
-    // Change Emily API Lambda Integrations to use cdk constructs if possible instead of specification
+    // TODO(269): Change Emily API Lambda Integrations to use cdk constructs if possible instead of specification
     // alteration.
     //
     // Add AWS extension to openapi specification so AWS CDK can attach the appropriate lambda endpoint.

--- a/.generated-sources/emily/openapi/emily-openapi-spec.json
+++ b/.generated-sources/emily/openapi/emily-openapi-spec.json
@@ -9,6 +9,131 @@
     "version": "0.1.0"
   },
   "paths": {
+    "/chainstate": {
+      "post": {
+        "tags": [
+          "chainstate"
+        ],
+        "summary": "Set chainstate handler.",
+        "operationId": "setChainstate",
+        "responses": {
+          "201": {
+            "description": "Chainstate updated successfully",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body"
+          },
+          "404": {
+            "description": "Address not found"
+          },
+          "405": {
+            "description": "Method not allowed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "x-amazon-apigateway-integration": {
+          "httpMethod": "POST",
+          "type": "aws_proxy",
+          "uri": {
+            "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${OperationLambda}/invocations"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "chainstate"
+        ],
+        "summary": "Update chainstate handler.",
+        "operationId": "updateChainstate",
+        "responses": {
+          "201": {
+            "description": "Chainstate updated successfully",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body"
+          },
+          "404": {
+            "description": "Address not found"
+          },
+          "405": {
+            "description": "Method not allowed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "x-amazon-apigateway-integration": {
+          "httpMethod": "POST",
+          "type": "aws_proxy",
+          "uri": {
+            "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${OperationLambda}/invocations"
+          }
+        }
+      }
+    },
+    "/chainstate/{height}": {
+      "get": {
+        "tags": [
+          "chainstate"
+        ],
+        "summary": "Get chainstate handler.",
+        "operationId": "getChainstate",
+        "parameters": [
+          {
+            "name": "height",
+            "in": "path",
+            "description": "Height of the blockchain data to receive.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Chainstate retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body"
+          },
+          "404": {
+            "description": "Address not found"
+          },
+          "405": {
+            "description": "Method not allowed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "x-amazon-apigateway-integration": {
+          "httpMethod": "POST",
+          "type": "aws_proxy",
+          "uri": {
+            "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${OperationLambda}/invocations"
+          }
+        }
+      }
+    },
     "/deposit": {
       "get": {
         "tags": [
@@ -241,6 +366,165 @@
                 "schema": {
                   "$ref": "#/components/schemas/HealthData"
                 }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body"
+          },
+          "404": {
+            "description": "Address not found"
+          },
+          "405": {
+            "description": "Method not allowed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "x-amazon-apigateway-integration": {
+          "httpMethod": "POST",
+          "type": "aws_proxy",
+          "uri": {
+            "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${OperationLambda}/invocations"
+          }
+        }
+      }
+    },
+    "/withdrawal": {
+      "get": {
+        "tags": [
+          "withdrawal"
+        ],
+        "summary": "Get withdrawals handler.",
+        "operationId": "getWithdrawals",
+        "responses": {
+          "200": {
+            "description": "Withdrawals retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body"
+          },
+          "404": {
+            "description": "Address not found"
+          },
+          "405": {
+            "description": "Method not allowed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "x-amazon-apigateway-integration": {
+          "httpMethod": "POST",
+          "type": "aws_proxy",
+          "uri": {
+            "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${OperationLambda}/invocations"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "withdrawal"
+        ],
+        "summary": "Create withdrawal handler.",
+        "operationId": "createWithdrawal",
+        "responses": {
+          "201": {
+            "description": "Withdrawals updated successfully",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body"
+          },
+          "404": {
+            "description": "Address not found"
+          },
+          "405": {
+            "description": "Method not allowed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "x-amazon-apigateway-integration": {
+          "httpMethod": "POST",
+          "type": "aws_proxy",
+          "uri": {
+            "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${OperationLambda}/invocations"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "withdrawal"
+        ],
+        "summary": "Update withdrawals handler.",
+        "operationId": "updateWithdrawals",
+        "responses": {
+          "201": {
+            "description": "Withdrawals updated successfully",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body"
+          },
+          "404": {
+            "description": "Address not found"
+          },
+          "405": {
+            "description": "Method not allowed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "x-amazon-apigateway-integration": {
+          "httpMethod": "POST",
+          "type": "aws_proxy",
+          "uri": {
+            "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${OperationLambda}/invocations"
+          }
+        }
+      }
+    },
+    "/withdrawal/{id}": {
+      "get": {
+        "tags": [
+          "withdrawal"
+        ],
+        "summary": "Get withdrawal handler.",
+        "operationId": "getWithdrawal",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "id associated with the Withdrawal",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Withdrawal retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {}
               }
             }
           },

--- a/.generated-sources/emily/openapi/emily-openapi-spec.json
+++ b/.generated-sources/emily/openapi/emily-openapi-spec.json
@@ -142,7 +142,7 @@
         "summary": "Get deposits handler.",
         "operationId": "getDeposits",
         "responses": {
-          "201": {
+          "200": {
             "description": "Deposits retrieved successfully",
             "content": {
               "application/json": {
@@ -263,7 +263,7 @@
           }
         ],
         "responses": {
-          "201": {
+          "200": {
             "description": "Deposits retrieved successfully",
             "content": {
               "application/json": {
@@ -321,7 +321,7 @@
           }
         ],
         "responses": {
-          "201": {
+          "200": {
             "description": "Deposit retrieved successfully",
             "content": {
               "application/json": {

--- a/emily/handler/src/api/handlers/chainstate.rs
+++ b/emily/handler/src/api/handlers/chainstate.rs
@@ -1,0 +1,73 @@
+//! Handlers for chainstate endpoints.
+
+use crate::common::error::Error;
+use warp::filters::path::FullPath;
+
+/// Get chainstate handler.
+#[utoipa::path(
+    get,
+    operation_id = "getChainstate",
+    path = "/chainstate/{height}",
+    params(
+        ("height" = u64, Path, description = "Height of the blockchain data to receive."),
+    ),
+    tag = "chainstate",
+    responses(
+        // TODO(271): Add success body.
+        (status = 200, description = "Chainstate retrieved successfully", body = serde_json::Value),
+        (status = 400, description = "Invalid request body"),
+        (status = 404, description = "Address not found"),
+        (status = 405, description = "Method not allowed"),
+        (status = 500, description = "Internal server error")
+    )
+)]
+pub fn get_chainstate(
+    _height: u64,
+    path: FullPath,
+) -> impl warp::reply::Reply {
+    Error::NotImplemented(path)
+}
+
+/// Set chainstate handler.
+#[utoipa::path(
+    post,
+    operation_id = "setChainstate",
+    path = "/chainstate",
+    tag = "chainstate",
+    responses(
+        // TODO(271): Add success body.
+        (status = 201, description = "Chainstate updated successfully", body = serde_json::Value),
+        (status = 400, description = "Invalid request body"),
+        (status = 404, description = "Address not found"),
+        (status = 405, description = "Method not allowed"),
+        (status = 500, description = "Internal server error")
+    )
+)]
+pub fn set_chainstate(
+    _request: serde_json::Value,
+    path: FullPath,
+) -> impl warp::reply::Reply {
+    Error::NotImplemented(path)
+}
+
+/// Update chainstate handler.
+#[utoipa::path(
+    put,
+    operation_id = "updateChainstate",
+    path = "/chainstate",
+    tag = "chainstate",
+    responses(
+        // TODO(271): Add success body.
+        (status = 201, description = "Chainstate updated successfully", body = serde_json::Value),
+        (status = 400, description = "Invalid request body"),
+        (status = 404, description = "Address not found"),
+        (status = 405, description = "Method not allowed"),
+        (status = 500, description = "Internal server error")
+    )
+)]
+pub fn update_chainstate(
+    _request: serde_json::Value,
+    path: FullPath,
+) -> impl warp::reply::Reply {
+    Error::NotImplemented(path)
+}

--- a/emily/handler/src/api/handlers/deposit.rs
+++ b/emily/handler/src/api/handlers/deposit.rs
@@ -16,7 +16,7 @@ use super::models;
     tag = "deposit",
     responses(
         // TODO(271): Add success body.
-        (status = 201, description = "Deposit retrieved successfully", body = serde_json::Value),
+        (status = 200, description = "Deposit retrieved successfully", body = serde_json::Value),
         (status = 400, description = "Invalid request body"),
         (status = 404, description = "Address not found"),
         (status = 405, description = "Method not allowed"),
@@ -42,7 +42,7 @@ pub fn get_deposit(
     tag = "deposit",
     responses(
         // TODO(271): Add success body.
-        (status = 201, description = "Deposits retrieved successfully", body = serde_json::Value),
+        (status = 200, description = "Deposits retrieved successfully", body = serde_json::Value),
         (status = 400, description = "Invalid request body"),
         (status = 404, description = "Address not found"),
         (status = 405, description = "Method not allowed"),
@@ -65,7 +65,7 @@ pub fn get_deposits_for_transaction(
     tag = "deposit",
     responses(
         // TODO(271): Add success body.
-        (status = 201, description = "Deposits retrieved successfully", body = serde_json::Value),
+        (status = 200, description = "Deposits retrieved successfully", body = serde_json::Value),
         (status = 400, description = "Invalid request body"),
         (status = 404, description = "Address not found"),
         (status = 405, description = "Method not allowed"),

--- a/emily/handler/src/api/handlers/mod.rs
+++ b/emily/handler/src/api/handlers/mod.rs
@@ -7,10 +7,14 @@ use std::convert::Infallible;
 use tracing::error;
 use warp::{http::StatusCode, Rejection, Reply};
 
+/// Chainstate handlers.
+pub mod chainstate;
 /// Deposit handlers.
 pub mod deposit;
 /// Health handlers.
 pub mod health;
+/// Withdrawal handlers.
+pub mod withdrawal;
 
 /// Central error handler for Warp rejections, converting them to appropriate HTTP responses.
 /// TODO(131): Alter handler for Emily API.

--- a/emily/handler/src/api/handlers/withdrawal.rs
+++ b/emily/handler/src/api/handlers/withdrawal.rs
@@ -1,0 +1,96 @@
+//! Handlers for withdrawal endpoints.
+
+use crate::common::error::Error;
+use warp::filters::path::FullPath;
+use super::models;
+
+/// Get withdrawal handler.
+#[utoipa::path(
+    get,
+    operation_id = "getWithdrawal",
+    path = "/withdrawal/{id}",
+    params(
+        ("id" = String, Path, description = "id associated with the Withdrawal"),
+    ),
+    tag = "withdrawal",
+    responses(
+        // TODO(271): Add success body.
+        (status = 200, description = "Withdrawal retrieved successfully", body = serde_json::Value),
+        (status = 400, description = "Invalid request body"),
+        (status = 404, description = "Address not found"),
+        (status = 405, description = "Method not allowed"),
+        (status = 500, description = "Internal server error")
+    )
+)]
+pub fn get_withdrawal(
+    _id: u64,
+    path: FullPath,
+) -> impl warp::reply::Reply {
+    Error::NotImplemented(path)
+}
+
+/// Get withdrawals handler.
+#[utoipa::path(
+    get,
+    operation_id = "getWithdrawals",
+    path = "/withdrawal",
+    tag = "withdrawal",
+    responses(
+        // TODO(271): Add success body.
+        (status = 200, description = "Withdrawals retrieved successfully", body = serde_json::Value),
+        (status = 400, description = "Invalid request body"),
+        (status = 404, description = "Address not found"),
+        (status = 405, description = "Method not allowed"),
+        (status = 500, description = "Internal server error")
+    )
+)]
+pub fn get_withdrawals(
+    _query: models::requests::PaginatedQuery<String>,
+    path: FullPath,
+) -> impl warp::reply::Reply {
+    Error::NotImplemented(path)
+}
+
+/// Create withdrawal handler.
+#[utoipa::path(
+    post,
+    operation_id = "createWithdrawal",
+    path = "/withdrawal",
+    tag = "withdrawal",
+    responses(
+        // TODO(271): Add success body.
+        (status = 201, description = "Withdrawals updated successfully", body = serde_json::Value),
+        (status = 400, description = "Invalid request body"),
+        (status = 404, description = "Address not found"),
+        (status = 405, description = "Method not allowed"),
+        (status = 500, description = "Internal server error")
+    )
+)]
+pub fn create_withdrawal(
+    _body: serde_json::Value,
+    path: FullPath,
+) -> impl warp::reply::Reply {
+    Error::NotImplemented(path)
+}
+
+/// Update withdrawals handler.
+#[utoipa::path(
+    put,
+    operation_id = "updateWithdrawals",
+    path = "/withdrawal",
+    tag = "withdrawal",
+    responses(
+        // TODO(271): Add success body.
+        (status = 201, description = "Withdrawals updated successfully", body = serde_json::Value),
+        (status = 400, description = "Invalid request body"),
+        (status = 404, description = "Address not found"),
+        (status = 405, description = "Method not allowed"),
+        (status = 500, description = "Internal server error")
+    )
+)]
+pub fn update_withdrawals(
+    _body: serde_json::Value,
+    path: FullPath,
+) -> impl warp::reply::Reply {
+    Error::NotImplemented(path)
+}

--- a/emily/handler/src/api/routes/chainstate.rs
+++ b/emily/handler/src/api/routes/chainstate.rs
@@ -1,0 +1,41 @@
+//! Route definitions for the chainstate endpoint.
+
+use warp::Filter;
+
+use super::handlers;
+
+/// Chainstate routes.
+pub fn routes() -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    get_chainstate()
+        .or(set_chainstate())
+        .or(update_chainstate())
+}
+
+/// Get chainstate endpoint.
+fn get_chainstate() -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    warp::path!("chainstate" / u64)
+        .and(warp::get())
+        // Only get full path because the handler is unimplemented.
+        .and(warp::path::full())
+        .map(handlers::chainstate::get_chainstate)
+}
+
+/// Set chainstate endpoint.
+fn set_chainstate() -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    warp::path!("chainstate")
+        .and(warp::post())
+        .and(warp::body::json())
+        // Only get full path because the handler is unimplemented.
+        .and(warp::path::full())
+        .map(handlers::chainstate::set_chainstate)
+}
+
+/// Update chainstate endpoint.
+fn update_chainstate() -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    warp::path!("chainstate")
+        .and(warp::put())
+        .and(warp::body::json())
+        // Only get full path because the handler is unimplemented.
+        .and(warp::path::full())
+        .map(handlers::chainstate::update_chainstate)
+}

--- a/emily/handler/src/api/routes/chainstate.rs
+++ b/emily/handler/src/api/routes/chainstate.rs
@@ -39,3 +39,81 @@ fn update_chainstate() -> impl Filter<Extract = impl warp::Reply, Error = warp::
         .and(warp::path::full())
         .map(handlers::chainstate::update_chainstate)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use warp::http::StatusCode;
+
+    #[tokio::test]
+    async fn test_get_chainstate() {
+        let filter = get_chainstate();
+
+        let response = warp::test::request()
+            .method("GET")
+            .path("/chainstate/123")
+            .reply(&filter)
+            .await;
+
+        assert_eq!(response.status(), StatusCode::NOT_IMPLEMENTED);
+    }
+
+    #[tokio::test]
+    async fn test_set_chainstate() {
+        let filter = set_chainstate();
+
+        let response = warp::test::request()
+            .method("POST")
+            .path("/chainstate")
+            .json(&serde_json::json!({ "key": "value" }))
+            .reply(&filter)
+            .await;
+
+        assert_eq!(response.status(), StatusCode::NOT_IMPLEMENTED);
+    }
+
+    #[tokio::test]
+    async fn test_update_chainstate() {
+        let filter = update_chainstate();
+
+        let response = warp::test::request()
+            .method("PUT")
+            .path("/chainstate")
+            .json(&serde_json::json!({ "key": "value" }))
+            .reply(&filter)
+            .await;
+
+        assert_eq!(response.status(), StatusCode::NOT_IMPLEMENTED);
+    }
+
+    #[tokio::test]
+    async fn test_routes() {
+        let filter = routes();
+
+        // Test get_chainstate
+        let response = warp::test::request()
+            .method("GET")
+            .path("/chainstate/123")
+            .reply(&filter)
+            .await;
+        assert_eq!(response.status(), StatusCode::NOT_IMPLEMENTED);
+
+        // Test set_chainstate
+        let response = warp::test::request()
+            .method("POST")
+            .path("/chainstate")
+            .json(&serde_json::json!({ "key": "value" }))
+            .reply(&filter)
+            .await;
+        assert_eq!(response.status(), StatusCode::NOT_IMPLEMENTED);
+
+        // Test update_chainstate
+        let response = warp::test::request()
+            .method("PUT")
+            .path("/chainstate")
+            .json(&serde_json::json!({ "key": "value" }))
+            .reply(&filter)
+            .await;
+        assert_eq!(response.status(), StatusCode::NOT_IMPLEMENTED);
+    }
+}

--- a/emily/handler/src/api/routes/deposit.rs
+++ b/emily/handler/src/api/routes/deposit.rs
@@ -13,7 +13,7 @@ pub fn routes() -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejecti
 }
 
 /// Get deposit endpoint.
-pub fn get_deposit() -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+fn get_deposit() -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
     warp::path!("deposit" / String / u16)
         .and(warp::get())
         // Only get full path because the handler is unimplemented.
@@ -21,8 +21,8 @@ pub fn get_deposit() -> impl Filter<Extract = impl warp::Reply, Error = warp::Re
         .map(handlers::deposit::get_deposit)
 }
 
-/// Get deposits endpoint.
-pub fn get_deposits_for_transaction() -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+/// Get deposits for transaction endpoint.
+fn get_deposits_for_transaction() -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
     warp::path!("deposit" / String)
         .and(warp::get())
         .and(warp::query())
@@ -32,7 +32,7 @@ pub fn get_deposits_for_transaction() -> impl Filter<Extract = impl warp::Reply,
 }
 
 /// Get deposits endpoint.
-pub fn get_deposits() -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+fn get_deposits() -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
     warp::path!("deposit")
         .and(warp::get())
         .and(warp::query())
@@ -41,8 +41,8 @@ pub fn get_deposits() -> impl Filter<Extract = impl warp::Reply, Error = warp::R
         .map(handlers::deposit::get_deposits)
 }
 
-/// Create deposits endpoint.
-pub fn create_deposit() -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+/// Create deposit endpoint.
+fn create_deposit() -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
     warp::path!("deposit")
         .and(warp::post())
         .and(warp::query())
@@ -52,7 +52,7 @@ pub fn create_deposit() -> impl Filter<Extract = impl warp::Reply, Error = warp:
 }
 
 /// Update deposits endpoint.
-pub fn update_deposits() -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+fn update_deposits() -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
     warp::path!("deposit")
         .and(warp::post())
         .and(warp::body::json())

--- a/emily/handler/src/api/routes/health.rs
+++ b/emily/handler/src/api/routes/health.rs
@@ -9,7 +9,7 @@ pub fn routes() -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejecti
 }
 
 /// Get health endpoint.
-pub fn get_health() -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+fn get_health() -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
     warp::path("health")
         .and(warp::get())
         // Only get full path because the handler is unimplemented.

--- a/emily/handler/src/api/routes/mod.rs
+++ b/emily/handler/src/api/routes/mod.rs
@@ -6,9 +6,9 @@ use warp::Filter;
 /// Chainstate routes.
 mod chainstate;
 /// Deposit routes.
-pub mod deposit;
+mod deposit;
 /// Health routes.
-pub mod health;
+mod health;
 /// Withdrawal routes.
 mod withdrawal;
 

--- a/emily/handler/src/api/routes/mod.rs
+++ b/emily/handler/src/api/routes/mod.rs
@@ -3,10 +3,14 @@
 use super::handlers;
 use warp::Filter;
 
+/// Chainstate routes.
+mod chainstate;
 /// Deposit routes.
 pub mod deposit;
 /// Health routes.
 pub mod health;
+/// Withdrawal routes.
+mod withdrawal;
 
 /// This function sets up the Warp filters for handling all requests.
 pub fn routes() -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
@@ -14,5 +18,7 @@ pub fn routes() -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejecti
     // testing calls seem to forcibly start with `local`.
     warp::path("local")
         .and(health::routes()
+            .or(chainstate::routes())
             .or(deposit::routes()))
+            .or(withdrawal::routes())
 }

--- a/emily/handler/src/api/routes/withdrawal.rs
+++ b/emily/handler/src/api/routes/withdrawal.rs
@@ -49,3 +49,102 @@ fn update_withdrawals() -> impl Filter<Extract = impl warp::Reply, Error = warp:
         .and(warp::path::full())
         .map(handlers::withdrawal::update_withdrawals)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use warp::http::StatusCode;
+
+    #[tokio::test]
+    async fn test_get_withdrawal() {
+        let filter = get_withdrawal();
+
+        let response = warp::test::request()
+            .method("GET")
+            .path("/withdrawal/123")
+            .reply(&filter)
+            .await;
+
+        assert_eq!(response.status(), StatusCode::NOT_IMPLEMENTED);
+    }
+
+    #[tokio::test]
+    async fn test_get_withdrawals() {
+        let filter = get_withdrawals();
+
+        let response = warp::test::request()
+            .method("GET")
+            .path("/withdrawal?param=value")
+            .reply(&filter)
+            .await;
+
+        assert_eq!(response.status(), StatusCode::NOT_IMPLEMENTED);
+    }
+
+    #[tokio::test]
+    async fn test_create_withdrawal() {
+        let filter = create_withdrawal();
+
+        let response = warp::test::request()
+            .method("POST")
+            .path("/withdrawal")
+            .json(&serde_json::json!({ "key": "value" }))
+            .reply(&filter)
+            .await;
+
+        assert_eq!(response.status(), StatusCode::NOT_IMPLEMENTED);
+    }
+
+    #[tokio::test]
+    async fn test_update_withdrawals() {
+        let filter = update_withdrawals();
+
+        let response = warp::test::request()
+            .method("PUT")
+            .path("/withdrawal")
+            .json(&serde_json::json!({ "key": "value" }))
+            .reply(&filter)
+            .await;
+
+        assert_eq!(response.status(), StatusCode::NOT_IMPLEMENTED);
+    }
+
+    #[tokio::test]
+    async fn test_routes() {
+        let filter = routes();
+
+        // Test get_withdrawal
+        let response = warp::test::request()
+            .method("GET")
+            .path("/withdrawal/123")
+            .reply(&filter)
+            .await;
+        assert_eq!(response.status(), StatusCode::NOT_IMPLEMENTED);
+
+        // Test get_withdrawals
+        let response = warp::test::request()
+            .method("GET")
+            .path("/withdrawal?param=value")
+            .reply(&filter)
+            .await;
+        assert_eq!(response.status(), StatusCode::NOT_IMPLEMENTED);
+
+        // Test create_withdrawal
+        let response = warp::test::request()
+            .method("POST")
+            .path("/withdrawal")
+            .json(&serde_json::json!({ "key": "value" }))
+            .reply(&filter)
+            .await;
+        assert_eq!(response.status(), StatusCode::NOT_IMPLEMENTED);
+
+        // Test update_withdrawals
+        let response = warp::test::request()
+            .method("PUT")
+            .path("/withdrawal")
+            .json(&serde_json::json!({ "key": "value" }))
+            .reply(&filter)
+            .await;
+        assert_eq!(response.status(), StatusCode::NOT_IMPLEMENTED);
+    }
+}

--- a/emily/handler/src/api/routes/withdrawal.rs
+++ b/emily/handler/src/api/routes/withdrawal.rs
@@ -1,0 +1,51 @@
+//! Route definitions for the withdrawal endpoint.
+use warp::Filter;
+
+use super::handlers;
+
+/// Withdrawal routes.
+pub fn routes() -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    get_withdrawal()
+        .or(get_withdrawals())
+        .or(create_withdrawal())
+        .or(update_withdrawals())
+}
+
+/// Get withdrawal endpoint.
+fn get_withdrawal() -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    warp::path!("withdrawal" / u64)
+        .and(warp::get())
+        // Only get full path because the handler is unimplemented.
+        .and(warp::path::full())
+        .map(handlers::withdrawal::get_withdrawal)
+}
+
+/// Get withdrawals endpoint.
+fn get_withdrawals() -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    warp::path!("withdrawal")
+        .and(warp::get())
+        .and(warp::query())
+        // Only get full path because the handler is unimplemented.
+        .and(warp::path::full())
+        .map(handlers::withdrawal::get_withdrawals)
+}
+
+/// Create withdrawal endpoint.
+fn create_withdrawal() -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    warp::path!("withdrawal")
+        .and(warp::post())
+        .and(warp::body::json())
+        // Only get full path because the handler is unimplemented.
+        .and(warp::path::full())
+        .map(handlers::withdrawal::create_withdrawal)
+}
+
+/// Update withdrawals endpoint.
+fn update_withdrawals() -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    warp::path!("withdrawal")
+        .and(warp::put())
+        .and(warp::body::json())
+        // Only get full path because the handler is unimplemented.
+        .and(warp::path::full())
+        .map(handlers::withdrawal::update_withdrawals)
+}


### PR DESCRIPTION
## Description

Resolves #272 

This PR does the following:
1. Adds the `chainstate` and `withdrawal` endpoints to the warp paths.
2. Adds dummy event handlers for the the `chainstate` and `withdrawal` endpoints
3. Adds `utoipa` annotations to every handler
4. Updates the `build.rs` script for the Emily openapi spec

**Bonus:** Minor fix to `utoipa` annotations for the deposit endpoint so that `GET` api calls are said to return `200` as opposed to `201`.

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `make test` passes
