### PR TITLE
Add `testing` endpoint to emily api

### DIFF
--- a/.generated-sources/emily/openapi/build.rs
+++ b/.generated-sources/emily/openapi/build.rs
@@ -25,6 +25,8 @@ use utoipa::OpenApi;
         api::handlers::chainstate::get_chainstate_at_height,
         api::handlers::chainstate::set_chainstate,
         api::handlers::chainstate::update_chainstate,
+        // Testing endpoints.
+        api::handlers::testing::wipe_databases,
     ),
     components(schemas(
         // Chainstate models.

--- a/.generated-sources/emily/openapi/emily-openapi-spec.json
+++ b/.generated-sources/emily/openapi/emily-openapi-spec.json
@@ -485,6 +485,39 @@
         }
       }
     },
+    "/testing/wipe": {
+      "post": {
+        "tags": [
+          "testing"
+        ],
+        "summary": "Get health handler.",
+        "operationId": "wipeDatabases",
+        "responses": {
+          "204": {
+            "description": "Successfully wiped databases."
+          },
+          "400": {
+            "description": "Invalid request body"
+          },
+          "404": {
+            "description": "Address not found"
+          },
+          "405": {
+            "description": "Method not allowed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "x-amazon-apigateway-integration": {
+          "httpMethod": "POST",
+          "type": "aws_proxy",
+          "uri": {
+            "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${OperationLambda}/invocations"
+          }
+        }
+      }
+    },
     "/withdrawal": {
       "get": {
         "tags": [

--- a/.generated-sources/emily/openapi/emily-openapi-spec.json
+++ b/.generated-sources/emily/openapi/emily-openapi-spec.json
@@ -490,7 +490,7 @@
         "tags": [
           "testing"
         ],
-        "summary": "Get health handler.",
+        "summary": "Wipe databases handler.",
         "operationId": "wipeDatabases",
         "responses": {
           "204": {

--- a/emily/handler/src/api/handlers/mod.rs
+++ b/emily/handler/src/api/handlers/mod.rs
@@ -12,11 +12,11 @@ pub mod chainstate;
 pub mod deposit;
 /// Health handlers.
 pub mod health;
-/// Withdrawal handlers.
-pub mod withdrawal;
 /// Testing handlers.
 #[cfg(feature = "testing")]
 pub mod testing;
+/// Withdrawal handlers.
+pub mod withdrawal;
 
 /// Central error handler for Warp rejections, converting them to appropriate HTTP responses.
 /// TODO(131): Alter handler for Emily API.

--- a/emily/handler/src/api/handlers/mod.rs
+++ b/emily/handler/src/api/handlers/mod.rs
@@ -14,6 +14,9 @@ pub mod deposit;
 pub mod health;
 /// Withdrawal handlers.
 pub mod withdrawal;
+/// Testing handlers.
+#[cfg(feature = "testing")]
+pub mod testing;
 
 /// Central error handler for Warp rejections, converting them to appropriate HTTP responses.
 /// TODO(131): Alter handler for Emily API.

--- a/emily/handler/src/api/handlers/testing.rs
+++ b/emily/handler/src/api/handlers/testing.rs
@@ -8,7 +8,6 @@ use crate::common::error::Error;
 use crate::context::EmilyContext;
 use crate::database::accessors;
 
-
 /// Get health handler.
 #[utoipa::path(
     post,
@@ -24,20 +23,14 @@ use crate::database::accessors;
         (status = 500, description = "Internal server error")
     )
 )]
-pub async fn wipe_databases(
-    context: EmilyContext,
-) -> impl warp::reply::Reply {
+pub async fn wipe_databases(context: EmilyContext) -> impl warp::reply::Reply {
     // Internal handler so `?` can be used correctly while still returning a reply.
-    async fn handler(
-        context: EmilyContext,
-    ) -> Result<impl warp::reply::Reply, Error> {
-       accessors::wipe_all_tables(&context).await?;
+    async fn handler(context: EmilyContext) -> Result<impl warp::reply::Reply, Error> {
+        accessors::wipe_all_tables(&context).await?;
         Ok(warp::reply::with_status(
-            warp::reply::json(
-                &json!({
-                    "message": "wiped database"
-                })
-            ),
+            warp::reply::json(&json!({
+                "message": "wiped database"
+            })),
             StatusCode::NO_CONTENT,
         ))
     }

--- a/emily/handler/src/api/handlers/testing.rs
+++ b/emily/handler/src/api/handlers/testing.rs
@@ -8,7 +8,7 @@ use crate::common::error::Error;
 use crate::context::EmilyContext;
 use crate::database::accessors;
 
-/// Get health handler.
+/// Wipe databases handler.
 #[utoipa::path(
     post,
     operation_id = "wipeDatabases",

--- a/emily/handler/src/api/handlers/testing.rs
+++ b/emily/handler/src/api/handlers/testing.rs
@@ -1,4 +1,4 @@
-//! Handlers for Health endpoint endpoints.
+//! Handlers for testing endpoint endpoints.
 
 use reqwest::StatusCode;
 use serde_json::json;

--- a/emily/handler/src/api/handlers/testing.rs
+++ b/emily/handler/src/api/handlers/testing.rs
@@ -1,7 +1,6 @@
 //! Handlers for testing endpoint endpoints.
 
 use reqwest::StatusCode;
-use serde_json::json;
 use warp::reply::Reply;
 
 use crate::common::error::Error;

--- a/emily/handler/src/api/handlers/testing.rs
+++ b/emily/handler/src/api/handlers/testing.rs
@@ -1,0 +1,49 @@
+//! Handlers for Health endpoint endpoints.
+
+use reqwest::StatusCode;
+use serde_json::json;
+use warp::reply::Reply;
+
+use crate::common::error::Error;
+use crate::context::EmilyContext;
+use crate::database::accessors;
+
+
+/// Get health handler.
+#[utoipa::path(
+    post,
+    operation_id = "wipeDatabases",
+    path = "/testing/wipe",
+    tag = "testing",
+    responses(
+        // TODO(271): Add success body.
+        (status = 204, description = "Successfully wiped databases."),
+        (status = 400, description = "Invalid request body"),
+        (status = 404, description = "Address not found"),
+        (status = 405, description = "Method not allowed"),
+        (status = 500, description = "Internal server error")
+    )
+)]
+pub async fn wipe_databases(
+    context: EmilyContext,
+) -> impl warp::reply::Reply {
+    // Internal handler so `?` can be used correctly while still returning a reply.
+    async fn handler(
+        context: EmilyContext,
+    ) -> Result<impl warp::reply::Reply, Error> {
+       accessors::wipe_all_tables(&context).await?;
+        Ok(warp::reply::with_status(
+            warp::reply::json(
+                &json!({
+                    "message": "wiped database"
+                })
+            ),
+            StatusCode::NO_CONTENT,
+        ))
+    }
+
+    // Handle and respond.
+    handler(context)
+        .await
+        .map_or_else(Reply::into_response, Reply::into_response)
+}

--- a/emily/handler/src/api/handlers/testing.rs
+++ b/emily/handler/src/api/handlers/testing.rs
@@ -28,9 +28,7 @@ pub async fn wipe_databases(context: EmilyContext) -> impl warp::reply::Reply {
     async fn handler(context: EmilyContext) -> Result<impl warp::reply::Reply, Error> {
         accessors::wipe_all_tables(&context).await?;
         Ok(warp::reply::with_status(
-            warp::reply::json(&json!({
-                "message": "wiped database"
-            })),
+            warp::reply(),
             StatusCode::NO_CONTENT,
         ))
     }

--- a/emily/handler/src/api/routes/mod.rs
+++ b/emily/handler/src/api/routes/mod.rs
@@ -11,11 +11,11 @@ mod chainstate;
 mod deposit;
 /// Health routes.
 mod health;
-/// Withdrawal routes.
-mod withdrawal;
 /// Testing routes.
 #[cfg(feature = "testing")]
 mod testing;
+/// Withdrawal routes.
+mod withdrawal;
 
 /// This function sets up the Warp filters for handling all requests.
 #[cfg(feature = "testing")]

--- a/emily/handler/src/api/routes/mod.rs
+++ b/emily/handler/src/api/routes/mod.rs
@@ -34,7 +34,9 @@ pub fn routes(
 }
 
 #[cfg(not(feature = "testing"))]
-fn debug_routes() -> Option<impl Filter<Extract = impl warp::Reply, Error = warp::Rejection>> {
+pub fn routes(
+    context: EmilyContext,
+) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
     // TODO(273):  Remove the "local" prefix once we figure out why all local
     // testing calls seem to forcibly start with `local`.
     warp::path("local").and(

--- a/emily/handler/src/api/routes/testing.rs
+++ b/emily/handler/src/api/routes/testing.rs
@@ -18,9 +18,7 @@ fn wipe_databases(
 ) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
     warp::any()
         .map(move || context.clone())
-        .and(warp::path!(
-            "testing" / "wipe"
-        ))
+        .and(warp::path!("testing" / "wipe"))
         .and(warp::post())
         .then(handlers::testing::wipe_databases)
 }

--- a/emily/handler/src/api/routes/testing.rs
+++ b/emily/handler/src/api/routes/testing.rs
@@ -1,6 +1,5 @@
-//! Route definitions for the deposit endpoint.
+//! Route definitions for the testing endpoint.
 use warp::Filter;
-
 
 use crate::context::EmilyContext;
 
@@ -10,7 +9,7 @@ use super::handlers;
 pub fn routes(
     context: EmilyContext,
 ) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
-    wipe_databases(context.clone())
+    wipe_databases(context)
 }
 
 /// Wipe databases

--- a/emily/handler/src/api/routes/testing.rs
+++ b/emily/handler/src/api/routes/testing.rs
@@ -1,0 +1,27 @@
+//! Route definitions for the deposit endpoint.
+use warp::Filter;
+
+
+use crate::context::EmilyContext;
+
+use super::handlers;
+
+/// Debug routes
+pub fn routes(
+    context: EmilyContext,
+) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    wipe_databases(context.clone())
+}
+
+/// Wipe databases
+fn wipe_databases(
+    context: EmilyContext,
+) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    warp::any()
+        .map(move || context.clone())
+        .and(warp::path!(
+            "testing" / "wipe"
+        ))
+        .and(warp::post())
+        .then(handlers::testing::wipe_databases)
+}

--- a/emily/handler/src/api/routes/testing.rs
+++ b/emily/handler/src/api/routes/testing.rs
@@ -5,7 +5,7 @@ use crate::context::EmilyContext;
 
 use super::handlers;
 
-/// Debug routes
+/// Testing routes
 pub fn routes(
     context: EmilyContext,
 ) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {

--- a/emily/handler/src/common/error.rs
+++ b/emily/handler/src/common/error.rs
@@ -5,8 +5,7 @@ use std::env;
 use aws_sdk_dynamodb::{
     error::SdkError,
     operation::{
-        delete_item::DeleteItemError, get_item::GetItemError, put_item::PutItemError,
-        query::QueryError, scan::ScanError,
+        batch_write_item::BatchWriteItemError, delete_item::DeleteItemError, get_item::GetItemError, put_item::PutItemError, query::QueryError, scan::ScanError
     },
 };
 use reqwest::StatusCode;
@@ -142,6 +141,11 @@ impl From<SdkError<DeleteItemError>> for Error {
 impl From<SdkError<ScanError>> for Error {
     fn from(err: SdkError<ScanError>) -> Self {
         Error::Debug(format!("SdkError<ScanError> - {err:?}"))
+    }
+}
+impl From<SdkError<BatchWriteItemError>> for Error {
+    fn from(err: SdkError<BatchWriteItemError>) -> Self {
+        Error::Debug(format!("SdkError<BatchWriteItemError> - {err:?}"))
     }
 }
 impl From<aws_sdk_dynamodb::error::BuildError> for Error {

--- a/emily/handler/src/common/error.rs
+++ b/emily/handler/src/common/error.rs
@@ -6,7 +6,7 @@ use aws_sdk_dynamodb::{
     error::SdkError,
     operation::{
         delete_item::DeleteItemError, get_item::GetItemError, put_item::PutItemError,
-        query::QueryError,
+        query::QueryError, scan::ScanError,
     },
 };
 use reqwest::StatusCode;
@@ -137,6 +137,16 @@ impl From<SdkError<QueryError>> for Error {
 impl From<SdkError<DeleteItemError>> for Error {
     fn from(err: SdkError<DeleteItemError>) -> Self {
         Error::Debug(format!("SdkError<DeleteItemError> - {err:?}"))
+    }
+}
+impl From<SdkError<ScanError>> for Error {
+    fn from(err: SdkError<ScanError>) -> Self {
+        Error::Debug(format!("SdkError<ScanError> - {err:?}"))
+    }
+}
+impl From<aws_sdk_dynamodb::error::BuildError> for Error {
+    fn from(err: aws_sdk_dynamodb::error::BuildError) -> Self {
+        Error::Debug(format!("aws_sdk_dynamodb::error::BuildError - {err:?}"))
     }
 }
 impl From<base64::DecodeError> for Error {

--- a/emily/handler/src/common/error.rs
+++ b/emily/handler/src/common/error.rs
@@ -5,7 +5,8 @@ use std::env;
 use aws_sdk_dynamodb::{
     error::SdkError,
     operation::{
-        batch_write_item::BatchWriteItemError, delete_item::DeleteItemError, get_item::GetItemError, put_item::PutItemError, query::QueryError, scan::ScanError
+        batch_write_item::BatchWriteItemError, delete_item::DeleteItemError,
+        get_item::GetItemError, put_item::PutItemError, query::QueryError, scan::ScanError,
     },
 };
 use reqwest::StatusCode;

--- a/emily/handler/src/database/accessors.rs
+++ b/emily/handler/src/database/accessors.rs
@@ -236,7 +236,7 @@ async fn wipe_withdrawal_table(context: &EmilyContext) -> Result<(), Error> {
 async fn wipe_chainstate_table(context: &EmilyContext) -> Result<(), Error> {
     wipe_table::<ChainstateEntry, ChainstateEntryKey>(
         &context.dynamodb_client,
-        &context.settings.chainstate_table_name.as_str(),
+        context.settings.chainstate_table_name.as_str(),
         |entry: ChainstateEntry| entry.key,
     )
     .await
@@ -312,8 +312,8 @@ where
         write_delete_requests.push(write_request);
     }
 
-    let mut chunks = write_delete_requests.chunks(25);
-    while let Some(chunk) = chunks.next() {
+    // let chunks = write_delete_requests.chunks(25);
+    for chunk in write_delete_requests.chunks(25) {
         dynamodb_client
             .batch_write_item()
             .request_items(table_name, chunk.to_vec())

--- a/emily/handler/src/database/accessors.rs
+++ b/emily/handler/src/database/accessors.rs
@@ -314,11 +314,11 @@ where
 
     let mut chunks = write_delete_requests.chunks(25);
     while let Some(chunk) = chunks.next() {
-        let _ = dynamodb_client
+        dynamodb_client
             .batch_write_item()
             .request_items(table_name, chunk.to_vec())
             .send()
-            .await;
+            .await?;
     }
 
     Ok(())

--- a/emily/handler/src/database/accessors.rs
+++ b/emily/handler/src/database/accessors.rs
@@ -2,11 +2,10 @@
 
 use std::collections::HashMap;
 
-use aws_sdk_dynamodb::{operation::{batch_write_item::BatchWriteItemInput, scan::builders::ScanFluentBuilder}, types::{AttributeValue, DeleteRequest, WriteRequest}};
+use aws_sdk_dynamodb::types::{AttributeValue, DeleteRequest, WriteRequest};
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 
 use serde::{Deserialize, Serialize};
-use tracing::info;
 
 use crate::{
     api::models::{common::BlockHeight, withdrawal::WithdrawalId},

--- a/emily/handler/src/database/accessors.rs
+++ b/emily/handler/src/database/accessors.rs
@@ -2,10 +2,11 @@
 
 use std::collections::HashMap;
 
-use aws_sdk_dynamodb::types::AttributeValue;
+use aws_sdk_dynamodb::{operation::{batch_write_item::BatchWriteItemInput, scan::builders::ScanFluentBuilder}, types::{AttributeValue, DeleteRequest, WriteRequest}};
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 
 use serde::{Deserialize, Serialize};
+use tracing::info;
 
 use crate::{
     api::models::{common::BlockHeight, withdrawal::WithdrawalId},
@@ -203,6 +204,50 @@ pub async fn get_withdrawal_entries(
     .await
 }
 
+/// Wipes all the tables.
+/// TODO(TBD): Include check for whether the table is running locally.
+pub async fn wipe_all_tables(
+    context: &EmilyContext,
+) -> Result<(), Error> {
+    wipe_deposit_table(context).await?;
+    wipe_withdrawal_table(context).await?;
+    wipe_chainstate_table(context).await?;
+    Ok(())
+}
+
+/// Wipes the deposit table.
+async fn wipe_deposit_table(
+    context: &EmilyContext,
+) -> Result<(), Error> {
+    wipe_table::<DepositEntry, DepositEntryKey>(
+        &context.dynamodb_client,
+        context.settings.deposit_table_name.as_str(),
+        |entry: DepositEntry| entry.key
+    ).await
+}
+
+/// Wipes the withdrawal table.
+async fn wipe_withdrawal_table(
+    context: &EmilyContext,
+) -> Result<(), Error> {
+    wipe_table::<WithdrawalEntry, WithdrawalEntryKey>(
+        &context.dynamodb_client,
+        context.settings.withdrawal_table_name.as_str(),
+        |entry: WithdrawalEntry| entry.key
+    ).await
+}
+
+/// Wipes the chainstate table.
+async fn wipe_chainstate_table(
+    context: &EmilyContext,
+) -> Result<(), Error> {
+    wipe_table::<ChainstateEntry, ChainstateEntryKey>(
+        &context.dynamodb_client,
+        &context.settings.chainstate_table_name.as_str(),
+        |entry: ChainstateEntry| entry.key
+    ).await
+}
+
 // Generics --------------------------------------------------------------------
 
 /// Generic put table entry.
@@ -241,6 +286,86 @@ pub async fn _delete_entry(
         .await?;
     // Return.
     Ok(())
+}
+
+/// Wipes a specific table.
+async fn wipe_table<T, K>(
+    dynamodb_client: &aws_sdk_dynamodb::Client,
+    table_name: &str,
+    key_from_entry: fn(T) -> K,
+) -> Result<(), Error>
+where
+    T: for<'de> Deserialize<'de>,
+    K: Serialize + for<'de> Deserialize<'de>,
+{
+    let keys_to_delete: Vec<K> = serde_dynamo::from_items(
+        get_all_entries(
+            dynamodb_client,
+            table_name,
+        ).await?
+    )?
+    .into_iter()
+    .map(key_from_entry)
+    .collect();
+
+    // Get keys
+    let mut write_delete_requests: Vec<WriteRequest> = Vec::new();
+    for key in keys_to_delete {
+        let key_item = serde_dynamo::to_item::<K, Item>(key)?;
+        let write_request = WriteRequest::builder()
+            .delete_request(DeleteRequest::builder()
+                .set_key(Some(key_item.into()))
+                .build()?
+            )
+            .build();
+        write_delete_requests.push(write_request);
+    }
+
+    let mut chunks = write_delete_requests.chunks(25);
+    while let Some(chunk) = chunks.next() {
+        let _ = dynamodb_client
+            .batch_write_item()
+            .request_items(table_name, chunk.to_vec())
+            .send()
+            .await;
+    }
+
+    Ok(())
+}
+
+/// Get all entries from a dynamodb table.
+async fn get_all_entries(
+    dynamodb_client: &aws_sdk_dynamodb::Client,
+    table_name: &str,
+) -> Result<Vec<HashMap<String, AttributeValue>>, Error> {
+    // Create vector to aggregate items in.
+    let mut all_items: Vec<HashMap<String, AttributeValue>> = Vec::new();
+
+    // Create the base scan builder with the table name.
+    let scan_builder = dynamodb_client
+        .scan()
+        .table_name(table_name);
+
+    // Scan the table for as many entries as possible.
+    let mut scan_output = scan_builder
+        .clone()
+        .send()
+        .await?;
+
+    // Put items into aggregate list.
+    all_items.extend_from_slice(scan_output.items());
+
+    // Continue to query until the scan is done.
+    while let Some(exclusive_start_key) = scan_output.last_evaluated_key {
+        scan_output = scan_builder
+            .clone()
+            .set_exclusive_start_key(Some(exclusive_start_key))
+            .send()
+            .await?;
+        all_items.extend_from_slice(scan_output.items());
+    }
+
+    Ok(all_items)
 }
 
 /// Generic table get.


### PR DESCRIPTION
## Description

Closes: #375 

Adds a `/testing/wipe` endpoint to the Emily API that wipes the databases.

## Changes

Adds a `/testing` endpoint that is only created when the `testing` feature is activated which can wipe the databases.

The following are added in this PR:
- A database accessor function that wipes a database
- A database accessor that gets all entries in a table
- A `testing` endpoint route
- A `testing` endpoint route handler

## Testing Information

Tested locally by populating the database with the sequence:

```bash
# Terminal 1
make emily-integration-env-up
```

```bash
# Terminal 2
make emily-populate-database

# Get deposits and withdrawals.
curl "localhost:3000/withdrawal?status=pending&pageSize=1000" | jq
curl "localhost:3000/deposit?status=pending&pageSize=1000" | jq

curl -X POST "localhost:3000/testing/wipe"

# Get deposits and withdrawals.
curl "localhost:3000/withdrawal?status=pending&pageSize=1000" | jq
curl "localhost:3000/deposit?status=pending&pageSize=1000" | jq
```

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
