### PR TITLE
ci: remove java from CI and bump pnpm version

### DIFF
--- a/.github/workflows/contract-tests.yaml
+++ b/.github/workflows/contract-tests.yaml
@@ -10,7 +10,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: pnpm/action-setup@v2
         with:
-          version: 9.0.6
+          version: 9.1.0
       - name: Set Node Version
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -27,11 +27,6 @@ jobs:
           node-version: 22.1.0
           cache: "pnpm"
 
-      - uses: actions/setup-java@v4
-        with:
-          distribution: "corretto"
-          java-version: "21"
-
       - uses: arduino/setup-protoc@v3
         with:
           version: "25.3"

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: pnpm/action-setup@v2
         with:
-          version: 9.0.6
+          version: 9.1.0
 
       - name: Set Node Version
         uses: actions/setup-node@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,19 +16,12 @@ RUN mv /tmp/smithy-install/smithy-cli-linux-aarch64/* /tmp/smithy-install/smithy
 RUN /tmp/smithy-install/smithy/install
 RUN rm -rf /tmp/smithy-install
 
-RUN mkdir -p /tmp/java-install
-RUN curl -L https://download.oracle.com/java/21/latest/jdk-21_linux-aarch64_bin.tar.gz -o /tmp/java-install/jdk-21_linux-aarch64_bin.tar.gz
-
 RUN cargo install sqlx-cli
 
 RUN mkdir -p /tmp/node-install
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x -o /tmp/node-install/nodesource_setup.sh
 RUN bash /tmp/node-install/nodesource_setup.sh
 RUN apt-get -y install nodejs
-
-RUN mkdir -p /usr/local/java
-RUN cd /usr/local/java && tar xvzf /tmp/java-install/jdk-21_linux-aarch64_bin.tar.gz
-ENV PATH="${PATH}:/usr/local/java/jdk-21.0.3/bin"
 
 RUN mkdir -p /tmp/rustup-install
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o /tmp/rustup-install/rustup-install.sh
@@ -37,7 +30,6 @@ RUN /tmp/rustup-install/rustup-install.sh -y
 
 RUN rm -rf /tmp/smithy-install
 RUN rm -rf /tmp/node-install
-RUN rm -rf /tmp/java-install
 RUN rm -rf /tmp/rustup-install
 
 RUN apt-get clean

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ The following are the developer tools that you should install on your local mach
 - **[pnpm](https://pnpm.io)** - [Installation guide](https://pnpm.io/installation) - Manages node packages
 - **[Smithy](https://smithy.io/2.0/index.html)** - [Installation Guide](https://smithy.io/2.0/guides/smithy-cli/cli_installation.html) - Generates OpenAPI templates
 - **[Make](https://www.gnu.org/software/make/)** - Development task runner; natively present on nearly every system.
-- **[Java 21](https://www.oracle.com/java/)** - [Installation Guide](https://www.oracle.com/java/technologies/downloads/) - Required for OpenAPI Generator
 - **[Docker](https://docs.docker.com/manuals/)** - [Installation Guide](https://docs.docker.com/desktop/). This is used for running integration tests.
 - **[protoc](https://github.com/protocolbuffers/protobuf)** - [Installation Guide](https://grpc.io/docs/protoc-installation/). Compiles protobuf files.
 - **[sqlx-cli](https://github.com/launchbadge/sqlx/tree/main/sqlx-cli)** - [Installation Guide](https://github.com/launchbadge/sqlx/tree/main/sqlx-cli#install) - Needed only for developing, and only when modifying queries or adding new ones.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ echo "\n--- sBTC tool versions ---" \
     && echo "pnpm $(pnpm --version)" \
     && echo "smithy $(smithy --version)" \
     && make --version | head -n 1 \
-    && java --version | head -n 1
 ```
 
 Below is the output on a machine that is able to build and run all the sources and tests.
@@ -64,7 +63,6 @@ cargo-lambda 1.2.1 (12f9b61 2024-04-05Z)
 pnpm 8.15.4
 smithy 1.47.0
 GNU Make 3.81
-openjdk 21.0.2 2024-01-16
 ```
 
 ### Building


### PR DESCRIPTION
I don't think we use java anymore. Also, let's update the version of pnpm that we use locally.