### PR TITLE
Remove placeholder `validate-caller` clarity function

### DIFF
--- a/contracts/contracts/sbtc-registry.clar
+++ b/contracts/contracts/sbtc-registry.clar
@@ -65,6 +65,7 @@
 (map-set protocol-contracts .sbtc-deposit true)
 (map-set protocol-contracts .sbtc-withdrawal true)
 (if (not is-in-mainnet) (map-set protocol-contracts tx-sender true) true)
+(map-set protocol-contracts .sbtc-token true)
 
 ;; Read-only functions
 ;; Get a withdrawal request by its ID.

--- a/contracts/contracts/sbtc-registry.clar
+++ b/contracts/contracts/sbtc-registry.clar
@@ -65,7 +65,6 @@
 (map-set protocol-contracts .sbtc-deposit true)
 (map-set protocol-contracts .sbtc-withdrawal true)
 (if (not is-in-mainnet) (map-set protocol-contracts tx-sender true) true)
-(map-set protocol-contracts .sbtc-token true)
 
 ;; Read-only functions
 ;; Get a withdrawal request by its ID.
@@ -250,5 +249,10 @@
 
 ;; Checks whether the contract-caller is a protocol contract
 (define-read-only (is-protocol-caller)
-  (ok (asserts! (is-some (map-get? protocol-contracts contract-caller)) ERR_UNAUTHORIZED))
+  (validate-protocol-caller contract-caller)
+)
+
+;; Validate that a given principal is a protocol contract
+(define-read-only (validate-protocol-caller (caller principal))
+  (ok (asserts! (is-some (map-get? protocol-contracts caller)) ERR_UNAUTHORIZED))
 )

--- a/contracts/contracts/sbtc-registry.clar
+++ b/contracts/contracts/sbtc-registry.clar
@@ -134,7 +134,7 @@
     (
       (id (increment-last-withdrawal-request-id))
     )
