### PR TITLE
feat: Transaction signer responding to WSTS messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4067,6 +4067,7 @@ dependencies = [
  "electrum-client",
  "fake",
  "futures",
+ "hashbrown 0.14.5",
  "mockito 1.4.0",
  "more-asserts",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ bitvec = { version = "1.0", default-features = false }
 config = "0.11.0"
 clap = { version = "4.5.4", features = ["derive", "env"] }
 futures = "0.3.24"
+hashbrown = "0.14.5"
 http = "1.1.0"
 lambda_runtime = "0.11.1"
 # This is necessary to compile the AWS Lambda as a lambda.

--- a/signer/Cargo.toml
+++ b/signer/Cargo.toml
@@ -28,6 +28,7 @@ clap.workspace = true
 config = "0.14"
 electrum-client = "0.19.0"
 futures.workspace = true
+hashbrown.workspace = true
 once_cell.workspace = true
 p256k1.workspace = true
 prost.workspace = true

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -157,7 +157,7 @@ pub enum Error {
 
     /// WSTS error
     #[error("WSTS error: {0}")]
-    WSTS(#[source] wsts::state_machine::signer::Error),
+    Wsts(#[source] wsts::state_machine::signer::Error),
 }
 
 impl From<std::convert::Infallible> for Error {

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 
 use blockstack_lib::types::chainstate::StacksBlockId;
 
-use crate::{ecdsa, network};
+use crate::{codec, ecdsa, network};
 
 /// Top-level signer error
 #[derive(Debug, thiserror::Error)]
@@ -102,6 +102,18 @@ pub enum Error {
     #[error("missing block")]
     MissingBlock,
 
+    /// Missing dkg shares
+    #[error("missing dkg shares")]
+    MissingDkgShares,
+
+    /// Missing public key
+    #[error("missing public key")]
+    MissingPublicKey,
+
+    /// Missing state machine
+    #[error("missing state machine")]
+    MissingStateMachine,
+
     /// Invalid signature
     #[error("invalid signature")]
     InvalidSignature,
@@ -114,6 +126,10 @@ pub enum Error {
     #[error("ECDSA error: {0}")]
     Ecdsa(#[from] ecdsa::Error),
 
+    /// Codec error
+    #[error("codec error: {0}")]
+    Codec(#[source] codec::Error),
+
     /// In-memory network error
     #[error("in-memory network error: {0}")]
     InMemoryNetwork(#[from] network::in_memory::Error),
@@ -123,13 +139,21 @@ pub enum Error {
     GrpcRelayNetworkError(#[from] network::grpc_relay::RelayError),
 
     /// Type conversion error
-    #[error("Type conversion error")]
+    #[error("type conversion error")]
     TypeConversion,
+
+    /// Encryption error
+    #[error("encryption error")]
+    Encryption,
 
     /// Thrown when the recoverable signature has a public key that is
     /// unexpected.
-    #[error("Unexpected public key from signature. key {0}; digest: {1}")]
+    #[error("unexpected public key from signature. key {0}; digest: {1}")]
     UnknownPublicKey(secp256k1::PublicKey, secp256k1::Message),
+
+    /// WSTS error
+    #[error("WSTS error: {0}")]
+    WSTS(#[source] wsts::state_machine::signer::Error),
 }
 
 impl From<std::convert::Infallible> for Error {

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -146,6 +146,10 @@ pub enum Error {
     #[error("encryption error")]
     Encryption,
 
+    /// Invalid configuration
+    #[error("invalid configuration")]
+    InvalidConfiguration,
+
     /// Thrown when the recoverable signature has a public key that is
     /// unexpected.
     #[error("unexpected public key from signature. key {0}; digest: {1}")]

--- a/signer/src/message.rs
+++ b/signer/src/message.rs
@@ -127,6 +127,8 @@ pub struct StacksTransactionSignature {
 pub struct BitcoinTransactionSignRequest {
     /// The transaction.
     pub tx: bitcoin::Transaction,
+    /// The aggregate key used to sign the transaction,
+    pub aggregate_key: p256k1::point::Point,
 }
 
 /// Represents an acknowledgment of a signed Bitcoin transaction.
@@ -138,7 +140,13 @@ pub struct BitcoinTransactionSignAck {
 
 /// A wsts message.
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-pub struct WstsMessage(pub wsts::net::Message);
+pub struct WstsMessage {
+    /// The transaction ID this message relates to,
+    /// will be a dummy ID for DKG messages
+    pub txid: bitcoin::Txid,
+    /// The wsts message
+    pub inner: wsts::net::Message,
+}
 
 impl wsts::net::Signable for SignerMessage {
     fn hash(&self, hasher: &mut sha2::Sha256) {
@@ -151,7 +159,7 @@ impl wsts::net::Signable for SignerMessage {
 impl wsts::net::Signable for Payload {
     fn hash(&self, hasher: &mut sha2::Sha256) {
         match self {
-            Self::WstsMessage(msg) => msg.0.hash(hasher),
+            Self::WstsMessage(msg) => msg.hash(hasher),
             Self::SignerDepositDecision(msg) => msg.hash(hasher),
             Self::SignerWithdrawDecision(msg) => msg.hash(hasher),
             Self::BitcoinTransactionSignRequest(msg) => msg.hash(hasher),
@@ -206,6 +214,14 @@ impl wsts::net::Signable for StacksTransactionSignature {
         hasher.update("SIGNER_STACKS_TRANSACTION_SIGNATURE");
         hasher.update(self.txid);
         hasher.update(self.signature.to_bytes());
+    }
+}
+
+impl wsts::net::Signable for WstsMessage {
+    fn hash(&self, hasher: &mut sha2::Sha256) {
+        hasher.update("SIGNER_WSTS_MESSAGE");
+        hasher.update(self.txid);
+        self.inner.hash(hasher);
     }
 }
 

--- a/signer/src/storage.rs
+++ b/signer/src/storage.rs
@@ -82,6 +82,13 @@ pub trait DbRead {
         &self,
         block_id: StacksBlockId,
     ) -> impl Future<Output = Result<bool, Self::Error>> + Send;
+
+    /// Return the applicable DKG shares for the
+    /// given aggregate key
+    fn get_encrypted_dkg_shares(
+        &self,
+        aggregate_key: &model::PubKey,
+    ) -> impl Future<Output = Result<Option<model::EncryptedDkgShares>, Self::Error>> + Send;
 }
 
 /// Represents the ability to write data to the signer storage.
@@ -148,5 +155,11 @@ pub trait DbWrite {
     fn write_stacks_blocks(
         &self,
         blocks: &[NakamotoBlock],
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+
+    /// Write encrypted DKG shares
+    fn write_encrypted_dkg_shares(
+        &self,
+        shares: &model::EncryptedDkgShares,
     ) -> impl Future<Output = Result<(), Self::Error>> + Send;
 }

--- a/signer/src/storage/in_memory.rs
+++ b/signer/src/storage/in_memory.rs
@@ -57,6 +57,9 @@ pub struct Store {
 
     /// Stacks blocks under nakamoto
     pub stacks_nakamoto_blocks: HashMap<StacksBlockId, NakamotoBlock>,
+
+    /// Encrypted DKG shares
+    pub encrypted_dkg_shares: HashMap<model::PubKey, model::EncryptedDkgShares>,
 }
 
 impl Store {
@@ -272,6 +275,18 @@ impl super::DbRead for SharedStore {
             .stacks_nakamoto_blocks
             .contains_key(&block_id))
     }
+
+    async fn get_encrypted_dkg_shares(
+        &self,
+        aggregate_key: &model::PubKey,
+    ) -> Result<Option<model::EncryptedDkgShares>, Self::Error> {
+        Ok(self
+            .lock()
+            .await
+            .encrypted_dkg_shares
+            .get(aggregate_key)
+            .cloned())
+    }
 }
 
 impl super::DbWrite for SharedStore {
@@ -423,6 +438,18 @@ impl super::DbWrite for SharedStore {
                 .stacks_nakamoto_blocks
                 .insert(block.block_id(), block.clone());
         });
+
+        Ok(())
+    }
+
+    async fn write_encrypted_dkg_shares(
+        &self,
+        shares: &model::EncryptedDkgShares,
+    ) -> Result<(), Self::Error> {
+        self.lock()
+            .await
+            .encrypted_dkg_shares
+            .insert(shares.aggregate_key.clone(), shares.clone());
 
         Ok(())
     }

--- a/signer/src/storage/model.rs
+++ b/signer/src/storage/model.rs
@@ -163,6 +163,20 @@ pub struct Transaction {
     pub created_at: time::OffsetDateTime,
 }
 
+/// Persisted DKG shares
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "testing", derive(fake::Dummy))]
+pub struct EncryptedDkgShares {
+    /// The aggregate key for these shares
+    pub aggregate_key: PubKey,
+    /// The tweaked aggregate key for these shares
+    pub tweaked_aggregate_key: PubKey,
+    /// The encrypted DKG shares
+    pub encrypted_shares: Bytes,
+    /// The time this entry was created by the signer.
+    pub created_at: time::OffsetDateTime,
+}
+
 /// The types of transactions the signer is interested in.
 #[derive(
     Debug,

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -344,7 +344,7 @@ impl super::DbRead for PgStore {
         &self,
         _signer: &model::PubKey,
     ) -> Result<Vec<model::DepositRequest>, Self::Error> {
-        todo!() // TODO
+        todo!() // TODO(295): Implement
     }
 
     async fn get_deposit_signers(
@@ -502,6 +502,13 @@ impl super::DbRead for PgStore {
         .await
         .map(|row| row.is_some())
         .map_err(Error::SqlxQuery)
+    }
+
+    async fn get_encrypted_dkg_shares(
+        &self,
+        _aggregate_key: &model::PubKey,
+    ) -> Result<Option<model::EncryptedDkgShares>, Self::Error> {
+        todo!() // TODO(295): Implement
     }
 }
 
@@ -725,6 +732,13 @@ impl super::DbWrite for PgStore {
     async fn write_stacks_blocks(&self, blocks: &[NakamotoBlock]) -> Result<(), Self::Error> {
         self.write_stacks_block_header(blocks).await?;
         self.write_stacks_sbtc_txs(blocks).await
+    }
+
+    async fn write_encrypted_dkg_shares(
+        &self,
+        _shares: &model::EncryptedDkgShares,
+    ) -> Result<(), Self::Error> {
+        todo!() // TODO(295): Implement
     }
 }
 

--- a/signer/src/testing/message.rs
+++ b/signer/src/testing/message.rs
@@ -69,7 +69,15 @@ impl fake::Dummy<fake::Faker> for message::SignerDepositDecision {
 
 impl fake::Dummy<fake::Faker> for message::BitcoinTransactionSignRequest {
     fn dummy_with_rng<R: rand::RngCore + ?Sized>(config: &fake::Faker, rng: &mut R) -> Self {
-        Self { tx: dummy::tx(config, rng) }
+        let mut bytes: [u8; 32] = [0; 32];
+        rng.fill_bytes(&mut bytes);
+        let scalar = p256k1::scalar::Scalar::from(bytes);
+        let aggregate_key = p256k1::point::Point::from(&scalar);
+
+        Self {
+            tx: dummy::tx(config, rng),
+            aggregate_key,
+        }
     }
 }
 
@@ -104,7 +112,10 @@ impl fake::Dummy<fake::Faker> for message::WstsMessage {
             key_ids: config.fake_with_rng(rng),
         };
 
-        Self(wsts::net::Message::DkgEndBegin(dkg_end_begin))
+        Self {
+            txid: dummy::txid(config, rng),
+            inner: wsts::net::Message::DkgEndBegin(dkg_end_begin),
+        }
     }
 }
 

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -613,6 +613,9 @@ where
         let saved_state =
             wsts::traits::SignerState::decode(decrypted.as_slice()).map_err(error::Error::Codec)?;
 
+        // This may panic if the saved state doesn't contain exactly one party,
+        // however, that should never be the case since wsts maintains this invariant
+        // when we save the state.
         let signer = wsts::v2::Party::load(&saved_state);
 
         let mut state_machine = self.create_new_state_machine()?;

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -299,15 +299,9 @@ where
                 self.relay_message(msg.txid, &msg.inner, bitcoin_chain_tip)
                     .await?;
             }
-            wsts::net::Message::DkgPublicShares(_) => {
-                self.relay_message(msg.txid, &msg.inner, bitcoin_chain_tip)
-                    .await?;
-            }
-            wsts::net::Message::DkgPrivateBegin(_) => {
-                self.relay_message(msg.txid, &msg.inner, bitcoin_chain_tip)
-                    .await?;
-            }
-            wsts::net::Message::DkgPrivateShares(_) => {
+            wsts::net::Message::DkgPublicShares(_)
+            | wsts::net::Message::DkgPrivateBegin(_)
+            | wsts::net::Message::DkgPrivateShares(_) => {
                 self.relay_message(msg.txid, &msg.inner, bitcoin_chain_tip)
                     .await?;
             }

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -5,16 +5,23 @@
 //!
 //! For more details, see the [`TxSignerEventLoop`] documentation.
 
+use std::collections::BTreeSet;
+use std::collections::HashMap;
+
 use crate::blocklist_client;
-use crate::ecdsa::SignEcdsa;
 use crate::error;
 use crate::message;
 use crate::network;
 use crate::storage;
 use crate::storage::model;
 
+use crate::codec::Decode as _;
+use crate::codec::Encode as _;
+use crate::ecdsa::SignEcdsa as _;
+
 use bitcoin::hashes::Hash;
 use futures::StreamExt;
+use wsts::traits::Signer;
 
 #[cfg_attr(doc, aquamarine::aquamarine)]
 /// # Transaction signer event loop
@@ -76,7 +83,7 @@ use futures::StreamExt;
 ///     SM --> |WSTS message| RWSM(Relay to WSTS state machine)
 /// ```
 #[derive(Debug)]
-pub struct TxSignerEventLoop<Network, Storage, BlocklistChecker> {
+pub struct TxSignerEventLoop<Network, Storage, BlocklistChecker, Rng> {
     /// Interface to the signer network.
     pub network: Network,
     /// Database connection.
@@ -87,11 +94,27 @@ pub struct TxSignerEventLoop<Network, Storage, BlocklistChecker> {
     pub block_observer_notifications: tokio::sync::watch::Receiver<()>,
     /// Private key of the signer for network communication.
     pub signer_private_key: p256k1::scalar::Scalar,
+    /// WSTS state machines for active signing rounds and DKG rounds
+    ///
+    /// - For signing rounds, the TxID is the ID of the transaction to be
+    ///   signed.
+    ///
+    /// - For DKG rounds, TxID should be the ID of the transaction that
+    ///   defined the signer set.
+    pub wsts_state_machines: HashMap<bitcoin::Txid, SignerStateMachine>,
+    /// Public keys of the other signers
+    pub signer_public_keys: BTreeSet<p256k1::ecdsa::PublicKey>,
+    /// The threshold for the signer
+    pub threshold: u32,
     /// How many bitcoin blocks back from the chain tip the signer will look for requests.
     pub context_window: usize,
+    /// Random number generator used for encryption
+    pub rng: Rng,
 }
 
-impl<N, S, B> TxSignerEventLoop<N, S, B>
+type SignerStateMachine = wsts::state_machine::signer::Signer<wsts::v2::Party>;
+
+impl<N, S, B, Rng> TxSignerEventLoop<N, S, B, Rng>
 where
     N: network::MessageTransfer,
     error::Error: From<N::Error>,
@@ -99,6 +122,7 @@ where
     S: storage::DbRead + storage::DbWrite,
     error::Error: From<<S as storage::DbRead>::Error>,
     error::Error: From<<S as storage::DbWrite>::Error>,
+    Rng: rand::RngCore + rand::CryptoRng,
 {
     /// Run the signer event loop
     #[tracing::instrument(skip(self))]
@@ -174,6 +198,9 @@ where
             return Err(error::Error::InvalidSignature);
         }
 
+        // TODO(297): Validate the chain tip against database
+        let bitcoin_chain_tip = msg.bitcoin_chain_tip.to_byte_array().to_vec();
+
         match &msg.inner.payload {
             message::Payload::SignerDepositDecision(decision) => {
                 self.persist_received_deposit_decision(decision, &msg.signer_pub_key)
@@ -190,12 +217,13 @@ where
             }
 
             message::Payload::BitcoinTransactionSignRequest(request) => {
-                self.handle_bitcoin_transaction_sign_request(request)
+                self.handle_bitcoin_transaction_sign_request(request, &bitcoin_chain_tip)
                     .await?;
             }
 
-            message::Payload::WstsMessage(_) => {
-                //TODO(257): Implement
+            message::Payload::WstsMessage(wsts_msg) => {
+                self.handle_wsts_message(wsts_msg, &bitcoin_chain_tip)
+                    .await?;
             }
 
             // Message types ignored by the transaction signer
@@ -210,23 +238,25 @@ where
     async fn handle_bitcoin_transaction_sign_request(
         &mut self,
         request: &message::BitcoinTransactionSignRequest,
+        bitcoin_chain_tip: &model::BitcoinBlockHash,
     ) -> Result<(), error::Error> {
-        let bitcoin_chain_tip = self
-            .storage
-            .get_bitcoin_canonical_chain_tip()
-            .await?
-            .ok_or(Error::NoChainTip)?;
-
         let is_valid_sign_request = self
-            .is_valid_bitcoin_transaction_sign_request(request, &bitcoin_chain_tip)
+            .is_valid_bitcoin_transaction_sign_request(request)
             .await?;
 
         if is_valid_sign_request {
+            let new_state_machine = self
+                .creat_state_machine_with_loaded_state(&request.aggregate_key)
+                .await?;
+
+            let txid = request.tx.compute_txid();
+            self.wsts_state_machines.insert(txid, new_state_machine);
+
             let msg = message::BitcoinTransactionSignAck {
                 txid: request.tx.compute_txid(),
             };
 
-            self.send_message(msg, &bitcoin_chain_tip).await?;
+            self.send_message(msg, bitcoin_chain_tip).await?;
         } else {
             tracing::warn!("received invalid sign request");
         }
@@ -237,9 +267,8 @@ where
     async fn is_valid_bitcoin_transaction_sign_request(
         &mut self,
         _request: &message::BitcoinTransactionSignRequest,
-        _bitcoin_chain_tip: &model::BitcoinBlockHash,
     ) -> Result<bool, error::Error> {
-        let signer_pub_key = self.signer_pub_key()?;
+        let signer_pub_key = self.signer_pub_key_model()?;
         let _accepted_deposit_requests = self
             .storage
             .get_accepted_deposit_requests(&signer_pub_key)
@@ -254,6 +283,87 @@ where
         //    `max_fee` of any request.
 
         Ok(true)
+    }
+
+    #[tracing::instrument(skip(self))]
+    async fn handle_wsts_message(
+        &mut self,
+        msg: &message::WstsMessage,
+        bitcoin_chain_tip: &model::BitcoinBlockHash,
+    ) -> Result<(), error::Error> {
+        tracing::info!("handling message");
+        match &msg.inner {
+            wsts::net::Message::DkgBegin(_) => {
+                let state_machine = self.create_new_state_machine()?;
+                self.wsts_state_machines.insert(msg.txid, state_machine);
+                self.relay_message(msg.txid, &msg.inner, bitcoin_chain_tip)
+                    .await?;
+            }
+            wsts::net::Message::DkgPublicShares(_) => {
+                self.relay_message(msg.txid, &msg.inner, bitcoin_chain_tip)
+                    .await?;
+            }
+            wsts::net::Message::DkgPrivateBegin(_) => {
+                self.relay_message(msg.txid, &msg.inner, bitcoin_chain_tip)
+                    .await?;
+            }
+            wsts::net::Message::DkgPrivateShares(_) => {
+                self.relay_message(msg.txid, &msg.inner, bitcoin_chain_tip)
+                    .await?;
+            }
+            wsts::net::Message::DkgEndBegin(_) => {
+                self.relay_message(msg.txid, &msg.inner, bitcoin_chain_tip)
+                    .await?;
+                self.store_dkg_shares(&msg.txid).await?;
+            }
+            wsts::net::Message::NonceRequest(_) => {
+                // TODO(296): Validate that message is the appropriate sighash
+                self.relay_message(msg.txid, &msg.inner, bitcoin_chain_tip)
+                    .await?;
+            }
+            wsts::net::Message::SignatureShareRequest(_) => {
+                // TODO(296): Validate that message is the appropriate sighash
+                self.relay_message(msg.txid, &msg.inner, bitcoin_chain_tip)
+                    .await?;
+            }
+            _ => {
+                tracing::debug!("ignoring message");
+            }
+        }
+
+        Ok(())
+    }
+
+    #[tracing::instrument(skip(self))]
+    async fn relay_message(
+        &mut self,
+        txid: bitcoin::Txid,
+        msg: &wsts::net::Message,
+        bitcoin_chain_tip: &model::BitcoinBlockHash,
+    ) -> Result<(), error::Error> {
+        let Some(state_machine) = self.wsts_state_machines.get_mut(&txid) else {
+            tracing::warn!("missing signing round");
+            return Ok(());
+        };
+
+        let outbound_messages = state_machine.process(msg).map_err(error::Error::WSTS)?;
+
+        for outbound_message in outbound_messages.iter() {
+            // The WSTS state machine assume we read our own messages
+            state_machine
+                .process(outbound_message)
+                .map_err(error::Error::WSTS)?;
+        }
+
+        for outbound_message in outbound_messages {
+            let msg = message::WstsMessage { txid, inner: outbound_message };
+
+            tracing::debug!(?msg, "sending message");
+
+            self.send_message(msg, bitcoin_chain_tip).await?;
+        }
+
+        Ok(())
     }
 
     #[tracing::instrument(skip(self))]
@@ -303,7 +413,7 @@ where
             })
             .await;
 
-        let signer_pub_key = self.signer_pub_key()?;
+        let signer_pub_key = self.signer_pub_key_model()?;
 
         let created_at = time::OffsetDateTime::now_utc();
 
@@ -345,7 +455,7 @@ where
             .await
             .unwrap_or(false);
 
-        let signer_pub_key = self.signer_pub_key()?;
+        let signer_pub_key = self.signer_pub_key_model()?;
 
         let created_at = time::OffsetDateTime::now_utc();
 
@@ -425,6 +535,125 @@ where
         Ok(())
     }
 
+    fn create_new_state_machine(&mut self) -> Result<SignerStateMachine, error::Error> {
+        let signers: hashbrown::HashMap<u32, _> = self
+            .signer_public_keys
+            .iter()
+            .cloned()
+            .enumerate()
+            .map(|(id, key)| {
+                id.try_into()
+                    .map(|id| (id, key))
+                    .map_err(|_| error::Error::TypeConversion)
+            })
+            .collect::<Result<_, _>>()?;
+        let key_ids = signers
+            .clone()
+            .into_iter()
+            .map(|(id, key)| (id + 1, key))
+            .collect();
+
+        let public_keys = wsts::state_machine::PublicKeys { signers, key_ids };
+
+        let threshold = self.threshold;
+        let num_parties = self
+            .signer_public_keys
+            .len()
+            .try_into()
+            .map_err(|_| error::Error::TypeConversion)?;
+        let num_keys = num_parties;
+
+        let signer_pub_key = self.signer_pub_key()?;
+
+        let id: u32 = self
+            .signer_public_keys
+            .iter()
+            .enumerate()
+            .find(|(_, key)| *key == &signer_pub_key)
+            .ok_or_else(|| error::Error::MissingPublicKey)?
+            .0
+            .try_into()
+            .map_err(|_| error::Error::TypeConversion)?;
+
+        let key_ids = vec![id + 1];
+
+        let state_machine = SignerStateMachine::new(
+            threshold,
+            num_parties,
+            num_keys,
+            id,
+            key_ids,
+            self.signer_private_key,
+            public_keys,
+        );
+
+        Ok(state_machine)
+    }
+
+    async fn creat_state_machine_with_loaded_state(
+        &mut self,
+        aggregate_key: &p256k1::point::Point,
+    ) -> Result<SignerStateMachine, error::Error> {
+        let encrypted_shares = self
+            .storage
+            .get_encrypted_dkg_shares(&aggregate_key.x().to_bytes().to_vec())
+            .await?
+            .ok_or(error::Error::MissingDkgShares)?;
+
+        let decrypted = wsts::util::decrypt(
+            &self.signer_private_key.to_bytes(),
+            &encrypted_shares.encrypted_shares,
+        )
+        .map_err(|_| error::Error::Encryption)?;
+
+        let saved_state =
+            wsts::traits::SignerState::decode(decrypted.as_slice()).map_err(error::Error::Codec)?;
+
+        let signer = wsts::v2::Party::load(&saved_state);
+
+        let mut state_machine = self.create_new_state_machine()?;
+
+        state_machine.signer = signer;
+
+        Ok(state_machine)
+    }
+
+    #[tracing::instrument(skip(self))]
+    async fn store_dkg_shares(&mut self, txid: &bitcoin::Txid) -> Result<(), error::Error> {
+        let state_machine = self
+            .wsts_state_machines
+            .get(txid)
+            .ok_or(error::Error::MissingStateMachine)?;
+
+        let saved_state = state_machine.signer.save();
+        let aggregate_key = saved_state.group_key.x().to_bytes().to_vec();
+        let tweaked_aggregate_key = wsts::compute::tweaked_public_key(&saved_state.group_key, None)
+            .x()
+            .to_bytes()
+            .to_vec();
+
+        let encoded = saved_state.encode_to_vec().map_err(error::Error::Codec)?;
+
+        let encrypted_shares =
+            wsts::util::encrypt(&self.signer_private_key.to_bytes(), &encoded, &mut self.rng)
+                .map_err(|_| error::Error::Encryption)?;
+
+        let created_at = time::OffsetDateTime::now_utc();
+
+        let encrypted_dkg_shares = model::EncryptedDkgShares {
+            aggregate_key,
+            tweaked_aggregate_key,
+            encrypted_shares,
+            created_at,
+        };
+
+        self.storage
+            .write_encrypted_dkg_shares(&encrypted_dkg_shares)
+            .await?;
+
+        Ok(())
+    }
+
     #[tracing::instrument(skip(self, msg))]
     async fn send_message(
         &mut self,
@@ -444,10 +673,12 @@ where
         Ok(())
     }
 
-    fn signer_pub_key(&self) -> Result<model::PubKey, error::Error> {
-        Ok(p256k1::ecdsa::PublicKey::new(&self.signer_private_key)?
-            .to_bytes()
-            .to_vec())
+    fn signer_pub_key_model(&self) -> Result<model::PubKey, error::Error> {
+        Ok(self.signer_pub_key()?.to_bytes().to_vec())
+    }
+
+    fn signer_pub_key(&self) -> Result<p256k1::ecdsa::PublicKey, error::Error> {
+        Ok(p256k1::ecdsa::PublicKey::new(&self.signer_private_key)?)
     }
 }
 
@@ -470,6 +701,7 @@ mod tests {
             storage_constructor: storage::in_memory::Store::new_shared,
             context_window: 3,
             num_signers: 7,
+            signing_threshold: 5,
         }
     }
 
@@ -498,6 +730,20 @@ mod tests {
     async fn should_respond_to_bitcoin_transaction_sign_requests() {
         test_environment()
             .assert_should_respond_to_bitcoin_transaction_sign_requests()
+            .await;
+    }
+
+    #[tokio::test]
+    async fn should_be_able_to_participate_in_dkg() {
+        test_environment()
+            .assert_should_be_able_to_participate_in_dkg()
+            .await;
+    }
+
+    #[tokio::test]
+    async fn should_be_able_to_participate_in_signing_round() {
+        test_environment()
+            .assert_should_be_able_to_participate_in_signing_round()
             .await;
     }
 }

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -535,7 +535,7 @@ where
         Ok(())
     }
 
-    fn create_new_state_machine(&mut self) -> Result<SignerStateMachine, error::Error> {
+    fn create_new_state_machine(&self) -> Result<SignerStateMachine, error::Error> {
         let signers: hashbrown::HashMap<u32, _> = self
             .signer_public_keys
             .iter()

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -571,7 +571,7 @@ where
 
         let key_ids = vec![id + 1];
 
-        if threshold <= num_keys {
+        if threshold > num_keys {
             return Err(error::Error::InvalidConfiguration);
         };
 

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -340,13 +340,13 @@ where
             return Ok(());
         };
 
-        let outbound_messages = state_machine.process(msg).map_err(error::Error::WSTS)?;
+        let outbound_messages = state_machine.process(msg).map_err(error::Error::Wsts)?;
 
         for outbound_message in outbound_messages.iter() {
             // The WSTS state machine assume we read our own messages
             state_machine
                 .process(outbound_message)
-                .map_err(error::Error::WSTS)?;
+                .map_err(error::Error::Wsts)?;
         }
 
         for outbound_message in outbound_messages {

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -577,6 +577,10 @@ where
 
         let key_ids = vec![id + 1];
 
+        if threshold <= num_keys {
+            return Err(error::Error::InvalidConfiguration);
+        };
+
         let state_machine = SignerStateMachine::new(
             threshold,
             num_parties,

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -588,6 +588,8 @@ where
         Ok(state_machine)
     }
 
+    /// Load the saved DKG shares for the given aggregate key
+    /// and instantiates a new WSTS state machine with the loaded shares.
     async fn creat_state_machine_with_loaded_state(
         &mut self,
         aggregate_key: &p256k1::point::Point,

--- a/signer/tests/integration/transaction_signer.rs
+++ b/signer/tests/integration/transaction_signer.rs
@@ -9,6 +9,7 @@ async fn test_environment(
     pool: sqlx::PgPool,
 ) -> testing::transaction_signer::TestEnvironment<impl FnMut() -> storage::postgres::PgStore> {
     let num_signers = 3;
+    let signing_threshold = 2;
     let context_window = 3;
     let test_databases: Vec<_> = futures::stream::iter(0..num_signers)
         .then(|_| async { new_database(&pool).await })
@@ -24,6 +25,7 @@ async fn test_environment(
         },
         context_window,
         num_signers,
+        signing_threshold,
     }
 }
 


### PR DESCRIPTION
closes #257 

This PR extends the transaction signer to be able to participate in DKG rounds and signing rounds. To achieve this, each transaction signer keeps track of a set of WSTS state machines identified by the TXID of the transaction they are signing. These state machines are created from persisted DKG shares upon a sign request.