### PR TITLE
Update config.rs for multiple stacks node urls

### DIFF
--- a/signer/src/config.rs
+++ b/signer/src/config.rs
@@ -149,8 +149,18 @@ impl StacksSettings {
             .build()
             .map_err(Error::SignerConfig)?;
 
-        conf.get::<StacksSettings>("stacks")
-            .map_err(Error::StacksApiConfig)
+        let settings: Self = conf.get::<StacksSettings>("stacks")
+            .map_err(Error::StacksApiConfig);
+
+        settings.validate()?;
+
+        Ok(settings)
+    }
+
+    fn validate(&self) -> Result<(), ConfigError> {
+        if self.nodes.is_empty() {
+            return Err(ConfigError::Message("nodes cannot be empty".to_string()));
+        }
     }
 }
 

--- a/signer/src/config.rs
+++ b/signer/src/config.rs
@@ -106,7 +106,7 @@ where
 #[derive(Debug, Clone, serde::Deserialize)]
 pub struct StacksSettings {
     /// The configuration entries related to the Stacks node
-    pub node: StacksNodeSettings,
+    pub nodes: Vec<StacksNodeSettings>,
 }
 
 /// Settings associated with the stacks node that this signer uses for information
@@ -163,29 +163,29 @@ mod tests {
         // The default toml used here specifies http://localhost:20443
         // as the stacks node endpoint.
         let settings = StacksSettings::new_from_config().unwrap();
-        let host = settings.node.endpoint.host();
+        let host = settings.nodes[0].endpoint.host();
         assert_eq!(host, Some(url::Host::Domain("localhost")));
-        assert_eq!(settings.node.endpoint.port(), Some(20443));
+        assert_eq!(settings.nodes[0].endpoint.port(), Some(20443));
 
         std::env::set_var("SIGNER_STACKS_NODE_ENDPOINT", "http://whatever:1234");
 
         let settings = StacksSettings::new_from_config().unwrap();
-        let host = settings.node.endpoint.host();
+        let host = settings.nodes[0].endpoint.host();
         assert_eq!(host, Some(url::Host::Domain("whatever")));
-        assert_eq!(settings.node.endpoint.port(), Some(1234));
+        assert_eq!(settings.nodes[0].endpoint.port(), Some(1234));
 
         std::env::set_var("SIGNER_STACKS_NODE_ENDPOINT", "http://127.0.0.1:5678");
 
         let settings = StacksSettings::new_from_config().unwrap();
         let ip: std::net::Ipv4Addr = "127.0.0.1".parse().unwrap();
-        assert_eq!(settings.node.endpoint.host(), Some(url::Host::Ipv4(ip)));
-        assert_eq!(settings.node.endpoint.port(), Some(5678));
+        assert_eq!(settings.nodes[0].endpoint.host(), Some(url::Host::Ipv4(ip)));
+        assert_eq!(settings.nodes[0].endpoint.port(), Some(5678));
 
         std::env::set_var("SIGNER_STACKS_NODE_ENDPOINT", "http://[::1]:9101");
 
         let settings = StacksSettings::new_from_config().unwrap();
         let ip: std::net::Ipv6Addr = "::1".parse().unwrap();
-        assert_eq!(settings.node.endpoint.host(), Some(url::Host::Ipv6(ip)));
-        assert_eq!(settings.node.endpoint.port(), Some(9101));
+        assert_eq!(settings.nodes[0].endpoint.host(), Some(url::Host::Ipv6(ip)));
+        assert_eq!(settings.nodes[0].endpoint.port(), Some(9101));
     }
 }

--- a/signer/src/config.rs
+++ b/signer/src/config.rs
@@ -157,9 +157,9 @@ impl StacksSettings {
         Ok(settings)
     }
 
