### PR TITLE
feat: fetching nonce from stacks node

### DIFF
--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -53,6 +53,10 @@ pub enum Error {
     #[error("Invalid wallet definition, signatures required: {0}, number of keys: {1}")]
     InvalidWalletDefinition(u16, usize),
 
+    /// This is thrown when failing to parse a hex string into an integer.
+    #[error("Could not parse the hex string into an integer")]
+    ParseHexInt(#[source] std::num::ParseIntError),
+
     /// Reqwest error
     #[error(transparent)]
     Reqwest(#[from] reqwest::Error),

--- a/signer/src/stacks/api.rs
+++ b/signer/src/stacks/api.rs
@@ -479,6 +479,8 @@ mod tests {
     use crate::storage::postgres::PgStore;
     use crate::storage::DbWrite;
 
+    use test_case::test_case;
+
     use super::*;
     use std::io::Read;
 
@@ -660,17 +662,17 @@ mod tests {
         assert!(!blocks.is_empty());
     }
 
-    #[test_case::test_case("0x1A3B5C7D9E", 112665066910; "uppercase-112665066910")]
-    #[test_case::test_case("0x1a3b5c7d9e", 112665066910; "lowercase-112665066910")]
-    #[test_case::test_case("1a3b5c7d9e", 112665066910; "unprefixed-lowercase-112665066910")]
+    #[test_case("0x1A3B5C7D9E", 112665066910; "uppercase-112665066910")]
+    #[test_case("0x1a3b5c7d9e", 112665066910; "lowercase-112665066910")]
+    #[test_case("1a3b5c7d9e", 112665066910; "unprefixed-lowercase-112665066910")]
     fn parsing_integers(hex: &str, expected: u128) {
         let actual = parse_hex_u128(hex).unwrap();
         assert_eq!(actual, expected);
     }
 
-    #[test_case::test_case(""; "empty-string")]
-    #[test_case::test_case("0x"; "almost-empty-string")]
-    #[test_case::test_case("ZZZ"; "invalid hex")]
+    #[test_case(""; "empty-string")]
+    #[test_case("0x"; "almost-empty-string")]
+    #[test_case("ZZZ"; "invalid hex")]
     fn parsing_integers_bad_input(hex: &str) {
         assert!(parse_hex_u128(hex).is_err());
     }

--- a/signer/src/stacks/api.rs
+++ b/signer/src/stacks/api.rs
@@ -8,7 +8,9 @@ use blockstack_lib::burnchains::Txid;
 use blockstack_lib::chainstate::nakamoto::NakamotoBlock;
 use blockstack_lib::chainstate::stacks::StacksTransaction;
 use blockstack_lib::codec::StacksMessageCodec;
+use blockstack_lib::net::api::getaccount::AccountEntryResponse;
 use blockstack_lib::net::api::gettenureinfo::RPCGetTenureInfo;
+use blockstack_lib::types::chainstate::StacksAddress;
 use blockstack_lib::types::chainstate::StacksBlockId;
 use reqwest::header::CONTENT_LENGTH;
 use reqwest::header::CONTENT_TYPE;
@@ -150,6 +152,39 @@ pub enum SubmitTxResponse {
     Rejection(TxRejection),
 }
 
+/// The account info for a stacks account.
+pub struct AccountInfo {
+    /// The balance of the account in micro-STX
+    pub balance: u128,
+    /// The amount locked (stacked?) in micro-STX
+    pub locked: u128,
+    /// The last known nonce of the account.
+    pub nonce: u64,
+}
+
+/// Helper function for converting a hexidecimal string into an integer.
+fn parse_hex_u128(hex: &str) -> Result<u128, Error> {
+    let hex_str = if hex.starts_with("0x") {
+        &hex[2..]
+    } else {
+        hex
+    };
+
+    u128::from_str_radix(hex_str, 16).map_err(Error::ParseHexInt)
+}
+
+impl TryFrom<AccountEntryResponse> for AccountInfo {
+    type Error = Error;
+    fn try_from(value: AccountEntryResponse) -> Result<Self, Self::Error> {
+        Ok(AccountInfo {
+            balance: parse_hex_u128(&value.balance)?,
+            locked: parse_hex_u128(&value.locked)?,
+            nonce: value.nonce,
+        })
+        
+    }
+}
+
 /// A client for interacting with Stacks nodes and the Stacks API
 pub struct StacksClient {
     /// The base URL (with the port) that will be used when making requests
@@ -171,6 +206,36 @@ impl StacksClient {
             nakamoto_start_height: settings.node.nakamoto_start_height,
             client: reqwest::Client::new(),
         }
+    }
+
+    /// Get the latest account info for the given address.
+    ///
+    /// This is done by making a GET /v2/accounts/<principal> request. In
+    /// the request we specify that the nonce and balance proofs should not
+    /// be included in the response.
+    #[tracing::instrument(skip_all)]
+    pub async fn get_account(&self, address: &StacksAddress) -> Result<AccountInfo, Error> {
+        let path = format!("/v2/accounts/{}?proof=0", address);
+        let base = self.node_endpoint.clone();
+        let url = base
+            .join(&path)
+            .map_err(|err| Error::PathJoin(err, base, Cow::Owned(path)))?;
+
+        tracing::debug!(%address, "Fetching the latest account information");
+
+        let response = self
+            .client
+            .get(url)
+            .timeout(REQUEST_TIMEOUT)
+            .send()
+            .await
+            .map_err(Error::StacksNodeRequest)?;
+
+        response
+            .json::<AccountEntryResponse>()
+            .await
+            .map_err(Error::UnexpectedStacksResponse)
+            .and_then(AccountInfo::try_from)
     }
 
     /// Submit a transaction to a Stacks node.

--- a/signer/src/stacks/api.rs
+++ b/signer/src/stacks/api.rs
@@ -164,7 +164,7 @@ pub struct AccountInfo {
 
 /// Helper function for converting a hexidecimal string into an integer.
 fn parse_hex_u128(hex: &str) -> Result<u128, Error> {
-    let hex_str = hex.strip_prefix("0x").unwrap_or(hex);
+    let hex_str = hex.trim_start_matches("0x");
     u128::from_str_radix(hex_str, 16).map_err(Error::ParseHexInt)
 }
 
@@ -665,6 +665,8 @@ mod tests {
     #[test_case("0x1A3B5C7D9E", 112665066910; "uppercase-112665066910")]
     #[test_case("0x1a3b5c7d9e", 112665066910; "lowercase-112665066910")]
     #[test_case("1a3b5c7d9e", 112665066910; "unprefixed-lowercase-112665066910")]
+    #[test_case("0xF0", 240; "uppercase-240")]
+    #[test_case("f0", 240; "unprefixed-lowercase-240")]
     fn parsing_integers(hex: &str, expected: u128) {
         let actual = parse_hex_u128(hex).unwrap();
         assert_eq!(actual, expected);


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/301. Add a function that gets account information, including the nonce.

## Changes

* Adds a function that fetches the account info from a stacks node.

## Testing information

There is an integration test that does not run in CI. It was tested against a local stacks node.