### PR TITLE
feat: extract deposit request transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,6 +295,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae74d9bd0a7530e8afd1770739ad34b36838829d6ad61818f9230f683f5ad77"
+dependencies = [
+ "aws-lc-sys",
+ "mirai-annotations",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e89b6941c2d1a7045538884d6e760ccfffdf8e1ffc2613d8efa74305e1f3752"
+dependencies = [
+ "bindgen 0.69.4",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "libc",
+ "paste",
+]
+
+[[package]]
 name = "aws-runtime"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -502,7 +529,7 @@ dependencies = [
  "once_cell",
  "pin-project-lite",
  "pin-utils",
- "rustls",
+ "rustls 0.21.12",
  "tokio",
  "tracing",
 ]
@@ -677,8 +704,8 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
 dependencies = [
- "bitcoin-internals 0.3.0",
- "bitcoin_hashes 0.14.0",
+ "bitcoin-internals",
+ "bitcoin_hashes",
 ]
 
 [[package]]
@@ -714,12 +741,6 @@ name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
-
-[[package]]
-name = "bech32"
-version = "0.10.0-beta"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98f7eed2b2781a6f0b5c903471d48e15f56fb4e1165df8a9a2337fd1a59d45ea"
 
 [[package]]
 name = "bech32"
@@ -759,18 +780,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitcoin"
-version = "0.31.2"
+name = "bindgen"
+version = "0.69.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c85783c2fe40083ea54a33aa2f0ba58831d90fcd190f5bdc47e74e84d2a96ae"
+checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
 dependencies = [
- "bech32 0.10.0-beta",
- "bitcoin-internals 0.2.0",
- "bitcoin_hashes 0.13.0",
- "hex-conservative 0.1.2",
- "hex_lit",
- "secp256k1 0.28.2",
- "serde 1.0.203",
+ "bitflags 2.5.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.65",
+ "which",
 ]
 
 [[package]]
@@ -780,23 +809,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7170e7750a20974246f17ece04311b4205a6155f1db564c5b224af817663c3ea"
 dependencies = [
  "base58ck",
- "bech32 0.11.0",
- "bitcoin-internals 0.3.0",
+ "bech32",
+ "bitcoin-internals",
  "bitcoin-io",
  "bitcoin-units",
- "bitcoin_hashes 0.14.0",
- "hex-conservative 0.2.0",
+ "bitcoin_hashes",
+ "hex-conservative",
  "hex_lit",
  "secp256k1 0.29.0",
- "serde 1.0.203",
-]
-
-[[package]]
-name = "bitcoin-internals"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9425c3bf7089c983facbae04de54513cce73b41c7f9ff8c845b54e7bc64ebbfb"
-dependencies = [
  "serde 1.0.203",
 ]
 
@@ -821,18 +841,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb54da0b28892f3c52203a7191534033e051b6f4b52bc15480681b57b7e036f5"
 dependencies = [
- "bitcoin-internals 0.3.0",
- "serde 1.0.203",
-]
-
-[[package]]
-name = "bitcoin_hashes"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1930a4dabfebb8d7d9992db18ebe3ae2876f0a305fab206fd168df931ede293b"
-dependencies = [
- "bitcoin-internals 0.2.0",
- "hex-conservative 0.1.2",
+ "bitcoin-internals",
  "serde 1.0.203",
 ]
 
@@ -843,7 +852,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
 dependencies = [
  "bitcoin-io",
- "hex-conservative 0.2.0",
+ "hex-conservative",
  "serde 1.0.203",
 ]
 
@@ -866,7 +875,7 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8909583c5fab98508e80ef73e5592a651c954993dc6b7739963257d19f0e71a"
 dependencies = [
- "bitcoin 0.32.0",
+ "bitcoin",
  "serde 1.0.203",
  "serde_json",
 ]
@@ -1003,6 +1012,11 @@ name = "cc"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
+dependencies = [
+ "jobserver",
+ "libc",
+ "once_cell",
+]
 
 [[package]]
 name = "cexpr"
@@ -1122,6 +1136,15 @@ dependencies = [
  "slog",
  "stacks-common",
  "time 0.2.27",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1513,6 +1536,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
+
+[[package]]
 name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1549,15 +1578,15 @@ dependencies = [
 
 [[package]]
 name = "electrum-client"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89008f106be6f303695522f2f4c1f28b40c3e8367ed8b3bb227f1f882cb52cc2"
+checksum = "8c7b1f8783238bb18e6e137875b0a66f3dffe6c7ea84066e05d033cf180b150f"
 dependencies = [
- "bitcoin 0.31.2",
+ "bitcoin",
  "byteorder",
  "libc",
  "log",
- "rustls",
+ "rustls 0.23.12",
  "serde 1.0.203",
  "serde_json",
  "webpki-roots",
@@ -1779,6 +1808,12 @@ name = "fragile"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fuchsia-zircon"
@@ -2104,12 +2139,6 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hex-conservative"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212ab92002354b4819390025006c897e8140934349e8635c9b077f47b4dcbd20"
-
-[[package]]
-name = "hex-conservative"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1aa273bf451e37ed35ced41c71a5e2a4e29064afb104158f2514bcd71c2c986"
@@ -2282,7 +2311,7 @@ dependencies = [
  "http 0.2.12",
  "hyper 0.14.28",
  "log",
- "rustls",
+ "rustls 0.21.12",
  "rustls-native-certs",
  "tokio",
  "tokio-rustls",
@@ -2537,6 +2566,15 @@ name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
+name = "jobserver"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -2874,6 +2912,12 @@ dependencies = [
  "winapi 0.2.8",
  "ws2_32-sys",
 ]
+
+[[package]]
+name = "mirai-annotations"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
 
 [[package]]
 name = "mockall"
@@ -3223,7 +3267,7 @@ version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a40a031a559eb38c35a14096f21c366254501a06d41c4b327d2a7515d713a5b7"
 dependencies = [
- "bindgen",
+ "bindgen 0.64.0",
  "bitvec",
  "bs58 0.4.0",
  "cc",
@@ -4134,8 +4178,23 @@ checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
+dependencies = [
+ "aws-lc-rs",
+ "log",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.6",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -4186,6 +4245,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-webpki"
+version = "0.102.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e6b52d4fda176fd835fdc55a835d4a89b8499cad995885a21149d5ad62f852e"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4210,10 +4281,14 @@ dependencies = [
 name = "sbtc"
 version = "0.1.0"
 dependencies = [
- "bitcoin 0.32.0",
+ "bitcoin",
+ "bitcoincore-rpc",
  "clarity",
+ "electrum-client",
  "rand 0.8.5",
  "secp256k1 0.29.0",
+ "serde 1.0.203",
+ "serde_json",
  "stacks-common",
  "test-case",
  "thiserror",
@@ -4265,22 +4340,11 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.28.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d24b59d129cdadea20aea4fb2352fa053712e5d713eee47d700cd4b2bc002f10"
-dependencies = [
- "bitcoin_hashes 0.13.0",
- "secp256k1-sys 0.9.2",
- "serde 1.0.203",
-]
-
-[[package]]
-name = "secp256k1"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e0cc0f1cf93f4969faf3ea1c7d8a9faed25918d96affa959720823dfe86d4f3"
 dependencies = [
- "bitcoin_hashes 0.14.0",
+ "bitcoin_hashes",
  "rand 0.8.5",
  "secp256k1-sys 0.10.0",
  "serde 1.0.203",
@@ -4291,15 +4355,6 @@ name = "secp256k1-sys"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83080e2c2fc1006e625be82e5d1eb6a43b7fd9578b617fcc55814daf286bba4b"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "secp256k1-sys"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d1746aae42c19d583c3c1a8c646bfad910498e2051c551a7f2e3c0c9fbb7eb"
 dependencies = [
  "cc",
 ]
@@ -4610,7 +4665,7 @@ dependencies = [
  "aquamarine",
  "backoff",
  "bincode",
- "bitcoin 0.32.0",
+ "bitcoin",
  "bitcoincore-rpc",
  "bitvec",
  "blocklist-api",
@@ -4780,7 +4835,7 @@ dependencies = [
  "once_cell",
  "paste",
  "percent-encoding",
- "rustls",
+ "rustls 0.21.12",
  "rustls-pemfile 1.0.4",
  "serde 1.0.203",
  "serde_json",
@@ -5451,7 +5506,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls",
+ "rustls 0.21.12",
  "tokio",
 ]
 
@@ -6398,3 +6453,17 @@ name = "zeroize"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.65",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,8 +704,8 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
 dependencies = [
- "bitcoin-internals",
- "bitcoin_hashes",
+ "bitcoin-internals 0.3.0",
+ "bitcoin_hashes 0.14.0",
 ]
 
 [[package]]
@@ -741,6 +741,12 @@ name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
+name = "bech32"
+version = "0.10.0-beta"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98f7eed2b2781a6f0b5c903471d48e15f56fb4e1165df8a9a2337fd1a59d45ea"
 
 [[package]]
 name = "bech32"
@@ -804,19 +810,43 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c85783c2fe40083ea54a33aa2f0ba58831d90fcd190f5bdc47e74e84d2a96ae"
+dependencies = [
+ "bech32 0.10.0-beta",
+ "bitcoin-internals 0.2.0",
+ "bitcoin_hashes 0.13.0",
+ "hex-conservative 0.1.2",
+ "hex_lit",
+ "secp256k1 0.28.2",
+ "serde 1.0.203",
+]
+
+[[package]]
+name = "bitcoin"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7170e7750a20974246f17ece04311b4205a6155f1db564c5b224af817663c3ea"
 dependencies = [
  "base58ck",
- "bech32",
- "bitcoin-internals",
+ "bech32 0.11.0",
+ "bitcoin-internals 0.3.0",
  "bitcoin-io",
  "bitcoin-units",
- "bitcoin_hashes",
- "hex-conservative",
+ "bitcoin_hashes 0.14.0",
+ "hex-conservative 0.2.0",
  "hex_lit",
  "secp256k1 0.29.0",
+ "serde 1.0.203",
+]
+
+[[package]]
+name = "bitcoin-internals"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9425c3bf7089c983facbae04de54513cce73b41c7f9ff8c845b54e7bc64ebbfb"
+dependencies = [
  "serde 1.0.203",
 ]
 
@@ -841,7 +871,18 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb54da0b28892f3c52203a7191534033e051b6f4b52bc15480681b57b7e036f5"
 dependencies = [
- "bitcoin-internals",
+ "bitcoin-internals 0.3.0",
+ "serde 1.0.203",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1930a4dabfebb8d7d9992db18ebe3ae2876f0a305fab206fd168df931ede293b"
+dependencies = [
+ "bitcoin-internals 0.2.0",
+ "hex-conservative 0.1.2",
  "serde 1.0.203",
 ]
 
@@ -852,7 +893,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
 dependencies = [
  "bitcoin-io",
- "hex-conservative",
+ "hex-conservative 0.2.0",
  "serde 1.0.203",
 ]
 
@@ -875,7 +916,7 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8909583c5fab98508e80ef73e5592a651c954993dc6b7739963257d19f0e71a"
 dependencies = [
- "bitcoin",
+ "bitcoin 0.32.0",
  "serde 1.0.203",
  "serde_json",
 ]
@@ -1578,11 +1619,28 @@ dependencies = [
 
 [[package]]
 name = "electrum-client"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89008f106be6f303695522f2f4c1f28b40c3e8367ed8b3bb227f1f882cb52cc2"
+dependencies = [
+ "bitcoin 0.31.2",
+ "byteorder",
+ "libc",
+ "log",
+ "rustls 0.21.12",
+ "serde 1.0.203",
+ "serde_json",
+ "webpki-roots",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "electrum-client"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c7b1f8783238bb18e6e137875b0a66f3dffe6c7ea84066e05d033cf180b150f"
 dependencies = [
- "bitcoin",
+ "bitcoin 0.32.0",
  "byteorder",
  "libc",
  "log",
@@ -2136,6 +2194,12 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex-conservative"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212ab92002354b4819390025006c897e8140934349e8635c9b077f47b4dcbd20"
 
 [[package]]
 name = "hex-conservative"
@@ -4281,10 +4345,10 @@ dependencies = [
 name = "sbtc"
 version = "0.1.0"
 dependencies = [
- "bitcoin",
+ "bitcoin 0.32.0",
  "bitcoincore-rpc",
  "clarity",
- "electrum-client",
+ "electrum-client 0.20.0",
  "rand 0.8.5",
  "secp256k1 0.29.0",
  "serde 1.0.203",
@@ -4340,11 +4404,22 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
+version = "0.28.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24b59d129cdadea20aea4fb2352fa053712e5d713eee47d700cd4b2bc002f10"
+dependencies = [
+ "bitcoin_hashes 0.13.0",
+ "secp256k1-sys 0.9.2",
+ "serde 1.0.203",
+]
+
+[[package]]
+name = "secp256k1"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e0cc0f1cf93f4969faf3ea1c7d8a9faed25918d96affa959720823dfe86d4f3"
 dependencies = [
- "bitcoin_hashes",
+ "bitcoin_hashes 0.14.0",
  "rand 0.8.5",
  "secp256k1-sys 0.10.0",
  "serde 1.0.203",
@@ -4355,6 +4430,15 @@ name = "secp256k1-sys"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83080e2c2fc1006e625be82e5d1eb6a43b7fd9578b617fcc55814daf286bba4b"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d1746aae42c19d583c3c1a8c646bfad910498e2051c551a7f2e3c0c9fbb7eb"
 dependencies = [
  "cc",
 ]
@@ -4665,13 +4749,13 @@ dependencies = [
  "aquamarine",
  "backoff",
  "bincode",
- "bitcoin",
+ "bitcoin 0.32.0",
  "bitcoincore-rpc",
  "bitvec",
  "blocklist-api",
  "clap",
  "config 0.14.0",
- "electrum-client",
+ "electrum-client 0.19.0",
  "fake",
  "futures",
  "hashbrown 0.14.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,11 @@ backoff = { version = "0.4.0", features = ["tokio"] }
 base64 = "0.22.1"
 bincode = "1.3.3"
 bitcoin = { version = "0.32", features = ["serde"] }
+bitcoincore-rpc = { version = "0.19" }
 bitvec = { version = "1.0", default-features = false }
 config = "0.11.0"
 clap = { version = "4.5.4", features = ["derive", "env"] }
+electrum-client = { version = "0.20" }
 futures = "0.3.24"
 hashbrown = "0.14.5"
 http = "1.1.0"

--- a/sbtc/Cargo.toml
+++ b/sbtc/Cargo.toml
@@ -5,10 +5,19 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = []
+integration-tests = ["testing"]
+testing = []
+
 [dependencies]
 bitcoin = { workspace = true, features = ["rand-std"] }
+bitcoincore-rpc.workspace = true
 clarity = { git = "https://github.com/Trust-Machines/stacks-blockchain/", branch = "develop-upstream" }
+electrum-client.workspace = true
 rand.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 stacks-common = { git = "https://github.com/Trust-Machines/stacks-blockchain/", branch = "develop-upstream" }
 thiserror.workspace = true
 tracing.workspace = true

--- a/sbtc/src/deposits.rs
+++ b/sbtc/src/deposits.rs
@@ -18,6 +18,8 @@ use clarity::vm::types::PrincipalData;
 use secp256k1::SECP256K1;
 use stacks_common::types::chainstate::STACKS_ADDRESS_ENCODED_SIZE;
 
+use crate::error::Error;
+
 /// This is the length of the fixed portion of the deposit script, which
 /// is:
 /// ```text
@@ -55,50 +57,6 @@ const OP_PUSHNUM_1: u8 = opcodes::OP_PUSHNUM_1.to_u8();
 const OP_PUSHNUM_16: u8 = opcodes::OP_PUSHNUM_16.to_u8();
 /// Represents the number -1.
 const OP_PUSHNUM_NEG1: u8 = opcodes::OP_PUSHNUM_NEG1.to_u8();
-
-/// Errors
-#[derive(Debug, thiserror::Error)]
-pub enum Error {
-    /// The deposit script was invalid
-    #[error("invalid deposit script")]
-    InvalidDepositScript,
-    /// The lock time included in the reclaim script was invalid.
-    #[error("the lock time included in the reclaim script was invalid: {0}")]
-    InvalidReclaimScriptLockTime(i64),
-    /// The reclaim script was invalid.
-    #[error("the reclaim script format was invalid")]
-    InvalidReclaimScript,
-    /// The reclaim script lock time was invalid
-    #[error("reclaim script lock time was either too large or non-minimal: {0}")]
-    ScriptNum(#[source] bitcoin::script::Error),
-    /// The X-only public key was invalid
-    #[error("the x-only public key in the script was invalid: {0}")]
-    InvalidXOnlyPublicKey(#[source] secp256k1::Error),
-    /// Could not parse the Stacks principal address.
-    #[error("could not parse the stacks principal address: {0}")]
-    ParseStacksAddress(#[source] stacks_common::codec::Error),
-    /// Failed to parse the hex as a bitcoin::Transaction.
-    #[error("could not parse the BTC transaction hex: {0}")]
-    DecodeFromHex(#[source] bitcoin::consensus::encode::FromHexError),
-    /// Failed to extract the outpoint from the bitcoin::Transaction.
-    #[error("could not get outpoint {1} from BTC transaction: {0}")]
-    OutpointIndex(
-        #[source] bitcoin::blockdata::transaction::OutputsIndexError,
-        OutPoint,
-    ),
-    /// The ScriptPubKey of the UTXO did not match what was expected from
-    /// the given deposit script and reclaim script.
-    #[error("mismatch in expected and actual ScriptPubKeys. outpoint: {0}")]
-    UtxoScriptPubKeyMismatch(OutPoint),
-    /// Failed to parse the hex as a bitcoin::Transaction.
-    #[error("could not parse the bitcoin transaction hex")]
-    TxidMismatch {
-        /// This is the transaction ID of the actual transaction
-        from_tx: Txid,
-        /// This is the transaction ID of from the request
-        from_request: Txid,
-    },
-}
 
 /// All the info required to verify the validity of a deposit
 /// transaction. This info is sent by the user to the Emily API

--- a/sbtc/src/deposits.rs
+++ b/sbtc/src/deposits.rs
@@ -483,6 +483,7 @@ mod tests {
     use bitcoin::transaction::Version;
     use bitcoin::AddressType;
     use bitcoin::Amount;
+    use bitcoin::Txid;
     use bitcoin::TxOut;
     use rand::rngs::OsRng;
     use secp256k1::SecretKey;

--- a/sbtc/src/error.rs
+++ b/sbtc/src/error.rs
@@ -1,0 +1,64 @@
+//! Top-level error type for the sbtc library
+//!
+
+use bitcoin::OutPoint;
+use bitcoin::Txid;
+
+/// Errors
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// Bitcoin-core RPC error
+    #[error("{0}")]
+    BitcoinCoreRpcClient(#[source] bitcoincore_rpc::Error, String),
+    /// Bitcoin-core RPC error
+    #[error("{0}")]
+    DecodeTx(#[source] bitcoin::consensus::encode::Error, Txid),
+    /// Bitcoin-core RPC error
+    #[error("{0}")]
+    DeserializeGetTransaction(#[source] serde_json::Error, Txid),
+    /// Could not build the electrum client
+    #[error("{0}")]
+    ElectrumClientBuild(#[source] electrum_client::Error, String),
+    /// Bitcoin-core RPC error
+    #[error("{0}")]
+    GetTransactionBitcoinCore(#[source] bitcoincore_rpc::Error, Txid),
+    /// Bitcoin-core RPC error
+    #[error("{0}")]
+    GetTransactionElectrum(#[source] electrum_client::Error, Txid),
+    /// The deposit script was invalid
+    #[error("invalid deposit script")]
+    InvalidDepositScript,
+    /// The lock time included in the reclaim script was invalid.
+    #[error("the lock time included in the reclaim script was invalid: {0}")]
+    InvalidReclaimScriptLockTime(i64),
+    /// The reclaim script was invalid.
+    #[error("the reclaim script format was invalid")]
+    InvalidReclaimScript,
+    /// The reclaim script lock time was invalid
+    #[error("reclaim script lock time was either too large or non-minimal: {0}")]
+    ScriptNum(#[source] bitcoin::script::Error),
+    /// The X-only public key was invalid
+    #[error("the x-only public key in the script was invalid: {0}")]
+    InvalidXOnlyPublicKey(#[source] secp256k1::Error),
+    /// Could not parse the Stacks principal address.
+    #[error("could not parse the stacks principal address: {0}")]
+    ParseStacksAddress(#[source] stacks_common::codec::Error),
+    /// Failed to extract the outpoint from the bitcoin::Transaction.
+    #[error("could not get outpoint {1} from BTC transaction: {0}")]
+    OutpointIndex(
+        #[source] bitcoin::blockdata::transaction::OutputsIndexError,
+        OutPoint,
+    ),
+    /// The ScriptPubKey of the UTXO did not match what was expected from
+    /// the given deposit script and reclaim script.
+    #[error("mismatch in expected and actual ScriptPubKeys. outpoint: {0}")]
+    UtxoScriptPubKeyMismatch(OutPoint),
+    /// Failed to parse the hex as a bitcoin::Transaction.
+    #[error("The txid of the transaction did not match the given txid")]
+    TxidMismatch {
+        /// This is the transaction ID of the actual transaction
+        from_tx: Txid,
+        /// This is the transaction ID of from the request
+        from_request: Txid,
+    },
+}

--- a/sbtc/src/lib.rs
+++ b/sbtc/src/lib.rs
@@ -8,6 +8,7 @@ use std::sync::OnceLock;
 use bitcoin::XOnlyPublicKey;
 
 pub mod deposits;
+pub mod error;
 pub mod logging;
 
 /// The x-coordinate public key with no known discrete logarithm.

--- a/sbtc/src/lib.rs
+++ b/sbtc/src/lib.rs
@@ -10,6 +10,7 @@ use bitcoin::XOnlyPublicKey;
 pub mod deposits;
 pub mod error;
 pub mod logging;
+pub mod rpc;
 
 /// The x-coordinate public key with no known discrete logarithm.
 ///

--- a/sbtc/src/rpc.rs
+++ b/sbtc/src/rpc.rs
@@ -1,0 +1,169 @@
+//! Contains client wrappers for bitcoin core and electrum.
+
+use std::num::NonZeroU8;
+
+use bitcoin::consensus;
+use bitcoin::consensus::Decodable as _;
+use bitcoin::BlockHash;
+use bitcoin::Transaction;
+use bitcoin::Txid;
+use bitcoincore_rpc::Auth;
+use bitcoincore_rpc::RpcApi;
+use electrum_client::ElectrumApi as _;
+use electrum_client::Param;
+use serde::Deserialize;
+
+use crate::error::Error;
+
+/// A slimmed down type representing a response from bitcoin-core's
+/// getrawtransaction RPC.
+///
+/// The docs for the getrawtransaction RPC call can be found here:
+/// https://bitcoincore.org/en/doc/27.0.0/rpc/rawtransactions/getrawtransaction/.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetTxResponse {
+    /// The raw bitcoin transaction.
+    #[serde(with = "consensus::serde::With::<consensus::serde::Hex>")]
+    #[serde(rename = "hex")]
+    pub tx: Transaction,
+    /// The transaction ID.
+    pub txid: Txid,
+    /// The block hash of the Bitcoin block that includes this transaction.
+    #[serde(rename = "blockhash")]
+    pub block_hash: Option<BlockHash>,
+    /// The number of confirmations deep from that chain tip of the bitcoin
+    /// block that includes this transaction.
+    pub confirmations: Option<u32>,
+    /// The Unix epoch time when the block was mined. It reflects the
+    /// timestamp as recorded by the miner of the block.
+    #[serde(rename = "blocktime")]
+    pub block_time: Option<u64>,
+    /// Whether the specified block (in the getrawtransaction RPC) is in
+    /// the active chain or not. It is only present when the "blockhash"
+    /// argument is present in the RPC.
+    pub in_active_chain: Option<bool>,
+}
+
+/// Trait for interacting with bitcoin-core
+pub trait BitcoinRpcClient {
+    /// Return the transaction if the transaction is in the mempool or in
+    /// any block.
+    fn get_tx(&self, txid: &Txid) -> Result<GetTxResponse, Error>;
+}
+
+/// A client for interacting with bitcoin-core
+pub struct BtcClient {
+    /// The underlying bitcoin-core client
+    pub client: bitcoincore_rpc::Client,
+}
+
+impl BtcClient {
+    /// Return a bitcoin-core RPC client. Will error if the URL is an invalid URL.
+    ///
+    /// # Notes
+    ///
+    /// This function does not attempt to establish a connection to bitcoin-core.
+    pub fn new(url: &str, username: String, password: String) -> Result<Self, Error> {
+        let auth = Auth::UserPass(username, password);
+        let client = bitcoincore_rpc::Client::new(url, auth)
+            .map_err(|err| Error::BitcoinCoreRpcClient(err, url.to_string()))?;
+
+        Ok(Self { client })
+    }
+    /// Fetch and decode raw transaction from bitcoin-core using the
+    /// getrawtransaction RPC.
+    ///
+    /// # Notes
+    ///
+    /// By default, this call only returns a transaction if it is in the
+    /// mempool. If -txindex is enabled on bitcoin-core and no blockhash
+    /// argument is passed, it will return the transaction if it is in the
+    /// mempool or any block.
+    pub fn get_tx(&self, txid: &Txid) -> Result<GetTxResponse, Error> {
+        let response = self
+            .client
+            .get_raw_transaction_info(txid, None)
+            .map_err(|err| Error::GetTransactionBitcoinCore(err, *txid))?;
+        let tx = Transaction::consensus_decode(&mut response.hex.as_slice())
+            .map_err(|err| Error::DecodeTx(err, *txid))?;
+
+        debug_assert_eq!(txid, &response.txid);
+
+        Ok(GetTxResponse {
+            tx,
+            txid: response.txid,
+            block_hash: response.blockhash,
+            confirmations: response.confirmations,
+            block_time: response.blocktime.map(|time| time as u64),
+            in_active_chain: response.in_active_chain,
+        })
+    }
+}
+
+impl BitcoinRpcClient for BtcClient {
+    fn get_tx(&self, txid: &Txid) -> Result<GetTxResponse, Error> {
+        self.get_tx(txid)
+    }
+}
+
+/// A client for interacting with Electrum server
+pub struct ElectrumClient {
+    /// The underlying electrum client
+    pub client: electrum_client::Client,
+}
+
+impl ElectrumClient {
+    /// Establish a connection to the electrum server and return a client.
+    ///
+    /// # Notes
+    ///
+    /// * Attempts to establish a connection with the server using the
+    ///   given URL.
+    /// * The URL must be prefixed with either tcp:// or ssl://.
+    /// * The electrum-client authors use an u8 for the timeout instead
+    ///   Duration, so we mirror that here. A timeout of zero will error so
+    ///   disallow it. A timeout of None means no timeout.
+    pub fn new(url: &str, timeout: Option<NonZeroU8>) -> Result<Self, Error> {
+        // The config builder will panic if the timeout is set to zero, so
+        // we set it to None, which means no timeout. Kind of surprising
+        // but this is what is usually meant by a timeout of zero anyway.
+        let config = electrum_client::Config::builder()
+            .timeout(timeout.map(NonZeroU8::get))
+            .retry(2)
+            .validate_domain(true)
+            .build();
+        // This actually attempts to establish a connection with the server
+        // and returns and Error otherwise.
+        let client = electrum_client::Client::from_config(url, config)
+            .map_err(|err| Error::ElectrumClientBuild(err, url.to_string()))?;
+
+        Ok(Self { client })
+    }
+    /// Fetch and decode raw transaction from the electrum server.
+    ///
+    /// # Notes
+    ///
+    /// This function uses the `blockchain.transaction.get` Electrum
+    /// protocol method for the response. That method uses bitcoin-core's
+    /// getrawtransaction RPC under the hood, but supplies the correct
+    /// block hash fetched from Electrum server's index. The benefit of
+    /// using electrum for this is that you do not need to set -txindex = 1
+    /// in bitcoin-core, and electrum is (presumably) much more efficient.
+    pub fn get_tx(&self, txid: &Txid) -> Result<GetTxResponse, Error> {
+        let params = [Param::String(txid.to_string()), Param::Bool(true)];
+        let value = self
+            .client
+            .raw_call("blockchain.transaction.get", params)
+            .map_err(|err| Error::GetTransactionElectrum(err, *txid))?;
+
+        serde_json::from_value::<GetTxResponse>(value)
+            .inspect(|response| debug_assert_eq!(txid, &response.txid))
+            .map_err(|err| Error::DeserializeGetTransaction(err, *txid))
+    }
+}
+
+impl BitcoinRpcClient for ElectrumClient {
+    fn get_tx(&self, txid: &Txid) -> Result<GetTxResponse, Error> {
+        self.get_tx(txid)
+    }
+}

--- a/sbtc/src/rpc.rs
+++ b/sbtc/src/rpc.rs
@@ -54,7 +54,7 @@ pub trait BitcoinRpcClient {
 /// A client for interacting with bitcoin-core
 pub struct BtcClient {
     /// The underlying bitcoin-core client
-    pub client: bitcoincore_rpc::Client,
+    inner: bitcoincore_rpc::Client,
 }
 
 impl BtcClient {
@@ -68,7 +68,7 @@ impl BtcClient {
         let client = bitcoincore_rpc::Client::new(url, auth)
             .map_err(|err| Error::BitcoinCoreRpcClient(err, url.to_string()))?;
 
-        Ok(Self { client })
+        Ok(Self { inner: client })
     }
     /// Fetch and decode raw transaction from bitcoin-core using the
     /// getrawtransaction RPC.
@@ -81,7 +81,7 @@ impl BtcClient {
     /// mempool or any block.
     pub fn get_tx(&self, txid: &Txid) -> Result<GetTxResponse, Error> {
         let response = self
-            .client
+            .inner
             .get_raw_transaction_info(txid, None)
             .map_err(|err| Error::GetTransactionBitcoinCore(err, *txid))?;
         let tx = Transaction::consensus_decode(&mut response.hex.as_slice())
@@ -109,7 +109,7 @@ impl BitcoinRpcClient for BtcClient {
 /// A client for interacting with Electrum server
 pub struct ElectrumClient {
     /// The underlying electrum client
-    pub client: electrum_client::Client,
+    inner: electrum_client::Client,
 }
 
 impl ElectrumClient {
@@ -137,7 +137,7 @@ impl ElectrumClient {
         let client = electrum_client::Client::from_config(url, config)
             .map_err(|err| Error::ElectrumClientBuild(err, url.to_string()))?;
 
-        Ok(Self { client })
+        Ok(Self { inner: client })
     }
     /// Fetch and decode raw transaction from the electrum server.
     ///
@@ -152,7 +152,7 @@ impl ElectrumClient {
     pub fn get_tx(&self, txid: &Txid) -> Result<GetTxResponse, Error> {
         let params = [Param::String(txid.to_string()), Param::Bool(true)];
         let value = self
-            .client
+            .inner
             .raw_call("blockchain.transaction.get", params)
             .map_err(|err| Error::GetTransactionElectrum(err, *txid))?;
 


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/363. This PR adds a bitcoin-core and electrum server implementation for fetching the deposit transaction (and validating it).

The only reason why this adds two implementations was because of how I went about working on it. I finished the bitcoin-core RPC implementation and then realized that using bitcoin-core's [getrawtransaction RPC](https://bitcoincore.org/en/doc/27.0.0/rpc/rawtransactions/getrawtransaction/) might not be ideal. For it to work as intended, it requires the `-txindex` flag to be `1`, which might not be setup on the signers' bitcoin-core (no idea one way or the other). Also, we plan on having electrum server set up anyway, and that offers similar functionality but without the requirement of the `-txindex` flag being set on bitcoin-core, so I went ahead and implemented a client for that as well.

## Change

* Add implementation for fetching transactions from bitcoin-core
* Add implementation for fetching transactions from electrum server.
* Mild reorganization

## Testing information

The tests required a slight refactor, so in order to keep the PR size manageable they'll come in a follow-up PR.