### PR TITLE
feat: Transaction signer acknowledging bitcoin transaction sign requests

### DIFF
--- a/signer/src/storage.rs
+++ b/signer/src/storage.rs
@@ -44,6 +44,12 @@ pub trait DbRead {
         context_window: i32,
     ) -> impl Future<Output = Result<Vec<model::DepositRequest>, Self::Error>> + Send;
 
+    /// Get the deposit requests that the signer has accepted to sign
+    fn get_accepted_deposit_requests(
+        &self,
+        signer: &model::PubKey,
+    ) -> impl Future<Output = Result<Vec<model::DepositRequest>, Self::Error>> + Send;
+
     /// Get signer decisions for a deposit request
     fn get_deposit_signers(
         &self,

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -340,6 +340,13 @@ impl super::DbRead for PgStore {
         .map_err(Error::SqlxQuery)
     }
 
+    async fn get_accepted_deposit_requests(
+        &self,
+        _signer: &model::PubKey,
+    ) -> Result<Vec<model::DepositRequest>, Self::Error> {
+        todo!() // TODO
+    }
+
     async fn get_deposit_signers(
         &self,
         txid: &model::BitcoinTxId,

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -189,8 +189,9 @@ where
                 //TODO(255): Implement
             }
 
-            message::Payload::BitcoinTransactionSignRequest(_) => {
-                //TODO(256): Implement
+            message::Payload::BitcoinTransactionSignRequest(request) => {
+                self.handle_bitcoin_transaction_sign_request(request)
+                    .await?;
             }
 
             message::Payload::WstsMessage(_) => {
@@ -203,6 +204,55 @@ where
         };
 
         Ok(())
+    }
+
+    #[tracing::instrument(skip(self))]
+    async fn handle_bitcoin_transaction_sign_request(
+        &mut self,
+        request: &message::BitcoinTransactionSignRequest,
+    ) -> Result<(), error::Error> {
+        let bitcoin_chain_tip = self
+            .storage
+            .get_bitcoin_canonical_chain_tip()
+            .await?
+            .ok_or(Error::NoChainTip)?;
+
+        if self
+            .is_valid_bitcoin_transaction_sign_request(request, &bitcoin_chain_tip)
+            .await?
+        {
+            let msg = message::BitcoinTransactionSignAck {
+                txid: request.tx.compute_txid(),
+            };
+
+            self.send_message(msg, &bitcoin_chain_tip).await?;
+        } else {
+            tracing::warn!("received invalid sign request");
+        }
+
+        Ok(())
+    }
+
+    async fn is_valid_bitcoin_transaction_sign_request(
+        &mut self,
+        _request: &message::BitcoinTransactionSignRequest,
+        _bitcoin_chain_tip: &model::BitcoinBlockHash,
+    ) -> Result<bool, error::Error> {
+        let signer_pub_key = self.signer_pub_key()?;
+        let _accepted_deposit_requests = self
+            .storage
+            .get_accepted_deposit_requests(&signer_pub_key)
+            .await?;
+
+        // TODO(286): Validate transaction
+        // - Ensure all inputs are either accepted deposit requests
+        //    or directly spendable by the signers.
+        // - Ensure all outputs are either accepted withdrawals
+        //    or pays to an approved signer set.
+        // - Ensure the transaction fee is lower than the minimum
+        //    `max_fee` of any request.
+
+        Ok(true)
     }
 
     #[tracing::instrument(skip(self))]
@@ -252,13 +302,11 @@ where
             })
             .await;
 
-        let signer_pub_key = p256k1::ecdsa::PublicKey::new(&self.signer_private_key)?
-            .to_bytes()
-            .to_vec();
+        let signer_pub_key = self.signer_pub_key()?;
 
         let created_at = time::OffsetDateTime::now_utc();
 
