### PR TITLE
feat: support waiting for a transaction signer to finish processing pending messages in tests

### DIFF
--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -160,6 +160,10 @@ pub enum Error {
     #[error("invalid configuration")]
     InvalidConfiguration,
 
+    /// Observer dropped
+    #[error("observer dropped")]
+    ObserverDropped,
+
     /// Thrown when the recoverable signature has a public key that is
     /// unexpected.
     #[error("unexpected public key from signature. key {0}; digest: {1}")]

--- a/signer/src/storage/model.rs
+++ b/signer/src/storage/model.rs
@@ -1,5 +1,6 @@
 //! Database models for the signer.
 
+#[cfg(feature = "testing")]
 use fake::faker::time::en::DateTimeAfter;
 
 /// Bitcoin block.
@@ -7,18 +8,21 @@ use fake::faker::time::en::DateTimeAfter;
 #[cfg_attr(feature = "testing", derive(fake::Dummy))]
 pub struct BitcoinBlock {
     /// Block hash.
-    #[dummy(expr = "fake::vec![u8; 32]")]
+    #[cfg_attr(feature = "testing", dummy(expr = "fake::vec![u8; 32]"))]
     pub block_hash: BitcoinBlockHash,
     /// Block height.
     pub block_height: i64,
     /// Hash of the parent block.
-    #[dummy(expr = "fake::vec![u8; 32]")]
+    #[cfg_attr(feature = "testing", dummy(expr = "fake::vec![u8; 32]"))]
     pub parent_hash: BitcoinBlockHash,
     /// Stacks block confirmed by this block.
-    #[dummy(default)]
+    #[cfg_attr(feature = "testing", dummy(default))]
     pub confirms: Vec<StacksBlockHash>,
     /// The time this block entry was created by the signer.
-    #[dummy(faker = "DateTimeAfter(time::OffsetDateTime::UNIX_EPOCH)")]
+    #[cfg_attr(
+        feature = "testing",
+        dummy(faker = "DateTimeAfter(time::OffsetDateTime::UNIX_EPOCH)")
+    )]
     pub created_at: time::OffsetDateTime,
 }
 
@@ -27,15 +31,18 @@ pub struct BitcoinBlock {
 #[cfg_attr(feature = "testing", derive(fake::Dummy))]
 pub struct StacksBlock {
     /// Block hash.
-    #[dummy(expr = "fake::vec![u8; 32]")]
+    #[cfg_attr(feature = "testing", dummy(expr = "fake::vec![u8; 32]"))]
     pub block_hash: StacksBlockHash,
     /// Block height.
     pub block_height: i64,
     /// Hash of the parent block.
-    #[dummy(expr = "fake::vec![u8; 32]")]
+    #[cfg_attr(feature = "testing", dummy(expr = "fake::vec![u8; 32]"))]
     pub parent_hash: StacksBlockHash,
     /// The time this block entry was created by the signer.
-    #[dummy(faker = "DateTimeAfter(time::OffsetDateTime::UNIX_EPOCH)")]
+    #[cfg_attr(
+        feature = "testing",
+        dummy(faker = "DateTimeAfter(time::OffsetDateTime::UNIX_EPOCH)")
+    )]
     pub created_at: time::OffsetDateTime,
 }
 
@@ -44,10 +51,10 @@ pub struct StacksBlock {
 #[cfg_attr(feature = "testing", derive(fake::Dummy))]
 pub struct DepositRequest {
     /// Transaction ID of the deposit request transaction.
-    #[dummy(expr = "fake::vec![u8; 32]")]
+    #[cfg_attr(feature = "testing", dummy(expr = "fake::vec![u8; 32]"))]
     pub txid: BitcoinTxId,
     /// Index of the deposit request UTXO.
-    #[dummy(faker = "0..100")]
+    #[cfg_attr(feature = "testing", dummy(faker = "0..100"))]
     pub output_index: i32,
     /// Script spendable by the sBTC signers.
     pub spend_script: Bytes,
@@ -62,10 +69,13 @@ pub struct DepositRequest {
     /// be used to pay for transaction fees.
     pub max_fee: i64,
     /// The addresses of the input UTXOs funding the deposit request.
-    #[dummy(expr = "fake::vec![String; 1..8]")]
+    #[cfg_attr(feature = "testing", dummy(expr = "fake::vec![String; 1..8]"))]
     pub sender_addresses: Vec<BitcoinAddress>,
     /// The time this block entry was created by the signer.
-    #[dummy(faker = "DateTimeAfter(time::OffsetDateTime::UNIX_EPOCH)")]
+    #[cfg_attr(
+        feature = "testing",
+        dummy(faker = "DateTimeAfter(time::OffsetDateTime::UNIX_EPOCH)")
+    )]
     pub created_at: time::OffsetDateTime,
 }
 
