### PR TITLE
feat: add a deposit script parsing function

### DIFF
--- a/common/src/deposits.rs
+++ b/common/src/deposits.rs
@@ -13,6 +13,39 @@ use bitcoin::XOnlyPublicKey;
 use clarity::codec::StacksMessageCodec;
 use clarity::vm::types::PrincipalData;
 use secp256k1::SECP256K1;
+use stacks_common::types::chainstate::STACKS_ADDRESS_ENCODED_SIZE;
+
+/// This is the length of the fixed portion of the deposit script, which
+/// is:
+/// ```text
+///  OP_DROP OP_PUSHBYTES_32 <x-only-public-key> OP_CHECKSIG
+/// ```
+/// Since we are using Schnorr signatures, we only use the x-coordinate of
+/// the public key. The full public key is assumed to be even.
+const DEPOSIT_SCRIPT_FIXED_LENGTH: usize = 35;
+
+/// This is the typical number of bytes of a deposit script. It's 1 byte
+/// for the length of the following 30 bytes of data, which is 8 bytes for
+/// the max fee followed by 1 byte for the address type, 21 bytes the
+/// actual standard stacks address, followed by 34 bytes for the fixed
+/// length portion of the deposit script. So we have the standard length is
+/// 1 + 1 + 8 + 21 + 34 = 65.
+const STANDARD_SCRIPT_LENGTH: usize =
+    1 + 1 + 8 + STACKS_ADDRESS_ENCODED_SIZE as usize + DEPOSIT_SCRIPT_FIXED_LENGTH;
+
+/// Errors
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// The deposit script was invalid
+    #[error("Invalid deposit script")]
+    InvalidDepositScript,
+    /// The X-only public key was invalid
+    #[error("the x-only public key in the script was invalid: {0}")]
+    InvalidXOnlyPublicKey(#[source] secp256k1::Error),
+    /// Could not parse the Stacks principal address.
+    #[error("could not parse the stacks principal address: {0}")]
+    ParseStacksAddress(#[source] stacks_common::codec::Error),
+}
 
 /// This struct contains the key variable inputs when constructing a
 /// deposit script address.
@@ -83,11 +116,79 @@ impl DepositScript {
     }
 }
 