-    fn validate(&self) -> Result<(), ConfigError> {
+    fn validate(&self) -> Result<(), Error> {
         if self.nodes.is_empty() {
-            return Err(ConfigError::Message("nodes cannot be empty".to_string()));
+            return Err(Error::StacksApiConfig);
         }
 
         Ok(())

--- a/signer/src/config.rs
+++ b/signer/src/config.rs
@@ -150,7 +150,7 @@ impl StacksSettings {
             .map_err(Error::SignerConfig)?;
 
         let settings: Self = conf.get::<StacksSettings>("stacks")
-            .map_err(Error::StacksApiConfig);
+            .map_err(Error::StacksApiConfig)?;
 
         settings.validate()?;
 
@@ -161,6 +161,8 @@ impl StacksSettings {
         if self.nodes.is_empty() {
             return Err(ConfigError::Message("nodes cannot be empty".to_string()));
         }
+
+        Ok(())
     }
 }
 

--- a/signer/src/config.rs
+++ b/signer/src/config.rs
@@ -159,7 +159,7 @@ impl StacksSettings {
 
     fn validate(&self) -> Result<(), Error> {
         if self.nodes.is_empty() {
-            return Err(Error::StacksApiConfig);
+            return Err(Error::StacksApiConfig(ConfigError::Message("Host cannot be empty".to_string())));
         }
 
         Ok(())

--- a/signer/src/stacks/api.rs
+++ b/signer/src/stacks/api.rs
@@ -756,11 +756,13 @@ mod tests {
             .expect(1)
             .create();
 
-        let settings = StacksSettings {
-            node: StacksNodeSettings {
+        let nodes = Vec::new();
+        nodes.push(StacksNodeSettings {
                 endpoint: url::Url::parse(stacks_node_server.url().as_str()).unwrap(),
                 nakamoto_start_height: 20,
-            },
+            });
+        let settings = StacksSettings {
+            nodes,
         };
 
         let client = StacksClient::new(settings);

--- a/signer/src/stacks/api.rs
+++ b/signer/src/stacks/api.rs
@@ -263,7 +263,7 @@ impl StacksClient {
     /// StacksSettings.
     pub fn new(settings: StacksSettings) -> Self {
         Self {
-            node_endpoint: settings.nodes[0].endpoint,
+            node_endpoint: settings.nodes[0].endpoint.clone(),
             nakamoto_start_height: settings.nodes[0].nakamoto_start_height,
             client: reqwest::Client::new(),
         }

--- a/signer/src/stacks/api.rs
+++ b/signer/src/stacks/api.rs
@@ -263,8 +263,8 @@ impl StacksClient {
     /// StacksSettings.
     pub fn new(settings: StacksSettings) -> Self {
         Self {
-            node_endpoint: settings.node.endpoint,
-            nakamoto_start_height: settings.node.nakamoto_start_height,
+            node_endpoint: settings.nodes[0].endpoint,
+            nakamoto_start_height: settings.nodes[0].nakamoto_start_height,
             client: reqwest::Client::new(),
         }
     }

--- a/signer/src/stacks/api.rs
+++ b/signer/src/stacks/api.rs
@@ -756,7 +756,7 @@ mod tests {
             .expect(1)
             .create();
 
-        let nodes = Vec::new();
+        let mut nodes = Vec::new();
         nodes.push(StacksNodeSettings {
                 endpoint: url::Url::parse(stacks_node_server.url().as_str()).unwrap(),
                 nakamoto_start_height: 20,
@@ -810,11 +810,14 @@ mod tests {
             .expect(1)
             .create();
 
-        let settings = StacksSettings {
-            node: StacksNodeSettings {
+        let mut nodes = Vec::new();
+
+        nodes.push(StacksNodeSettings {
                 endpoint: url::Url::parse(stacks_node_server.url().as_str()).unwrap(),
                 nakamoto_start_height: 20,
-            },
+            });
+        let settings = StacksSettings {
+            nodes,
         };
 
         let client = StacksClient::new(settings);
@@ -855,12 +858,16 @@ mod tests {
             .with_body(raw_json_response)
             .expect(4)
             .create();
+        
+        let mut nodes = Vec::new();
 
-        let settings = StacksSettings {
-            node: StacksNodeSettings {
+        nodes.push(StacksNodeSettings {
                 endpoint: url::Url::parse(stacks_node_server.url().as_str()).unwrap(),
                 nakamoto_start_height: 20,
-            },
+            });
+
+        let settings = StacksSettings {
+            nodes,
         };
 
         let client = StacksClient::new(settings);


### PR DESCRIPTION
## Description

This change adds support for multiple stacks node urls. 

For details refer to issue #225

## Type of Change
- New feature 

## Does this introduce a breaking change?
No, single node config is still supported. 

## Are documentation updates required?
The relevant struct doc comments have been updated.  

## Testing information
Existing unit tests have been updated to verify the new code paths

## Checklist
- [ x] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [ ] `npm run test` passes
- [ ] Changelog is updated
- [ ] Tag 1 of @person1 or @person2