@@ -74,17 +84,20 @@ pub struct DepositRequest {
 #[cfg_attr(feature = "testing", derive(fake::Dummy))]
 pub struct DepositSigner {
     /// TxID of the deposit request.
-    #[dummy(expr = "fake::vec![u8; 32]")]
+    #[cfg_attr(feature = "testing", dummy(expr = "fake::vec![u8; 32]"))]
     pub txid: BitcoinTxId,
     /// Ouput index of the deposit request.
-    #[dummy(faker = "0..100")]
+    #[cfg_attr(feature = "testing", dummy(faker = "0..100"))]
     pub output_index: i32,
     /// Public key of the signer.
     pub signer_pub_key: PubKey,
     /// Signals if the signer is prepared to sign for this request.
     pub is_accepted: bool,
     /// The time this block entry was created by the signer.
-    #[dummy(faker = "DateTimeAfter(time::OffsetDateTime::UNIX_EPOCH)")]
+    #[cfg_attr(
+        feature = "testing",
+        dummy(faker = "DateTimeAfter(time::OffsetDateTime::UNIX_EPOCH)")
+    )]
     pub created_at: time::OffsetDateTime,
 }
 
@@ -95,7 +108,7 @@ pub struct WithdrawRequest {
     /// Request ID of the withdraw request.
     pub request_id: i32,
     /// Stacks block hash of the withdraw request.
-    #[dummy(expr = "fake::vec![u8; 32]")]
+    #[cfg_attr(feature = "testing", dummy(expr = "fake::vec![u8; 32]"))]
     pub block_hash: StacksBlockHash,
     /// The address that shuld receive the BTC withdrawal.
     pub recipient: BitcoinAddress,
@@ -107,7 +120,10 @@ pub struct WithdrawRequest {
     /// The address that initiated the request.
     pub sender_address: StacksAddress,
     /// The time this block entry was created by the signer.
-    #[dummy(faker = "DateTimeAfter(time::OffsetDateTime::UNIX_EPOCH)")]
+    #[cfg_attr(
+        feature = "testing",
+        dummy(faker = "DateTimeAfter(time::OffsetDateTime::UNIX_EPOCH)")
+    )]
     pub created_at: time::OffsetDateTime,
 }
 
@@ -118,14 +134,17 @@ pub struct WithdrawSigner {
     /// Request ID of the withdraw request.
     pub request_id: i32,
     /// Stacks block hash of the withdraw request.
-    #[dummy(expr = "fake::vec![u8; 32]")]
+    #[cfg_attr(feature = "testing", dummy(expr = "fake::vec![u8; 32]"))]
     pub block_hash: StacksBlockHash,
     /// Public key of the signer.
     pub signer_pub_key: PubKey,
     /// Signals if the signer is prepared to sign for this request.
     pub is_accepted: bool,
     /// The time this block entry was created by the signer.
-    #[dummy(faker = "DateTimeAfter(time::OffsetDateTime::UNIX_EPOCH)")]
+    #[cfg_attr(
+        feature = "testing",
+        dummy(faker = "DateTimeAfter(time::OffsetDateTime::UNIX_EPOCH)")
+    )]
     pub created_at: time::OffsetDateTime,
 }
 
@@ -152,14 +171,17 @@ pub struct StacksTransaction {
 #[cfg_attr(feature = "testing", derive(fake::Dummy))]
 pub struct Transaction {
     /// Transaction ID.
-    #[dummy(expr = "fake::vec![u8; 32]")]
+    #[cfg_attr(feature = "testing", dummy(expr = "fake::vec![u8; 32]"))]
     pub txid: Bytes,
     /// Encoded transaction.
     pub tx: Bytes,
     /// The type of the transaction.
     pub tx_type: TransactionType,
     /// The time this transaction entry was created by the signer.
-    #[dummy(faker = "DateTimeAfter(time::OffsetDateTime::UNIX_EPOCH)")]
+    #[cfg_attr(
+        feature = "testing",
+        dummy(faker = "DateTimeAfter(time::OffsetDateTime::UNIX_EPOCH)")
+    )]
     pub created_at: time::OffsetDateTime,
 }
 

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -110,9 +110,20 @@ pub struct TxSignerEventLoop<Network, Storage, BlocklistChecker, Rng> {
     pub context_window: usize,
     /// Random number generator used for encryption
     pub rng: Rng,
+    /// Optional channel to communicate progress usable for testing
+    pub test_observer_tx: Option<tokio::sync::mpsc::Sender<TxSignerEvent>>, //TODO: Feature gate on testing
 }
 
 type SignerStateMachine = wsts::state_machine::signer::Signer<wsts::v2::Party>;
