### PR TITLE
feat: validate bitcoin deposit transactions

### DIFF
--- a/signer/src/utxo.rs
+++ b/signer/src/utxo.rs
@@ -265,14 +265,14 @@ pub struct DepositRequest {
     pub deposit_script: ScriptBuf,
     /// The reclaim script for the deposit.
     pub reclaim_script: ScriptBuf,
-    /// The public key used in the deposit script. The signers public key
-    /// is a Schnorr public key.
+    /// The public key used in the deposit script.
     ///
-    /// Note that taproot Schnorr public keys are slightly different from
-    /// the usual compressed public keys since they use only the x-coordinate
-    /// with the y-coordinate assumed to be even. This means they use
-    /// 32 bytes instead of the 33 byte public keys used before where the
-    /// additional byte indicated the y-coordinate's parity.
+    /// Note that taproot public keys for Schnorr signatures are slightly
+    /// different from the usual compressed public keys since they use only
+    /// the x-coordinate with the y-coordinate assumed to be even. This
+    /// means they use 32 bytes instead of the 33 byte public keys used
+    /// before where the additional byte indicated the y-coordinate's
+    /// parity.
     pub signers_public_key: XOnlyPublicKey,
 }
 
@@ -315,7 +315,7 @@ impl DepositRequest {
     /// signature. The deposit script is:
     ///
     /// ```text
-    ///   <data> OP_DROP OP_DUP OP_HASH160 <pubkey_hash> OP_EQUALVERIFY OP_CHECKSIG
+    ///   <data> OP_DROP <public-key> OP_CHECKSIG
     /// ```
     ///
     /// where `<data>` is the stacks deposit address and <pubkey_hash> is


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/330.

The last part (or second-to-last part) of "BTC deposit transaction analysis" is validating that the transaction is "valid". Basically, we check that the deposit and reclaim scripts in the transaction follow our proscribed formats.

## Changes
1. A slight refactor involving the parsing functions https://github.com/stacks-network/sbtc/pull/344 and https://github.com/stacks-network/sbtc/pull/334.
2. Add a function that takes in a BTC transaction encoded as a hex string and makes sure that the relevant UTXO matches what was sent in the `CreateDepositRequest` (the object from the [Emily API LLD](https://docs.google.com/document/d/13AN9GdLfPYKKPkeHNU4niq_CyJCDxFR7DGBLzLc5gxU/edit#heading=h.hbinuw8xakzd)).
3. Update some of the comments in the signer codebase.

## Testing information

The unit tests check that:
* We detect mismatches between what is in the transaction and what is in the user's request.
* We detect deposit and reclaim scripts that do not follow the expected format.