### PR TITLE
feat: use bitcoin-core as the block notifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4721,7 +4721,6 @@ dependencies = [
  "time 0.3.36",
  "tokio",
  "tokio-stream",
- "tokio-util",
  "tonic",
  "tonic-build",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,6 +231,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "asynchronous-codec"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a860072022177f903e59730004fb5dc13db9275b79bb2aef7ba8ce831956c233"
+dependencies = [
+ "bytes",
+ "futures-sink",
+ "futures-util",
+ "memchr",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "atoi"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1407,6 +1420,19 @@ dependencies = [
  "darling_core",
  "quote",
  "syn 2.0.65",
+]
+
+[[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if 1.0.0",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core 0.9.10",
 ]
 
 [[package]]
@@ -4695,6 +4721,7 @@ dependencies = [
  "time 0.3.36",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "tonic",
  "tonic-build",
  "tracing",
@@ -4702,6 +4729,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "wsts",
+ "zeromq",
 ]
 
 [[package]]
@@ -5543,6 +5571,7 @@ checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
@@ -6467,4 +6496,31 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.65",
+]
+
+[[package]]
+name = "zeromq"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb0560d00172817b7f7c2265060783519c475702ae290b154115ca75e976d4d0"
+dependencies = [
+ "async-trait",
+ "asynchronous-codec",
+ "bytes",
+ "crossbeam-queue",
+ "dashmap",
+ "futures-channel",
+ "futures-io",
+ "futures-task",
+ "futures-util",
+ "log",
+ "num-traits 0.2.19",
+ "once_cell",
+ "parking_lot 0.12.2",
+ "rand 0.8.5",
+ "regex",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "uuid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,11 +58,13 @@ tonic = "0.11.0"
 tonic-build = "0.11.0"
 tokio = "1.32.0"
 tokio-stream = {version = "0.1.15", features = ["sync"] }
+tokio-util = "0.7"
 tracing = { version = "0.1", default-features = false }
 tracing-attributes = "0.1"
 url = "2.5"
 warp_lambda = "0.1.4"
 wsts = "9.1.0"
+zeromq = { version = "0.4.0", default-features = false, features = ["tokio-runtime", "all-transport"] }
 
 [workspace.dependencies.tracing-subscriber]
 version = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,6 @@ tonic = "0.11.0"
 tonic-build = "0.11.0"
 tokio = "1.32.0"
 tokio-stream = {version = "0.1.15", features = ["sync"] }
-tokio-util = "0.7"
 tracing = { version = "0.1", default-features = false }
 tracing-attributes = "0.1"
 url = "2.5"

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -6,6 +6,10 @@ services:
     volumes:
       - ./signer/tests/service-configs/bitcoin.conf:/data/.bitcoin/bitcoin.conf:ro
     restart: on-failure
+    # For some reason, the CMD is set to publish events on zeromq, and it
+    # might interfere with the events that we want to publish somehow. So
+    # we overwrite the command by just setting the server argument.
+    command: ["-server"]
     stop_grace_period: 10s
     ports:
       - 8333:8333

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -6,10 +6,11 @@ services:
     volumes:
       - ./signer/tests/service-configs/bitcoin.conf:/data/.bitcoin/bitcoin.conf:ro
     restart: on-failure
-    # For some reason, the CMD is set to publish events on zeromq, and it
-    # might interfere with the events that we want to publish somehow. So
-    # we overwrite the command by just setting the server argument.
-    command: ["-server"]
+    # For some reason, the CMD in the original Dockerfile is set to publish
+    # events on zeromq, and it seems to interfere with the events that we
+    # want to publish. So we overwrite the CMD by just setting the
+    # -logtimestamps argument in the command here.
+    command: ["-logtimestamps"]
     stop_grace_period: 10s
     ports:
       - 8333:8333

--- a/sbtc/src/deposits.rs
+++ b/sbtc/src/deposits.rs
@@ -157,9 +157,9 @@ impl CreateDepositRequest {
     ///   ScriptPubKey.
     pub fn validate_tx(&self, tx: &Transaction) -> Result<DepositInfo, Error> {
         if tx.compute_txid() != self.outpoint.txid {
-            // The expectation is that the transaction hex was fetched from
-            // the blockchain using the txid, so in practice this should
-            // never happen.
+            // The expectation is that the transaction was fetched from the
+            // blockchain using the txid, so in practice this should never
+            // happen.
             return Err(Error::TxidMismatch {
                 from_request: self.outpoint.txid,
                 from_tx: tx.compute_txid(),

--- a/sbtc/src/testing/regtest.rs
+++ b/sbtc/src/testing/regtest.rs
@@ -9,6 +9,7 @@ use bitcoin::transaction::Version;
 use bitcoin::Address;
 use bitcoin::AddressType;
 use bitcoin::Amount;
+use bitcoin::BlockHash;
 use bitcoin::CompressedPublicKey;
 use bitcoin::EcdsaSighashType;
 use bitcoin::Network;
@@ -230,10 +231,10 @@ impl Faucet {
 
     /// Generate num_blocks blocks with coinbase rewards being sent to this
     /// recipient.
-    pub fn generate_blocks(&self, num_blocks: u64) {
+    pub fn generate_blocks(&self, num_blocks: u64) -> Vec<BlockHash> {
         self.rpc
             .generate_to_address(num_blocks, &self.address)
-            .unwrap();
+            .unwrap()
     }
 
     /// Return all UTXOs for this recipient where the amount is greater

--- a/signer/Cargo.toml
+++ b/signer/Cargo.toml
@@ -45,11 +45,13 @@ time.workspace = true
 tonic.workspace = true
 tokio = { workspace = true, features = ["signal", "macros", "rt-multi-thread"] }
 tokio-stream.workspace = true
+tokio-util.workspace = true
 tracing.workspace = true
 tracing-attributes.workspace = true
 tracing-subscriber.workspace = true
 url.workspace = true
 wsts.workspace = true
+zeromq.workspace = true
 
 # Only for testing
 fake = { version = "2.9.2", features = ["derive", "time"], optional = true }

--- a/signer/Cargo.toml
+++ b/signer/Cargo.toml
@@ -45,7 +45,6 @@ time.workspace = true
 tonic.workspace = true
 tokio = { workspace = true, features = ["signal", "macros", "rt-multi-thread"] }
 tokio-stream.workspace = true
-tokio-util.workspace = true
 tracing.workspace = true
 tracing-attributes.workspace = true
 tracing-subscriber.workspace = true

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -8,6 +8,24 @@ use crate::{codec, ecdsa, network};
 /// Top-level signer error
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
+    /// Error when breaking out the ZeroMQ message into three parts.
+    #[error("Bitcoin messages should have a three part layout, receieved {0} parts")]
+    BitcoinCoreZmqMessageLayout(usize),
+
+    /// Happens when the bitcoin block hash in the ZeroMQ message is not 32
+    /// bytes.
+    #[error("Block hashes should be 32 bytes, but we received {0} bytes")]
+    BitcoinCoreZmqBlockHash(usize),
+
+    /// Happens when the ZeroMQ sequence number is not 4 bytes.
+    #[error("Sequence numbers should be 4 bytes, but we received {0} bytes")]
+    BitcoinCoreZmqSequenceNumber(usize),
+
+    /// The given message type is unsupported. We attempt to parse what the
+    /// topic is but that might fail as well.
+    #[error("The message topic {0:?} is unsupported")]
+    BitcoinCoreZmqUnsupported(Result<String, std::str::Utf8Error>),
+
     /// Invalid amount
     #[error("the change amounts for the transaction is negative: {0}")]
     InvalidAmount(i64),
@@ -195,10 +213,6 @@ pub enum Error {
     /// socket.
     #[error("{0}")]
     ZmqConnect(#[source] zeromq::ZmqError),
-
-    /// Error when receiving a message from to bitcoin-core over zeromq.
-    #[error("{0}")]
-    ZmqMessage(#[source] zeromq::ZmqError),
 
     /// Error when receiving a message from to bitcoin-core over zeromq.
     #[error("{0}")]

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -25,6 +25,10 @@ pub enum Error {
     ParseStacksBlockId(#[source] blockstack_lib::util::HexError, String),
 
     /// Parsing the Hex Error
+    #[error("could not decode the bitcoin block: {0}")]
+    DecodeBitcoinBlock(#[source] bitcoin::consensus::encode::Error),
+
+    /// Parsing the Hex Error
     #[error("could not decode the Nakamoto block with ID: {1}; {0}")]
     DecodeNakamotoBlock(#[source] blockstack_lib::codec::Error, StacksBlockId),
 
@@ -186,6 +190,24 @@ pub enum Error {
     /// Parsing address failed
     #[error("failed to parse address")]
     ParseAddress(#[source] bitcoin::address::ParseError),
+
+    /// Could not connect to bitcoin-core with a zeromq subscription
+    /// socket.
+    #[error("{0}")]
+    ZmqConnect(#[source] zeromq::ZmqError),
+
+    /// Error when receiving a message from to bitcoin-core over zeromq.
+    #[error("{0}")]
+    ZmqMessage(#[source] zeromq::ZmqError),
+
+    /// Error when receiving a message from to bitcoin-core over zeromq.
+    #[error("{0}")]
+    ZmqReceive(#[source] zeromq::ZmqError),
+
+    /// Could not subscribe to bitcoin-core with a zeromq subscription
+    /// socket.
+    #[error("{0}")]
+    ZmqSubscribe(#[source] zeromq::ZmqError),
 }
 
 impl From<std::convert::Infallible> for Error {

--- a/signer/src/lib.rs
+++ b/signer/src/lib.rs
@@ -21,6 +21,7 @@ pub mod transaction_coordinator;
 pub mod transaction_signer;
 pub mod utxo;
 pub mod wsts_state_machine;
+pub mod zmq;
 
 /// Package version
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/signer/src/zmq.rs
+++ b/signer/src/zmq.rs
@@ -1,8 +1,8 @@
-//! This module provides functionality for reciveing new blocks from
+//! This module provides functionality for receiving new blocks from
 //! bitcoin-core's ZeroMQ interface[1]. From the bitcoin-core docs:
 //!
 //! > The ZeroMQ facility implements a notification interface through a set
-//! > of specific notifiers. Currently there are notifiers that publish
+//! > of specific notifiers. Currently, there are notifiers that publish
 //! > blocks and transactions. This read-only facility requires only the
 //! > connection of a corresponding ZeroMQ subscriber port in receiving
 //! > software; it is not authenticated nor is there any two-way protocol
@@ -142,7 +142,7 @@ pub fn parse_bitcoin_core_message(message: ZmqMessage) -> Result<BitcoinCoreMess
 /// A struct for messages over bitcoin-core's ZeroMQ interface.
 pub struct BitcoinCoreMessageStream {
     /// We actually want this type to be a futures::stream::Unfold<...>, or
-    /// maybe a pinned version of that, but we cannot write the type down
+    /// maybe a pinned version of that, but we cannot write the type down,
     /// so we Box it up.
     inner: Pin<Box<dyn Stream<Item = Result<BitcoinCoreMessage, Error>> + Send>>,
 }

--- a/signer/src/zmq.rs
+++ b/signer/src/zmq.rs
@@ -1,0 +1,205 @@
+//! This module provides functionality for reciveing new blocks from
+//! bitcoin-core's ZeroMQ interface[1]. From the bitcoin-core docs:
+//!
+//! > The ZeroMQ facility implements a notification interface through a set
+//! > of specific notifiers. Currently there are notifiers that publish
+//! > blocks and transactions. This read-only facility requires only the
+//! > connection of a corresponding ZeroMQ subscriber port in receiving
+//! > software; it is not authenticated nor is there any two-way protocol
+//! > involvement. Therefore, subscribers should validate the received data
+//! > since it may be out of date, incomplete or even invalid.
+//!
+//! > ZeroMQ sockets are self-connecting and self-healing; that is,
+//! > connections made between two endpoints will be automatically restored
+//! > after an outage, and either end may be freely started or stopped in
+//! > any order.
+//!
+//! > Because ZeroMQ is message oriented, subscribers receive transactions
+//! > and blocks all-at-once and do not need to implement any sort of
+//! > buffering or reassembly.
+//!
+//! The code here can only process bitcoin blocks and bitcoin block hash
+//! notifications, and there is currently no code for receiving
+//! notifications about transactions. It does not attempt to "validate" the
+//! transactions in the received blocks, it only attempts to parse the data
+//! using the rust-bitcoin library.
+//!
+//! [^1]: https://github.com/bitcoin/bitcoin/blob/870447fd585e5926b4ce4e83db31c59b1be45a50/doc/zmq.md
+
+use std::future::ready;
+use std::pin::Pin;
+use std::task::Context;
+use std::task::Poll;
+
+use bitcoin::consensus::Decodable as _;
+use bitcoin::hashes::Hash as _;
+use bitcoin::Block;
+use bitcoin::BlockHash;
+use futures::stream::Stream;
+use futures::stream::StreamExt as _;
+use zeromq::Socket as _;
+use zeromq::SocketRecv as _;
+use zeromq::SubSocket;
+use zeromq::ZmqMessage;
+
+use crate::config::Settings;
+use crate::error::Error;
+
+/// These are the types of messages that we can get from bitcoin-core by
+/// listing to its zeromq socket subscriptions.
+///
+/// There are 5 message types, but we only care about the ones below: The
+/// documentation for each type is taken from:
+/// https://github.com/bitcoin/bitcoin/blob/870447fd585e5926b4ce4e83db31c59b1be45a50/doc/zmq.md
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum BitcoinCoreMessage {
+    /// `hashblock`: Notifies when the chain tip is updated. When
+    /// assumeutxo is in use, this notification will not be issued for
+    /// historical blocks connected to the background validation
+    /// chainstate. Messages are ZMQ multipart messages with three parts.
+    /// The first part is the topic (hashblock), the second part is the
+    /// 32-byte block hash, and the last part is a sequence number
+    /// (representing the message count to detect lost messages). The
+    /// format of the messages are:
+    ///
+    /// ```text
+    /// | hashblock | <32-byte block hash in Little Endian> | <uint32 sequence number in Little Endian>
+    /// ```
+    HashBlock(BlockHash, u32),
+    /// `rawblock`: Notifies when the chain tip is updated. When assumeutxo
+    /// is in use, this notification will not be issued for historical
+    /// blocks connected to the background validation chainstate. Messages
+    /// are ZMQ multipart messages with three parts. The first part is the
+    /// topic (rawblock), the second part is the serialized block, and the
+    /// last part is a sequence number (representing the message count to
+    /// detect lost messages).
+    /// ```text
+    /// | rawblock | <serialized block> | <uint32 sequence number in Little Endian>
+    /// ```
+    RawBlock(Block, u32),
+}
+
+/// Parse the given ZmqMessage from bitcoin-core.
+///
+/// # Notes
+///
+/// Bitcoin core sends one of 5 different message types. The messages
+/// themselves all follow a similar multipart layout: topic, body,
+/// sequence.
+///
+/// The bitcoin repo has a nice python example for what to expect here:
+/// https://github.com/bitcoin/bitcoin/blob/902dd14382256c9d33bce667795a64079f3bee6b/contrib/zmq/zmq_sub.py
+pub fn parse_bitcoin_core_message(message: ZmqMessage) -> Result<BitcoinCoreMessage, Error> {
+    // We expect three parts to the message, so let's expect get that.
+    let data: [&[u8]; 3] = message
+        .iter()
+        .map(AsRef::as_ref)
+        .collect::<Vec<&[u8]>>()
+        .try_into()
+        .map_err(|_err| Error::Encryption)?;
+
+    // The sequence number is always sent as a little endian 4 byte
+    // unsigned integer.
+    match data {
+        [b"hashblock", block_hash, sequence_bytes] => {
+            // The hash here is returned as Little-endian bytes while the
+            // BlockHash::from_byte_array function expects Big-endian
+            // bytes, so we need to reverse them.
+            let mut block_hash_bytes: [u8; 32] =
+                block_hash.try_into().map_err(|_err| Error::Encryption)?;
+            block_hash_bytes.reverse();
+            let block_hash = BlockHash::from_byte_array(block_hash_bytes);
+
+            let seq: [u8; 4] = sequence_bytes
+                .try_into()
+                .map_err(|_err| Error::Encryption)?;
+            let sequence = u32::from_le_bytes(seq);
+
+            Ok(BitcoinCoreMessage::HashBlock(block_hash, sequence))
+        }
+        [b"rawblock", mut raw_block, sequence_bytes] => {
+            let block =
+                Block::consensus_decode(&mut raw_block).map_err(Error::DecodeBitcoinBlock)?;
+
+            let seq: [u8; 4] = sequence_bytes
+                .try_into()
+                .map_err(|_err| Error::Encryption)?;
+            let sequence = u32::from_le_bytes(seq);
+
+            Ok(BitcoinCoreMessage::RawBlock(block, sequence))
+        }
+        // We do not implement parsing for any other message types.
+        _ => Err(Error::Encryption),
+    }
+}
+
+/// A struct for messages over bitcoin-core's ZeroMQ interface.
+pub struct BitcoinCoreMessageStream {
+    /// We actually want this type to be a futures::stream::Unfold<...>, or
+    /// maybe a pinned version of that, but we cannot write the type down
+    /// so we Box it up.
+    inner: Pin<Box<dyn Stream<Item = Result<BitcoinCoreMessage, Error>> + Send>>,
+}
+
+impl BitcoinCoreMessageStream {
+    /// Create a new `BitcoinCoreMessageStream`.
+    pub fn new_from_socket(socket: SubSocket) -> Self {
+        let stream = futures::stream::unfold(socket, |mut socket| async move {
+            let item = socket
+                .recv()
+                .await
+                .map_err(Error::ZmqReceive)
+                .and_then(parse_bitcoin_core_message);
+            Some((item, socket))
+        });
+        Self { inner: Box::pin(stream) }
+    }
+
+    /// Creat a new one using the endpoint(s) in the config.
+    pub async fn new_from_endpoint(endpoint: &str) -> Result<Self, Error> {
+        let mut socket = SubSocket::new();
+        socket.connect(endpoint).await.map_err(Error::ZmqConnect)?;
+        // Note that setting the subscription to the empty string is
+        // equivalent to setting the subscription to all available
+        // subscriptions enabled on bitcoin-core. We only care about raw
+        // bitcoin blocks (and maybe block hashes) so we only subscribe to
+        // those events.
+        socket
+            .subscribe("rawblock")
+            .await
+            .map_err(Error::ZmqSubscribe)?;
+
+        Ok(Self::new_from_socket(socket))
+    }
+
+    /// Creat a new one using the endpoint(s) in the config.
+    pub async fn new_from_config(settings: Settings) -> Result<Self, Error> {
+        Self::new_from_endpoint(&settings.block_notifier.server).await
+    }
+
+    /// Convert this stream into one that returns only blocks
+    pub fn to_block_stream(self) -> impl Stream<Item = Result<Block, Error>> {
+        self.filter_map(|msg| match msg {
+            Ok(BitcoinCoreMessage::RawBlock(block, _)) => ready(Some(Ok(block))),
+            Ok(_) => ready(None),
+            Err(err) => ready(Some(Err(err))),
+        })
+    }
+
+    /// Convert this stream into one that returns only block hashes
+    pub fn to_block_hash_stream(self) -> impl Stream<Item = Result<BlockHash, Error>> {
+        self.filter_map(|msg| match msg {
+            Ok(BitcoinCoreMessage::HashBlock(hash, _)) => ready(Some(Ok(hash))),
+            Ok(_) => ready(None),
+            Err(err) => ready(Some(Err(err))),
+        })
+    }
+}
+
+impl Stream for BitcoinCoreMessageStream {
+    type Item = Result<BitcoinCoreMessage, Error>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.inner.poll_next_unpin(cx)
+    }
+}

--- a/signer/src/zmq.rs
+++ b/signer/src/zmq.rs
@@ -130,8 +130,8 @@ pub fn parse_bitcoin_core_message(message: ZmqMessage) -> Result<BitcoinCoreMess
             Ok(BitcoinCoreMessage::RawBlock(block, sequence))
         }
         // We do not implement parsing for any other message types but if
-        // we are, then we probably have a valid message from bitcoin-core,
-        // so let's try to note the topic for easier debugging.
+        // we're here, then we probably have a valid message from
+        // bitcoin-core. Let's try to note the topic for easier debugging.
         _ => {
             let topic = core::str::from_utf8(data[0]).map(ToString::to_string);
             Err(Error::BitcoinCoreZmqUnsupported(topic))

--- a/signer/tests/integration/main.rs
+++ b/signer/tests/integration/main.rs
@@ -4,3 +4,4 @@ mod postgres;
 mod rbf;
 mod transaction_signer;
 mod utxo_construction;
+mod zmq;

--- a/signer/tests/integration/zmq.rs
+++ b/signer/tests/integration/zmq.rs
@@ -1,0 +1,59 @@
+use bitcoin::Block;
+use futures::StreamExt;
+use sbtc::testing::regtest;
+use signer::zmq::BitcoinCoreMessageStream;
+
+const BITCOIN_CORE_ZMQ_ENDPOINT: &str = "tcp://localhost:28332";
+
+/// This tests that out bitcoin block stream receives new blocks from
+/// bitcoin-core as it receives them. We create the stream, generate
+/// bitcoin blocks, and wait for the blocks to be received from the stream.
+#[tokio::test]
+#[cfg_attr(not(feature = "integration-tests"), ignore)]
+async fn helper_struct_methods_work() {
+    sbtc::logging::setup_logging("info,signer=debug", false);
+    let (_, faucet) = regtest::initialize_blockchain();
+
+    let stream = BitcoinCoreMessageStream::new_from_endpoint(BITCOIN_CORE_ZMQ_ENDPOINT)
+        .await
+        .unwrap();
+
+    let mut block_stream = stream.to_block_stream();
+
+    // We want to have our stream always waiting for blocks so that we get
+    // them as they arrise. The issue is that await points essentially
+    // block progress on the current code execution path. So we spawn a new
+    // task to handle the blocking part, and have the task send us blocks
+    // through a channel as they arrive.
+    let (sx, mut rx) = tokio::sync::mpsc::channel::<Block>(100);
+
+    // This task will "watch" for bitcoin blocks and send them to us.
+    tokio::spawn(async move {
+        while let Some(Ok(block)) = block_stream.next().await {
+            if sx.is_closed() {
+                tracing::info!("Closed?");
+                break;
+            }
+
+            tracing::info!("Sending block {:?}", block.block_hash());
+            sx.send(block).await.unwrap();
+        }
+    });
+
+    // Our faucet can generate blocks, and when it does it notes the block
+    // hash of the generated block. We'll match this hash with the hash of
+    // the block received from our task above.
+    let block_hashes = faucet.generate_blocks(1);
+    let item = rx.recv().await;
+
+    // We only generated one block, so we should only have one block hash.
+    assert_eq!(block_hashes.len(), 1);
+    assert_eq!(block_hashes[0], item.unwrap().block_hash());
+
+    // Let's try again for good measure, couldn't hurt.
+    let block_hashes = faucet.generate_blocks(1);
+    let item = rx.recv().await;
+
+    assert_eq!(block_hashes.len(), 1);
+    assert_eq!(block_hashes[0], item.unwrap().block_hash());
+}

--- a/signer/tests/integration/zmq.rs
+++ b/signer/tests/integration/zmq.rs
@@ -22,9 +22,9 @@ async fn block_stream_streams_blocks() {
     let mut block_stream = stream.to_block_stream();
 
     // We want to have our stream always waiting for blocks so that we get
-    // them as they arrise. The issue is that await points essentially
-    // block progress on the current code execution path. So we spawn a new
-    // task to handle the blocking part, and have the task send us blocks
+    // them as they arise. The issue is that await points essentially block
+    // progress on the current code execution path. So we spawn a new task
+    // to handle the blocking part, and have the task send us blocks
     // through a channel as they arrive.
     let (sx, mut rx) = tokio::sync::mpsc::channel::<Block>(100);
 
@@ -40,9 +40,9 @@ async fn block_stream_streams_blocks() {
         }
     });
 
-    // Our faucet can generate blocks, and when it does it notes the block
-    // hash of the generated block. We'll match this hash with the hash of
-    // the block received from our task above.
+    // When the faucet generates a blocks it returns the block hash of the
+    // generated block. We'll match this hash with the hash of the block
+    // received from our task above.
     let block_hashes = faucet.generate_blocks(1);
     let item = rx.recv().await;
 
@@ -75,11 +75,11 @@ async fn block_hash_stream_streams_block_hashes() {
 
     let mut block_hash_stream = stream.to_block_hash_stream();
 
-    // We want to have our stream always waiting for blocks so that we get
-    // them as they arrise. The issue is that await points essentially
-    // block progress on the current code execution path. So we spawn a new
-    // task to handle the blocking part, and have the task send us blocks
-    // through a channel as they arrive.
+    // We want to have our stream always waiting for block hashes so that
+    // we get them as they arise. The issue is that await points
+    // essentially block progress on the current code execution path. So we
+    // spawn a new task to handle the blocking part, and have the task send
+    // us blocks through a channel as they arrive.
     let (sx, mut rx) = tokio::sync::mpsc::channel::<BlockHash>(100);
 
     // This task will "watch" for bitcoin blocks and send them to us.
@@ -94,9 +94,9 @@ async fn block_hash_stream_streams_block_hashes() {
         }
     });
 
-    // Our faucet can generate blocks, and when it does it notes the block
-    // hash of the generated block. We'll match this hash with the hash of
-    // the block received from our task above.
+    // When the faucet generates a blocks it returns the block hash of the
+    // generated block. We'll match this hash with the hash received from
+    // our task above.
     let block_hashes = faucet.generate_blocks(1);
     let item = rx.recv().await;
 

--- a/signer/tests/integration/zmq.rs
+++ b/signer/tests/integration/zmq.rs
@@ -1,4 +1,5 @@
 use bitcoin::Block;
+use bitcoin::BlockHash;
 use futures::StreamExt;
 use sbtc::testing::regtest;
 use signer::zmq::BitcoinCoreMessageStream;
@@ -10,13 +11,14 @@ const BITCOIN_CORE_ZMQ_ENDPOINT: &str = "tcp://localhost:28332";
 /// bitcoin blocks, and wait for the blocks to be received from the stream.
 #[tokio::test]
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
-async fn helper_struct_methods_work() {
+async fn block_stream_streams_blocks() {
     sbtc::logging::setup_logging("info,signer=debug", false);
     let (_, faucet) = regtest::initialize_blockchain();
 
-    let stream = BitcoinCoreMessageStream::new_from_endpoint(BITCOIN_CORE_ZMQ_ENDPOINT)
-        .await
-        .unwrap();
+    let stream =
+        BitcoinCoreMessageStream::new_from_endpoint(BITCOIN_CORE_ZMQ_ENDPOINT, &["rawblock"])
+            .await
+            .unwrap();
 
     let mut block_stream = stream.to_block_stream();
 
@@ -56,4 +58,60 @@ async fn helper_struct_methods_work() {
 
     assert_eq!(block_hashes.len(), 1);
     assert_eq!(block_hashes[0], item.unwrap().block_hash());
+}
+
+/// This tests that out bitcoin block hash stream receives new block hashes
+/// from bitcoin-core as it receives blocks. We create the stream, generate
+/// bitcoin blocks, and wait for the block hashes to be received from the
+/// stream. This also checks that we parse block hashes correctly, since
+/// they are supposed to be little-endian formatted.
+#[tokio::test]
+#[cfg_attr(not(feature = "integration-tests"), ignore)]
+async fn block_hash_stream_streams_block_hashes() {
+    sbtc::logging::setup_logging("info,signer=debug", false);
+    let (_, faucet) = regtest::initialize_blockchain();
+
+    let stream =
+        BitcoinCoreMessageStream::new_from_endpoint(BITCOIN_CORE_ZMQ_ENDPOINT, &["hashblock"])
+            .await
+            .unwrap();
+
+    let mut block_hash_stream = stream.to_block_hash_stream();
+
+    // We want to have our stream always waiting for blocks so that we get
+    // them as they arrise. The issue is that await points essentially
+    // block progress on the current code execution path. So we spawn a new
+    // task to handle the blocking part, and have the task send us blocks
+    // through a channel as they arrive.
+    let (sx, mut rx) = tokio::sync::mpsc::channel::<BlockHash>(100);
+
+    // This task will "watch" for bitcoin blocks and send them to us.
+    tokio::spawn(async move {
+        while let Some(Ok(block_hash)) = block_hash_stream.next().await {
+            if sx.is_closed() {
+                tracing::info!("Closed?");
+                break;
+            }
+
+            tracing::info!("Sending block hash {block_hash}");
+            sx.send(block_hash).await.unwrap();
+        }
+    });
+
+    // Our faucet can generate blocks, and when it does it notes the block
+    // hash of the generated block. We'll match this hash with the hash of
+    // the block received from our task above.
+    let block_hashes = faucet.generate_blocks(1);
+    let item = rx.recv().await;
+
+    // We only generated one block, so we should only have one block hash.
+    assert_eq!(block_hashes.len(), 1);
+    assert_eq!(block_hashes[0], item.unwrap());
+
+    // Let's try again for good measure, couldn't hurt.
+    let block_hashes = faucet.generate_blocks(1);
+    let item = rx.recv().await;
+
+    assert_eq!(block_hashes.len(), 1);
+    assert_eq!(block_hashes[0], item.unwrap());
 }

--- a/signer/tests/integration/zmq.rs
+++ b/signer/tests/integration/zmq.rs
@@ -12,7 +12,6 @@ const BITCOIN_CORE_ZMQ_ENDPOINT: &str = "tcp://localhost:28332";
 #[tokio::test]
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 async fn block_stream_streams_blocks() {
-    sbtc::logging::setup_logging("info,signer=debug", false);
     let (_, faucet) = regtest::initialize_blockchain();
 
     let stream =
@@ -33,7 +32,6 @@ async fn block_stream_streams_blocks() {
     tokio::spawn(async move {
         while let Some(Ok(block)) = block_stream.next().await {
             if sx.is_closed() {
-                tracing::info!("Closed?");
                 break;
             }
 
@@ -68,7 +66,6 @@ async fn block_stream_streams_blocks() {
 #[tokio::test]
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 async fn block_hash_stream_streams_block_hashes() {
-    sbtc::logging::setup_logging("info,signer=debug", false);
     let (_, faucet) = regtest::initialize_blockchain();
 
     let stream =
@@ -89,7 +86,6 @@ async fn block_hash_stream_streams_block_hashes() {
     tokio::spawn(async move {
         while let Some(Ok(block_hash)) = block_hash_stream.next().await {
             if sx.is_closed() {
-                tracing::info!("Closed?");
                 break;
             }
 

--- a/signer/tests/integration/zmq.rs
+++ b/signer/tests/integration/zmq.rs
@@ -40,7 +40,7 @@ async fn block_stream_streams_blocks() {
         }
     });
 
-    // When the faucet generates a blocks it returns the block hash of the
+    // When the faucet generates a block it returns the block hash of the
     // generated block. We'll match this hash with the hash of the block
     // received from our task above.
     let block_hashes = faucet.generate_blocks(1);
@@ -94,7 +94,7 @@ async fn block_hash_stream_streams_block_hashes() {
         }
     });
 
-    // When the faucet generates a blocks it returns the block hash of the
+    // When the faucet generates a block it returns the block hash of the
     // generated block. We'll match this hash with the hash received from
     // our task above.
     let block_hashes = faucet.generate_blocks(1);

--- a/signer/tests/service-configs/bitcoin.conf
+++ b/signer/tests/service-configs/bitcoin.conf
@@ -448,7 +448,7 @@ txindex=1
 
 
 # Enable publish hash block in <address>
-#zmqpubhashblock=<address>
+zmqpubhashblock=tcp://*:28332
 
 # Set publish hash block outbound message high water mark (default: 1000)
 #zmqpubhashblockhwm=<n>

--- a/signer/tests/service-configs/bitcoin.conf
+++ b/signer/tests/service-configs/bitcoin.conf
@@ -461,7 +461,7 @@ zmqpubhashblock=tcp://*:28332
 #zmqpubhashtxhwm=<n>
 
 # Enable publish raw block in <address>
-#zmqpubrawblock=<address>
+zmqpubrawblock=tcp://*:28332
 
 # Set publish raw block outbound message high water mark (default: 1000)
 #zmqpubrawblockhwm=<n>


### PR DESCRIPTION
## Description

Closes: https://github.com/stacks-network/sbtc/issues/383.

The electrum client that we have for rust requires you to poll the server for bitcoin blocks. While not terrible, using the ZeroMQ interface on bitcoin-core gives us real-time notifications, and allows us to remove electrum server as a requirement for running the signer application.

## Changes

* Add structs subscribe to bitcoin-cores ZeroMQ notification interface for block and block hash notifications.
* Add an integration test that listens to bitcoin-core messages and checks the new code.

## Testing Information

The two integration tests check the new logic that was added here. It does not validate the messages received and does not reproduce the logic laid out in the bitcoin docs for what happens during a reorg. That we should do later in https://github.com/stacks-network/sbtc/issues/405.

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
