### PR TITLE
feat: extract sBTC transactions in block observer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1368,7 +1368,7 @@ dependencies = [
  "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
- "parking_lot_core 0.9.10",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -6307,7 +6307,7 @@ dependencies = [
  "log",
  "num-traits 0.2.19",
  "once_cell",
- "parking_lot 0.12.2",
+ "parking_lot",
  "rand 0.8.5",
  "regex",
  "thiserror",

--- a/emily/handler/tests/integration/complex/reorg.rs
+++ b/emily/handler/tests/integration/complex/reorg.rs
@@ -39,11 +39,13 @@ impl ReorgScenario {
     }
 
     /// Lowest reorganized block height.
+    #[allow(dead_code)]
     fn lowest_reorganized_block_height(&self) -> u64 {
         self.initial_chain_length - self.reorg_depth
     }
 
     /// Creates a list of reorganized chainstates with the standard test block hash format.
+    #[allow(dead_code)]
     fn reorganized_chainstates(&self, fork_id: u32) -> Vec<Chainstate> {
         ((self.lowest_reorganized_block_height())..self.initial_chain_length)
             .map(|height| util::test_chainstate(height, fork_id))
@@ -81,7 +83,7 @@ async fn simple_reorg_test_base(scenario: ReorgScenario) {
     client.setup_test().await;
 
     // Identifier for the current fork.
-    let mut fork_id: u32 = 0;
+    let fork_id: u32 = 0;
 
     // Step 1: Make an initial fork.
     // -------------------------------------------------------------------------

--- a/signer/migrations/0003__create_tables.sql
+++ b/signer/migrations/0003__create_tables.sql
@@ -79,6 +79,7 @@ CREATE TABLE sbtc_signer.transactions (
 CREATE TABLE sbtc_signer.dkg_shares (
     aggregate_key BYTEA PRIMARY KEY,
     tweaked_aggregate_key BYTEA NOT NULL,
+    script_pubkey BYTEA NOT NULL,
     encrypted_shares BYTEA NOT NULL,
     created_at TIMESTAMPTZ NOT NULL
 );

--- a/signer/src/bitcoin/utxo.rs
+++ b/signer/src/bitcoin/utxo.rs
@@ -3,7 +3,6 @@
 use bitcoin::absolute::LockTime;
 use bitcoin::address::NetworkUnchecked;
 use bitcoin::hashes::Hash;
-use bitcoin::key::Secp256k1;
 use bitcoin::secp256k1::SECP256K1;
 use bitcoin::sighash::Prevouts;
 use bitcoin::sighash::SighashCache;
@@ -62,6 +61,34 @@ const SATS_PER_VBYTE_INCREMENT: f64 = 0.001;
 /// The OP_RETURN operation byte for deposit or withdrawal sweeps. This is
 /// the UTF8 encoded string "B".
 const OP_RETURN_OP: u8 = b'B';
+
+/// This trait is used to provide a unifying interface for converting
+/// different public key types to the `scriptPubkey` associated with the
+/// signers. We represent the `scriptPubkey` using rust-bitcoin's ScriptBuf
+/// type.
+pub trait SignerScriptPubkey {
+    /// Convert this type to the `scriptPubkey` used by the signers to lock
+    /// their UTXO.
+    fn signers_script_pubkey(&self) -> ScriptBuf;
+}
+
+impl SignerScriptPubkey for XOnlyPublicKey {
+    fn signers_script_pubkey(&self) -> ScriptBuf {
+        ScriptBuf::new_p2tr(SECP256K1, *self, None)
+    }
+}
+
+impl SignerScriptPubkey for p256k1::point::Point {
+    fn signers_script_pubkey(&self) -> ScriptBuf {
+        // The type is a thin wrapper of the a libsecp256k1 type. The
+        // underlying type represents a group element of the secp256k1
+        // curve, in jacobian coordinates. So this should always be on the
+        // curve.
+        XOnlyPublicKey::from_slice(&self.x().to_bytes())
+            .expect("BUG: p256k1::point::Points should lie on the curve!")
+            .signers_script_pubkey()
+    }
+}
 
 /// Describes the fees for a transaction.
 #[derive(Debug, Clone, Copy)]
@@ -525,11 +552,9 @@ impl SignerUtxo {
     ///
     /// The signers' UTXO is always a key-spend only taproot UTXO.
     fn new_tx_output(public_key: XOnlyPublicKey, sats: u64) -> TxOut {
-        let secp = Secp256k1::new();
-
         TxOut {
             value: Amount::from_sat(sats),
-            script_pubkey: ScriptBuf::new_p2tr(&secp, public_key, None),
+            script_pubkey: public_key.signers_script_pubkey(),
         }
     }
 }

--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -198,7 +198,7 @@ where
         txs: &[Transaction],
     ) -> Result<(), Error> {
         // We store all of the scriptPubKeys associated with the signers'
-        // aggregate public key. Let's get the last years worth of them. 
+        // aggregate public key. Let's get the last years worth of them.
         let signer_script_pubkeys: HashSet<ScriptBuf> = self
             .storage
             .get_signers_script_pubkeys()

--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -197,7 +197,7 @@ where
         block_hash: BlockHash,
         txs: &[Transaction],
     ) -> Result<(), Error> {
-        // We store all of the scriptPubKeys associated with the signers'
+        // We store all the scriptPubKeys associated with the signers'
         // aggregate public key. Let's get the last years worth of them.
         let signer_script_pubkeys: HashSet<ScriptBuf> = self
             .storage
@@ -207,7 +207,7 @@ where
             .map(ScriptBuf::from_bytes)
             .collect();
 
-        // Look through all of the UTXOs in the given transaction slice and
+        // Look through all the UTXOs in the given transaction slice and
         // keep the transactions where a UTXO is locked with a
         // `scriptPubKey` controlled by the signers.
         let sbtc_txs = txs
@@ -274,7 +274,7 @@ where
     }
 }
 
-// Placehoder traits. To be replaced with the actual traits once implemented.
+// Placeholder traits. To be replaced with the actual traits once implemented.
 
 /// Placeholder trait
 pub trait EmilyInteract {
@@ -558,7 +558,7 @@ mod tests {
         // and another not spending to the signers. We use
         // sbtc::testing::deposits::tx_setup just to quickly create a
         // transaction; any one will do since we will be adding the UTXO
-        // that spends to the signer afterwards.
+        // that spends to the signer afterward.
         let mut tx_setup0 = sbtc::testing::deposits::tx_setup(0, 0, 100);
         tx_setup0.tx.output.push(TxOut {
             value: Amount::ONE_BTC,
@@ -605,7 +605,7 @@ mod tests {
             assert!(stored_transactions.is_none());
         }
 
-        // Noe we try again but we include the transaction that spends to
+        // Now we try again, but we include the transaction that spends to
         // the signer. This one should turn out differently.
         let txs = [tx_setup0.tx.clone(), tx_setup1.tx.clone()];
         block_observer
@@ -621,15 +621,15 @@ mod tests {
         // Is our one transaction stored? This block hash should now have
         // only one transaction with the expected txid.
         let tx_ids = stored_transactions.unwrap();
-        let expexted_tx_id = tx_setup0.tx.compute_txid().to_byte_array().to_vec();
+        let expected_tx_id = tx_setup0.tx.compute_txid().to_byte_array().to_vec();
         assert_eq!(tx_ids.len(), 1);
-        assert_eq!(tx_ids[0], expexted_tx_id);
+        assert_eq!(tx_ids[0], expected_tx_id);
     }
 
     #[derive(Debug, Clone)]
     struct TestHarness {
         bitcoin_blocks: Vec<bitcoin::Block>,
-        /// This represents the Stacks block chain. The bitcoin::BlockHash
+        /// This represents the Stacks blockchain. The bitcoin::BlockHash
         /// is used to identify tenures. That is, all NakamotoBlocks that
         /// have the same bitcoin::BlockHash occur within the same tenure.
         stacks_blocks: Vec<(StacksBlockId, NakamotoBlock, BlockHash)>,

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -9,22 +9,27 @@ use crate::{codec, ecdsa, network};
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     /// Error when breaking out the ZeroMQ message into three parts.
-    #[error("Bitcoin messages should have a three part layout, receieved {0} parts")]
+    #[error("bitcoin messages should have a three part layout, receieved {0} parts")]
     BitcoinCoreZmqMessageLayout(usize),
 
     /// Happens when the bitcoin block hash in the ZeroMQ message is not 32
     /// bytes.
-    #[error("Block hashes should be 32 bytes, but we received {0} bytes")]
+    #[error("block hashes should be 32 bytes, but we received {0} bytes")]
     BitcoinCoreZmqBlockHash(usize),
 
     /// Happens when the ZeroMQ sequence number is not 4 bytes.
-    #[error("Sequence numbers should be 4 bytes, but we received {0} bytes")]
+    #[error("sequence numbers should be 4 bytes, but we received {0} bytes")]
     BitcoinCoreZmqSequenceNumber(usize),
 
     /// The given message type is unsupported. We attempt to parse what the
     /// topic is but that might fail as well.
-    #[error("The message topic {0:?} is unsupported")]
+    #[error("the message topic {0:?} is unsupported")]
     BitcoinCoreZmqUnsupported(Result<String, std::str::Utf8Error>),
+
+    /// This is for when bitcoin::Transaction::consensus_encode fails. It
+    /// should never happen.
+    #[error("could not serialize bitcoin transaction into bytes.")]
+    BitcoinEncodeTransaction(#[source] bitcoin::io::Error),
 
     /// Invalid amount
     #[error("the change amounts for the transaction is negative: {0}")]

--- a/signer/src/stacks/contracts.rs
+++ b/signer/src/stacks/contracts.rs
@@ -133,11 +133,15 @@ pub trait AsContractCall {
 /// AsTxPayload automatically. What we want is to have something like the
 /// following:
 ///
+/// ```text
 /// impl<T: AsContractCall> AsTxPayload for T { ... }
+/// ```
 ///
 /// But that would preclude us from adding something like:
 ///
+/// ```text
 /// impl<T: AsSmartContract> AsTxPayload for T { ... }
+/// ```
 ///
 /// since doing so is prevented by the compiler because it introduces
 /// ambiguity. One work-around is to use a wrapper type that implements the

--- a/signer/src/storage/in_memory.rs
+++ b/signer/src/storage/in_memory.rs
@@ -344,10 +344,14 @@ impl super::DbRead for SharedStore {
             .cloned())
     }
 
-    fn get_signers_script_pubkeys(
-        &self,
-    ) -> impl std::future::Future<Output = Result<Vec<model::Bytes>, Self::Error>> + Send {
-        std::future::ready(Ok(Vec::new()))
+    async fn get_signers_script_pubkeys(&self) -> Result<Vec<model::Bytes>, Self::Error> {
+        Ok(self
+            .lock()
+            .await
+            .encrypted_dkg_shares
+            .values()
+            .map(|share| share.script_pubkey.clone())
+            .collect())
     }
 }
 

--- a/signer/src/storage/in_memory.rs
+++ b/signer/src/storage/in_memory.rs
@@ -363,6 +363,21 @@ impl super::DbWrite for SharedStore {
         Ok(())
     }
 
+    async fn write_bitcoin_transactions(
+        &self,
+        txs: Vec<model::Transaction>,
+    ) -> Result<(), Self::Error> {
+        for tx in txs {
+            let bitcoin_transaction = model::BitcoinTransaction {
+                txid: tx.txid,
+                block_hash: tx.block_hash,
+            };
+            self.write_bitcoin_transaction(&bitcoin_transaction).await?;
+        }
+
+        Ok(())
+    }
+
     async fn write_stacks_block(&self, block: &model::StacksBlock) -> Result<(), Self::Error> {
         self.lock()
             .await

--- a/signer/src/storage/in_memory.rs
+++ b/signer/src/storage/in_memory.rs
@@ -343,6 +343,12 @@ impl super::DbRead for SharedStore {
             .get(aggregate_key)
             .cloned())
     }
+
+    fn get_signers_script_pubkeys(
+        &self,
+    ) -> impl std::future::Future<Output = Result<Vec<model::Bytes>, Self::Error>> + Send {
+        std::future::ready(Ok(Vec::new()))
+    }
 }
 
 impl super::DbWrite for SharedStore {

--- a/signer/src/storage/mod.rs
+++ b/signer/src/storage/mod.rs
@@ -104,6 +104,11 @@ pub trait DbRead {
         &self,
         aggregate_key: &model::PubKey,
     ) -> impl Future<Output = Result<Option<model::EncryptedDkgShares>, Self::Error>> + Send;
+
+    /// Get the last 365 days worth of the signers' `scriptPubkey`s.
+    fn get_signers_script_pubkeys(
+        &self,
+    ) -> impl Future<Output = Result<Vec<model::Bytes>, Self::Error>> + Send;
 }
 
 /// Represents the ability to write data to the signer storage.

--- a/signer/src/storage/mod.rs
+++ b/signer/src/storage/mod.rs
@@ -170,6 +170,12 @@ pub trait DbWrite {
         bitcoin_transaction: &model::BitcoinTransaction,
     ) -> impl Future<Output = Result<(), Self::Error>> + Send;
 
+    /// Write the bitcoin transactions to the data store.
+    fn write_bitcoin_transactions(
+        &self,
+        txs: Vec<model::Transaction>,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+
     /// Write a connection between a stacks block and a transaction
     fn write_stacks_transaction(
         &self,

--- a/signer/src/storage/model.rs
+++ b/signer/src/storage/model.rs
@@ -239,13 +239,15 @@ pub struct Transaction {
 }
 
 /// Persisted DKG shares
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, sqlx::FromRow)]
 #[cfg_attr(feature = "testing", derive(fake::Dummy))]
 pub struct EncryptedDkgShares {
     /// The aggregate key for these shares
     pub aggregate_key: PubKey,
     /// The tweaked aggregate key for these shares
     pub tweaked_aggregate_key: PubKey,
+    /// The encrypted DKG shares
+    pub script_pubkey: Bytes,
     /// The encrypted DKG shares
     pub encrypted_shares: Bytes,
     /// The time this entry was created by the signer.

--- a/signer/src/storage/model.rs
+++ b/signer/src/storage/model.rs
@@ -222,6 +222,15 @@ pub struct StacksTransaction {
     pub block_hash: StacksBlockHash,
 }
 
+/// For writing to the stacks_transactions or bitcoin_transactions table.
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct TransactionIds {
+    /// Transaction IDs.
+    pub tx_ids: Vec<Vec<u8>>,
+    /// The blocks in which the transactions exists.
+    pub block_hashes: Vec<Vec<u8>>,
+}
+
 /// A raw transaction on either Bitcoin or Stacks.
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "testing", derive(fake::Dummy))]

--- a/signer/src/storage/model.rs
+++ b/signer/src/storage/model.rs
@@ -87,7 +87,7 @@ pub struct DepositRequest {
     pub created_at: time::OffsetDateTime,
 }
 
-/// Used to for fine grained control of generating fake testing addresses.
+/// Used to for fine-grained control of generating fake testing addresses.
 #[cfg(feature = "testing")]
 #[derive(Debug)]
 pub struct BitcoinAddresses(Range<usize>);
@@ -140,7 +140,7 @@ pub struct DepositSigner {
     /// TxID of the deposit request.
     #[cfg_attr(feature = "testing", dummy(expr = "fake::vec![u8; 32]"))]
     pub txid: BitcoinTxId,
-    /// Ouput index of the deposit request.
+    /// Output index of the deposit request.
     #[cfg_attr(feature = "testing", dummy(faker = "0..100"))]
     pub output_index: i32,
     /// Public key of the signer.
@@ -160,12 +160,12 @@ pub struct DepositSigner {
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "testing", derive(fake::Dummy))]
 pub struct WithdrawRequest {
-    /// Request ID of the withdraw request.
+    /// Request ID of the withdrawal request.
     pub request_id: i32,
-    /// Stacks block hash of the withdraw request.
+    /// Stacks block hash of the withdrawal request.
     #[cfg_attr(feature = "testing", dummy(expr = "fake::vec![u8; 32]"))]
     pub block_hash: StacksBlockHash,
-    /// The address that shuld receive the BTC withdrawal.
+    /// The address that should receive the BTC withdrawal.
     pub recipient: BitcoinAddress,
     /// The amount to withdraw.
     pub amount: i64,
@@ -186,9 +186,9 @@ pub struct WithdrawRequest {
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "testing", derive(fake::Dummy))]
 pub struct WithdrawSigner {
-    /// Request ID of the withdraw request.
+    /// Request ID of the withdrawal request.
     pub request_id: i32,
-    /// Stacks block hash of the withdraw request.
+    /// Stacks block hash of the withdrawal request.
     #[cfg_attr(feature = "testing", dummy(expr = "fake::vec![u8; 32]"))]
     pub block_hash: StacksBlockHash,
     /// Public key of the signer.
@@ -227,7 +227,7 @@ pub struct StacksTransaction {
 pub struct TransactionIds {
     /// Transaction IDs.
     pub tx_ids: Vec<Vec<u8>>,
-    /// The blocks in which the transactions exists.
+    /// The blocks in which the transactions exist.
     pub block_hashes: Vec<Vec<u8>>,
 }
 
@@ -255,7 +255,7 @@ pub struct EncryptedDkgShares {
     pub aggregate_key: PubKey,
     /// The tweaked aggregate key for these shares
     pub tweaked_aggregate_key: PubKey,
-    /// The encrypted DKG shares
+    /// The `scriptPubKey` for the aggregate public key.
     pub script_pubkey: Bytes,
     /// The encrypted DKG shares
     pub encrypted_shares: Bytes,
@@ -273,15 +273,15 @@ pub enum TransactionType {
     SbtcTransaction,
     /// A deposit request transaction on Bitcoin.
     DepositRequest,
-    /// A withdraw request transaction on Stacks.
+    /// A withdrawal request transaction on Stacks.
     WithdrawRequest,
     /// A deposit accept transaction on Stacks.
     DepositAccept,
-    /// A withdraw accept transaction on Stacks.
+    /// A withdrawal accept transaction on Stacks.
     WithdrawAccept,
     /// A withdraw reject transaction on Stacks.
     WithdrawReject,
-    /// A update signer set call on Stacks.
+    /// An update signer set call on Stacks.
     UpdateSignerSet,
     /// A set aggregate key call on Stacks.
     SetAggregateKey,

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -1120,7 +1120,7 @@ impl super::DbWrite for PgStore {
         .bind(&shares.tweaked_aggregate_key)
         .bind(&shares.encrypted_shares)
         .bind(&shares.script_pubkey)
-        .bind(&shares.created_at)
+        .bind(shares.created_at)
         .execute(&self.0)
         .await
         .map_err(Error::SqlxQuery)?;

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -604,6 +604,19 @@ impl super::DbRead for PgStore {
         .await
         .map_err(Error::SqlxQuery)
     }
+
+    async fn get_signers_script_pubkeys(&self) -> Result<Vec<model::Bytes>, Self::Error> {
+        sqlx::query_scalar::<_, model::Bytes>(
+            r#"
+            SELECT script_pubkey
+            FROM sbtc_signer.dkg_shares
+            WHERE created_at > CURRENT_TIMESTAMP - INTERVAL '365 DAYS';
+            "#,
+        )
+        .fetch_all(&self.0)
+        .await
+        .map_err(Error::SqlxQuery)
+    }
 }
 
 impl super::DbWrite for PgStore {

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -10,7 +10,6 @@ use blockstack_lib::types::chainstate::StacksBlockId;
 
 use crate::error::Error;
 use crate::storage::model;
-use crate::storage::model::Transaction;
 use crate::storage::model::TransactionType;
 
 const CONTRACT_NAMES: [&str; 4] = [
@@ -48,7 +47,7 @@ fn contract_transaction_kinds() -> &'static HashMap<&'static str, TransactionTyp
 
 /// This function extracts the signer relevant sBTC related transactions
 /// from the given blocks.
-pub fn extract_relevant_transactions(blocks: &[NakamotoBlock]) -> Vec<Transaction> {
+pub fn extract_relevant_transactions(blocks: &[NakamotoBlock]) -> Vec<model::Transaction> {
     let transaction_kinds = contract_transaction_kinds();
     blocks
         .iter()
@@ -57,7 +56,7 @@ pub fn extract_relevant_transactions(blocks: &[NakamotoBlock]) -> Vec<Transactio
             TransactionPayload::ContractCall(x)
                 if CONTRACT_NAMES.contains(&x.contract_name.as_str()) =>
             {
-                Some(Transaction {
+                Some(model::Transaction {
                     txid: tx.txid().to_bytes().to_vec(),
                     block_hash: block_id.to_bytes().to_vec(),
                     tx: tx.serialize_to_vec(),

--- a/signer/src/testing/dummy.rs
+++ b/signer/src/testing/dummy.rs
@@ -6,6 +6,7 @@ use fake::faker::time::en::DateTimeAfter;
 use fake::Fake;
 use rand::Rng;
 
+use crate::bitcoin::utxo::SignerScriptPubkey as _;
 use crate::storage::model;
 
 use crate::codec::Encode as _;
@@ -166,10 +167,7 @@ pub fn encrypted_dkg_shares<R: rand::RngCore + rand::CryptoRng>(
     group_key: p256k1::point::Point,
 ) -> model::EncryptedDkgShares {
     let aggregate_key = group_key.x().to_bytes().to_vec();
-    let tweaked_aggregate_key = wsts::compute::tweaked_public_key(&group_key, None)
-        .x()
-        .to_bytes()
-        .to_vec();
+    let tweaked_aggregate_key = wsts::compute::tweaked_public_key(&group_key, None);
     let party_state = wsts::traits::PartyState {
         polynomial: None,
         private_keys: vec![],
@@ -197,7 +195,8 @@ pub fn encrypted_dkg_shares<R: rand::RngCore + rand::CryptoRng>(
 
     model::EncryptedDkgShares {
         aggregate_key,
-        tweaked_aggregate_key,
+        tweaked_aggregate_key: tweaked_aggregate_key.x().to_bytes().to_vec(),
+        script_pubkey: tweaked_aggregate_key.signers_script_pubkey().into_bytes(),
         encrypted_shares,
         created_at,
     }

--- a/signer/src/testing/wallet.rs
+++ b/signer/src/testing/wallet.rs
@@ -48,7 +48,7 @@ pub trait AsContractDeploy {
 /// A wrapper type for smart contract deployment that implements
 /// AsTxPayload. This is analogous to the
 /// crate::stacks::contracts::ContractCall struct.
-pub struct ContractDeploy<T: AsContractDeploy>(pub T);
+pub struct ContractDeploy<T>(pub T);
 
 impl<T: AsContractDeploy> AsTxPayload for ContractDeploy<T> {
     fn tx_payload(&self) -> TransactionPayload {

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -8,6 +8,7 @@
 use std::collections::BTreeSet;
 use std::collections::HashMap;
 
+use crate::bitcoin::utxo::SignerScriptPubkey as _;
 use crate::blocklist_client;
 use crate::error;
 use crate::message;
@@ -579,10 +580,7 @@ where
 
         let saved_state = state_machine.signer.save();
         let aggregate_key = saved_state.group_key.x().to_bytes().to_vec();
-        let tweaked_aggregate_key = wsts::compute::tweaked_public_key(&saved_state.group_key, None)
-            .x()
-            .to_bytes()
-            .to_vec();
+        let tweaked_aggregate_key = wsts::compute::tweaked_public_key(&saved_state.group_key, None);
 
         let encoded = saved_state.encode_to_vec().map_err(error::Error::Codec)?;
 
@@ -594,7 +592,8 @@ where
 
         let encrypted_dkg_shares = model::EncryptedDkgShares {
             aggregate_key,
-            tweaked_aggregate_key,
+            tweaked_aggregate_key: tweaked_aggregate_key.x().to_bytes().to_vec(),
+            script_pubkey: tweaked_aggregate_key.signers_script_pubkey().into_bytes(),
             encrypted_shares,
             created_at,
         };

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -1,5 +1,6 @@
 use std::io::Read;
 
+use bitcoin::hashes::Hash as _;
 use bitvec::array::BitArray;
 use blockstack_lib::chainstate::nakamoto::NakamotoBlock;
 use blockstack_lib::clarity::vm::types::PrincipalData;
@@ -538,5 +539,78 @@ async fn writing_deposit_requests_postgres(pool: sqlx::PgPool) {
             .unwrap();
 
     // No new records written right?
+    assert_eq!(num_rows, count as usize);
+}
+
+/// This is very similar to the above test; we test that we can store
+/// transaction model objects. We also test that if we attempt to write
+/// duplicate transactions then we do not write it and that we do not
+/// error.
+#[cfg_attr(not(feature = "integration-tests"), ignore)]
+#[sqlx::test]
+async fn writing_transactions_postgres(pool: sqlx::PgPool) {
+    let num_rows = 12;
+    let store = storage::postgres::PgStore::from(pool.clone());
+    let mut rng = rand::rngs::StdRng::seed_from_u64(51);
+    let mut txs: Vec<model::Transaction> =
+        std::iter::repeat_with(|| fake::Faker.fake_with_rng(&mut rng))
+            .take(num_rows)
+            .collect();
+
+    let parent_hash = bitcoin::BlockHash::from_byte_array([0; 32]);
+    let block_hash = bitcoin::BlockHash::from_byte_array([1; 32]);
+
+    txs.iter_mut().for_each(|tx| {
+        tx.block_hash = block_hash.to_byte_array().to_vec();
+    });
+
+    let db_block = model::BitcoinBlock {
+        block_hash: block_hash.to_byte_array().to_vec(),
+        block_height: 15,
+        parent_hash: parent_hash.to_byte_array().to_vec(),
+        confirms: Vec::new(),
+        created_at: time::OffsetDateTime::now_utc(),
+    };
+
+    // We start by writing the bitcoin block because of the foreign key
+    // constrait
+    store.write_bitcoin_block(&db_block).await.unwrap();
+
+    // Let's see if we can write these transactions to the database. 
+    store.write_bitcoin_transactions(txs.clone()).await.unwrap();
+    let count =
+        sqlx::query_scalar::<_, i64>(r#"SELECT COUNT(*) FROM sbtc_signer.bitcoin_transactions"#)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    // Were they all written?
+    assert_eq!(num_rows, count as usize);
+
+    // what about the transactions table, the same number of rows should
+    // have been written there as well.
+    let count = sqlx::query_scalar::<_, i64>(r#"SELECT COUNT(*) FROM sbtc_signer.transactions"#)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+    assert_eq!(num_rows, count as usize);
+    // Okay now lets test that we do not write duplicates.
+    store.write_bitcoin_transactions(txs).await.unwrap();
+    let count =
+        sqlx::query_scalar::<_, i64>(r#"SELECT COUNT(*) FROM sbtc_signer.bitcoin_transactions"#)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+
+    // No new records written right?
+    assert_eq!(num_rows, count as usize);
+
+    // what about duplicates in the transactions table.
+    let count = sqlx::query_scalar::<_, i64>(r#"SELECT COUNT(*) FROM sbtc_signer.transactions"#)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+    // let's see, who knows what will happen!
     assert_eq!(num_rows, count as usize);
 }

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -576,7 +576,7 @@ async fn writing_transactions_postgres(pool: sqlx::PgPool) {
     // constrait
     store.write_bitcoin_block(&db_block).await.unwrap();
 
-    // Let's see if we can write these transactions to the database. 
+    // Let's see if we can write these transactions to the database.
     store.write_bitcoin_transactions(txs.clone()).await.unwrap();
     let count =
         sqlx::query_scalar::<_, i64>(r#"SELECT COUNT(*) FROM sbtc_signer.bitcoin_transactions"#)


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/204.

We can probably remove the `tweaked_aggregate_key` column from the `dkg_shares` table now.

## Changes

* Add a `script_pubkey` column to the `dkg_shares` table. This makes it simple for us to find BTC transactions that the signers have sent. The alternative is to assume that witness program version is always 1, and derive the `scriptPubKey` from the tweaked public key. It also makes it easy for us to find donations for https://github.com/stacks-network/sbtc/issues/353.
* Add a trait for converting `p256k1` types and `rust-secp256k1` types to the signers' `scriptPubKey`.
* Implement the `BlockObserver::extract_sbtc_transactions` function.
* Add function for writing bitcoin transactions into the database.

## Testing Information

There are unit tests for the new block observer functionality and integration tests for the query.

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