-        let msg_payload: message::Payload = message::SignerDepositDecision {
+        let msg = message::SignerDepositDecision {
             txid: bitcoin::Txid::from_slice(&deposit_request.txid)
                 .map_err(error::Error::SliceConversion)?,
             output_index: deposit_request
@@ -266,15 +314,7 @@ where
                 .try_into()
                 .map_err(|_| error::Error::TypeConversion)?,
             accepted: is_accepted,
-        }
-        .into();
-
-        let msg = msg_payload
-            .to_message(
-                bitcoin::BlockHash::from_slice(bitcoin_chain_tip)
-                    .map_err(error::Error::SliceConversion)?,
-            )
-            .sign_ecdsa(&self.signer_private_key)?;
+        };
 
         let signer_decision = model::DepositSigner {
             txid: deposit_request.txid,
@@ -288,7 +328,7 @@ where
             .write_deposit_signer_decision(&signer_decision)
             .await?;
 
-        self.network.broadcast(msg).await?;
+        self.send_message(msg, bitcoin_chain_tip).await?;
 
         Ok(())
     }
@@ -304,9 +344,7 @@ where
             .await
             .unwrap_or(false);
 
-        let signer_pub_key = p256k1::ecdsa::PublicKey::new(&self.signer_private_key)?
-            .to_bytes()
-            .to_vec();
+        let signer_pub_key = self.signer_pub_key()?;
 
         let created_at = time::OffsetDateTime::now_utc();
 
@@ -385,6 +423,31 @@ where
 
         Ok(())
     }
+
+    #[tracing::instrument(skip(self, msg))]
+    async fn send_message(
+        &mut self,
+        msg: impl Into<message::Payload>,
+        bitcoin_chain_tip: &model::BitcoinBlockHash,
+    ) -> Result<(), error::Error> {
+        let msg = msg
+            .into()
+            .to_message(
+                bitcoin::BlockHash::from_slice(bitcoin_chain_tip)
+                    .map_err(error::Error::SliceConversion)?,
+            )
+            .sign_ecdsa(&self.signer_private_key)?;
+
+        self.network.broadcast(msg).await?;
+
+        Ok(())
+    }
+
+    fn signer_pub_key(&self) -> Result<model::PubKey, error::Error> {
+        Ok(p256k1::ecdsa::PublicKey::new(&self.signer_private_key)?
+            .to_bytes()
+            .to_vec())
+    }
 }
 
 /// Errors occurring in the transaction signer loop.
@@ -427,6 +490,13 @@ mod tests {
     async fn should_store_decisions_received_from_other_signers() {
         test_environment()
             .assert_should_store_decisions_received_from_other_signers()
+            .await;
+    }
+
+    #[tokio::test]
+    async fn should_respond_to_bitcoin_transaction_sign_requests() {
+        test_environment()
+            .assert_should_respond_to_bitcoin_transaction_sign_requests()
             .await;
     }
 }

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -217,10 +217,11 @@ where
             .await?
             .ok_or(Error::NoChainTip)?;
 
-        if self
+        let is_valid_sign_request = self
             .is_valid_bitcoin_transaction_sign_request(request, &bitcoin_chain_tip)
-            .await?
-        {
+            .await?;
+
+        if is_valid_sign_request {
             let msg = message::BitcoinTransactionSignAck {
                 txid: request.tx.compute_txid(),
             };

--- a/signer/tests/integration/transaction_signer.rs
+++ b/signer/tests/integration/transaction_signer.rs
@@ -74,7 +74,6 @@ async fn should_store_decisions_for_pending_withdraw_requests(pool: sqlx::PgPool
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[sqlx::test(migrations = false)]
 async fn should_store_decisions_received_from_other_signers(pool: sqlx::PgPool) {
-    sbtc_common::logging::setup_logging(true);
     test_environment(pool)
         .await
         .assert_should_store_decisions_received_from_other_signers()


### PR DESCRIPTION
closes #256 

This PR adds a few utility functions for the transaction validation, but since the validation logic depends on transaction parsing logic we'll leave the validation to a follow-up