+
+/// Event useful for tests
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum TxSignerEvent {
+    /// Received a deposit decision
+    ReceviedDepositDecision,
+    /// Received a withdraw decision
+    ReceivedWithdrawDecision,
+}
 
 impl<N, S, B, Rng> TxSignerEventLoop<N, S, B, Rng>
 where
@@ -495,6 +506,12 @@ where
             .write_deposit_signer_decision(&signer_decision)
             .await?;
 
+        if let Some(ref tx) = self.test_observer_tx {
+            tx.send(TxSignerEvent::ReceviedDepositDecision)
+                .await
+                .map_err(|_| error::Error::ObserverDropped)?;
+        }
+
         Ok(())
     }
 
@@ -525,6 +542,13 @@ where
         self.storage
             .write_withdraw_signer_decision(&signer_decision)
             .await?;
+
+        #[cfg(feature = "testing")]
+        if let Some(ref tx) = self.test_observer_tx {
+            tx.send(TxSignerEvent::ReceivedWithdrawDecision)
+                .await
+                .map_err(|_| error::Error::ObserverDropped)?;
+        }
 
         Ok(())
     }
@@ -700,11 +724,19 @@ mod tests {
 
     fn test_environment(
     ) -> testing::transaction_signer::TestEnvironment<fn() -> storage::in_memory::SharedStore> {
+        let test_model_parameters = testing::storage::model::Params {
+            num_bitcoin_blocks: 20,
+            num_stacks_blocks_per_bitcoin_block: 3,
+            num_deposit_requests_per_block: 5,
+            num_withdraw_requests_per_block: 5,
+        };
+
         testing::transaction_signer::TestEnvironment {
             storage_constructor: storage::in_memory::Store::new_shared,
             context_window: 3,
             num_signers: 7,
             signing_threshold: 5,
+            test_model_parameters,
         }
     }
 

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -110,8 +110,9 @@ pub struct TxSignerEventLoop<Network, Storage, BlocklistChecker, Rng> {
     pub context_window: usize,
     /// Random number generator used for encryption
     pub rng: Rng,
+    #[cfg(feature = "testing")]
     /// Optional channel to communicate progress usable for testing
-    pub test_observer_tx: Option<tokio::sync::mpsc::Sender<TxSignerEvent>>, //TODO: Feature gate on testing
+    pub test_observer_tx: Option<tokio::sync::mpsc::Sender<TxSignerEvent>>,
 }
 
 type SignerStateMachine = wsts::state_machine::signer::Signer<wsts::v2::Party>;
@@ -506,6 +507,7 @@ where
             .write_deposit_signer_decision(&signer_decision)
             .await?;
 
+        #[cfg(feature = "testing")]
         if let Some(ref tx) = self.test_observer_tx {
             tx.send(TxSignerEvent::ReceviedDepositDecision)
                 .await

--- a/signer/tests/integration/transaction_signer.rs
+++ b/signer/tests/integration/transaction_signer.rs
@@ -18,6 +18,13 @@ async fn test_environment(
 
     let mut idx = 0;
 
+    let test_model_parameters = testing::storage::model::Params {
+        num_bitcoin_blocks: 20,
+        num_stacks_blocks_per_bitcoin_block: 3,
+        num_deposit_requests_per_block: 5,
+        num_withdraw_requests_per_block: 5,
+    };
+
     testing::transaction_signer::TestEnvironment {
         storage_constructor: move || {
             idx = (idx + 1) % test_databases.len();
@@ -26,6 +33,7 @@ async fn test_environment(
         context_window,
         num_signers,
         signing_threshold,
+        test_model_parameters,
     }
 }
 


### PR DESCRIPTION
closes #258 

This PR extends the transaction signer in testing with a mpsc channel, signalling when decisions are received and persisted. This allows test cases to wait for a transaction signer to receive and process other signer decisions, which previously wasn't possible - thus removing an inherently flaky and slow timeout from our tests.