### PR TITLE
ci: integration test stacks smart contracts

### DIFF
--- a/contracts/contracts/sbtc-bootstrap-signers.clar
+++ b/contracts/contracts/sbtc-bootstrap-signers.clar
@@ -105,7 +105,7 @@
 )
 
 ;; Concatenate a pubkey buffer with a length prefix.
-;; The max size of the iterator is 510 bytes, which is (33 * 15) 495 bytes
+;; The max size of the iterator is 4239 bytes, which is (33 * 128) 4224 bytes
 ;; for the public keys and 15 bytes for the length prefixes.
 (define-read-only (concat-pubkeys-fold (pubkey (buff 33)) (iterator (buff 510)))
   (let

--- a/contracts/docs/sbtc-bootstrap-signers.md
+++ b/contracts/docs/sbtc-bootstrap-signers.md
@@ -242,7 +242,7 @@ Concat a list of pubkeys into a buffer with length prefixes
 `(define-read-only (concat-pubkeys-fold ((pubkey (buff 33)) (iterator (buff 510))) (buff 510))`
 
 Concatenate a pubkey buffer with a length prefix.
-The max size of the iterator is 510 bytes, which is (33 \* 15) 495 bytes
+The max size of the iterator is 4239 bytes, which is (33 \* 128) 4224 bytes
 for the public keys and 15 bytes for the length prefixes.
 
 <details>

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -21,23 +21,23 @@ pub enum Error {
     NoGoodFeeEstimates,
 
     /// Parsing the Hex Error
-    #[error("Could not parse the Hex string to a StacksBlockId: {0}, original: {1}")]
+    #[error("could not parse the Hex string to a StacksBlockId: {0}, original: {1}")]
     ParseStacksBlockId(#[source] blockstack_lib::util::HexError, String),
 
     /// Parsing the Hex Error
-    #[error("Could not decode the Nakamoto block with ID: {1}; {0}")]
+    #[error("could not decode the Nakamoto block with ID: {1}; {0}")]
     DecodeNakamotoBlock(#[source] blockstack_lib::codec::Error, StacksBlockId),
 
     /// Thrown when parsing a Nakamoto block within a given tenure.
-    #[error("Could not decode Nakamoto block from tenure with block: {1}; {0}")]
+    #[error("could not decode Nakamoto block from tenure with block: {1}; {0}")]
     DecodeNakamotoTenure(#[source] blockstack_lib::codec::Error, StacksBlockId),
 
     /// An error when serializing an object to JSON
     #[error("{0}")]
     JsonSerialize(#[source] serde_json::Error),
 
-    /// Could not parse the path part of a url
-    #[error("Failed to construct a valid URL from {1} and {2}: {0}")]
+    /// Could not parse the path part of a URL
+    #[error("failed to construct a valid URL from {1} and {2}: {0}")]
     PathJoin(#[source] url::ParseError, url::Url, Cow<'static, str>),
 
     /// This occurs when combining many public keys would result in a
@@ -47,7 +47,7 @@ pub enum Error {
 
     /// This happens when we attempt to recover a public key from a
     /// recoverable EDCSA signature.
-    #[error("Could not recover the public key from the signature: {0}, digest: {1}")]
+    #[error("could not recover the public key from the signature: {0}, digest: {1}")]
     InvalidRecoverableSignature(#[source] secp256k1::Error, secp256k1::Message),
 
     /// This is thrown when we attempt to create a wallet with:
@@ -56,11 +56,11 @@ pub enum Error {
     /// 3. The number of required signatures exceeding the number of public
     ///    keys.
     /// 4. The number of public keys exceeds the MAX_KEYS constant.
-    #[error("Invalid wallet definition, signatures required: {0}, number of keys: {1}")]
+    #[error("invalid wallet definition, signatures required: {0}, number of keys: {1}")]
     InvalidWalletDefinition(u16, usize),
 
     /// This is thrown when failing to parse a hex string into an integer.
-    #[error("Could not parse the hex string into an integer")]
+    #[error("could not parse the hex string into an integer")]
     ParseHexInt(#[source] std::num::ParseIntError),
 
     /// Reqwest error
@@ -68,38 +68,38 @@ pub enum Error {
     Reqwest(#[from] reqwest::Error),
 
     /// Error when reading the signer config.toml
-    #[error("Failed to read the signers config file: {0}")]
+    #[error("failed to read the signers config file: {0}")]
     SignerConfig(#[source] config::ConfigError),
 
     /// An error when querying the signer's database.
-    #[error("Received an error when attempting to query the database: {0}")]
+    #[error("received an error when attempting to query the database: {0}")]
     SqlxQuery(#[source] sqlx::Error),
 
     /// An error for the case where we cannot create a multi-sig
     /// StacksAddress using given public keys.
-    #[error("Could not create a StacksAddress from the public keys: threshold {0}, keys {1}")]
+    #[error("could not create a StacksAddress from the public keys: threshold {0}, keys {1}")]
     StacksMultiSig(u16, usize),
 
     /// Error when reading the stacks API part of the config.toml
-    #[error("Failed to parse the stacks.api portion of the config: {0}")]
+    #[error("failed to parse the stacks.api portion of the config: {0}")]
     StacksApiConfig(#[source] config::ConfigError),
 
     /// This error happens when converting a sepc256k1::PublicKey into a
     /// blockstack_lib::util::secp256k1::Secp256k1PublicKey. In general, it
     /// shouldn't happen.
-    #[error("Could not transform sepc256k1::PublicKey to stacks variant: {0}")]
+    #[error("could not transform sepc256k1::PublicKey to stacks variant: {0}")]
     StacksPublicKey(&'static str),
 
     /// Could not make a successful request to the stacks API.
-    #[error("Failed to make a request to the stacks API: {0}")]
+    #[error("failed to make a request to the stacks API: {0}")]
     StacksApiRequest(#[source] reqwest::Error),
 
-    /// Could not make a successful request to the stacks node.
-    #[error("Failed to make a request to the stacks Node: {0}")]
+    /// Could not make a successful request to the Stacks node.
+    #[error("failed to make a request to the stacks Node: {0}")]
     StacksNodeRequest(#[source] reqwest::Error),
 
     /// Reqwest error
-    #[error("Response from stacks node did not conform to the expected schema: {0}")]
+    #[error("response from stacks node did not conform to the expected schema: {0}")]
     UnexpectedStacksResponse(#[source] reqwest::Error),
 
     /// Taproot error

--- a/signer/src/stacks/api.rs
+++ b/signer/src/stacks/api.rs
@@ -146,19 +146,23 @@ pub struct TxRejection {
 #[derive(Debug, serde::Deserialize)]
 #[serde(untagged)]
 pub enum SubmitTxResponse {
-    /// The transaction ID for the submitted transaction
+    /// The transaction ID for the submitted transaction.
     Acceptance(Txid),
     /// The response when the transaction is rejected from the node.
     Rejection(TxRejection),
 }
 
-/// The account info for a stacks account.
+/// The account info for a stacks address.
 pub struct AccountInfo {
-    /// The balance of the account in micro-STX
+    /// The total balance of the account in micro-STX. This amount includes
+    /// the amount locked.
     pub balance: u128,
-    /// The amount locked (stacked?) in micro-STX
+    /// The amount locked (stacked) in micro-STX.
     pub locked: u128,
-    /// The last known nonce of the account.
+    /// The height of the stacks block where the above locked micro-STX
+    /// will be unlocked.
+    pub unlock_height: u64,
+    /// The next nonce for the account.
     pub nonce: u64,
 }
 
@@ -176,6 +180,7 @@ impl TryFrom<AccountEntryResponse> for AccountInfo {
             balance: parse_hex_u128(&value.balance)?,
             locked: parse_hex_u128(&value.locked)?,
             nonce: value.nonce,
+            unlock_height: value.unlock_height,
         })
     }
 }

--- a/signer/src/stacks/contracts.rs
+++ b/signer/src/stacks/contracts.rs
@@ -238,7 +238,6 @@ impl AsContractCall for AcceptWithdrawalV1 {
         vec![
             Value::UInt(self.request_id as u128),
             Value::Sequence(SequenceData::Buffer(txid)),
-            Value::UInt(self.outpoint.vout as u128),
             Value::UInt(self.signer_bitmap.load()),
             Value::UInt(self.outpoint.vout as u128),
             Value::UInt(self.tx_fee as u128),

--- a/signer/src/stacks/contracts.rs
+++ b/signer/src/stacks/contracts.rs
@@ -429,7 +429,7 @@ mod tests {
             SecretKey::new(&mut rng),
         ];
         let public_keys = secret_keys.map(|sk| sk.public_key(SECP256K1));
-        let wallet = SignerWallet::new(&public_keys, 2, NetworkKind::Testnet).unwrap();
+        let wallet = SignerWallet::new(&public_keys, 2, NetworkKind::Testnet, 0).unwrap();
         let deployer = StacksAddress::burn_address(false);
 
         let call = RotateKeysV1::new(&wallet, deployer);

--- a/signer/src/stacks/wallet.rs
+++ b/signer/src/stacks/wallet.rs
@@ -169,7 +169,7 @@ impl SignerWallet {
 #[derive(Debug)]
 pub struct SignerStxState {
     /// The multi-sig wallet for all known signers during this PoX cycle.
-    wallet: SignerWallet,
+    pub wallet: SignerWallet,
     /// The next nonce for the StacksAddress associated with the address of
     /// the wallet.
     nonce: AtomicU64,

--- a/signer/src/stacks/wallet.rs
+++ b/signer/src/stacks/wallet.rs
@@ -5,7 +5,6 @@ use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
-use std::sync::Arc;
 
 use blockstack_lib::address::C32_ADDRESS_VERSION_MAINNET_MULTISIG;
 use blockstack_lib::address::C32_ADDRESS_VERSION_TESTNET_MULTISIG;
@@ -47,7 +46,7 @@ const MULTISIG_ADDRESS_HASH_MODE: OrderIndependentMultisigHashMode =
     OrderIndependentMultisigHashMode::P2SH;
 
 /// Requisite info for the signers' multi-sig wallet on Stacks.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct SignerWallet {
     /// The current set of public keys for all known signers during this
     /// PoX cycle.
@@ -63,7 +62,7 @@ pub struct SignerWallet {
     address: StacksAddress,
     /// The next nonce for the StacksAddress associated with the address of
     /// the wallet.
-    nonce: Arc<AtomicU64>,
+    nonce: AtomicU64,
 }
 
 impl SignerWallet {
@@ -148,7 +147,7 @@ impl SignerWallet {
             network_kind,
             address: StacksAddress::from_public_keys(version, &hash_mode, num_sigs, &pubkeys)
                 .ok_or(Error::StacksMultiSig(signatures_required, num_keys))?,
-            nonce: Arc::new(AtomicU64::new(nonce)),
+            nonce: AtomicU64::new(nonce),
         })
     }
 

--- a/signer/src/stacks/wallet.rs
+++ b/signer/src/stacks/wallet.rs
@@ -35,9 +35,9 @@ use crate::stacks::contracts::AsTxPayload;
 use crate::stacks::contracts::ContractCall;
 use crate::MAX_KEYS;
 
-/// Stacks multisig addresses are RIPEMD-160 hashes of bitcoin Scripts
-/// (more or less). The enum value below defines which Script will be used
-/// to construct the address, and so implicitly describes how the multisig
+/// Stacks multisig addresses are Hash160 hashes of bitcoin Scripts (more
+/// or less). The enum value below defines which Script will be used to
+/// construct the address, and so implicitly describes how the multisig
 /// Stacks address is created. The specific hash mode chosen here needs to
 /// match the hash mode used in our smart contracts. This is defined in the
 /// `sbtc-bootstrap-signers.clar` contract in the `pubkeys-to-spend-script`

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -50,7 +50,7 @@ fn contract_transaction_kinds() -> &'static HashMap<&'static str, TransactionTyp
 #[derive(Debug, serde::Serialize)]
 pub struct StacksTx {
     /// The transaction id for the transaction
-    txid: String,
+    pub txid: String,
     /// The block id for the nakamoto block that this transaction was
     /// included in.
     block_id: String,

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -28,10 +28,14 @@ const CONTRACT_NAMES: [&str; 4] = [
     "sbtc-withdrawal",
 ];
 /// TODO(250): Update once we settle on all of the relevant function names.
-const CONTRACT_FUNCTION_NAMES: [(&str, TransactionType); 1] = [(
-    "initiate-withdrawal-request",
-    TransactionType::WithdrawAccept,
-)];
+#[rustfmt::skip]
+const CONTRACT_FUNCTION_NAMES: [(&str, TransactionType); 5] = [
+    ("initiate-withdrawal-request", TransactionType::WithdrawRequest),
+    ("complete-deposit-wrapper", TransactionType::DepositAccept),
+    ("accept-withdrawal-request", TransactionType::WithdrawAccept),
+    ("reject-withdrawal-request", TransactionType::WithdrawReject),
+    ("rotate-keys-wrapper", TransactionType::UpdateSignerSet),
+];
 
 /// Returns the mapping between functions in a contract call and the
 /// transaction type.
@@ -44,7 +48,7 @@ fn contract_transaction_kinds() -> &'static HashMap<&'static str, TransactionTyp
 
 /// A type used for storing transactions in the stacks_transactions table
 #[derive(Debug, serde::Serialize)]
-struct StacksTx {
+pub struct StacksTx {
     /// The transaction id for the transaction
     txid: String,
     /// The block id for the nakamoto block that this transaction was
@@ -71,7 +75,7 @@ struct StacksBlockSummary {
 
 /// This function extracts the signer relevant sBTC related transactions
 /// from the given blocks.
-fn extract_relevant_transactions(blocks: &[NakamotoBlock]) -> Vec<StacksTx> {
+pub fn extract_relevant_transactions(blocks: &[NakamotoBlock]) -> Vec<StacksTx> {
     let transaction_kinds = contract_transaction_kinds();
     blocks
         .iter()

--- a/signer/src/testing/wallet.rs
+++ b/signer/src/testing/wallet.rs
@@ -25,7 +25,7 @@ pub fn generate_wallet() -> (SignerWallet, [Keypair; 3]) {
     ];
 
     let public_keys = key_pairs.map(|kp| kp.public_key());
-    let wallet = SignerWallet::new(&public_keys, 2, NetworkKind::Testnet).unwrap();
+    let wallet = SignerWallet::new(&public_keys, 2, NetworkKind::Testnet, 0).unwrap();
 
     (wallet, key_pairs)
 }

--- a/signer/tests/integration/contracts.rs
+++ b/signer/tests/integration/contracts.rs
@@ -1,26 +1,35 @@
+use std::collections::HashSet;
 use std::sync::OnceLock;
 
-use bitcoin::hashes::Hash;
-use bitcoin::Txid;
+use bitvec::array::BitArray;
 use blockstack_lib::chainstate::stacks::StacksTransaction;
 use blockstack_lib::types::chainstate::StacksAddress;
 use blockstack_lib::types::Address;
+use secp256k1::ecdsa::RecoverableSignature;
+use secp256k1::Keypair;
+use signer::stacks::contracts::AcceptWithdrawalV1;
+use signer::stacks::contracts::AsContractCall;
+use signer::stacks::contracts::ContractCall;
+use signer::stacks::contracts::RejectWithdrawalV1;
+use signer::stacks::contracts::RotateKeysV1;
+use tokio::sync::OnceCell;
+
+use signer::config::StacksSettings;
+use signer::stacks;
 use signer::stacks::api::RejectionReason;
+use signer::stacks::api::StacksClient;
 use signer::stacks::api::SubmitTxResponse;
 use signer::stacks::api::TxRejection;
 use signer::stacks::contracts::CompleteDepositV1;
-use tokio::sync::OnceCell;
-
-use secp256k1::ecdsa::RecoverableSignature;
-use secp256k1::Keypair;
-use signer::config::StacksSettings;
-use signer::stacks;
-use signer::stacks::api::StacksClient;
 use signer::stacks::wallet::MultisigTx;
 use signer::stacks::wallet::SignerStxState;
+use signer::storage::in_memory::Store;
+use signer::storage::postgres;
 use signer::testing;
 use signer::testing::wallet::AsContractDeploy;
 use signer::testing::wallet::ContractDeploy;
+
+use test_case::test_case;
 
 const TX_FEE: u64 = 1500000;
 
@@ -64,10 +73,10 @@ impl AsContractDeploy for SbtcBootstrapContract {
         include_str!("../../../contracts/contracts/sbtc-bootstrap-signers.clar");
 }
 
-pub struct SignerKeyState {
+pub struct SignerKeys {
     pub state: SignerStxState,
     pub keys: [Keypair; 3],
-    pub client: &'static StacksClient,
+    pub stacks_client: &'static StacksClient,
 }
 
 fn make_signatures(tx: &StacksTransaction, keys: &[Keypair]) -> Vec<RecoverableSignature> {
@@ -77,7 +86,7 @@ fn make_signatures(tx: &StacksTransaction, keys: &[Keypair]) -> Vec<RecoverableS
 }
 
 /// Deploy an sBTC smart contract to the stacks node
-async fn deploy_smart_contract<T>(state: &SignerKeyState, client: &StacksClient, deploy: T)
+async fn deploy_smart_contract<T>(state: &SignerKeys, deploy: T)
 where
     T: AsContractDeploy,
 {
@@ -92,7 +101,7 @@ where
 
     let tx = unsigned.finalize_transaction();
 
-    match client.submit_tx(&tx).await.unwrap() {
+    match state.stacks_client.submit_tx(&tx).await.unwrap() {
         SubmitTxResponse::Acceptance(_) => (),
         SubmitTxResponse::Rejection(TxRejection {
             reason: RejectionReason::ContractAlreadyExists,
@@ -103,9 +112,11 @@ where
 }
 
 /// Deploy all sBTC smart contracts to the stacks node
-pub async fn deploy_smart_contracts() -> SignerKeyState {
+pub async fn deploy_smart_contracts() -> &'static SignerKeys {
     static SBTC_DEPLOYMENT: OnceCell<()> = OnceCell::const_new();
     static STACKS_CLIENT: OnceLock<StacksClient> = OnceLock::new();
+    static SIGNER_STATE: OnceCell<SignerKeys> = OnceCell::const_new();
+    
     let (signer_wallet, key_pairs) = testing::wallet::generate_wallet();
 
     let client = STACKS_CLIENT.get_or_init(|| {
@@ -113,23 +124,27 @@ pub async fn deploy_smart_contracts() -> SignerKeyState {
         StacksClient::new(settings)
     });
 
-    let account_info = client.get_account(&signer_wallet.address()).await.unwrap();
-    let state = SignerKeyState {
-        state: SignerStxState::new(signer_wallet, account_info.nonce),
-        keys: key_pairs,
-        client,
-    };
+    let state = SIGNER_STATE
+        .get_or_init(|| async {
+            let account_info = client.get_account(&signer_wallet.address()).await.unwrap();
+            SignerKeys {
+                state: SignerStxState::new(signer_wallet.clone(), account_info.nonce),
+                keys: key_pairs,
+                stacks_client: client,
+            }
+        })
+        .await;
 
     SBTC_DEPLOYMENT
         .get_or_init(|| async {
             // The registry and token contracts need to be deployed first
             // and second respectively. The rest can be deployed in any
             // order.
-            deploy_smart_contract(&state, client, SbtcRegistryContract).await;
-            deploy_smart_contract(&state, client, SbtcTokenContract).await;
-            deploy_smart_contract(&state, client, SbtcDepositContract).await;
-            deploy_smart_contract(&state, client, SbtcWithdrawalContract).await;
-            deploy_smart_contract(&state, client, SbtcBootstrapContract).await;
+            deploy_smart_contract(state, SbtcRegistryContract).await;
+            deploy_smart_contract(state, SbtcTokenContract).await;
+            deploy_smart_contract(state, SbtcDepositContract).await;
+            deploy_smart_contract(state, SbtcWithdrawalContract).await;
+            deploy_smart_contract(state, SbtcBootstrapContract).await;
         })
         .await;
 
@@ -137,47 +152,71 @@ pub async fn deploy_smart_contracts() -> SignerKeyState {
 }
 
 #[ignore]
+#[test_case(ContractCall(CompleteDepositV1 {
+    outpoint: bitcoin::OutPoint::null(),
+    amount: 123654,
+    recipient: StacksAddress::from_string("ST1RQHF4VE5CZ6EK3MZPZVQBA0JVSMM9H5PMHMS1Y").unwrap(),
+    deployer: testing::wallet::generate_wallet().0.address(),
+}); "complete-deposit")]
+#[test_case(ContractCall(AcceptWithdrawalV1 {
+    request_id: 0,
+    outpoint: bitcoin::OutPoint::null(),
+    tx_fee: 3500,
+    signer_bitmap: BitArray::new([0; 2]),
+    deployer: testing::wallet::generate_wallet().0.address(),
+}); "accept-withdrawal")]
+#[test_case(ContractCall(RejectWithdrawalV1 {
+    request_id: 0,
+    signer_bitmap: BitArray::new([0; 2]),
+    deployer: testing::wallet::generate_wallet().0.address(),
+}); "reject-withdrawal")]
+#[test_case(ContractCall(RotateKeysV1::new(
+    &testing::wallet::generate_wallet().0,
+    testing::wallet::generate_wallet().0.address(),
+)); "rotate-keys")]
 #[tokio::test]
-async fn test_deploy() {
-    let _state = deploy_smart_contracts().await;
-}
+async fn complete_deposit_wrapper_tx_accepted<T: AsContractCall>(contract: ContractCall<T>) {
+    let signer = deploy_smart_contracts().await;
+    let mut unsigned = MultisigTx::new_tx(contract, &signer.state, TX_FEE);
 
-#[ignore]
-#[tokio::test]
-async fn complete_deposit_wrapper_tx_accepted() {
-    let key_state = deploy_smart_contracts().await;
-
-    let contract = CompleteDepositV1 {
-        outpoint: bitcoin::OutPoint {
-            txid: Txid::all_zeros(),
-            vout: 0,
-        },
-        amount: 123654,
-        recipient: StacksAddress::from_string("ST1RQHF4VE5CZ6EK3MZPZVQBA0JVSMM9H5PMHMS1Y").unwrap(),
-        deployer: key_state.state.wallet.address(),
-    };
-
-    let mut unsigned = MultisigTx::new_contract_call(contract, &key_state.state, TX_FEE);
-
-    for signature in make_signatures(unsigned.tx(), &key_state.keys) {
+    for signature in make_signatures(unsigned.tx(), &signer.keys) {
         unsigned.add_signature(signature).unwrap();
     }
     let tx = unsigned.finalize_transaction();
 
-    match key_state.client.submit_tx(&tx).await.unwrap() {
+    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+
+    match signer.stacks_client.submit_tx(&tx).await.unwrap() {
         SubmitTxResponse::Acceptance(_) => (),
         SubmitTxResponse::Rejection(err) => panic!("{}", serde_json::to_string(&err).unwrap()),
     }
-}
 
-#[ignore]
-#[tokio::test]
-async fn accept_withdrawal_request_tx_accepted() {
-    // TODO(#264): Add integration test for signing Stacks smart contracts
-}
+    // The submitted transaction tends to linger in the mempool for quite
+    // some time before being confirmed in a Nakamoto block (best guess is
+    // 5-10 minutes). It's not clear why this is the case.
+    
+    if true {
+        println!("{}", tx.txid());
+        return;
+    }
 
-#[ignore]
-#[tokio::test]
-async fn reject_withdrawal_request_tx_accepted() {
-    // TODO(#264): Add integration test for signing Stacks smart contracts
+    // We need a block id
+    let info = signer.stacks_client.get_tenure_info().await.unwrap();
+    let storage = Store::new_shared();
+
+    let blocks =
+        stacks::api::fetch_unknown_ancestors(signer.stacks_client, &storage, info.tip_block_id)
+            .await
+            .unwrap();
+
+    let transactions = postgres::extract_relevant_transactions(&blocks);
+    assert!(!transactions.is_empty());
+
+    let txids = transactions
+        .iter()
+        .map(|stx| blockstack_lib::burnchains::Txid::from_hex(&stx.txid))
+        .collect::<Result<HashSet<_>, _>>()
+        .unwrap();
+
+    assert!(txids.contains(&tx.txid()));
 }

--- a/signer/tests/integration/contracts.rs
+++ b/signer/tests/integration/contracts.rs
@@ -80,8 +80,11 @@ fn make_signatures(tx: &StacksTransaction, keys: &[Keypair]) -> Vec<RecoverableS
 }
 
 pub struct SignerStxState {
+    /// A multi-sig wallet for the signers.
     pub wallet: SignerWallet,
+    /// These are the private keys to public keys in the above wallet.
     pub keys: [Keypair; 3],
+    /// A stacks client built using the src/config/default.toml config.
     pub stacks_client: &'static StacksClient,
 }
 
@@ -93,10 +96,7 @@ impl SignerStxState {
     {
         let mut unsigned = MultisigTx::new_tx(ContractDeploy(deploy), &self.wallet, TX_FEE);
 
-        let signatures: Vec<RecoverableSignature> = make_signatures(unsigned.tx(), &self.keys);
-
-        // This only fails when we are given an invalid signature.
-        for signature in signatures {
+        for signature in make_signatures(unsigned.tx(), &self.keys) {
             unsigned.add_signature(signature).unwrap();
         }
 
@@ -199,7 +199,6 @@ async fn complete_deposit_wrapper_tx_accepted<T: AsContractCall>(contract: Contr
     // The submitted transaction tends to linger in the mempool for quite
     // some time before being confirmed in a Nakamoto block (best guess is
     // 5-10 minutes). It's not clear why this is the case.
-
     if true {
         println!("{}", tx.txid());
         return;


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/264.

We have a bunch of code for creating and signing stacks contract call transactions. This PR adds tests for whether these transactions will be accepted by a stacks node post-Nakamoto.


## Changes

* Update comments/documentation in a sBTC clarity contract. This became outdated after https://github.com/stacks-network/sbtc/pull/308.
* Updated the documentation of fields in some Stacks structs. Specifically, the nonce returned by `GET /v2/account/<principal>` request is the next nonce.
* Combine the `SignerWallet` and `SignerStxState` structs into one.
* Add a tests that checks whether each our contract calls will be accepted by a stacks node.

## Testing information

The tests that are added here are not run in CI, since we do not have Nakamoto running there yet. Tests were run against a local stacks node running Nakamoto. This was done by running the `feat/signer` branch of the [stacks-regtest-env](https://github.com/hirosystems/stacks-regtest-env/tree/feat/signer) repo using a stacks node built on commit https://github.com/stacks-network/stacks-core/commit/3d96d53b35409859ca2baa2f0b6ddaa1fbd80265.

For my regtest setup, I manually added the following to my stacks node config file
```toml
[[ustx_balance]]
# secret_key: 99dd7fc1ad584d9b174275ef9de7bda04fc61e38899fdce22fd31a49f3fc47d6
address = "ST1RQHF4VE5CZ6EK3MZPZVQBA0JVSMM9H5PMHMS1Y"
amount = 100000000000000

[[ustx_balance]]
# secret_key: 126242834c575d4ccd51fa7081775c09746305ab0889844fff09c2018a5548bd
address = "ST23T3EMEKV8MD6WMEWRHX4HQG0EC4GYM1W1NEQHQ"
amount = 100000000000000

[[ustx_balance]]
# secret_key: 440adaf1522f26e3d981d114c137090c6bf627ebb163b5cbb449c73f9659a003
address = "ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5"
amount = 100000000000000

[[ustx_balance]]
# This is a 2-3 multi-sig address controlled using the above three addresses
address = "SN2V7WTJ7BHR03MPHZ1C9A9ZR6NZGR4WM8HT4V67Y"
amount = 100000000000000
```

Some of the logic included in these tests check whether the contract call transaction is included in a block. This implicitly checks a few of our other functions, and it turns out they work as expected. Unfortunately, this logic isn't enabled by default, even locally, since they would take a long time to complete. In my local regtest setup, Nakamoto blocks seem to be created every ~5 seconds, but the contract call transaction stays in the mempool for quite some time (on the order of 10 minutes).