### PR TITLE
feat: construct bitcoin deposit addresses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3698,6 +3698,13 @@ dependencies = [
 name = "sbtc-common"
 version = "0.1.0"
 dependencies = [
+ "bitcoin 0.32.0",
+ "clarity",
+ "rand 0.8.5",
+ "secp256k1 0.29.0",
+ "stacks-common",
+ "test-case",
+ "thiserror",
  "tracing",
  "tracing-attributes",
  "tracing-subscriber",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -6,6 +6,18 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+bitcoin = { workspace = true, features = ["rand-std"] }
+clarity = { git = "https://github.com/Trust-Machines/stacks-blockchain/", branch = "develop-upstream" }
+rand.workspace = true
+stacks-common = { git = "https://github.com/Trust-Machines/stacks-blockchain/", branch = "develop-upstream" }
+thiserror.workspace = true
 tracing.workspace = true
 tracing-attributes.workspace = true
 tracing-subscriber.workspace = true
+
+[dependencies.secp256k1]
+version = "0.29.0"
+features = ["rand-std", "global-context"]
+
+[dev-dependencies]
+test-case = "3.1"

--- a/common/src/deposits.rs
+++ b/common/src/deposits.rs
@@ -1,0 +1,114 @@
+//! This is the transaction analysis module
+//!
+
+use bitcoin::opcodes::all as opcodes;
+use bitcoin::script::PushBytesBuf;
+use bitcoin::taproot::LeafVersion;
+use bitcoin::taproot::NodeInfo;
+use bitcoin::taproot::TaprootSpendInfo;
+use bitcoin::Address;
+use bitcoin::Network;
+use bitcoin::ScriptBuf;
+use bitcoin::XOnlyPublicKey;
+use clarity::codec::StacksMessageCodec;
+use clarity::vm::types::PrincipalData;
+use secp256k1::SECP256K1;
+
+/// This struct contains the key variable inputs when constructing a
+/// deposit script address.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DepositScript {
+    /// The last known public key of the signers.
+    pub signers_public_key: XOnlyPublicKey,
+    /// The stacks address to deposit the sBTC to. This can be either a
+    /// standard address or a contract address.
+    pub stacks_address: PrincipalData,
+    /// The max fee amount to use for the BTC deposit transaction.
+    pub max_fee: u64,
+}
+
+impl DepositScript {
+    /// Construct a bitcoin address for a deposit transaction on the given
+    /// network.
+    pub fn to_address(&self, reclaim_script: ScriptBuf, network: Network) -> Address {
+        let deposit_script = self.deposit_script();
+        let ver = LeafVersion::TapScript;
+
+        // For such a simple tree, we construct it by hand.
+        let leaf1 = NodeInfo::new_leaf_with_ver(deposit_script, ver);
+        let leaf2 = NodeInfo::new_leaf_with_ver(reclaim_script, ver);
+
+        // A Result::Err is returned by NodeInfo::combine if the depth of
+        // our taproot tree exceeds the maximum depth of taproot trees,
+        // which is 128. We have two nodes so the depth is 1 so this will
+        // never panic.
+        let node =
+            NodeInfo::combine(leaf1, leaf2).expect("Tree depth is greater than the max of 128");
+        let internal_key = crate::unspendable_taproot_key();
+
+        let merkle_root =
+            TaprootSpendInfo::from_node_info(SECP256K1, *internal_key, node).merkle_root();
+        Address::p2tr(SECP256K1, *internal_key, merkle_root, network)
+    }
+
+    /// Construct a deposit script from the inputs
+    pub fn deposit_script(&self) -> ScriptBuf {
+        // The format of the OP_DROP data, as shown in
+        // https://github.com/stacks-network/sbtc/issues/30, is 8 bytes for
+        // the max fee followed by up to 151 bytes for the stacks address.
+        let stacks_address_bytes = self.stacks_address.serialize_to_vec();
+        let mut op_drop_data = PushBytesBuf::with_capacity(stacks_address_bytes.len() + 8);
+        // These should never fail. The PushBytesBuf type only
+        // errors if the total length of the buffer is greater than
+        // u32::MAX. We're pushing a max of 159 bytes.
+        op_drop_data
+            .extend_from_slice(&self.max_fee.to_be_bytes())
+            .expect("8 is greater than u32::MAX?");
+        op_drop_data
+            .extend_from_slice(&stacks_address_bytes)
+            .expect("159 is greater than u32::MAX?");
+
+        // When using the bitcoin::script::Builder, push_slice
+        // automatically inserts the appropriate opcodes based on the data
+        // size to be pushed onto the stack. Here, OP_PUSHBYTES_32 is
+        // pushed before the public key. Also, OP_PUSHBYTES_N is used if
+        // the OP_DROP data length is between 1 and 75 otherwise
+        // OP_PUSHDATA1 is used since the data length is less than 255.
+        ScriptBuf::builder()
+            .push_slice(op_drop_data)
+            .push_opcode(opcodes::OP_DROP)
+            .push_slice(self.signers_public_key.serialize())
+            .push_opcode(opcodes::OP_CHECKSIG)
+            .into_script()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bitcoin::AddressType;
+    use rand::rngs::OsRng;
+    use secp256k1::SecretKey;
+    use stacks_common::types::chainstate::StacksAddress;
+
+    use super::*;
+
+    use test_case::test_case;
+
+    const CONTRACT_ADDRESS: &str = "ST1RQHF4VE5CZ6EK3MZPZVQBA0JVSMM9H5PMHMS1Y.contract-name";
+
+    /// Basic check that we can create an address without any issues
+    #[test_case(PrincipalData::from(StacksAddress::burn_address(false)) ; "standard address")]
+    #[test_case(PrincipalData::parse(CONTRACT_ADDRESS).unwrap(); "contract address")]
+    fn btc_address(stacks_address: PrincipalData) {
+        let secret_key = SecretKey::new(&mut OsRng);
+
+        let deposit = DepositScript {
+            signers_public_key: secret_key.x_only_public_key(SECP256K1).0,
+            max_fee: 15000,
+            stacks_address,
+        };
+
+        let address = deposit.to_address(ScriptBuf::new(), Network::Regtest);
+        assert_eq!(address.address_type(), Some(AddressType::P2tr));
+    }
+}

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -3,5 +3,46 @@
 //! # SBTC Common Library
 //!
 //! This library provides common functionality for the sBTC project, including logging setup
+use std::sync::OnceLock;
 
+use bitcoin::XOnlyPublicKey;
+
+pub mod deposits;
 pub mod logging;
+
+/// The x-coordinate public key with no known discrete logarithm.
+///
+/// # Notes
+///
+/// This particular X-coordinate was discussed in the original taproot BIP
+/// on spending rules BIP-0341[1]. Specifically, the X-coordinate is formed
+/// by taking the hash of the standard uncompressed encoding of the 
+/// secp256k1 base point G as the X-coordinate. In that BIP the authors
+/// wrote the X-coordinate that is reproduced below.
+///
+/// [1]: https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#constructing-and-spending-taproot-outputs
+#[rustfmt::skip]
+pub const NUMS_X_COORDINATE: [u8; 32] = [
+    0x50, 0x92, 0x9b, 0x74, 0xc1, 0xa0, 0x49, 0x54,
+    0xb7, 0x8b, 0x4b, 0x60, 0x35, 0xe9, 0x7a, 0x5e,
+    0x07, 0x8a, 0x5a, 0x0f, 0x28, 0xec, 0x96, 0xd5,
+    0x47, 0xbf, 0xee, 0x9a, 0xce, 0x80, 0x3a, 0xc0,
+];
+
+/// The number of bitcoin blocks that must elapse from when the deposit
+/// transaction is confirmed before it can be reclaimed by the depositor.
+pub const LOCK_TIME: u32 = 150;
+
+/// Returns an address with no known private key, since it has no known
+/// discrete logarithm.
+///
+/// # Notes
+///
+/// This function returns the public key to used in the key-spend path of
+/// the taproot address. Since we do not want a key-spend path for sBTC
+/// deposit transactions, this address is such that it does not have a
+/// known private key.
+pub fn unspendable_taproot_key() -> &'static XOnlyPublicKey {
+    static UNSPENDABLE_KEY: OnceLock<XOnlyPublicKey> = OnceLock::new();
+    UNSPENDABLE_KEY.get_or_init(|| XOnlyPublicKey::from_slice(&NUMS_X_COORDINATE).unwrap())
+}

--- a/signer/src/utxo.rs
+++ b/signer/src/utxo.rs
@@ -260,8 +260,8 @@ pub struct DepositRequest {
     pub amount: u64,
     /// The deposit script used so that the signers' can spend funds.
     pub deposit_script: ScriptBuf,
-    /// The redeem script for the deposit.
-    pub redeem_script: ScriptBuf,
+    /// The reclaim script for the deposit.
+    pub reclaim_script: ScriptBuf,
     /// The public key used in the deposit script. The signers public key
     /// is a Schnorr public key.
     ///
@@ -305,8 +305,8 @@ impl DepositRequest {
 
     /// Construct the witness data for the taproot script of the deposit.
     ///
-    /// Deposit UTXOs are taproot spend what a "null" key spend path,
-    /// a deposit script-path spend, and a redeem script-path spend. This
+    /// Deposit UTXOs are taproot spend with a "null" key spend path,
+    /// a deposit script-path spend, and a reclaim script-path spend. This
     /// function creates the witness data for the deposit script-path
     /// spend where the script takes only one piece of data as input, the
     /// signature. The deposit script is:
@@ -345,7 +345,7 @@ impl DepositRequest {
     fn construct_taproot_info(&self, ver: LeafVersion) -> TaprootSpendInfo {
         // For such a simple tree, we construct it by hand.
         let leaf1 = NodeInfo::new_leaf_with_ver(self.deposit_script.clone(), ver);
-        let leaf2 = NodeInfo::new_leaf_with_ver(self.redeem_script.clone(), ver);
+        let leaf2 = NodeInfo::new_leaf_with_ver(self.reclaim_script.clone(), ver);
 
         // A Result::Err is returned by NodeInfo::combine if the depth of
         // our taproot tree exceeds the maximum depth of taproot trees,
@@ -814,7 +814,7 @@ mod tests {
             signer_bitmap: std::iter::repeat(false).take(votes_against).collect(),
             amount,
             deposit_script: testing::peg_in_deposit_script(&signers_public_key),
-            redeem_script: ScriptBuf::new(),
+            reclaim_script: ScriptBuf::new(),
             signers_public_key,
         }
     }
@@ -897,7 +897,7 @@ mod tests {
             signer_bitmap: signer_bitmap.to_vec(),
             amount: 100_000,
             deposit_script: ScriptBuf::new(),
-            redeem_script: ScriptBuf::new(),
+            reclaim_script: ScriptBuf::new(),
             signers_public_key: XOnlyPublicKey::from_str(X_ONLY_PUBLIC_KEY1).unwrap(),
         };
 
@@ -914,7 +914,7 @@ mod tests {
             signer_bitmap: Vec::new(),
             amount: 100_000,
             deposit_script: ScriptBuf::from_bytes(vec![1, 2, 3]),
-            redeem_script: ScriptBuf::new(),
+            reclaim_script: ScriptBuf::new(),
             signers_public_key: XOnlyPublicKey::from_str(X_ONLY_PUBLIC_KEY1).unwrap(),
         };
 

--- a/signer/tests/integration/utxo_construction.rs
+++ b/signer/tests/integration/utxo_construction.rs
@@ -36,10 +36,10 @@ where
     let fee = regtest::BITCOIN_CORE_FALLBACK_FEE.to_sat();
     let deposit_script = signer::testing::peg_in_deposit_script(&signers_public_key);
 
-    let redeem_script = ScriptBuf::new_op_return([0u8, 1, 2, 3]);
+    let reclaim_script = ScriptBuf::new_op_return([0u8, 1, 2, 3]);
     let ver = LeafVersion::TapScript;
     let leaf1 = NodeInfo::new_leaf_with_ver(deposit_script.clone(), ver);
-    let leaf2 = NodeInfo::new_leaf_with_ver(redeem_script.clone(), ver);
+    let leaf2 = NodeInfo::new_leaf_with_ver(reclaim_script.clone(), ver);
 
     let node = NodeInfo::combine(leaf1, leaf2).unwrap();
 
@@ -76,7 +76,7 @@ where
         signer_bitmap: Vec::new(),
         amount,
         deposit_script: deposit_script.clone(),
-        redeem_script: redeem_script.clone(),
+        reclaim_script: reclaim_script.clone(),
         signers_public_key,
     };
     (deposit_tx, req)


### PR DESCRIPTION
Use the following template to create your pull request

## Description

Closes https://github.com/stacks-network/sbtc/issues/329.

## Changes

1. Add a function that can construct a deposit script from the deposit info (the signers' public key, the recipient address, and the max fee).
2. Add a function that can construct a BTC address given the deposit script variables.
3. Saw that the `utxo::DepositRequest` struct had a typo in one of the field names, corrected it.

## Testing information

The unit tests here are okay