### PR TITLE
feat: support contract principals in complete-deposit contract calls

### DIFF
--- a/signer/tests/integration/contracts.rs
+++ b/signer/tests/integration/contracts.rs
@@ -3,6 +3,7 @@ use std::sync::OnceLock;
 
 use bitvec::array::BitArray;
 use blockstack_lib::chainstate::stacks::StacksTransaction;
+use blockstack_lib::clarity::vm::types::PrincipalData;
 use blockstack_lib::types::chainstate::StacksAddress;
 use blockstack_lib::types::Address;
 use secp256k1::ecdsa::RecoverableSignature;
@@ -158,7 +159,7 @@ pub async fn deploy_smart_contracts() -> &'static SignerStxState {
 #[test_case(ContractCall(CompleteDepositV1 {
     outpoint: bitcoin::OutPoint::null(),
     amount: 123654,
-    recipient: StacksAddress::from_string("ST1RQHF4VE5CZ6EK3MZPZVQBA0JVSMM9H5PMHMS1Y").unwrap(),
+    recipient: PrincipalData::from(StacksAddress::from_string("ST1RQHF4VE5CZ6EK3MZPZVQBA0JVSMM9H5PMHMS1Y").unwrap()),
     deployer: testing::wallet::generate_wallet().0.address(),
 }); "complete-deposit")]
 #[test_case(ContractCall(AcceptWithdrawalV1 {

--- a/signer/tests/integration/contracts.rs
+++ b/signer/tests/integration/contracts.rs
@@ -4,8 +4,6 @@ use std::sync::OnceLock;
 use bitvec::array::BitArray;
 use blockstack_lib::chainstate::stacks::StacksTransaction;
 use blockstack_lib::clarity::vm::types::PrincipalData;
-use blockstack_lib::types::chainstate::StacksAddress;
-use blockstack_lib::types::Address;
 use secp256k1::ecdsa::RecoverableSignature;
 use secp256k1::Keypair;
 use signer::stacks::contracts::AcceptWithdrawalV1;
@@ -159,9 +157,15 @@ pub async fn deploy_smart_contracts() -> &'static SignerStxState {
 #[test_case(ContractCall(CompleteDepositV1 {
     outpoint: bitcoin::OutPoint::null(),
     amount: 123654,
-    recipient: PrincipalData::from(StacksAddress::from_string("ST1RQHF4VE5CZ6EK3MZPZVQBA0JVSMM9H5PMHMS1Y").unwrap()),
+    recipient: PrincipalData::parse("ST1RQHF4VE5CZ6EK3MZPZVQBA0JVSMM9H5PMHMS1Y").unwrap(),
     deployer: testing::wallet::generate_wallet().0.address(),
-}); "complete-deposit")]
+}); "complete-deposit standard recipient")]
+#[test_case(ContractCall(CompleteDepositV1 {
+    outpoint: bitcoin::OutPoint::null(),
+    amount: 123654,
+    recipient: PrincipalData::parse("ST1RQHF4VE5CZ6EK3MZPZVQBA0JVSMM9H5PMHMS1Y.my-contract-name").unwrap(),
+    deployer: testing::wallet::generate_wallet().0.address(),
+}); "complete-deposit contract recipient")]
 #[test_case(ContractCall(AcceptWithdrawalV1 {
     request_id: 0,
     outpoint: bitcoin::OutPoint::null(),

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -105,7 +105,7 @@ impl AsContractCall for InitiateWithdrawalRequest {
     amount: 123654,
     recipient: PrincipalData::parse("ST1RQHF4VE5CZ6EK3MZPZVQBA0JVSMM9H5PMHMS1Y").unwrap(),
     deployer: testing::wallet::generate_wallet().0.address(),
-}); "complete-deposit")]
+}); "complete-deposit standard recipient")]
 #[test_case(ContractCall(CompleteDepositV1 {
     outpoint: bitcoin::OutPoint::null(),
     amount: 123654,

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -2,10 +2,10 @@ use std::io::Read;
 
 use bitvec::array::BitArray;
 use blockstack_lib::chainstate::nakamoto::NakamotoBlock;
+use blockstack_lib::clarity::vm::types::PrincipalData;
 use blockstack_lib::clarity::vm::Value;
 use blockstack_lib::codec::StacksMessageCodec;
 use blockstack_lib::types::chainstate::StacksAddress;
-use blockstack_lib::types::Address;
 use futures::StreamExt;
 
 use signer::stacks::contracts::AcceptWithdrawalV1;
@@ -103,9 +103,15 @@ impl AsContractCall for InitiateWithdrawalRequest {
 #[test_case(ContractCall(CompleteDepositV1 {
     outpoint: bitcoin::OutPoint::null(),
     amount: 123654,
-    recipient: StacksAddress::from_string("ST1RQHF4VE5CZ6EK3MZPZVQBA0JVSMM9H5PMHMS1Y").unwrap(),
+    recipient: PrincipalData::parse("ST1RQHF4VE5CZ6EK3MZPZVQBA0JVSMM9H5PMHMS1Y").unwrap(),
     deployer: testing::wallet::generate_wallet().0.address(),
 }); "complete-deposit")]
+#[test_case(ContractCall(CompleteDepositV1 {
+    outpoint: bitcoin::OutPoint::null(),
+    amount: 123654,
+    recipient: PrincipalData::parse("ST1RQHF4VE5CZ6EK3MZPZVQBA0JVSMM9H5PMHMS1Y.my-contract-name").unwrap(),
+    deployer: testing::wallet::generate_wallet().0.address(),
+}); "complete-deposit contract recipient")]
 #[test_case(ContractCall(AcceptWithdrawalV1 {
     request_id: 0,
     outpoint: bitcoin::OutPoint::null(),


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/332.

## Changes

* Update the contract-call struct to support any stacks principal as the recipient.
* Add integration test cases that exercise the contract principal case.

## Testing information

I ran the integration tests locally, using the same setup as in https://github.com/stacks-network/sbtc/pull/311, and tests passed.

Note that, similar to standard recipients, you do not need to "materialize" or "deploy" the smart contract before it can accept STX or other fungible tokens.