### PR TITLE
feat: extract deposit requests in block observer

### DIFF
--- a/sbtc/src/deposits.rs
+++ b/sbtc/src/deposits.rs
@@ -100,10 +100,10 @@ pub struct DepositInfo {
 /// A full deposit, with a fully extracted and verified `scriptPubKey`
 #[derive(Debug, Clone)]
 pub struct Deposit {
-    /// The transaction that includes the deposit information.
+    /// The transaction spent to the signers as a deposit for sBTC.
     pub tx: Transaction,
-    /// The deposit information included in one of the outputs of the above
-    /// transaction.
+    /// The deposit information included in one of the output
+    /// `scriptPubKey`s of the above transaction.
     pub info: DepositInfo,
     /// The block hash of the block that includes this transaction. If this
     /// is `None` then this transaction is in the mempool. TODO(384): In

--- a/sbtc/src/deposits.rs
+++ b/sbtc/src/deposits.rs
@@ -97,7 +97,9 @@ pub struct DepositInfo {
     pub lock_time: u64,
 }
 
-/// A full deposit, with a fully extracted and verified `scriptPubKey`
+/// A full "deposit", containing the bitcoin transaction and a fully
+/// extracted and verified `scriptPubKey` from one of the transaction's
+/// UTXOs.
 #[derive(Debug, Clone)]
 pub struct Deposit {
     /// The transaction spent to the signers as a deposit for sBTC.

--- a/sbtc/src/deposits.rs
+++ b/sbtc/src/deposits.rs
@@ -134,6 +134,7 @@ impl CreateDepositRequest {
         let response = client
             .get_tx(&self.outpoint.txid)
             .map_err(|err| Error::BitcoinClient(Box::new(err)))?;
+
         Ok(Deposit {
             info: self.validate_tx(&response.tx)?,
             tx: response.tx,

--- a/sbtc/src/deposits.rs
+++ b/sbtc/src/deposits.rs
@@ -1,12 +1,15 @@
 //! This is the transaction analysis module
 //!
 
+use std::marker::PhantomData;
+
 use bitcoin::opcodes::all as opcodes;
 use bitcoin::script::PushBytesBuf;
 use bitcoin::taproot::LeafVersion;
 use bitcoin::taproot::NodeInfo;
 use bitcoin::taproot::TaprootSpendInfo;
 use bitcoin::Address;
+use bitcoin::BlockHash;
 use bitcoin::Network;
 use bitcoin::OutPoint;
 use bitcoin::ScriptBuf;
@@ -18,7 +21,7 @@ use secp256k1::SECP256K1;
 use stacks_common::types::chainstate::STACKS_ADDRESS_ENCODED_SIZE;
 
 use crate::error::Error;
-use crate::rpc::BitcoinRpcClient;
+use crate::rpc::BitcoinClient;
 
 /// This is the length of the fixed portion of the deposit script, which
 /// is:
@@ -60,6 +63,7 @@ const OP_PUSHNUM_NEG1: u8 = opcodes::OP_PUSHNUM_NEG1.to_u8();
 
 /// All the info required to verify the validity of a deposit
 /// transaction. This info is sent by the user to the Emily API
+#[derive(Debug, Clone)]
 pub struct CreateDepositRequest {
     /// The output index and txid of the depositing transaction.
     pub outpoint: OutPoint,
@@ -72,7 +76,7 @@ pub struct CreateDepositRequest {
 /// All the deposit script with the relevant parts of the deposit and
 /// reclaim scripts parsed.
 #[derive(Debug, Clone)]
-pub struct ParsedDepositRequest {
+pub struct DepositInfo {
     /// The UTXO to be spent by the signers.
     pub outpoint: OutPoint,
     /// The max fee amount to use for the BTC deposit transaction.
@@ -93,19 +97,50 @@ pub struct ParsedDepositRequest {
     pub lock_time: u64,
 }
 
+/// A full deposit, with a fully extracted and verified `scriptPubKey`
+#[derive(Debug, Clone)]
+pub struct Deposit {
+    /// The transaction that includes the deposit information.
+    pub tx: Transaction,
+    /// The information included in one of the outputs of the above
+    /// transaction.
+    pub info: DepositInfo,
+    /// The block hash of the block that includes this transaction. If this
+    /// is `None` then this transaction is in the mempool. TODO(384): In
+    /// the case of a reorg, it's not clear what happens if this was
+    /// confirmed.
+    pub block_hash: Option<BlockHash>,
+    /// The number of confirmations deep from that chain tip of the bitcoin
+    /// block that includes this transaction. If `None` then this is in the
+    /// mempool. TODO(384): In the case of a reorg, it's not clear what
+    /// happens if this was confirmed.
+    pub confirmations: Option<u32>,
+    /// This is to make sure that this struct cannot be created without the
+    /// above invariants being upheld.
+    _phantom: PhantomData<()>,
+}
+
 impl CreateDepositRequest {
     /// Validate this deposit request from the transaction.
     ///
     /// This function fetches the transaction using the given client and
     /// checks that the transaction has been confirmed. The transaction
     /// need not be confirmed.
-    pub fn validate<C>(&self, client: &C) -> Result<ParsedDepositRequest, Error>
+    pub fn validate<C>(&self, client: &C) -> Result<Deposit, Error>
     where
-        C: BitcoinRpcClient,
+        C: BitcoinClient,
     {
         // Fetch the transaction from either a block or from the mempool
-        let response = client.get_tx(&self.outpoint.txid)?;
-        self.validate_tx(&response.tx)
+        let response = client
+            .get_tx(&self.outpoint.txid)
+            .map_err(|err| Error::BitcoinClient(Box::new(err)))?;
+        Ok(Deposit {
+            info: self.validate_tx(&response.tx)?,
+            tx: response.tx,
+            block_hash: response.block_hash,
+            confirmations: response.confirmations,
+            _phantom: PhantomData,
+        })
     }
     /// Validate this deposit request.
     ///
@@ -117,7 +152,7 @@ impl CreateDepositRequest {
     ///   the expected formats for deposit transactions.
     /// * That deposit script and the reclaim script are part of the UTXO
     ///   ScriptPubKey.
-    pub fn validate_tx(&self, tx: &Transaction) -> Result<ParsedDepositRequest, Error> {
+    pub fn validate_tx(&self, tx: &Transaction) -> Result<DepositInfo, Error> {
         if tx.compute_txid() != self.outpoint.txid {
             // The expectation is that the transaction hex was fetched from
             // the blockchain using the txid, so in practice this should
@@ -151,7 +186,7 @@ impl CreateDepositRequest {
             return Err(Error::UtxoScriptPubKeyMismatch(self.outpoint));
         }
 
-        Ok(ParsedDepositRequest {
+        Ok(DepositInfo {
             max_fee: deposit.max_fee,
             deposit_script: self.deposit_script.clone(),
             reclaim_script: self.reclaim_script.clone(),
@@ -507,7 +542,8 @@ mod tests {
         }
     }
 
-    impl BitcoinRpcClient for DummyClient {
+    impl BitcoinClient for DummyClient {
+        type Error = Error;
         fn get_tx(&self, txid: &Txid) -> Result<GetTxResponse, Error> {
             let tx = self
                 .0
@@ -519,7 +555,6 @@ mod tests {
                 ))?;
             Ok(GetTxResponse {
                 tx,
-                txid: *txid,
                 block_hash: None,
                 confirmations: None,
                 block_time: None,
@@ -726,7 +761,7 @@ mod tests {
 
         let parsed = if use_client {
             let client = DummyClient::new_from_tx(&setup.tx);
-            request.validate(&client).unwrap()
+            request.validate(&client).unwrap().info
         } else {
             request.validate_tx(&setup.tx).unwrap()
         };

--- a/sbtc/src/error.rs
+++ b/sbtc/src/error.rs
@@ -10,6 +10,9 @@ pub enum Error {
     /// Error when creating an RPC client to bitcoin-core
     #[error("could not create RPC client to {1}; {0}")]
     BitcoinCoreRpcClient(#[source] bitcoincore_rpc::Error, String),
+    /// Error when using a BtcClient trait function
+    #[error("could execute BTC RPC call {0}")]
+    BitcoinClient(#[source] Box<dyn std::error::Error>),
     /// Returned when we could not decode the hex into a
     /// bitcoin::Transaction.
     #[error("failed to decode the provided hex into a transaction. txid: {1}. {0}")]

--- a/sbtc/src/error.rs
+++ b/sbtc/src/error.rs
@@ -10,8 +10,8 @@ pub enum Error {
     /// Error when creating an RPC client to bitcoin-core
     #[error("could not create RPC client to {1}; {0}")]
     BitcoinCoreRpcClient(#[source] bitcoincore_rpc::Error, String),
-    /// Error when using a BtcClient trait function
-    #[error("could execute BTC RPC call {0}")]
+    /// Error when using a BitcoinClient trait function
+    #[error("could not execute bitcoin client RPC call {0}")]
     BitcoinClient(#[source] Box<dyn std::error::Error>),
     /// Returned when we could not decode the hex into a
     /// bitcoin::Transaction.

--- a/sbtc/src/rpc.rs
+++ b/sbtc/src/rpc.rs
@@ -116,7 +116,7 @@ impl BitcoinCoreClient {
     ///
     /// Modified from the bitcoin-core docs[1]:
     ///
-    /// Bitcoin-core has too different modes for fee rate estimation,
+    /// Bitcoin-core has two different modes for fee rate estimation,
     /// "conservative" and "economical". We use the "conservative" estimate
     /// because it is more likely to be sufficient for the desired target,
     /// but is not as responsive to short term drops in the prevailing fee
@@ -135,7 +135,7 @@ impl BitcoinCoreClient {
 
         // In local testing resp.fee_rate is `None` whenever there haven't
         // been enough transactions to make an estimate. Also, the fee rate
-        // is in BTC/kvB so we need to convert that to sats/vb.
+        // is in BTC/kvB, so we need to convert that to sats/vb.
         let sats_per_vbyte = match resp.fee_rate {
             Some(fee_rate) => fee_rate.to_float_in(Denomination::Satoshi) / 1000.,
             None => return Err(Error::EstimateSmartFeeResponse(resp.errors, num_blocks)),

--- a/sbtc/src/rpc.rs
+++ b/sbtc/src/rpc.rs
@@ -29,8 +29,6 @@ pub struct GetTxResponse {
     #[serde(with = "consensus::serde::With::<consensus::serde::Hex>")]
     #[serde(rename = "hex")]
     pub tx: Transaction,
-    /// The transaction ID.
-    pub txid: Txid,
     /// The block hash of the Bitcoin block that includes this transaction.
     #[serde(rename = "blockhash")]
     pub block_hash: Option<BlockHash>,
@@ -56,19 +54,21 @@ pub struct FeeEstimate {
 }
 
 /// Trait for interacting with bitcoin-core
-pub trait BitcoinRpcClient {
+pub trait BitcoinClient {
+    /// The error type returned for RPC calls.
+    type Error: std::error::Error + 'static;
     /// Return the transaction if the transaction is in the mempool or in
     /// any block.
-    fn get_tx(&self, txid: &Txid) -> Result<GetTxResponse, Error>;
+    fn get_tx(&self, txid: &Txid) -> Result<GetTxResponse, Self::Error>;
 }
 
 /// A client for interacting with bitcoin-core
-pub struct BtcClient {
+pub struct BitcoinCoreClient {
     /// The underlying bitcoin-core client
     inner: bitcoincore_rpc::Client,
 }
 
-impl BtcClient {
+impl BitcoinCoreClient {
     /// Return a bitcoin-core RPC client. Will error if the URL is an invalid URL.
     ///
     /// # Notes
@@ -102,7 +102,6 @@ impl BtcClient {
 
         Ok(GetTxResponse {
             tx,
-            txid: response.txid,
             block_hash: response.blockhash,
             confirmations: response.confirmations,
             block_time: response.blocktime.map(|time| time as u64),
@@ -117,12 +116,13 @@ impl BtcClient {
     ///
     /// Modified from the bitcoin-core docs[1]:
     ///
-    /// This returns a "conservative" estimate, which is potentially
-    /// returns a higher fee rate and is more likely to be sufficient for
-    /// the desired target, but is not as responsive to short term drops in
-    /// the prevailing fee market. Also, the docs mention the response is
-    /// in BTC/kB, but from the comments in  bitcoin-core[2] this is really
-    /// BTC/kvB (kvB is kilo-vbyte).
+    /// Bitcoin-core has too different modes for fee rate estimation,
+    /// "conservative" and "economical". We use the "conservative" estimate
+    /// because it is more likely to be sufficient for the desired target,
+    /// but is not as responsive to short term drops in the prevailing fee
+    /// market when compared to the "economical" fee rate. Also, the docs
+    /// mention the response is in BTC/kB, but from the comments in
+    /// bitcoin-core[2] this is really BTC/kvB (kvB is kilo-vbyte).
     ///
     /// [^1]: https://developer.bitcoin.org/reference/rpc/estimatesmartfee.html
     /// [^2]: https://github.com/bitcoin/bitcoin/blob/d367a4e36f7357c4ebd018e8e1c9c5071db2e1c2/src/rpc/fees.cpp#L90-L91
@@ -134,7 +134,8 @@ impl BtcClient {
             .map_err(|err| Error::EstimateSmartFee(err, num_blocks))?;
 
         // In local testing resp.fee_rate is `None` whenever there haven't
-        // been enough transactions to make an estimate.
+        // been enough transactions to make an estimate. Also, the fee rate
+        // is in BTC/kvB so we need to convert that to sats/vb.
         let sats_per_vbyte = match resp.fee_rate {
             Some(fee_rate) => fee_rate.to_float_in(Denomination::Satoshi) / 1000.,
             None => return Err(Error::EstimateSmartFeeResponse(resp.errors, num_blocks)),
@@ -144,7 +145,8 @@ impl BtcClient {
     }
 }
 
-impl BitcoinRpcClient for BtcClient {
+impl BitcoinClient for BitcoinCoreClient {
+    type Error = Error;
     fn get_tx(&self, txid: &Txid) -> Result<GetTxResponse, Error> {
         self.get_tx(txid)
     }
@@ -201,7 +203,7 @@ impl ElectrumClient {
             .map_err(|err| Error::GetTransactionElectrum(err, *txid))?;
 
         serde_json::from_value::<GetTxResponse>(value)
-            .inspect(|response| debug_assert_eq!(txid, &response.txid))
+            .inspect(|response| debug_assert_eq!(txid, &response.tx.compute_txid()))
             .map_err(|err| Error::DeserializeGetTransaction(err, *txid))
     }
     /// Estimate the current mempool fee rate using the
@@ -241,7 +243,8 @@ impl ElectrumClient {
     }
 }
 
-impl BitcoinRpcClient for ElectrumClient {
+impl BitcoinClient for ElectrumClient {
+    type Error = Error;
     fn get_tx(&self, txid: &Txid) -> Result<GetTxResponse, Error> {
         self.get_tx(txid)
     }

--- a/sbtc/tests/integration/validation.rs
+++ b/sbtc/tests/integration/validation.rs
@@ -9,8 +9,8 @@ use bitcoin::Witness;
 use bitcoincore_rpc::RpcApi;
 
 use sbtc::deposits::CreateDepositRequest;
-use sbtc::rpc::BitcoinRpcClient;
-use sbtc::rpc::BtcClient;
+use sbtc::rpc::BitcoinClient;
+use sbtc::rpc::BitcoinCoreClient;
 use sbtc::rpc::ElectrumClient;
 use sbtc::testing::deposits::TxSetup;
 use sbtc::testing::regtest;
@@ -23,14 +23,14 @@ use test_case::test_case;
 /// We check that we can validate a transaction in the mempool using the
 /// electrum and bitcoin-core clients
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
-#[test_case(BtcClient::new(
+#[test_case(BitcoinCoreClient::new(
         "http://localhost:18443",
         regtest::BITCOIN_CORE_RPC_USERNAME.to_string(),
         regtest::BITCOIN_CORE_RPC_PASSWORD.to_string(),
     )
     .unwrap(); "bitcoin client")]
 #[test_case(ElectrumClient::new("tcp://localhost:60401", None).unwrap() ; "electrum client")]
-fn tx_validation_from_mempool<C: BitcoinRpcClient>(client: C) {
+fn tx_validation_from_mempool<C: BitcoinClient>(client: C) {
     let max_fee: u64 = 15000;
     let amount_sats = 49_900_000;
     let lock_time = 150;
@@ -63,7 +63,7 @@ fn tx_validation_from_mempool<C: BitcoinRpcClient>(client: C) {
     regtest::p2tr_sign_transaction(&mut setup.tx, 0, &utxos, &depositor.keypair);
     rpc.send_raw_transaction(&setup.tx).unwrap();
 
-    let parsed = request.validate(&client).unwrap();
+    let parsed = request.validate(&client).unwrap().info;
 
     assert_eq!(parsed.outpoint, request.outpoint);
     assert_eq!(parsed.deposit_script, request.deposit_script);

--- a/signer/src/fees.rs
+++ b/signer/src/fees.rs
@@ -3,8 +3,8 @@
 use std::future::Future;
 use std::time::Duration;
 
-use serde::Deserialize;
 use sbtc::rpc::FeeEstimate;
+use serde::Deserialize;
 
 use crate::error::Error;
 

--- a/signer/src/storage.rs
+++ b/signer/src/storage.rs
@@ -129,6 +129,12 @@ pub trait DbWrite {
         deposit_request: &model::DepositRequest,
     ) -> impl Future<Output = Result<(), Self::Error>> + Send;
 
+    /// Write many deposit requests.
+    fn write_deposit_requests(
+        &self,
+        deposit_requests: Vec<model::DepositRequest>,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+
     /// Write a withdrawal request.
     fn write_withdraw_request(
         &self,

--- a/signer/src/storage/in_memory.rs
+++ b/signer/src/storage/in_memory.rs
@@ -378,6 +378,19 @@ impl super::DbWrite for SharedStore {
         Ok(())
     }
 
+    async fn write_deposit_requests(
+        &self,
+        deposit_requests: Vec<model::DepositRequest>,
+    ) -> Result<(), Self::Error> {
+        let mut store = self.lock().await;
+        for req in deposit_requests.into_iter() {
+            store
+                .deposit_requests
+                .insert((req.txid.clone(), req.output_index), req);
+        }
+        Ok(())
+    }
+
     async fn write_withdraw_request(
         &self,
         withdraw_request: &model::WithdrawRequest,

--- a/signer/src/storage/model.rs
+++ b/signer/src/storage/model.rs
@@ -98,6 +98,13 @@ impl From<&ParsedDepositRequest> for DepositRequest {
     }
 }
 
+impl From<ParsedDepositRequest> for DepositRequest {
+    fn from(value: ParsedDepositRequest) -> Self {
+        Self::from(&value)
+    }
+}
+
+
 /// A signer acknowledging a deposit request.
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "testing", derive(fake::Dummy))]

--- a/signer/src/storage/model.rs
+++ b/signer/src/storage/model.rs
@@ -104,7 +104,6 @@ impl From<ParsedDepositRequest> for DepositRequest {
     }
 }
 
-
 /// A signer acknowledging a deposit request.
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "testing", derive(fake::Dummy))]

--- a/signer/src/storage/model.rs
+++ b/signer/src/storage/model.rs
@@ -1,5 +1,8 @@
 //! Database models for the signer.
 
+use bitcoin::hashes::Hash as _;
+use sbtc::deposits::ParsedDepositRequest;
+
 #[cfg(feature = "testing")]
 use fake::faker::time::en::DateTimeAfter;
 
@@ -77,6 +80,22 @@ pub struct DepositRequest {
         dummy(faker = "DateTimeAfter(time::OffsetDateTime::UNIX_EPOCH)")
     )]
     pub created_at: time::OffsetDateTime,
+}
+
+impl From<&ParsedDepositRequest> for DepositRequest {
+    fn from(value: &ParsedDepositRequest) -> Self {
+        Self {
+            txid: value.outpoint.txid.to_byte_array().to_vec(),
+            output_index: value.outpoint.vout as i32,
+            spend_script: value.deposit_script.to_bytes(),
+            reclaim_script: value.reclaim_script.to_bytes(),
+            recipient: value.recipient.to_string(),
+            amount: value.amount as i64,
+            max_fee: value.max_fee as i64,
+            sender_addresses: Vec::new(),
+            created_at: time::OffsetDateTime::now_utc(),
+        }
+    }
 }
 
 /// A signer acknowledging a deposit request.

--- a/signer/src/storage/model.rs
+++ b/signer/src/storage/model.rs
@@ -77,7 +77,7 @@ pub struct DepositRequest {
     /// be used to pay for transaction fees.
     pub max_fee: i64,
     /// The addresses of the input UTXOs funding the deposit request.
-    #[cfg_attr(feature = "testing", dummy(faker = "BitcoinAddresses(1..5, Network::Regtest)"))]
+    #[cfg_attr(feature = "testing", dummy(faker = "BitcoinAddresses(1..5)"))]
     pub sender_addresses: Vec<BitcoinAddress>,
     /// The time this block entry was created by the signer.
     #[cfg_attr(
@@ -90,7 +90,7 @@ pub struct DepositRequest {
 /// Used to for fine grained control of generating fake testing addresses.
 #[cfg(feature = "testing")]
 #[derive(Debug)]
-pub struct BitcoinAddresses(Range<usize>, Network);
+pub struct BitcoinAddresses(Range<usize>);
 
 #[cfg(feature = "testing")]
 impl fake::Dummy<BitcoinAddresses> for Vec<String> {
@@ -100,7 +100,7 @@ impl fake::Dummy<BitcoinAddresses> for Vec<String> {
             .take(num_addresses)
             .map(|kp| {
                 let pk = bitcoin::CompressedPublicKey(kp.public_key());
-                Address::p2wpkh(&pk, config.1).to_string()
+                Address::p2wpkh(&pk, Network::Regtest).to_string()
             })
             .collect()
     }

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -716,13 +716,13 @@ impl super::DbWrite for PgStore {
         sqlx::query(
             r#"
             WITH tx_ids       AS (SELECT ROW_NUMBER() OVER (), txid FROM UNNEST($1::BYTEA[]) AS txid)
-            , output_index    AS (SELECT ROW_NUMBER() OVER (), tx FROM UNNEST($2::INTEGER[]) AS tx)
+            , output_index    AS (SELECT ROW_NUMBER() OVER (), output_index FROM UNNEST($2::INTEGER[]) AS output_index)
             , spend_script    AS (SELECT ROW_NUMBER() OVER (), spend_script FROM UNNEST($3::BYTEA[]) AS spend_script)
             , reclaim_script  AS (SELECT ROW_NUMBER() OVER (), reclaim_script FROM UNNEST($4::BYTEA[]) AS reclaim_script)
             , recipient       AS (SELECT ROW_NUMBER() OVER (), recipient FROM UNNEST($5::BYTEA[]) AS recipient)
             , amount          AS (SELECT ROW_NUMBER() OVER (), amount FROM UNNEST($6::BIGINT[]) AS amount)
             , max_fee         AS (SELECT ROW_NUMBER() OVER (), max_fee FROM UNNEST($7::BIGINT[]) AS max_fee)
-            INSERT INTO sbtc_signer.transactions (
+            INSERT INTO sbtc_signer.deposit_requests (
                   txid
                 , output_index
                 , spend_script
@@ -740,7 +740,7 @@ impl super::DbWrite for PgStore {
               , recipient
               , amount
               , max_fee
-              , {} as sender_addresses
+              , ARRAY[]::VARCHAR[] as sender_addresses
               , CURRENT_TIMESTAMP
             FROM tx_ids
             JOIN output_index USING (row_number)

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -712,6 +712,11 @@ impl super::DbWrite for PgStore {
             recipient.push(req.recipient);
             amount.push(req.amount);
             max_fee.push(req.max_fee);
+            // We need to join the addresses like this (and later split
+            // them), because handling of multi-dimensional arrays in
+            // postgres is tough. The naive approach of doing
+            // UNNEST($1::VARCHAR[][]) doesn't work, since that completely
+            // flattens the array.
             sender_addresses.push(req.sender_addresses.join(","));
         }
 

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -713,7 +713,7 @@ impl super::DbWrite for PgStore {
             amount.push(req.amount);
             max_fee.push(req.max_fee);
             // We need to join the addresses like this (and later split
-            // them), because handling of multi-dimensional arrays in
+            // them), because handling of multidimensional arrays in
             // postgres is tough. The naive approach of doing
             // UNNEST($1::VARCHAR[][]) doesn't work, since that completely
             // flattens the array.


### PR DESCRIPTION
## Description

Closes: https://github.com/stacks-network/sbtc/issues/203.

## Changes

* Rename structs and to conform more closely to our specs.
* Add a new storage trait function, `write_deposit_requests`, that stores deposit requests.
* Implement the `write_deposit_requests` function for postgres and the in-memory thing.

## Testing Information

There are unit tests for the new block observer logic and an integration test for the query.

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
