### PR TITLE
feat: support key rotation contract calls

### DIFF
--- a/contracts/contracts/sbtc-bootstrap-signers.clar
+++ b/contracts/contracts/sbtc-bootstrap-signers.clar
@@ -27,7 +27,7 @@
 ;; Rotate keys
 ;; Used to rotate the keys of the signers. This is called whenever
 ;; the signer set is updated.
-(define-public (rotate-keys-wrapper (new-keys (list 15 (buff 33))) (new-aggregate-pubkey (buff 33)))
+(define-public (rotate-keys-wrapper (new-keys (list 128 (buff 33))) (new-aggregate-pubkey (buff 33)))
     (let 
         (
             (current-signer-data (contract-call? .sbtc-registry get-current-signer-data))   
@@ -70,7 +70,7 @@
 
 ;; Generate the p2sh redeem script for a multisig
 (define-read-only (pubkeys-to-spend-script
-    (pubkeys (list 15 (buff 33)))
+    (pubkeys (list 128 (buff 33)))
     (m uint)
   )
   (concat (uint-to-byte (+ u80 m)) ;; "m" in m-of-n
@@ -82,7 +82,7 @@
 
 ;; hash160 of the p2sh redeem script
 (define-read-only (pubkeys-to-hash
-    (pubkeys (list 15 (buff 33)))
+    (pubkeys (list 128 (buff 33)))
     (m uint)
   )
   (hash160 (pubkeys-to-spend-script pubkeys m))
@@ -90,7 +90,7 @@
 
 ;; Given a set of pubkeys and an m-of-n, generate a principal
 (define-read-only (pubkeys-to-principal
-    (pubkeys (list 15 (buff 33)))
+    (pubkeys (list 128 (buff 33)))
     (m uint)
   )
   (unwrap-panic (principal-construct?
@@ -100,7 +100,7 @@
 )
 
 ;; Concat a list of pubkeys into a buffer with length prefixes
-(define-read-only (pubkeys-to-bytes (pubkeys (list 15 (buff 33))))
+(define-read-only (pubkeys-to-bytes (pubkeys (list 128 (buff 33))))
   (fold concat-pubkeys-fold pubkeys 0x)
 )
 

--- a/contracts/contracts/sbtc-registry.clar
+++ b/contracts/contracts/sbtc-registry.clar
@@ -10,7 +10,7 @@
 ;; Variables
 
 (define-data-var last-withdrawal-request-id uint u0)
-(define-data-var current-signer-set (list 15 (buff 33)) (list))
+(define-data-var current-signer-set (list 128 (buff 33)) (list))
 (define-data-var current-aggregate-pubkey (buff 33) 0x00)
 (define-data-var current-signer-principal principal tx-sender)
 
@@ -216,7 +216,7 @@
 ;; Rotate the signer set, multi-sig principal, & aggregate pubkey
 ;; This function can only be called by the bootstrap-signers contract.
 ;; #[allow(unchecked_data)]
-(define-public (rotate-keys (new-keys (list 15 (buff 33))) (new-address principal) (new-aggregate-pubkey (buff 33)))
+(define-public (rotate-keys (new-keys (list 128 (buff 33))) (new-address principal) (new-aggregate-pubkey (buff 33)))
   (begin
     ;; Check that caller is protocol contract
     (try! (validate-caller))

--- a/contracts/docs/sbtc-bootstrap-signers.md
+++ b/contracts/docs/sbtc-bootstrap-signers.md
@@ -41,7 +41,7 @@ sBTC Bootstrap Signers contract
 
 [View in file](../contracts/sbtc-bootstrap-signers.clar#L30)
 
-`(define-public (rotate-keys-wrapper ((new-keys (list 15 (buff 33))) (new-aggregate-pubkey (buff 33))) (response bool uint))`
+`(define-public (rotate-keys-wrapper ((new-keys (list 128 (buff 33))) (new-aggregate-pubkey (buff 33))) (response bool uint))`
 
 Rotate keys
 Used to rotate the keys of the signers. This is called whenever
@@ -51,7 +51,7 @@ the signer set is updated.
   <summary>Source code:</summary>
 
 ```clarity
-(define-public (rotate-keys-wrapper (new-keys (list 15 (buff 33))) (new-aggregate-pubkey (buff 33)))
+(define-public (rotate-keys-wrapper (new-keys (list 128 (buff 33))) (new-aggregate-pubkey (buff 33)))
     (let
         (
             (current-signer-data (contract-call? .sbtc-registry get-current-signer-data))
@@ -76,10 +76,10 @@ the signer set is updated.
 
 **Parameters:**
 
-| Name                 | Type                |
-| -------------------- | ------------------- |
-| new-keys             | (list 15 (buff 33)) |
-| new-aggregate-pubkey | (buff 33)           |
+| Name                 | Type                 |
+| -------------------- | -------------------- |
+| new-keys             | (list 128 (buff 33)) |
+| new-aggregate-pubkey | (buff 33)            |
 
 ### signer-key-length-check
 
@@ -120,7 +120,7 @@ Checks that the length of each key is exactly 33 bytes #[allow(unchecked_data)]
 
 [View in file](../contracts/sbtc-bootstrap-signers.clar#L72)
 
-`(define-read-only (pubkeys-to-spend-script ((pubkeys (list 15 (buff 33))) (m uint)) (buff 513))`
+`(define-read-only (pubkeys-to-spend-script ((pubkeys (list 128 (buff 33))) (m uint)) (buff 513))`
 
 Generate the p2sh redeem script for a multisig
 
@@ -129,7 +129,7 @@ Generate the p2sh redeem script for a multisig
 
 ```clarity
 (define-read-only (pubkeys-to-spend-script
-    (pubkeys (list 15 (buff 33)))
+    (pubkeys (list 128 (buff 33)))
     (m uint)
   )
   (concat (uint-to-byte (+ u80 m)) ;; "m" in m-of-n
@@ -144,16 +144,16 @@ Generate the p2sh redeem script for a multisig
 
 **Parameters:**
 
-| Name    | Type                |
-| ------- | ------------------- |
-| pubkeys | (list 15 (buff 33)) |
-| m       | uint                |
+| Name    | Type                 |
+| ------- | -------------------- |
+| pubkeys | (list 128 (buff 33)) |
+| m       | uint                 |
 
 ### pubkeys-to-hash
 
 [View in file](../contracts/sbtc-bootstrap-signers.clar#L84)
 
-`(define-read-only (pubkeys-to-hash ((pubkeys (list 15 (buff 33))) (m uint)) (buff 20))`
+`(define-read-only (pubkeys-to-hash ((pubkeys (list 128 (buff 33))) (m uint)) (buff 20))`
 
 hash160 of the p2sh redeem script
 
@@ -162,7 +162,7 @@ hash160 of the p2sh redeem script
 
 ```clarity
 (define-read-only (pubkeys-to-hash
-    (pubkeys (list 15 (buff 33)))
+    (pubkeys (list 128 (buff 33)))
     (m uint)
   )
   (hash160 (pubkeys-to-spend-script pubkeys m))
@@ -173,16 +173,16 @@ hash160 of the p2sh redeem script
 
 **Parameters:**
 
-| Name    | Type                |
-| ------- | ------------------- |
-| pubkeys | (list 15 (buff 33)) |
-| m       | uint                |
+| Name    | Type                 |
+| ------- | -------------------- |
+| pubkeys | (list 128 (buff 33)) |
+| m       | uint                 |
 
 ### pubkeys-to-principal
 
 [View in file](../contracts/sbtc-bootstrap-signers.clar#L92)
 
-`(define-read-only (pubkeys-to-principal ((pubkeys (list 15 (buff 33))) (m uint)) principal)`
+`(define-read-only (pubkeys-to-principal ((pubkeys (list 128 (buff 33))) (m uint)) principal)`
 
 Given a set of pubkeys and an m-of-n, generate a principal
 
@@ -191,7 +191,7 @@ Given a set of pubkeys and an m-of-n, generate a principal
 
 ```clarity
 (define-read-only (pubkeys-to-principal
-    (pubkeys (list 15 (buff 33)))
+    (pubkeys (list 128 (buff 33)))
     (m uint)
   )
   (unwrap-panic (principal-construct?
@@ -205,16 +205,16 @@ Given a set of pubkeys and an m-of-n, generate a principal
 
 **Parameters:**
 
-| Name    | Type                |
-| ------- | ------------------- |
-| pubkeys | (list 15 (buff 33)) |
-| m       | uint                |
+| Name    | Type                 |
+| ------- | -------------------- |
+| pubkeys | (list 128 (buff 33)) |
+| m       | uint                 |
 
 ### pubkeys-to-bytes
 
 [View in file](../contracts/sbtc-bootstrap-signers.clar#L103)
 
-`(define-read-only (pubkeys-to-bytes ((pubkeys (list 15 (buff 33)))) (buff 510))`
+`(define-read-only (pubkeys-to-bytes ((pubkeys (list 128 (buff 33)))) (buff 510))`
 
 Concat a list of pubkeys into a buffer with length prefixes
 
@@ -222,7 +222,7 @@ Concat a list of pubkeys into a buffer with length prefixes
   <summary>Source code:</summary>
 
 ```clarity
-(define-read-only (pubkeys-to-bytes (pubkeys (list 15 (buff 33))))
+(define-read-only (pubkeys-to-bytes (pubkeys (list 128 (buff 33))))
   (fold concat-pubkeys-fold pubkeys 0x)
 )
 ```
@@ -231,9 +231,9 @@ Concat a list of pubkeys into a buffer with length prefixes
 
 **Parameters:**
 
-| Name    | Type                |
-| ------- | ------------------- |
-| pubkeys | (list 15 (buff 33)) |
+| Name    | Type                 |
+| ------- | -------------------- |
+| pubkeys | (list 128 (buff 33)) |
 
 ### concat-pubkeys-fold
 

--- a/contracts/tests/clarigen-types.ts
+++ b/contracts/tests/clarigen-types.ts
@@ -36,7 +36,7 @@ export const contracts = {
         args: [
           {
             name: "new-keys",
-            type: { list: { type: { buffer: { length: 33 } }, length: 15 } },
+            type: { list: { type: { buffer: { length: 33 } }, length: 128 } },
           },
           { name: "new-aggregate-pubkey", type: { buffer: { length: 33 } } },
         ],
@@ -78,7 +78,7 @@ export const contracts = {
         args: [
           {
             name: "pubkeys",
-            type: { list: { type: { buffer: { length: 33 } }, length: 15 } },
+            type: { list: { type: { buffer: { length: 33 } }, length: 128 } },
           },
         ],
         outputs: { type: { buffer: { length: 510 } } },
@@ -92,7 +92,7 @@ export const contracts = {
         args: [
           {
             name: "pubkeys",
-            type: { list: { type: { buffer: { length: 33 } }, length: 15 } },
+            type: { list: { type: { buffer: { length: 33 } }, length: 128 } },
           },
           { name: "m", type: "uint128" },
         ],
@@ -110,7 +110,7 @@ export const contracts = {
         args: [
           {
             name: "pubkeys",
-            type: { list: { type: { buffer: { length: 33 } }, length: 15 } },
+            type: { list: { type: { buffer: { length: 33 } }, length: 128 } },
           },
           { name: "m", type: "uint128" },
         ],
@@ -128,7 +128,7 @@ export const contracts = {
         args: [
           {
             name: "pubkeys",
-            type: { list: { type: { buffer: { length: 33 } }, length: 15 } },
+            type: { list: { type: { buffer: { length: 33 } }, length: 128 } },
           },
           { name: "m", type: "uint128" },
         ],
@@ -779,7 +779,7 @@ export const contracts = {
         args: [
           {
             name: "new-keys",
-            type: { list: { type: { buffer: { length: 33 } }, length: 15 } },
+            type: { list: { type: { buffer: { length: 33 } }, length: 128 } },
           },
           { name: "new-address", type: "principal" },
           { name: "new-aggregate-pubkey", type: { buffer: { length: 33 } } },
@@ -841,7 +841,7 @@ export const contracts = {
               {
                 name: "current-signer-set",
                 type: {
-                  list: { type: { buffer: { length: 33 } }, length: 15 },
+                  list: { type: { buffer: { length: 33 } }, length: 128 },
                 },
               },
             ],
@@ -866,7 +866,7 @@ export const contracts = {
         access: "read_only",
         args: [],
         outputs: {
-          type: { list: { type: { buffer: { length: 33 } }, length: 15 } },
+          type: { list: { type: { buffer: { length: 33 } }, length: 128 } },
         },
       } as TypedAbiFunction<[], Uint8Array[]>,
       getWithdrawalRequest: {
@@ -1062,7 +1062,7 @@ export const contracts = {
                 length: 33,
               },
             },
-            length: 15,
+            length: 128,
           },
         },
         access: "variable",

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -78,14 +78,14 @@ pub enum Error {
     /// An error for the case where we cannot create a multi-sig
     /// StacksAddress using given public keys.
     #[error("Could not create a StacksAddress from the public keys: threshold {0}, keys {1}")]
-    StacksMusltiSig(u16, usize),
+    StacksMultiSig(u16, usize),
 
     /// Error when reading the stacks API part of the config.toml
     #[error("Failed to parse the stacks.api portion of the config: {0}")]
     StacksApiConfig(#[source] config::ConfigError),
 
     /// This error happens when converting a sepc256k1::PublicKey into a
-    /// blockstack_lib::util::secp256k1::Secp256k1PublicKey. In general it
+    /// blockstack_lib::util::secp256k1::Secp256k1PublicKey. In general, it
     /// shouldn't happen.
     #[error("Could not transform sepc256k1::PublicKey to stacks variant: {0}")]
     StacksPublicKey(&'static str),
@@ -103,7 +103,7 @@ pub enum Error {
     UnexpectedStacksResponse(#[source] reqwest::Error),
 
     /// Taproot error
-    #[error("an error occured when constructing the taproot signing digest: {0}")]
+    #[error("an error occurred when constructing the taproot signing digest: {0}")]
     Taproot(#[from] bitcoin::sighash::TaprootError),
 
     /// Signer loop error

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -40,12 +40,8 @@ pub enum Error {
     #[error("Failed to construct a valid URL from {1} and {2}: {0}")]
     PathJoin(#[source] url::ParseError, url::Url, Cow<'static, str>),
 
-    /// This occurs under any of the following conditions:
-    /// - The result would be the point at infinity, i.e. adding a point to
-    ///   its own negation.
-    /// - The provided slice is empty.
-    /// - The number of elements in the provided slice is greater than
-    ///   `i32::MAX`.
+    /// This occurs when combining many public keys would result in a
+    /// "public key" that is the point at infinity.
     #[error("{0}")]
     InvalidAggregateKey(#[source] secp256k1::Error),
 
@@ -59,6 +55,7 @@ pub enum Error {
     /// 2. No required signatures.
     /// 3. The number of required signatures exceeding the number of public
     ///    keys.
+    /// 4. The number of public keys exceeds the MAX_KEYS constant.
     #[error("Invalid wallet definition, signatures required: {0}, number of keys: {1}")]
     InvalidWalletDefinition(u16, usize),
 

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -40,6 +40,15 @@ pub enum Error {
     #[error("Failed to construct a valid URL from {1} and {2}: {0}")]
     PathJoin(#[source] url::ParseError, url::Url, Cow<'static, str>),
 
+    /// This occurs under any of the following conditions:
+    /// - The result would be the point at infinity, i.e. adding a point to
+    ///   its own negation.
+    /// - The provided slice is empty.
+    /// - The number of elements in the provided slice is greater than
+    ///   `i32::MAX`.
+    #[error("{0}")]
+    InvalidAggregateKey(#[source] secp256k1::Error),
+
     /// This happens when we attempt to recover a public key from a
     /// recoverable EDCSA signature.
     #[error("Could not recover the public key from the signature: {0}, digest: {1}")]

--- a/signer/src/lib.rs
+++ b/signer/src/lib.rs
@@ -34,4 +34,4 @@ pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 /// 3. The signer bitmap in the clarity contract can take only 128 signers.
 /// 4. The rotate-keys-wrapper public function in one of the clarity
 ///    contracts takes a maximum of 15 keys.
-const MAX_KEYS: u16 = 15;
+const MAX_KEYS: u16 = 128;

--- a/signer/src/lib.rs
+++ b/signer/src/lib.rs
@@ -22,3 +22,16 @@ pub mod utxo;
 
 /// Package version
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// The maximum number of keys in the signers multi-sig wallet on Stacks.
+/// There are a few practical limits on the maximum number of distinct
+/// public keys:
+/// 1. The maximum number of signatures allowed in a stacks transaction is
+///    capped at u16::MAX, which is 65535.
+/// 2. The maximum amount of data that can be sent as input into a clarity
+///    contract call is capped at 1 MB. That limits the maximum number of
+///    keys to ~31K.
+/// 3. The signer bitmap in the clarity contract can take only 128 signers.
+/// 4. The rotate-keys-wrapper public function in one of the clarity
+///    contracts takes a maximum of 15 keys.
+const MAX_KEYS: u16 = 15;

--- a/signer/src/lib.rs
+++ b/signer/src/lib.rs
@@ -33,5 +33,5 @@ pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 ///    keys to ~31K.
 /// 3. The signer bitmap in the clarity contract can take only 128 signers.
 /// 4. The rotate-keys-wrapper public function in one of the clarity
-///    contracts takes a maximum of 15 keys.
+///    contracts takes a maximum of 128 keys.
 const MAX_KEYS: u16 = 128;

--- a/signer/src/stacks/contracts.rs
+++ b/signer/src/stacks/contracts.rs
@@ -12,6 +12,12 @@
 //!   reject-withdrawal-request function in the sbtc-withdrawal contract.
 //!   This finalizes the withdrawal request by returning the locked sBTC to
 //!   the requester.
+//! * [`RotateKeysV1`]: Used for calling the rotate-keys-wrapper function
+//!   in the sbtc-bootstrap-signers contract. This changes the valid caller
+//!   of most sBTC related functions to a new multi-sig wallet.
+
+use std::collections::BTreeSet;
+use std::sync::OnceLock;
 
 use bitcoin::hashes::Hash as _;
 use bitcoin::OutPoint;
@@ -22,13 +28,21 @@ use blockstack_lib::chainstate::stacks::TransactionPayload;
 use blockstack_lib::chainstate::stacks::TransactionPostCondition;
 use blockstack_lib::chainstate::stacks::TransactionPostConditionMode;
 use blockstack_lib::clarity::vm::types::BuffData;
+use blockstack_lib::clarity::vm::types::ListData;
+use blockstack_lib::clarity::vm::types::ListTypeData;
 use blockstack_lib::clarity::vm::types::PrincipalData;
 use blockstack_lib::clarity::vm::types::SequenceData;
 use blockstack_lib::clarity::vm::types::StandardPrincipalData;
+use blockstack_lib::clarity::vm::types::BUFF_33;
 use blockstack_lib::clarity::vm::ClarityName;
 use blockstack_lib::clarity::vm::ContractName;
 use blockstack_lib::clarity::vm::Value;
 use blockstack_lib::types::chainstate::StacksAddress;
+use secp256k1::PublicKey;
+
+use crate::error::Error;
+
+use crate::stacks::wallet::SignerWallet;
 
 /// A struct describing any transaction post-execution conditions that we'd
 /// like to enforce.
@@ -162,7 +176,7 @@ pub struct CompleteDepositV1 {
     pub amount: u64,
     /// The address where the newly minted sBTC will be deposited.
     pub recipient: StacksAddress,
-    /// The address that deployed the contract,
+    /// The address that deployed the contract.
     pub deployer: StacksAddress,
 }
 
@@ -208,7 +222,7 @@ pub struct AcceptWithdrawalV1 {
     /// 128 distinct signers. Here, we assume that a 1 (or true) implies
     /// that the signer voted *against* the transaction.
     pub signer_bitmap: BitArray<[u64; 2]>,
-    /// The address that deployed the contract,
+    /// The address that deployed the contract.
     pub deployer: StacksAddress,
 }
 
@@ -247,7 +261,7 @@ pub struct RejectWithdrawalV1 {
     /// 128 distinct signers. Here, we assume that a 1 (or true) implies
     /// that the signer voted *against* the transaction.
     pub signer_bitmap: BitArray<[u64; 2]>,
-    /// The address that deployed the contract,
+    /// The address that deployed the contract.
     pub deployer: StacksAddress,
 }
 
@@ -266,8 +280,115 @@ impl AsContractCall for RejectWithdrawalV1 {
     }
 }
 
+/// This struct is used to generate a properly formatted Stacks transaction
+/// for calling the rotate-keys-wrapper function in the
+/// sbtc-bootstrap-signers smart contract.
+#[derive(Clone, Debug)]
+pub struct RotateKeysV1 {
+    /// The new set of public keys for all known signers during this
+    /// PoX cycle.
+    new_keys: BTreeSet<PublicKey>,
+    /// The aggregate key created by combining the above public keys.
+    aggregate_key: PublicKey,
+    /// The address that deployed the contract.
+    deployer: StacksAddress,
+}
+
+impl RotateKeysV1 {
+    /// Create a new instance of RotateKeysV1.
+    ///
+    /// This function errors when secp256k1::PublicKey::combine_keys
+    /// errors. Here, only happens when the result would be the point at
+    /// infinity.
+    ///
+    /// There are two other conditions where PublicKey::combine_keys
+    /// errors, which are:
+    ///
+    /// * The provided slice of public keys is empty.
+    /// * The number of elements in the provided slice is greater than
+    ///   `i32::MAX`.
+    ///
+    /// But the SignerWallet checks for these two cases and rejects them,
+    /// so they cannot happen here.
+    pub fn new(wallet: &SignerWallet, deployer: StacksAddress) -> Result<Self, Error> {
+        let keys: Vec<&PublicKey> = wallet.public_keys().iter().collect();
+
+        Ok(Self {
+            aggregate_key: PublicKey::combine_keys(&keys).map_err(Error::InvalidAggregateKey)?,
+            new_keys: keys.into_iter().copied().collect(),
+            deployer,
+        })
+    }
+
+    /// This function returns the clarity description of one of the inputs
+    /// to the contract call.
+    ///
+    /// # Notes
+    ///
+    /// One of the inputs, new-keys, is a (list 15 (buff 33)). This
+    /// function represents this data type.
+    fn list_data_type() -> &'static ListTypeData {
+        static KEYS_ARGUMENT_DATA_TYPE: OnceLock<ListTypeData> = OnceLock::new();
+        KEYS_ARGUMENT_DATA_TYPE.get_or_init(|| {
+            // A Result::Err is returned whenever the "depth" of the type
+            // is too large or if the the maximum size of an input with the
+            // given type is too large. None of this is true for us, the
+            // depth is 1 or 2 and the size is 15 * 33 bytes, which is
+            // under the limit of 1 MB.
+            ListTypeData::new_list(BUFF_33.clone(), crate::MAX_KEYS as u32)
+                .expect("Error: legal ListTypeData marked as invalid")
+        })
+    }
+}
+
+impl AsContractCall for RotateKeysV1 {
+    const CONTRACT_NAME: &'static str = "sbtc-bootstrap-signers";
+    const FUNCTION_NAME: &'static str = "rotate-keys-wrapper";
+
+    fn deployer_address(&self) -> StacksAddress {
+        self.deployer
+    }
+    /// The arguments to the contract call function
+    ///
+    /// # Notes
+    ///
+    /// The signature to this function is:
+    ///
+    ///     (new-keys (list 15 (buff 33))) (new-aggregate-pubkey (buff 33))
+    fn as_contract_args(&self) -> Vec<Value> {
+        let new_key_data: Vec<Value> = self
+            .new_keys
+            .iter()
+            .map(|pk| {
+                let data = pk.serialize().to_vec();
+                Value::Sequence(SequenceData::Buffer(BuffData { data }))
+            })
+            .collect();
+
+        let new_keys = ListData {
+            data: new_key_data,
+            type_signature: Self::list_data_type().clone(),
+        };
+
+        // The public key needs to be exactly 33 bytes in this contract
+        // call.
+        let key: [u8; 33] = self.aggregate_key.serialize();
+
+        vec![
+            Value::Sequence(SequenceData::List(new_keys)),
+            Value::Sequence(SequenceData::Buffer(BuffData { data: key.to_vec() })),
+        ]
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use rand::rngs::OsRng;
+    use secp256k1::SecretKey;
+    use secp256k1::SECP256K1;
+
+    use crate::config::NetworkKind;
+
     use super::*;
 
     #[test]
@@ -309,6 +430,33 @@ mod tests {
             deployer: StacksAddress::burn_address(false),
         };
 
+        let _ = call.as_contract_call();
+    }
+
+    #[test]
+    fn rotate_keys_wrapper_contract_call_creation() {
+        // This is to check that the RotateKeysV1::list_data_type function
+        // doesn't panic. If it doesn't panic now, it can never panic at
+        // runtime.
+        let _ = RotateKeysV1::list_data_type();
+
+        let secret_keys = [
+            SecretKey::new(&mut OsRng),
+            SecretKey::new(&mut OsRng),
+            SecretKey::new(&mut OsRng),
+        ];
+        let public_keys = secret_keys.map(|sk| sk.public_key(SECP256K1));
+        let wallet = SignerWallet::new(&public_keys, 2, NetworkKind::Testnet).unwrap();
+        let deployer = StacksAddress::burn_address(false);
+
+        // Now there is always a small risk that the RotateKeysV1::new
+        // function will return a Result::Err, even with perfectly fine
+        // inputs. This is highly unlikely by chance, but a Byzantine actor
+        // could trigger it purposefully if we aren't careful.
+        let call = RotateKeysV1::new(&wallet, deployer).unwrap();
+
+        // This is to check that this function doesn't implicitly panic. If
+        // it doesn't panic now, it can never panic at runtime.
         let _ = call.as_contract_call();
     }
 }

--- a/signer/src/stacks/contracts.rs
+++ b/signer/src/stacks/contracts.rs
@@ -330,7 +330,7 @@ impl RotateKeysV1 {
         static KEYS_ARGUMENT_DATA_TYPE: OnceLock<ListTypeData> = OnceLock::new();
         KEYS_ARGUMENT_DATA_TYPE.get_or_init(|| {
             // A Result::Err is returned whenever the "depth" of the type
-            // is too large or if the the maximum size of an input with the
+            // is too large or if the maximum size of an input with the
             // given type is too large. None of this is true for us, the
             // depth is 1 or 2 and the size is 128 * 33 bytes, which is
             // under the limit of 1 MB.

--- a/signer/src/stacks/contracts.rs
+++ b/signer/src/stacks/contracts.rs
@@ -325,7 +325,7 @@ impl RotateKeysV1 {
     ///
     /// # Notes
     ///
-    /// One of the inputs, new-keys, is a (list 15 (buff 33)). This
+    /// One of the inputs, new-keys, is a (list 128 (buff 33)). This
     /// function represents this data type.
     fn list_data_type() -> &'static ListTypeData {
         static KEYS_ARGUMENT_DATA_TYPE: OnceLock<ListTypeData> = OnceLock::new();
@@ -333,7 +333,7 @@ impl RotateKeysV1 {
             // A Result::Err is returned whenever the "depth" of the type
             // is too large or if the the maximum size of an input with the
             // given type is too large. None of this is true for us, the
-            // depth is 1 or 2 and the size is 15 * 33 bytes, which is
+            // depth is 1 or 2 and the size is 128 * 33 bytes, which is
             // under the limit of 1 MB.
             ListTypeData::new_list(BUFF_33.clone(), crate::MAX_KEYS as u32)
                 .expect("Error: legal ListTypeData marked as invalid")
@@ -354,7 +354,7 @@ impl AsContractCall for RotateKeysV1 {
     ///
     /// The signature to this function is:
     ///
-    ///     (new-keys (list 15 (buff 33))) (new-aggregate-pubkey (buff 33))
+    ///   (new-keys (list 128 (buff 33))) (new-aggregate-pubkey (buff 33))
     fn as_contract_args(&self) -> Vec<Value> {
         let new_key_data: Vec<Value> = self
             .new_keys

--- a/signer/src/stacks/wallet.rs
+++ b/signer/src/stacks/wallet.rs
@@ -48,7 +48,7 @@ const MULTISIG_ADDRESS_HASH_MODE: OrderIndependentMultisigHashMode =
 #[derive(Debug, Clone)]
 pub struct SignerWallet {
     /// The current set of public keys for all known signers during this
-    /// PoX cycle. These values must be sorted.
+    /// PoX cycle.
     public_keys: BTreeSet<PublicKey>,
     /// The number of signers necessary for successfully signing a
     /// multi-sig transaction.
@@ -121,6 +121,11 @@ impl SignerWallet {
     /// Return the stacks address for the signers
     pub fn address(&self) -> StacksAddress {
         self.address
+    }
+
+    /// Return the public keys for the signers' multi-sig wallet
+    pub fn public_keys(&self) -> &BTreeSet<PublicKey> {
+        &self.public_keys
     }
 }
 

--- a/signer/src/stacks/wallet.rs
+++ b/signer/src/stacks/wallet.rs
@@ -113,7 +113,7 @@ impl SignerWallet {
             signatures_required,
             network_kind,
             address: StacksAddress::from_public_keys(version, &hash_mode, num_sigs, &pubkeys)
-                .ok_or(Error::StacksMusltiSig(signatures_required, num_keys))?,
+                .ok_or(Error::StacksMultiSig(signatures_required, num_keys))?,
         })
     }
 

--- a/signer/src/stacks/wallet.rs
+++ b/signer/src/stacks/wallet.rs
@@ -33,6 +33,7 @@ use crate::error::Error;
 use crate::stacks::contracts::AsContractCall;
 use crate::stacks::contracts::AsTxPayload;
 use crate::stacks::contracts::ContractCall;
+use crate::MAX_KEYS;
 
 /// Stacks multisig addresses are RIPEMD-160 hashes of bitcoin Scripts
 /// (more or less). The enum value below defines which Script will be used
@@ -66,9 +67,10 @@ impl SignerWallet {
     ///
     /// An error is returned if:
     /// 1. There are no public keys.
-    /// 2. There are no required signatures.
+    /// 2. The required signatures is zero.
     /// 3. The number of required signatures exceeding the number of public
     ///    keys.
+    /// 4. The number of public keys exceeds the MAX_KEYS constant.
     pub fn new(
         public_keys: &[PublicKey],
         signatures_required: u16,
@@ -76,8 +78,9 @@ impl SignerWallet {
     ) -> Result<Self, Error> {
         let num_keys = public_keys.len();
         let invalid_threshold = num_keys < signatures_required as usize;
+        let invalid_num_keys = num_keys == 0 || num_keys > MAX_KEYS as usize;
 
-        if invalid_threshold || num_keys == 0 || signatures_required == 0 {
+        if invalid_threshold || invalid_num_keys || signatures_required == 0 {
             return Err(Error::InvalidWalletDefinition(
                 signatures_required,
                 num_keys,

--- a/signer/tests/stacks/stacks-node-config.toml
+++ b/signer/tests/stacks/stacks-node-config.toml
@@ -127,7 +127,7 @@ amount = 10000000000000000
 # three times using an rand::rng::StdRng struct created with a seed of 100.
 # Once we had 3 public-private key pairs, the SignerWallet struct was used
 # to generate the 2-3 multi sig address below.
-address = "SN326RW8148J2Q1P1MZ5K6JNY6WYDZPPZS45Z5ZBR"
+address = "SN2V7WTJ7BHR03MPHZ1C9A9ZR6NZGR4WM8HT4V67Y"
 amount = 10000000000000000
 
 [[ustx_balance]]


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/307.

I believe this is the last contract call that we need to support.

## Changes

* Bump the maximum number of signers to 128 from 15. @hstove @setzeus thoughts (it's this commit d6ac6ec046ef0bb8c1b22fba213dfdd3dc24c4e2)?
* Update the address hash mode to match the hash mode assumed in the clarity contracts.
* Add a constant in the signer codebase that sets the cap on the number of signers.
* Add an implementation of a struct that we can use to easily rotate the Signers' multi-sig wallet.

## Testing information

I added a test that checks that we do not error when creating the struct under common circumstances.