-    (try! (validate-caller))
+    (try! (is-protocol-caller))
     ;; #[allow(unchecked_data)]
     (map-insert withdrawal-requests id {
       amount: amount,
@@ -167,7 +167,7 @@
     (fee (optional uint))
   )
   (begin 
-    (try! (validate-caller))
+    (try! (is-protocol-caller))
     ;; Mark the withdrawal as completed
     (map-insert withdrawal-status request-id status)
     (print {
@@ -198,7 +198,7 @@
     (recipient principal)
   )
   (begin
-    (try! (validate-caller))
+    (try! (is-protocol-caller))
     (map-insert completed-deposits {txid: txid, vout-index: vout-index} {
       amount: amount,
       recipient: recipient
@@ -219,7 +219,7 @@
 (define-public (rotate-keys (new-keys (list 128 (buff 33))) (new-address principal) (new-aggregate-pubkey (buff 33)))
   (begin
     ;; Check that caller is protocol contract
-    (try! (validate-caller))
+    (try! (is-protocol-caller))
     ;; Check that the aggregate pubkey is not already in the map
     (asserts! (map-insert aggregate-pubkeys new-aggregate-pubkey true) ERR_AGG_PUBKEY_REPLAY)
     ;; Check that the new address (multi-sig) is not already in the map
@@ -247,20 +247,7 @@
   )
 )
 
-;; Validate the caller of the function.
-;; TODO: Once other contracts are in place, update this
-;; to use the sBTC controller.
-(define-private (validate-caller)
-  ;; To provide an explicit error type, add a branch that
-  ;; wont be hit
-  ;; (if (is-eq contract-caller .controller) (ok true) (err ERR_UNAUTHORIZED))
-  (if false ERR_UNAUTHORIZED (ok true))
-)
-
 ;; Checks whether the contract-caller is a protocol contract
-(define-read-only (is-protocol-caller (principal-checked principal))
-  (is-some (map-get? protocol-contracts principal-checked))
+(define-read-only (is-protocol-caller)
+  (ok (asserts! (is-some (map-get? protocol-contracts contract-caller)) ERR_UNAUTHORIZED))
 )
-
-;; TODO: Add a function to add a protocol contract
-;; TODO: Add a function to remove a protocol contract

--- a/contracts/contracts/sbtc-token.clar
+++ b/contracts/contracts/sbtc-token.clar
@@ -9,16 +9,12 @@
 (define-data-var token-uri (optional (string-utf8 256)) none)
 (define-constant token-decimals u8)
 
-(define-read-only (is-protocol-caller)
-	(ok (asserts! (contract-call? .sbtc-registry is-protocol-caller contract-caller) ERR_NOT_AUTH))
-)
-
 ;; --- Protocol functions
 
 ;; #[allow(unchecked_data)]
 (define-public (protocol-transfer (amount uint) (sender principal) (recipient principal))
 	(begin
-		(try! (is-protocol-caller))
+		(try! (contract-call? .sbtc-registry is-protocol-caller))
 		(ft-transfer? sbtc-token amount sender recipient)
 	)
 )
@@ -26,7 +22,7 @@
 ;; #[allow(unchecked_data)]
 (define-public (protocol-lock (amount uint) (owner principal))
 	(begin
-		(try! (is-protocol-caller))
+		(try! (contract-call? .sbtc-registry is-protocol-caller))
 		(try! (ft-burn? sbtc-token amount owner))
 		(ft-mint? sbtc-token-locked amount owner)
 	)
@@ -35,7 +31,7 @@
 ;; #[allow(unchecked_data)]
 (define-public (protocol-unlock (amount uint) (owner principal))
 	(begin
-		(try! (is-protocol-caller))
+		(try! (contract-call? .sbtc-registry is-protocol-caller))
 		(try! (ft-burn? sbtc-token-locked amount owner))
 		(ft-mint? sbtc-token amount owner)
 	)
@@ -44,7 +40,7 @@
 ;; #[allow(unchecked_data)]
 (define-public (protocol-mint (amount uint) (recipient principal))
 	(begin
-		(try! (is-protocol-caller))
+		(try! (contract-call? .sbtc-registry is-protocol-caller))
 		(ft-mint? sbtc-token amount recipient)
 	)
 )
@@ -52,7 +48,7 @@
 ;; #[allow(unchecked_data)]
 (define-public (protocol-burn (amount uint) (owner principal))
 	(begin
-		(try! (is-protocol-caller))
+		(try! (contract-call? .sbtc-registry is-protocol-caller))
 		(ft-burn? sbtc-token amount owner)
 	)
 )
@@ -60,7 +56,7 @@
 ;; #[allow(unchecked_data)]
 (define-public (protocol-burn-locked (amount uint) (owner principal))
 	(begin
-		(try! (is-protocol-caller))
+		(try! (contract-call? .sbtc-registry is-protocol-caller))
 		(ft-burn? sbtc-token-locked amount owner)
 	)
 )
@@ -68,7 +64,7 @@
 ;; #[allow(unchecked_data)]
 (define-public (protocol-set-name (new-name (string-ascii 32)))
 	(begin
-		(try! (is-protocol-caller))
+		(try! (contract-call? .sbtc-registry is-protocol-caller))
 		(ok (var-set token-name new-name))
 	)
 )
@@ -76,7 +72,7 @@
 ;; #[allow(unchecked_data)]
 (define-public (protocol-set-symbol (new-symbol (string-ascii 10)))
 	(begin
-		(try! (is-protocol-caller))
+		(try! (contract-call? .sbtc-registry is-protocol-caller))
 		(ok (var-set token-symbol new-symbol))
 	)
 )
@@ -84,7 +80,7 @@
 ;; #[allow(unchecked_data)]
 (define-public (protocol-set-token-uri (new-uri (optional (string-utf8 256))))
 	(begin
-		(try! (is-protocol-caller))
+		(try! (contract-call? .sbtc-registry is-protocol-caller))
 		(ok (var-set token-uri new-uri))
 	)
 )
@@ -97,7 +93,7 @@
 ;; #[allow(unchecked_data)]
 (define-public (protocol-mint-many (recipients (list 200 {amount: uint, recipient: principal})))
 	(begin
-		(try! (is-protocol-caller))
+		(try! (contract-call? .sbtc-registry is-protocol-caller))
 		(ok (map protocol-mint-many-iter recipients))
 	)
 )

--- a/contracts/contracts/sbtc-token.clar
+++ b/contracts/contracts/sbtc-token.clar
@@ -14,7 +14,7 @@
 ;; #[allow(unchecked_data)]
 (define-public (protocol-transfer (amount uint) (sender principal) (recipient principal))
 	(begin
-		(try! (contract-call? .sbtc-registry is-protocol-caller))
+		(try! (contract-call? .sbtc-registry validate-protocol-caller contract-caller))
 		(ft-transfer? sbtc-token amount sender recipient)
 	)
 )
@@ -22,7 +22,7 @@
 ;; #[allow(unchecked_data)]
 (define-public (protocol-lock (amount uint) (owner principal))
 	(begin
-		(try! (contract-call? .sbtc-registry is-protocol-caller))
+		(try! (contract-call? .sbtc-registry validate-protocol-caller contract-caller))
 		(try! (ft-burn? sbtc-token amount owner))
 		(ft-mint? sbtc-token-locked amount owner)
 	)
@@ -31,7 +31,7 @@
 ;; #[allow(unchecked_data)]
 (define-public (protocol-unlock (amount uint) (owner principal))
 	(begin
-		(try! (contract-call? .sbtc-registry is-protocol-caller))
+		(try! (contract-call? .sbtc-registry validate-protocol-caller contract-caller))
 		(try! (ft-burn? sbtc-token-locked amount owner))
 		(ft-mint? sbtc-token amount owner)
 	)
@@ -40,7 +40,7 @@
 ;; #[allow(unchecked_data)]
 (define-public (protocol-mint (amount uint) (recipient principal))
 	(begin
-		(try! (contract-call? .sbtc-registry is-protocol-caller))
+		(try! (contract-call? .sbtc-registry validate-protocol-caller contract-caller))
 		(ft-mint? sbtc-token amount recipient)
 	)
 )
@@ -48,7 +48,7 @@
 ;; #[allow(unchecked_data)]
 (define-public (protocol-burn (amount uint) (owner principal))
 	(begin
-		(try! (contract-call? .sbtc-registry is-protocol-caller))
+		(try! (contract-call? .sbtc-registry validate-protocol-caller contract-caller))
 		(ft-burn? sbtc-token amount owner)
 	)
 )
@@ -56,7 +56,7 @@
 ;; #[allow(unchecked_data)]
 (define-public (protocol-burn-locked (amount uint) (owner principal))
 	(begin
-		(try! (contract-call? .sbtc-registry is-protocol-caller))
+		(try! (contract-call? .sbtc-registry validate-protocol-caller contract-caller))
 		(ft-burn? sbtc-token-locked amount owner)
 	)
 )
@@ -64,7 +64,7 @@
 ;; #[allow(unchecked_data)]
 (define-public (protocol-set-name (new-name (string-ascii 32)))
 	(begin
-		(try! (contract-call? .sbtc-registry is-protocol-caller))
+		(try! (contract-call? .sbtc-registry validate-protocol-caller contract-caller))
 		(ok (var-set token-name new-name))
 	)
 )
@@ -72,7 +72,7 @@
 ;; #[allow(unchecked_data)]
 (define-public (protocol-set-symbol (new-symbol (string-ascii 10)))
 	(begin
-		(try! (contract-call? .sbtc-registry is-protocol-caller))
+		(try! (contract-call? .sbtc-registry validate-protocol-caller contract-caller))
 		(ok (var-set token-symbol new-symbol))
 	)
 )
@@ -80,7 +80,7 @@
 ;; #[allow(unchecked_data)]
 (define-public (protocol-set-token-uri (new-uri (optional (string-utf8 256))))
 	(begin
-		(try! (contract-call? .sbtc-registry is-protocol-caller))
+		(try! (contract-call? .sbtc-registry validate-protocol-caller contract-caller))
 		(ok (var-set token-uri new-uri))
 	)
 )
@@ -93,7 +93,7 @@
 ;; #[allow(unchecked_data)]
 (define-public (protocol-mint-many (recipients (list 200 {amount: uint, recipient: principal})))
 	(begin
-		(try! (contract-call? .sbtc-registry is-protocol-caller))
+		(try! (contract-call? .sbtc-registry validate-protocol-caller contract-caller))
 		(ok (map protocol-mint-many-iter recipients))
 	)
 )

--- a/contracts/tests/clarigen-types.ts
+++ b/contracts/tests/clarigen-types.ts
@@ -687,12 +687,6 @@ export const contracts = {
         args: [],
         outputs: { type: "uint128" },
       } as TypedAbiFunction<[], bigint>,
-      validateCaller: {
-        name: "validate-caller",
-        access: "private",
-        args: [],
-        outputs: { type: { response: { ok: "bool", error: "uint128" } } },
-      } as TypedAbiFunction<[], Response<boolean, bigint>>,
       completeDeposit: {
         name: "complete-deposit",
         access: "public",
@@ -912,11 +906,17 @@ export const contracts = {
       isProtocolCaller: {
         name: "is-protocol-caller",
         access: "read_only",
-        args: [{ name: "principal-checked", type: "principal" }],
-        outputs: { type: "bool" },
+        args: [],
+        outputs: { type: { response: { ok: "bool", error: "uint128" } } },
+      } as TypedAbiFunction<[], Response<boolean, bigint>>,
+      validateProtocolCaller: {
+        name: "validate-protocol-caller",
+        access: "read_only",
+        args: [{ name: "caller", type: "principal" }],
+        outputs: { type: { response: { ok: "bool", error: "uint128" } } },
       } as TypedAbiFunction<
-        [principalChecked: TypedAbiArg<string, "principalChecked">],
-        boolean
+        [caller: TypedAbiArg<string, "caller">],
+        Response<boolean, bigint>
       >,
     },
     maps: {
@@ -1391,12 +1391,6 @@ export const contracts = {
         args: [],
         outputs: { type: { response: { ok: "uint128", error: "none" } } },
       } as TypedAbiFunction<[], Response<bigint, null>>,
-      isProtocolCaller: {
-        name: "is-protocol-caller",
-        access: "read_only",
-        args: [],
-        outputs: { type: { response: { ok: "bool", error: "uint128" } } },
-      } as TypedAbiFunction<[], Response<boolean, bigint>>,
     },
     maps: {},
     variables: {

--- a/contracts/tests/sbtc-registry.test.ts
+++ b/contracts/tests/sbtc-registry.test.ts
@@ -33,7 +33,7 @@ describe("sBTC registry contract", () => {
           sender: alice,
           height: simnet.blockHeight,
         }),
-        alice
+        deployer
       );
       expect(receipt.value).toEqual(1n);
 
@@ -62,7 +62,7 @@ describe("sBTC registry contract", () => {
           sender: bob,
           height: simnet.blockHeight,
         }),
-        alice
+        deployer
       );
       const prints = filterEvents(
         receipt.events,
@@ -103,7 +103,7 @@ describe("sBTC registry contract", () => {
           maxFee: 10n,
           height: simnet.blockHeight,
         }),
-        alice
+        deployer
       );
 
       const request = rov(registry.getWithdrawalRequest(1n));

--- a/contracts/tests/sbtc-token.test.ts
+++ b/contracts/tests/sbtc-token.test.ts
@@ -95,7 +95,7 @@ describe("sBTC token contract", () => {
         }),
         bob
       );
-      expect(receipt.value).toEqual(errors.token.ERR_NOT_AUTH);
+      expect(receipt.value).toEqual(errors.registry.ERR_UNAUTHORIZED);
     });
 
     test("Fail transferring sbtc when not owner", () => {

--- a/contracts/tests/sbtc-withdrawal.test.ts
+++ b/contracts/tests/sbtc-withdrawal.test.ts
@@ -429,7 +429,7 @@ describe("Accepting a withdrawal request", () => {
     );
     expect(rovOk(token.getBalance(alice))).toEqual(1n);
   });
-})
+});
 
 describe("Reject a withdrawal request", () => {
   test("Fails with non-existant request-id", () => {
@@ -557,7 +557,7 @@ describe("Reject a withdrawal request", () => {
     );
     expect(receipt.value).toEqual(true);
   });
-})
+});
 
 describe("Complete multiple withdrawals", () => {
   test("Successfully pass in two withdrawals, one accept, one reject", () => {
@@ -597,26 +597,30 @@ describe("Complete multiple withdrawals", () => {
       }),
       bob
     );
-    // 
+    //
     const receipt = txOk(
-      withdrawal.completeWithdrawals({withdrawals: [{
-          requestId: 1n,
-          status: true,
-          signerBitmap: 1n,
-          bitcoinTxid: new Uint8Array(32).fill(1),
-          outputIndex: 10n,
-          fee: 10n,
-        },{
-          requestId: 2n,
-          status: false,
-          signerBitmap: 1n,
-          bitcoinTxid: null,
-          outputIndex: null,
-          fee: null,
-        } ]
+      withdrawal.completeWithdrawals({
+        withdrawals: [
+          {
+            requestId: 1n,
+            status: true,
+            signerBitmap: 1n,
+            bitcoinTxid: new Uint8Array(32).fill(1),
+            outputIndex: 10n,
+            fee: 10n,
+          },
+          {
+            requestId: 2n,
+            status: false,
+            signerBitmap: 1n,
+            bitcoinTxid: null,
+            outputIndex: null,
+            fee: null,
+          },
+        ],
       }),
       deployer
     );
     expect(receipt.value).toEqual(2n);
   });
-})
+});


### PR DESCRIPTION
- Closes #347 

This PR finishes the work that @setzeus started. Initially, the `sbtc-registry` utilized a placeholder function for validating contract callers, because we didn't yet have the data structures in place to properly handle things. Now, those data structures are in place, but the `validate-caller` function wasn't using them.