### PR TITLE
feat: add electrum for fee estimates

### DIFF
--- a/sbtc/src/deposits.rs
+++ b/sbtc/src/deposits.rs
@@ -262,10 +262,12 @@ impl DepositScriptInputs {
     /// the format for a principal from SIP-005. So the expected wire
     /// format is:
     ///
+    /// ```text
     /// 0         8             9         10        30            31             159
     /// |---------|-------------|---------|---------|-------------|---------------|
     ///   max fee   type prefix   version   hash160   name length   contract name
     ///                                               (optional)    (optional)
+    /// ```
     ///
     /// Above, the max fee is expressed as an 8-byte big endian integer and
     /// the contract name is a UTF-8 encoded string and must be accepted by

--- a/signer/tests/integration/rbf.rs
+++ b/signer/tests/integration/rbf.rs
@@ -21,12 +21,12 @@ use signer::utxo::SignerUtxo;
 use signer::utxo::UnsignedTransaction;
 use signer::utxo::WithdrawalRequest;
 
+use crate::utxo_construction::generate_withdrawal;
+use crate::utxo_construction::make_deposit_request;
+use regtest::Recipient;
 use sbtc::testing::regtest;
 use sbtc::testing::regtest::AsUtxo;
 use sbtc::testing::regtest::Faucet;
-use crate::utxo_construction::make_deposit_request;
-use crate::utxo_construction::generate_withdrawal;
-use regtest::Recipient;
 
 #[derive(Debug, Clone)]
 pub struct FullUtxo {

--- a/signer/tests/integration/utxo_construction.rs
+++ b/signer/tests/integration/utxo_construction.rs
@@ -24,9 +24,9 @@ use signer::utxo::SignerBtcState;
 use signer::utxo::SignerUtxo;
 use signer::utxo::WithdrawalRequest;
 
+use regtest::Recipient;
 use sbtc::testing::regtest;
 use sbtc::testing::regtest::AsUtxo;
-use regtest::Recipient;
 
 pub fn generate_withdrawal() -> (WithdrawalRequest, Recipient) {
     let recipient = Recipient::new(AddressType::P2tr);


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/160.

During the design phase, we aligned on using electrum as a source for fee estimates. This PR adds two implementations, one from electrum and another from bitcoin-core. The bitcoin-core implementation makes testing easier, since some implementations of electrum use bitcoin-core's `estimatesmartfee` RPC under the hood.

## Changes

* Add an implementation that estimates fees using electrum.
* Add an implementation that estimates fees using bitcoin-core.
* Update the `fees` module in the signer create to return a `FeeEstimate` type.
* Updated the error messages in the `sbtc` crate, I forgot to do this in an earlier PR.


## Testing information

This PR adds an integration test for the `electrum` and `bitcoin-core` estimate fee implementations, but I stopped short of making the test "self-contained". In order to test the we get reasonable fee estimates we need to make sure there are enough transactions on the block chain (I'm not sure what counts as enough). I tested these functions locally by running all integration tests and then running a slightly modified version of the `estimate_fee_rate` test to see if the output was reasonable.