### PR TITLE
feat: Make emily integration tests self containing - fix.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1610,7 +1610,6 @@ dependencies = [
  "serde 1.0.203",
  "serde_dynamo",
  "serde_json",
- "serial_test",
  "thiserror",
  "time 0.3.36",
  "tokio",
@@ -1888,7 +1887,7 @@ checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
 dependencies = [
  "futures-core",
  "lock_api",
- "parking_lot 0.12.2",
+ "parking_lot",
 ]
 
 [[package]]
@@ -3313,37 +3312,12 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.6",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e4af0ca4f6caed20e900d564c242b8e5d4903fdacf31d3daf527b66fe6f42fb"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.10",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
-dependencies = [
- "cfg-if 1.0.0",
- "instant",
- "libc",
- "redox_syscall 0.2.16",
- "smallvec",
- "winapi 0.3.9",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -3811,15 +3785,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -4544,28 +4509,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.65",
-]
-
-[[package]]
-name = "serial_test"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0bccbcf40c8938196944a3da0e133e031a33f4d6b72db3bda3cc556e361905d"
-dependencies = [
- "lazy_static",
- "parking_lot 0.11.2",
- "serial_test_derive",
-]
-
-[[package]]
-name = "serial_test_derive"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2acd6defeddb41eb60bb468f8825d0cfd0c2a76bc03bfd235b6a1dc4f6a1ad5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -5462,7 +5405,7 @@ dependencies = [
  "libc",
  "mio 0.8.11",
  "num_cpus",
- "parking_lot 0.12.2",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",

--- a/emily/handler/Cargo.toml
+++ b/emily/handler/Cargo.toml
@@ -38,4 +38,3 @@ fake = { version = "2.9.2", features = ["derive", "time"], optional = true }
 rand = "0.8"
 mockito = "0.28"
 mockall = "0.10"
-serial_test = "0.5"

--- a/emily/handler/src/database/accessors.rs
+++ b/emily/handler/src/database/accessors.rs
@@ -250,7 +250,8 @@ pub async fn add_chainstate_entry(
     //
     // TODO(TBD): Handle api status being "Reorg" during this period.
     let mut api_state = get_api_state(context).await?;
-    let blocks_higher_than_current_tip = (entry.key.height as i128) - (api_state.chaintip.key.height as i128);
+    let blocks_higher_than_current_tip =
+        (entry.key.height as i128) - (api_state.chaintip.key.height as i128);
 
     if blocks_higher_than_current_tip == 1 || api_state.chaintip.key.height == 0 {
         api_state.chaintip = entry.clone();

--- a/emily/handler/tests/integration/endpoints/chainstate.rs
+++ b/emily/handler/tests/integration/endpoints/chainstate.rs
@@ -1,6 +1,5 @@
-use crate::util::{self, constants::EMILY_CHAINSTATE_ENDPOINT};
+use crate::util::{self, constants::EMILY_CHAINSTATE_ENDPOINT, TestClient};
 use emily_handler::api::models::chainstate::Chainstate;
-use reqwest::Client;
 use serde_json::json;
 use serial_test::serial;
 use std::sync::LazyLock;
@@ -9,54 +8,46 @@ use tokio;
 // TODO(392): Use test setup functions to wipe the database before performing these
 // tests instead of relying on circumstantial test execution order.
 
+static NUM_TEST_CHAINSTATES: u32 = 10;
+
 /// Test data for chainstate tests.
 static TEST_CHAINSTATE_DATA: LazyLock<Vec<Chainstate>> = LazyLock::new(|| {
-    vec![
-        Chainstate {
-            stacks_block_height: 1,
-            stacks_block_hash: "test_hash_1".to_string(),
-        },
-        Chainstate {
-            stacks_block_height: 2,
-            stacks_block_hash: "test_hash_2".to_string(),
-        },
-        Chainstate {
-            stacks_block_height: 5,
-            stacks_block_hash: "test_hash_5".to_string(),
-        },
-    ]
+    (0..NUM_TEST_CHAINSTATES)
+        .map(|height| util::test_chainstate(height as u64, 0))
+        .collect()
 });
 
-/// Initialize the chainstate table with a bunch of chainstates.
-#[cfg_attr(not(feature = "integration-tests"), ignore)]
-#[tokio::test]
-#[serial]
-async fn create_chainstates() {
-    let client = Client::new();
+/// Setup function that wipes the database and populates it with the necessary
+/// chainstate data.
+async fn setup_chainstate_integration_test() -> TestClient {
+    let client = TestClient::new();
+    client.setup_test().await;
     for test_chainstate_data in TEST_CHAINSTATE_DATA.iter() {
         // Arrange.
         let Chainstate {
             stacks_block_height,
             stacks_block_hash,
         } = test_chainstate_data;
-
-        // Act.
-        let response = client
-            .post(EMILY_CHAINSTATE_ENDPOINT)
-            .json(&json!({
-              "stacksBlockHeight": stacks_block_height,
-              "stacksBlockHash": stacks_block_hash,
-            }))
-            .send()
-            .await
-            .expect("Request should succeed");
-
-        // Assert.
-        let actual: Chainstate = response.json().await.expect("msg");
-
-        let expected = test_chainstate_data;
-        util::assert_eq_pretty(&actual, expected);
+        let request: Chainstate = serde_json::from_value(json!({
+            "stacksBlockHeight": stacks_block_height,
+            "stacksBlockHash": stacks_block_hash,
+        }))
+        .expect("Failed to deserialize create chainstate request body in test setup");
+        let response = client.create_chainstate(&request).await;
+        util::assert_eq_pretty(&response, test_chainstate_data);
     }
+    client
+}
+
+/// Test that the creation works.
+#[cfg_attr(not(feature = "integration-tests"), ignore)]
+#[tokio::test]
+#[serial]
+async fn create_chainstates() {
+    // The setup function runs what was origninally the create tests by creating the
+    // resources and then assessing what was created.
+    let client = setup_chainstate_integration_test().await;
+    client.teardown().await;
 }
 
 /// Get every chainstate from the previous test one at a time.
@@ -64,7 +55,7 @@ async fn create_chainstates() {
 #[tokio::test]
 #[serial]
 async fn get_chainstate_at_height() {
-    let client = Client::new();
+    let client = setup_chainstate_integration_test().await;
     for test_chainstate_data in TEST_CHAINSTATE_DATA.iter() {
         // Arrange..
         let Chainstate {
@@ -74,6 +65,7 @@ async fn get_chainstate_at_height() {
 
         // Act.
         let response = client
+            .inner
             .get(format!("{EMILY_CHAINSTATE_ENDPOINT}/{stacks_block_height}"))
             .send()
             .await
@@ -88,4 +80,5 @@ async fn get_chainstate_at_height() {
         let expected = test_chainstate_data;
         util::assert_eq_pretty(&actual, expected);
     }
+    client.teardown().await;
 }

--- a/emily/handler/tests/integration/endpoints/chainstate.rs
+++ b/emily/handler/tests/integration/endpoints/chainstate.rs
@@ -1,7 +1,6 @@
 use crate::util::{self, constants::EMILY_CHAINSTATE_ENDPOINT, TestClient};
 use emily_handler::api::models::chainstate::Chainstate;
 use serde_json::json;
-use serial_test::serial;
 use std::sync::LazyLock;
 use tokio;
 
@@ -42,7 +41,6 @@ async fn setup_chainstate_integration_test() -> TestClient {
 /// Test that the creation works.
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
-#[serial]
 async fn create_chainstates() {
     // The setup function runs what was origninally the create tests by creating the
     // resources and then assessing what was created.
@@ -53,7 +51,6 @@ async fn create_chainstates() {
 /// Get every chainstate from the previous test one at a time.
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
-#[serial]
 async fn get_chainstate_at_height() {
     let client = setup_chainstate_integration_test().await;
     for test_chainstate_data in TEST_CHAINSTATE_DATA.iter() {

--- a/emily/handler/tests/integration/endpoints/deposit.rs
+++ b/emily/handler/tests/integration/endpoints/deposit.rs
@@ -1,15 +1,15 @@
-use crate::util::{self, constants::EMILY_DEPOSIT_ENDPOINT};
+use crate::util::{self, constants::EMILY_DEPOSIT_ENDPOINT, TestClient};
 use emily_handler::api::models::deposit::{
+    requests::CreateDepositRequestBody,
     responses::{GetDepositsForTransactionResponse, GetDepositsResponse},
     Deposit, DepositInfo, DepositParameters,
 };
-use reqwest::Client;
 use serde_json::json;
 use serial_test::serial;
 use std::sync::LazyLock;
 use tokio;
 
-use emily_handler::api::models::deposit::responses::{CreateDepositResponse, GetDepositResponse};
+use emily_handler::api::models::deposit::responses::GetDepositResponse;
 
 // TODO(392): Use test setup functions to wipe the database before performing these
 // tests instead of relying on circumstantial test execution order.
@@ -49,6 +49,30 @@ struct TestDepositData {
     pub bitcoin_tx_output_index: u32,
 }
 
+/// Setup function that wipes the database and populates it with the necessary
+/// deposit data.
+async fn setup_deposit_integration_test() -> TestClient {
+    let client = TestClient::new();
+    client.setup_test().await;
+    for test_deposit in all_test_deposit_data() {
+        let bitcoin_txid: String = test_deposit.bitcoin_txid;
+        let bitcoin_tx_output_index: u32 = test_deposit.bitcoin_tx_output_index;
+        let request: CreateDepositRequestBody = serde_json::from_value(json!({
+            "bitcoinTxid": bitcoin_txid.clone(),
+            "bitcoinTxOutputIndex": bitcoin_tx_output_index,
+            "reclaim": "example_reclaim_script",
+            "deposit": "example_deposit_script",
+        }))
+        .expect("Failed to deserialize create deposit request body in test setup");
+        let response = client.create_deposit(&request).await;
+        util::assert_eq_pretty(
+            response,
+            just_created_deposit(bitcoin_txid, bitcoin_tx_output_index),
+        );
+    }
+    client
+}
+
 /// Creates a list of test deposit datas based on `TEST_DEPOSIT_DATA`.
 fn all_test_deposit_data() -> impl Iterator<Item = TestDepositData> {
     TEST_DEPOSIT_DATA
@@ -82,42 +106,15 @@ fn just_created_deposit(bitcoin_txid: String, bitcoin_tx_output_index: u32) -> D
     }
 }
 
-/// Create all the deposits one at a time that are required for the rest of the
-/// tests. Note that this test suite assumes the database is empty when the integration
-/// tests start and this test should populate the table in its entirety.
+/// Test that the creation works.
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 #[serial]
 async fn create_deposits() {
-    let client = Client::new();
-    for test_deposit in all_test_deposit_data() {
-        // Arrange.
-        let bitcoin_txid: String = test_deposit.bitcoin_txid;
-        let bitcoin_tx_output_index: u32 = test_deposit.bitcoin_tx_output_index;
-
-        // Act.
-        let response = client
-            .post(EMILY_DEPOSIT_ENDPOINT)
-            .json(&json!({
-                "bitcoinTxid": bitcoin_txid.clone(),
-                "bitcoinTxOutputIndex": bitcoin_tx_output_index,
-                "reclaim": "example_reclaim_script",
-                "deposit": "example_deposit_script",
-            }))
-            .send()
-            .await
-            .expect("Request should succeed");
-
-        // Assert.
-        let actual: CreateDepositResponse = response
-            .json()
-            .await
-            .expect("Failed to parse JSON response");
-
-        let expected = just_created_deposit(bitcoin_txid, bitcoin_tx_output_index);
-
-        util::assert_eq_pretty(actual, expected);
-    }
+    // The setup function runs what was origninally the create tests by creating the
+    // resources and then assessing what was created.
+    let client = setup_deposit_integration_test().await;
+    client.teardown().await;
 }
 
 /// Get every deposit from the previous test one at a time.
@@ -125,7 +122,7 @@ async fn create_deposits() {
 #[tokio::test]
 #[serial]
 async fn get_deposit() {
-    let client = Client::new();
+    let client = setup_deposit_integration_test().await;
     for test_deposit in all_test_deposit_data() {
         // Arrange.
         let bitcoin_txid: String = test_deposit.bitcoin_txid.clone();
@@ -133,6 +130,7 @@ async fn get_deposit() {
 
         // Act.
         let response = client
+            .inner
             .get(format!(
                 "{EMILY_DEPOSIT_ENDPOINT}/{bitcoin_txid}/{bitcoin_tx_output_index}"
             ))
@@ -150,6 +148,7 @@ async fn get_deposit() {
 
         util::assert_eq_pretty(actual, expected);
     }
+    client.teardown().await;
 }
 
 /// Get all deposits for each transaction using a page size large enough to get all entries.
@@ -157,8 +156,7 @@ async fn get_deposit() {
 #[tokio::test]
 #[serial]
 async fn get_deposits_for_transaction() {
-    let client = Client::new();
-
+    let client = setup_deposit_integration_test().await;
     for test_deposit_transaction_data in TEST_DEPOSIT_DATA.iter() {
         // Arrange.
         let number_of_outputs = test_deposit_transaction_data.number_of_outputs;
@@ -166,6 +164,7 @@ async fn get_deposits_for_transaction() {
 
         // Act.
         let response = client
+            .inner
             .get(format!("{EMILY_DEPOSIT_ENDPOINT}/{bitcoin_txid}"))
             .query(&[
                 // Query for one more than expected so that the call
@@ -185,6 +184,7 @@ async fn get_deposits_for_transaction() {
         assert_eq!(actual.deposits.len(), number_of_outputs as usize);
         assert_eq!(actual.next_token, None);
     }
+    client.teardown().await;
 }
 
 /// Get deposits for transaction using a small page size that will require multiple calls
@@ -193,8 +193,7 @@ async fn get_deposits_for_transaction() {
 #[tokio::test]
 #[serial]
 async fn get_deposits_for_transaction_with_small_page_size() {
-    let client = Client::new();
-
+    let client = setup_deposit_integration_test().await;
     for test_deposit_transaction_data in TEST_DEPOSIT_DATA.iter() {
         // Arrange.
         let mut aggregate_deposits: Vec<Deposit> = vec![];
@@ -205,6 +204,7 @@ async fn get_deposits_for_transaction_with_small_page_size() {
 
         // Act.
         let mut response: GetDepositsForTransactionResponse = client
+            .inner
             .get(&uri)
             .query(&[("pageSize", page_size.to_string())])
             .send()
@@ -220,6 +220,7 @@ async fn get_deposits_for_transaction_with_small_page_size() {
         while let Some(next_token) = response.next_token.clone() {
             // Act.
             response = client
+                .inner
                 .get(&uri)
                 .query(&[
                     ("pageSize", page_size.to_string()),
@@ -247,6 +248,7 @@ async fn get_deposits_for_transaction_with_small_page_size() {
         expected_deposits.sort();
         assert_eq!(aggregate_deposits, expected_deposits);
     }
+    client.teardown().await;
 }
 
 /// Get pending deposits by searching for all deposits that have a `pending` status
@@ -257,13 +259,14 @@ async fn get_deposits_for_transaction_with_small_page_size() {
 #[serial]
 async fn get_pending_deposits() {
     // Arrange.
-    let client = Client::new();
+    let client = setup_deposit_integration_test().await;
     let page_size: i32 = 2;
 
     let mut aggregate_deposits: Vec<DepositInfo> = vec![];
 
     // Act 1.
     let mut response: GetDepositsResponse = client
+        .inner
         .get(EMILY_DEPOSIT_ENDPOINT)
         .query(&[
             ("pageSize", page_size.to_string()),
@@ -283,6 +286,7 @@ async fn get_pending_deposits() {
     // Act 2.
     while let Some(next_token) = response.next_token.clone() {
         response = client
+            .inner
             .get(EMILY_DEPOSIT_ENDPOINT)
             .query(&[
                 ("pageSize", page_size.to_string()),
@@ -314,17 +318,21 @@ async fn get_pending_deposits() {
     aggregate_deposits.sort();
     expected_deposit_infos.sort();
     assert_eq!(aggregate_deposits, expected_deposit_infos);
+    client.teardown().await;
 }
 
+/// Get failed deposits. Because there are no failed deposits in the set of test data
+/// this should always be empty.
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 #[serial]
 async fn get_failed_deposits() {
     // Arrange.
-    let client = Client::new();
+    let client = setup_deposit_integration_test().await;
 
     // Act.
     let response: GetDepositsResponse = client
+        .inner
         .get(EMILY_DEPOSIT_ENDPOINT)
         .query(&[("status", "failed".to_string())])
         .send()
@@ -336,4 +344,5 @@ async fn get_failed_deposits() {
 
     // Assert.
     assert_eq!(response.deposits.len(), 0);
+    client.teardown().await;
 }

--- a/emily/handler/tests/integration/endpoints/deposit.rs
+++ b/emily/handler/tests/integration/endpoints/deposit.rs
@@ -5,7 +5,6 @@ use emily_handler::api::models::deposit::{
     Deposit, DepositInfo, DepositParameters,
 };
 use serde_json::json;
-use serial_test::serial;
 use std::sync::LazyLock;
 use tokio;
 
@@ -109,7 +108,6 @@ fn just_created_deposit(bitcoin_txid: String, bitcoin_tx_output_index: u32) -> D
 /// Test that the creation works.
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
-#[serial]
 async fn create_deposits() {
     // The setup function runs what was origninally the create tests by creating the
     // resources and then assessing what was created.
@@ -120,7 +118,6 @@ async fn create_deposits() {
 /// Get every deposit from the previous test one at a time.
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
-#[serial]
 async fn get_deposit() {
     let client = setup_deposit_integration_test().await;
     for test_deposit in all_test_deposit_data() {
@@ -154,7 +151,6 @@ async fn get_deposit() {
 /// Get all deposits for each transaction using a page size large enough to get all entries.
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
-#[serial]
 async fn get_deposits_for_transaction() {
     let client = setup_deposit_integration_test().await;
     for test_deposit_transaction_data in TEST_DEPOSIT_DATA.iter() {
@@ -191,7 +187,6 @@ async fn get_deposits_for_transaction() {
 /// to the paginated endpoint to get all the deposits.
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
-#[serial]
 async fn get_deposits_for_transaction_with_small_page_size() {
     let client = setup_deposit_integration_test().await;
     for test_deposit_transaction_data in TEST_DEPOSIT_DATA.iter() {
@@ -256,7 +251,6 @@ async fn get_deposits_for_transaction_with_small_page_size() {
 /// endpoing to get all the pending deposits present.
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
-#[serial]
 async fn get_pending_deposits() {
     // Arrange.
     let client = setup_deposit_integration_test().await;
@@ -325,7 +319,6 @@ async fn get_pending_deposits() {
 /// this should always be empty.
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
-#[serial]
 async fn get_failed_deposits() {
     // Arrange.
     let client = setup_deposit_integration_test().await;

--- a/emily/handler/tests/integration/endpoints/withdrawal.rs
+++ b/emily/handler/tests/integration/endpoints/withdrawal.rs
@@ -1,17 +1,17 @@
 use emily_handler::api::models::{
     common::Status,
     withdrawal::{
-        responses::{CreateWithdrawalResponse, GetWithdrawalResponse, GetWithdrawalsResponse},
+        requests::CreateWithdrawalRequestBody,
+        responses::{GetWithdrawalResponse, GetWithdrawalsResponse},
         Withdrawal, WithdrawalInfo,
     },
 };
-use reqwest::Client;
 use serde_json::json;
 use serial_test::serial;
 use std::sync::LazyLock;
 use tokio;
 
-use crate::util::{self, constants::EMILY_WITHDRAWAL_ENDPOINT};
+use crate::util::{self, constants::EMILY_WITHDRAWAL_ENDPOINT, TestClient};
 
 // TODO(392): Use test setup functions to wipe the database before performing these
 // tests instead of relying on circumstantial test execution order.
@@ -46,6 +46,37 @@ static TEST_WITHDRAWAL_DATA: LazyLock<Vec<TestWithdrawalData>> = LazyLock::new(|
     ]
 });
 
+/// Setup function that wipes the database and populates it with the necessary
+/// withdrawal data.
+async fn setup_deposit_integration_test() -> TestClient {
+    let client = TestClient::new();
+    client.setup_test().await;
+    for test_withdrawal_data in TEST_WITHDRAWAL_DATA.iter() {
+        // Arrange.
+        let TestWithdrawalData {
+            request_id,
+            recipient,
+            stacks_block_hash,
+        } = test_withdrawal_data;
+        let request: CreateWithdrawalRequestBody = serde_json::from_value(json!({
+          "requestId": request_id,
+          "stacksBlockHash": stacks_block_hash,
+          "recipient": recipient,
+          "amount": 0,
+          "parameters": {
+             "maxFee": 0
+          }
+        }))
+        .expect("Failed to deserialize create withdrawal request body in test setup");
+        let response = client.create_withdrawal(&request).await;
+        util::assert_eq_pretty(
+            response,
+            just_created_withdrawal(request_id, recipient, stacks_block_hash),
+        );
+    }
+    client
+}
+
 /// Creates the withdrawal that one would expect to receive from the API
 /// after it was JUST created. Note that this will need to be changed when
 /// the API becomes more complicated and correct; many of the default values
@@ -74,47 +105,18 @@ fn just_created_withdrawal(
 #[tokio::test]
 #[serial]
 async fn create_withdrawals() {
-    let client = Client::new();
-    for test_withdrawal_data in TEST_WITHDRAWAL_DATA.iter() {
-        // Arrange.
-        let TestWithdrawalData {
-            request_id,
-            recipient,
-            stacks_block_hash,
-        } = test_withdrawal_data;
-
-        // Act.
-        let response = client
-            .post(EMILY_WITHDRAWAL_ENDPOINT)
-            .json(&json!({
-              "requestId": request_id,
-              "stacksBlockHash": stacks_block_hash,
-              "recipient": recipient,
-              "amount": 0,
-              "parameters": {
-                 "maxFee": 0
-              }
-            }))
-            .send()
-            .await
-            .expect("Request should succeed");
-
-        // Assert.
-        let actual: CreateWithdrawalResponse = response.json().await.expect("msg");
-
-        let expected: CreateWithdrawalResponse =
-            just_created_withdrawal(request_id, recipient, stacks_block_hash);
-
-        util::assert_eq_pretty(actual, expected);
-    }
+    // The setup function runs what was origninally the create tests by creating the
+    // resources and then assessing what was created.
+    let client = setup_deposit_integration_test().await;
+    client.teardown().await;
 }
 
-/// Get every withdrawal from the previous test one at a time.
+/// Get every withdrawal one at a time.
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 #[serial]
 async fn get_withdrawal() {
-    let client = Client::new();
+    let client = setup_deposit_integration_test().await;
     for test_withdrawal_data in TEST_WITHDRAWAL_DATA.iter() {
         // Arrange.
         let TestWithdrawalData {
@@ -125,6 +127,7 @@ async fn get_withdrawal() {
 
         // Act.
         let response = client
+            .inner
             .get(format!("{EMILY_WITHDRAWAL_ENDPOINT}/{request_id}"))
             .send()
             .await
@@ -140,6 +143,7 @@ async fn get_withdrawal() {
 
         util::assert_eq_pretty(actual, expected);
     }
+    client.teardown().await;
 }
 
 /// Get withdrawals from the paginated endpoit `ENDPOINT/withdrawal` searching
@@ -151,13 +155,14 @@ async fn get_withdrawal() {
 #[serial]
 async fn get_withdrawals() {
     // Arrange.
-    let client = Client::new();
+    let client = setup_deposit_integration_test().await;
     let page_size: i32 = 1;
 
     let mut aggregate_withdrawals: Vec<WithdrawalInfo> = vec![];
 
     // Act 1.
     let mut response: GetWithdrawalsResponse = client
+        .inner
         .get(EMILY_WITHDRAWAL_ENDPOINT)
         .query(&[
             ("pageSize", page_size.to_string()),
@@ -177,6 +182,7 @@ async fn get_withdrawals() {
     // Act 2.
     while let Some(next_token) = response.next_token.clone() {
         response = client
+            .inner
             .get(EMILY_WITHDRAWAL_ENDPOINT)
             .query(&[
                 ("pageSize", page_size.to_string()),
@@ -212,4 +218,5 @@ async fn get_withdrawals() {
     aggregate_withdrawals.sort();
     expected_withdrawal_infos.sort();
     assert_eq!(aggregate_withdrawals, expected_withdrawal_infos);
+    client.teardown().await;
 }

--- a/emily/handler/tests/integration/endpoints/withdrawal.rs
+++ b/emily/handler/tests/integration/endpoints/withdrawal.rs
@@ -7,7 +7,6 @@ use emily_handler::api::models::{
     },
 };
 use serde_json::json;
-use serial_test::serial;
 use std::sync::LazyLock;
 use tokio;
 
@@ -103,7 +102,6 @@ fn just_created_withdrawal(
 /// when this test suite starts up.
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
-#[serial]
 async fn create_withdrawals() {
     // The setup function runs what was origninally the create tests by creating the
     // resources and then assessing what was created.
@@ -114,7 +112,6 @@ async fn create_withdrawals() {
 /// Get every withdrawal one at a time.
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
-#[serial]
 async fn get_withdrawal() {
     let client = setup_deposit_integration_test().await;
     for test_withdrawal_data in TEST_WITHDRAWAL_DATA.iter() {
@@ -152,7 +149,6 @@ async fn get_withdrawal() {
 /// the table.
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
-#[serial]
 async fn get_withdrawals() {
     // Arrange.
     let client = setup_deposit_integration_test().await;

--- a/emily/handler/tests/integration/util/mod.rs
+++ b/emily/handler/tests/integration/util/mod.rs
@@ -76,6 +76,11 @@ impl TestClient {
         self.reset_environment().await;
     }
 
+    /// Sets up the test environment.
+    pub async fn teardown(&self) {
+        self.reset_environment().await;
+    }
+
     /// Reset test environment.
     pub async fn reset_environment(&self) {
         let endpoint: String = format!("{EMILY_TESTING_ENDPOINT}/wipe");


### PR DESCRIPTION
## Description

Closes: #392

This is a re-pr of the original because I pushed do the parent branch `emily-put-requests` instead of main 🤦 

- #400 

## Changes

Same as before

## Testing Information

Same as before

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
