### PR TITLE
ci: bump the pnpm action version

### DIFF
--- a/.github/workflows/contract-tests.yaml
+++ b/.github/workflows/contract-tests.yaml
@@ -8,9 +8,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - uses: pnpm/action-setup@v2
-        with:
-          version: 9.1.0
+      - uses: pnpm/action-setup@v4
+
       - name: Set Node Version
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -17,9 +17,7 @@ jobs:
       - name: Docker test service setup
         run: docker compose --file docker-compose.test.yml up --detach
 
-      - uses: pnpm/action-setup@v2
-        with:
-          version: 9.1.0
+      - uses: pnpm/action-setup@v4
 
       - name: Set Node Version
         uses: actions/setup-node@v3


### PR DESCRIPTION
This should fix CI issues.

Specifying the pnpm version causes an issue where the version specified in the action and the by the `package.json` don't match. This is an example of a job where CI failed because of this kind of version mismatch: https://github.com/stacks-network/sbtc/actions/runs/9803820830/job/27070555360.

The original need to update started with random CI failures (like in this [CI run](https://github.com/stacks-network/sbtc/actions/runs/9803450411/job/27069632164#step:4:14)), and the solution was noted in https://github.com/pnpm/pnpm/issues/6424.