+/// Drops the top stack item
+pub const DROP: u8 = opcodes::OP_DROP.to_u8();
+/// <https://en.bitcoin.it/wiki/OP_CHECKSIG> pushing 1/0 for
+/// success/failure.
+pub const CHECKSIG: u8 = opcodes::OP_CHECKSIG.to_u8();
+/// Read the next byte as N; push the next N bytes as an array onto the
+/// stack.
+pub const OP_PUSHDATA1: u8 = opcodes::OP_PUSHDATA1.to_u8();
+
+/// This function checks that the deposit script is valid. Specifically, it
+/// checks that it follows the format laid out in
+/// https://github.com/stacks-network/sbtc/issues/30, where the script is
+/// expected to be
+/// ```text
+///  <deposit-data> OP_DROP OP_PUSHBYTES_32 <x-only-public-key> OP_CHECKSIG
+/// ```
+pub fn parse_deposit_script(deposit_script: &ScriptBuf) -> Result<DepositScript, Error> {
+    let script = deposit_script.as_bytes();
+
+    // Valid deposit scripts cannot be less than this length.
+    if script.len() < STANDARD_SCRIPT_LENGTH {
+        return Err(Error::InvalidDepositScript);
+    }
+    // This cannot panic because of the above check and the fact that
+    // DEPOSIT_SCRIPT_FIXED_LENGTH < STANDARD_SCRIPT_LENGTH.
+    let (params, check) = script.split_at(script.len() - DEPOSIT_SCRIPT_FIXED_LENGTH);
+    // Below, we know the script length is DEPOSIT_SCRIPT_FIXED_LENGTH,
+    // because of how `slice::split_at` works, so we know the pubkey_hash
+    // variable has length 32.
+    let [DROP, 32, public_key @ .., CHECKSIG] = check else {
+        return Err(Error::InvalidDepositScript);
+    };
+
+    // In bitcoin script, the code for pushing N bytes onto the stack is
+    // OP_PUSHBYTES_N where N is between 1 and 75 inclusive. The byte
+    // representation of these opcodes is the byte representation of N. If
+    // you need to push between 76 and 255 bytes of data then you need to
+    // use the OP_PUSHDATA1 opcode (you can also use this opcode to push
+    // between 1 and 75 bytes on the stack, but it's cheaper to use the
+    // OP_PUSHBYTES_N opcodes when you can). When need to check all cases
+    // contract addresses can have a size of up to 151 bytes.
+    let data = match params {
+        // This branch represents a contract address.
+        [OP_PUSHDATA1, n, data @ ..] if data.len() == *n as usize && *n < 160 => data,
+        // This branch can be a standard (non-contract) Stacks addresses
+        // when n == 29 and is a contract address otherwise.
+        [n, data @ ..] if data.len() == *n as usize && *n < 76 => data,
+        _ => return Err(Error::InvalidDepositScript),
+    };
+    // Here, `split_first_chunk::<N>` returns Option<(&[u8; N], &[u8])>,
+    // where None is returned if the length of the slice is less than N.
+    // Since N is 8 and the data variable has a length 30 or greater, the
+    // error path cannot happen.
+    let Some((max_fee_bytes, mut address)) = data.split_first_chunk::<8>() else {
+        return Err(Error::InvalidDepositScript);
+    };
+    let stacks_address =
+        PrincipalData::consensus_deserialize(&mut address).map_err(Error::ParseStacksAddress)?;
+
+    Ok(DepositScript {
+        signers_public_key: XOnlyPublicKey::from_slice(public_key)
+            .map_err(Error::InvalidXOnlyPublicKey)?,
+        max_fee: u64::from_be_bytes(*max_fee_bytes),
+        stacks_address,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use bitcoin::AddressType;
     use rand::rngs::OsRng;
     use secp256k1::SecretKey;
+    use stacks_common::codec::StacksMessageCodec;
     use stacks_common::types::chainstate::StacksAddress;
 
     use super::*;
@@ -95,6 +196,57 @@ mod tests {
     use test_case::test_case;
 
     const CONTRACT_ADDRESS: &str = "ST1RQHF4VE5CZ6EK3MZPZVQBA0JVSMM9H5PMHMS1Y.contract-name";
+
+    /// Check that manually creating the expected script can correctly be
+    /// parsed.
+    #[test_case(PrincipalData::from(StacksAddress::burn_address(false)) ; "standard address")]
+    #[test_case(PrincipalData::parse(CONTRACT_ADDRESS).unwrap(); "contract address")]
+    fn deposit_script_parsing_works_standard_principal(stacks_address: PrincipalData) {
+        let secret_key = SecretKey::new(&mut OsRng);
+        let public_key = secret_key.x_only_public_key(SECP256K1).0;
+        let max_fee: u64 = 15000;
+
+        let mut deposit_data = max_fee.to_be_bytes().to_vec();
+        deposit_data.extend_from_slice(&stacks_address.serialize_to_vec());
+
+        let deposit_data: PushBytesBuf = deposit_data.try_into().unwrap();
+
+        let script = ScriptBuf::builder()
+            .push_slice(deposit_data)
+            .push_opcode(opcodes::OP_DROP)
+            .push_slice(public_key.serialize())
+            .push_opcode(opcodes::OP_CHECKSIG)
+            .into_script();
+
+        if matches!(stacks_address, PrincipalData::Standard(_)) {
+            assert_eq!(script.len(), STANDARD_SCRIPT_LENGTH);
+        }
+
+        let extracts = parse_deposit_script(&script).unwrap();
+        assert_eq!(extracts.signers_public_key, public_key);
+        assert_eq!(extracts.stacks_address, stacks_address);
+        assert_eq!(extracts.max_fee, max_fee);
+        assert_eq!(extracts.deposit_script(), script);
+    }
+
+    /// Check that `DepositScript::deposit_script` and the
+    /// `parse_deposit_script` function are inverses of one another.
+    #[test_case(PrincipalData::from(StacksAddress::burn_address(false)) ; "standard address")]
+    #[test_case(PrincipalData::parse(CONTRACT_ADDRESS).unwrap(); "contract address")]
+    fn deposit_script_parsing_and_creation_are_inverses(stacks_address: PrincipalData) {
+        let secret_key = SecretKey::new(&mut OsRng);
+
+        let deposit = DepositScript {
+            signers_public_key: secret_key.x_only_public_key(SECP256K1).0,
+            max_fee: 15000,
+            stacks_address,
+        };
+
+        let deposit_script = deposit.deposit_script();        
+        let parsed_deposit = parse_deposit_script(&deposit_script).unwrap();
+
+        assert_eq!(deposit, parsed_deposit);
+    }
 
     /// Basic check that we can create an address without any issues
     #[test_case(PrincipalData::from(StacksAddress::burn_address(false)) ; "standard address")]


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/327.

## Changes

- Add a function that can parse a deposit script and extract the relevant pieces of information.

## Testing information

The tests check that the parser function is an inverse of the `DepositScriptInputs::deposit_script` function.