### PR TITLE
refactor: use simplified crypto types

### DIFF
--- a/signer/examples/relay-client.rs
+++ b/signer/examples/relay-client.rs
@@ -1,10 +1,10 @@
 #[cfg(feature = "testing")]
 use clap::Parser;
 
-use p256k1::keys::PublicKey;
-use p256k1::scalar::Scalar;
 use rand::rngs::OsRng;
 use signer::ecdsa;
+use signer::keys::PrivateKey;
+use signer::keys::PublicKey;
 use signer::message;
 use signer::network::grpc_relay;
 
@@ -87,16 +87,16 @@ async fn main() {
     }
 }
 
-fn setup_keypair() -> Scalar {
-    let private_key = Scalar::random(&mut OsRng);
-    let public_key = PublicKey::new(&private_key).expect("Failed to generate public key");
+fn setup_keypair() -> PrivateKey {
+    let private_key = PrivateKey::new(&mut OsRng);
+    let public_key = PublicKey::from_private_key(&private_key);
 
     tracing::info!(%public_key, "generated key pair");
     private_key
 }
 
 fn spawn_message_source(
-    private_key: Scalar,
+    private_key: PrivateKey,
     send_period: std::time::Duration,
 ) -> tokio::sync::mpsc::Receiver<Msg> {
     let (heartbeat_tx, heartbeat_rx) = tokio::sync::mpsc::channel(128);

--- a/signer/src/bitcoin/packaging.rs
+++ b/signer/src/bitcoin/packaging.rs
@@ -5,14 +5,14 @@ use std::collections::BTreeMap;
 /// Package a list of items into bags where the total capacity of each bag
 /// is less than the given capacity.
 ///
-/// Note that items with wieght that is greater than the capacity are
+/// Note that items with weight that is greater than the capacity are
 /// filtered out.
 pub fn compute_optimal_packages<I, T>(items: I, capacity: u32) -> impl Iterator<Item = Vec<T>>
 where
     I: IntoIterator<Item = T>,
     T: Weighted,
 {
-    // This is an implementation of the Best-Fit-Decreasing algorithm so
+    // This is an implementation of the Best-Fit-Decreasing algorithm, so
     // we need to sort by weight decreasing.
     let mut item_vec: Vec<(u32, T)> = items
         .into_iter()
@@ -22,7 +22,7 @@ where
     item_vec.sort_by_key(|(weight, _)| std::cmp::Reverse(*weight));
 
     // Now we just add each item into a bag, and return the
-    // collection of bags afterwards.
+    // collection of bags afterward.
     let mut packager = BestFitPackager::new(capacity);
     for (weight, req) in item_vec {
         packager.insert_item(weight, req);
@@ -149,7 +149,7 @@ mod tests {
     }
 
     /// We want to use as few bags as possible for packaging the given
-    /// input "items". If OPL reperesents the optimal number of bags, then
+    /// input "items". If OPL represents the optimal number of bags, then
     /// this algorithm packages into N bags N <= (11 / 9) * OPL + 1
     #[test_case(&[5, 7, 5, 2, 4, 2, 5, 1, 6], 10, 4; "uci example")]
     #[test_case(&[6, 1, 0, 3, 0, 4, 4, 0, 0, 2], 10, 2; "made-up example")]

--- a/signer/src/bitcoin/utxo.rs
+++ b/signer/src/bitcoin/utxo.rs
@@ -933,14 +933,13 @@ mod tests {
     // `scriptPubKey`s must match.
     #[test]
     fn p256k1_point_and_secp256k1_pubkey_same_script() {
-        let public_key = generate_x_only_public_key();
-
-        let element = p256k1::field::Element::from(public_key.serialize());
-        let point = p256k1::point::Point::lift_x(&element).unwrap();
+        let x_part = generate_x_only_public_key();
+        let pk = secp256k1::PublicKey::from_x_only_public_key(x_part, secp256k1::Parity::Even);
+        let public_key = crate::keys::PublicKey::from(pk);
 
         assert_eq!(
             public_key.signers_script_pubkey(),
-            point.signers_script_pubkey()
+            x_part.signers_script_pubkey()
         );
     }
 

--- a/signer/src/bitcoin/utxo.rs
+++ b/signer/src/bitcoin/utxo.rs
@@ -32,7 +32,7 @@ use secp256k1::XOnlyPublicKey;
 use crate::bitcoin::packaging::compute_optimal_packages;
 use crate::bitcoin::packaging::Weighted;
 use crate::error::Error;
-use crate::keys::SignerScriptPubkey as _;
+use crate::keys::SignerScriptPubKey as _;
 use crate::storage::model;
 
 /// The minimum incremental fee rate in sats per virtual byte for RBF
@@ -926,21 +926,6 @@ mod tests {
             amount,
             address: generate_address(),
         }
-    }
-
-    // If we have a XOnlyPublicKey and a p256k1::point::Point that
-    // represent the same point on the curve, then the associated signer
-    // `scriptPubKey`s must match.
-    #[test]
-    fn p256k1_point_and_secp256k1_pubkey_same_script() {
-        let x_part = generate_x_only_public_key();
-        let pk = secp256k1::PublicKey::from_x_only_public_key(x_part, secp256k1::Parity::Even);
-        let public_key = crate::keys::PublicKey::from(pk);
-
-        assert_eq!(
-            public_key.signers_script_pubkey(),
-            x_part.signers_script_pubkey()
-        );
     }
 
     #[ignore = "For generating the SOLO_(DEPOSIT|WITHDRAWAL)_SIZE constants"]

--- a/signer/src/bitcoin/utxo.rs
+++ b/signer/src/bitcoin/utxo.rs
@@ -32,6 +32,7 @@ use secp256k1::XOnlyPublicKey;
 use crate::bitcoin::packaging::compute_optimal_packages;
 use crate::bitcoin::packaging::Weighted;
 use crate::error::Error;
+use crate::keys::SignerScriptPubkey as _;
 use crate::storage::model;
 
 /// The minimum incremental fee rate in sats per virtual byte for RBF
@@ -61,34 +62,6 @@ const SATS_PER_VBYTE_INCREMENT: f64 = 0.001;
 /// The OP_RETURN operation byte for deposit or withdrawal sweeps. This is
 /// the UTF8 encoded string "B".
 const OP_RETURN_OP: u8 = b'B';
-
-/// This trait is used to provide a unifying interface for converting
-/// different public key types to the `scriptPubkey` associated with the
-/// signers. We represent the `scriptPubkey` using rust-bitcoin's ScriptBuf
-/// type.
-pub trait SignerScriptPubkey {
-    /// Convert this type to the `scriptPubkey` used by the signers to lock
-    /// their UTXO.
-    fn signers_script_pubkey(&self) -> ScriptBuf;
-}
-
-impl SignerScriptPubkey for XOnlyPublicKey {
-    fn signers_script_pubkey(&self) -> ScriptBuf {
-        ScriptBuf::new_p2tr(SECP256K1, *self, None)
-    }
-}
-
-impl SignerScriptPubkey for p256k1::point::Point {
-    fn signers_script_pubkey(&self) -> ScriptBuf {
-        // The type is a thin wrapper of a libsecp256k1 type. The
-        // underlying type represents a group element of the secp256k1
-        // curve, in Jacobian coordinates. So this should always be on the
-        // curve.
-        XOnlyPublicKey::from_slice(&self.x().to_bytes())
-            .expect("BUG: p256k1::point::Points should lie on the curve!")
-            .signers_script_pubkey()
-    }
-}
 
 /// Describes the fees for a transaction.
 #[derive(Debug, Clone, Copy)]
@@ -376,8 +349,6 @@ impl DepositRequest {
             .try_into()
             .map_err(|_| Error::TypeConversion)?;
 
-        let outpoint = OutPoint { txid, vout };
-
         let max_fee = request
             .max_fee
             .try_into()
@@ -390,17 +361,13 @@ impl DepositRequest {
             .try_into()
             .map_err(|_| Error::TypeConversion)?;
 
-        let deposit_script = ScriptBuf::from_bytes(request.spend_script);
-
-        let reclaim_script = ScriptBuf::from_bytes(request.reclaim_script);
-
         Ok(Self {
-            outpoint,
+            outpoint: OutPoint { txid, vout },
             max_fee,
             signer_bitmap,
             amount,
-            deposit_script,
-            reclaim_script,
+            deposit_script: ScriptBuf::from_bytes(request.spend_script),
+            reclaim_script: ScriptBuf::from_bytes(request.reclaim_script),
             signers_public_key,
         })
     }

--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -301,6 +301,7 @@ mod tests {
 
     use crate::error::Error;
     use crate::keys::PublicKey;
+    use crate::keys::SignerScriptPubKey as _;
     use crate::stacks::api::AccountInfo;
     use crate::stacks::api::FeePriority;
     use crate::stacks::api::SubmitTxResponse;
@@ -552,9 +553,10 @@ mod tests {
 
         // We start by storing our `scriptPubKey`.
         let storage = storage::in_memory::Store::new_shared();
+        let aggregate_key = PublicKey::dummy_with_rng(&fake::Faker, &mut rng);
         let shares = model::EncryptedDkgShares {
-            aggregate_key: PublicKey::dummy_with_rng(&fake::Faker, &mut rng),
-            tweaked_aggregate_key: [0; 32],
+            aggregate_key,
+            tweaked_aggregate_key: aggregate_key.signers_tweaked_pubkey().unwrap(),
             script_pubkey: signers_script_pubkey.clone(),
             created_at: time::OffsetDateTime::now_utc(),
             encrypted_private_shares: Vec::new(),

--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -294,11 +294,13 @@ mod tests {
     use blockstack_lib::net::api::gettenureinfo::RPCGetTenureInfo;
     use blockstack_lib::types::chainstate::StacksAddress;
     use blockstack_lib::types::chainstate::StacksBlockId;
+    use fake::Dummy;
     use rand::seq::IteratorRandom;
     use rand::SeedableRng;
     use sbtc::rpc::BitcoinClient;
 
     use crate::error::Error;
+    use crate::keys::PublicKey;
     use crate::stacks::api::AccountInfo;
     use crate::stacks::api::FeePriority;
     use crate::stacks::api::SubmitTxResponse;
@@ -551,8 +553,8 @@ mod tests {
         // We start by storing our `scriptPubKey`.
         let storage = storage::in_memory::Store::new_shared();
         let shares = model::EncryptedDkgShares {
-            aggregate_key: Vec::new(),
-            tweaked_aggregate_key: Vec::new(),
+            aggregate_key: PublicKey::dummy_with_rng(&fake::Faker, &mut rng),
+            tweaked_aggregate_key: [0; 32],
             script_pubkey: signers_script_pubkey.clone(),
             created_at: time::OffsetDateTime::now_utc(),
             encrypted_private_shares: Vec::new(),

--- a/signer/src/ecdsa.rs
+++ b/signer/src/ecdsa.rs
@@ -40,9 +40,8 @@
 //! // Verify the signed message.
 //! assert!(signed_msg.verify());
 
-use p256k1::ecdsa;
-use p256k1::scalar::Scalar;
-
+use crate::keys::PrivateKey;
+use crate::keys::PublicKey;
 use sha2::Digest;
 
 /// Wraps an inner type with a public key and a signature,
@@ -52,7 +51,7 @@ pub struct Signed<T> {
     /// The signed structure.
     pub inner: T,
     /// The public key of the signer.
-    pub signer_pub_key: ecdsa::PublicKey,
+    pub signer_pub_key: PublicKey,
     /// A signature over the hash of the inner structure.
     pub signature: Vec<u8>,
 }
@@ -60,7 +59,8 @@ pub struct Signed<T> {
 impl<T: wsts::net::Signable> Signed<T> {
     /// Verify the signature over the inner data.
     pub fn verify(&self) -> bool {
-        self.inner.verify(&self.signature, &self.signer_pub_key)
+        self.inner
+            .verify(&self.signature, &self.signer_pub_key.into())
     }
 
     /// Unique identifier for the signed message
@@ -91,18 +91,17 @@ impl<T> std::ops::DerefMut for Signed<T> {
 /// Helper trait to provide the ability to construct a `Signed<T>`.
 pub trait SignEcdsa: Sized {
     /// Wrap this type into a [`Signed<Self>`]
-    fn sign_ecdsa(self, private_key: &Scalar) -> Result<Signed<Self>, Error>;
+    fn sign_ecdsa(self, private_key: &PrivateKey) -> Result<Signed<Self>, Error>;
 }
 
 impl<T: wsts::net::Signable> SignEcdsa for T {
     /// Create a `Signed<T>` instance with a signature and public key constructed from `private_key`.
-    fn sign_ecdsa(self, private_key: &Scalar) -> Result<Signed<Self>, Error> {
-        let signer_pub_key = ecdsa::PublicKey::new(private_key)?;
-        let signature = self.sign(private_key)?;
+    fn sign_ecdsa(self, private_key: &PrivateKey) -> Result<Signed<Self>, Error> {
+        let signature = self.sign(&private_key.into())?;
 
         Ok(Signed {
             inner: self,
-            signer_pub_key,
+            signer_pub_key: PublicKey::from_private_key(private_key),
             signature,
         })
     }
@@ -116,25 +115,25 @@ pub enum Error {
     KeyError(#[from] p256k1::keys::Error),
     /// Sign error
     #[error("SignError")]
-    SignError(#[from] ecdsa::Error),
+    SignError(#[from] p256k1::ecdsa::Error),
 }
 
 #[cfg(feature = "testing")]
 impl Signed<crate::message::SignerMessage> {
     /// Generate a random signed message
     pub fn random<R: rand::CryptoRng + rand::Rng>(rng: &mut R) -> Self {
-        let private_key = Scalar::random(rng);
+        let private_key = PrivateKey::new(rng);
         Self::random_with_private_key(rng, &private_key)
     }
 
     /// Generate a random signed message with the given private key
     pub fn random_with_private_key<R: rand::CryptoRng + rand::Rng>(
         rng: &mut R,
-        private_key: &Scalar,
+        private_key: &PrivateKey,
     ) -> Self {
         let inner = crate::message::SignerMessage::random(rng);
         inner
-            .sign_ecdsa(private_key)
+            .sign_ecdsa(&private_key)
             .expect("Failed to sign message")
     }
 }
@@ -142,13 +141,14 @@ impl Signed<crate::message::SignerMessage> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use p256k1::scalar::Scalar;
 
     use sha2::Digest;
 
     #[test]
     fn verify_should_return_true_given_properly_signed_data() {
         let msg = SignableStr("I'm Batman");
-        let bruce_wayne_private_key = Scalar::from(1337);
+        let bruce_wayne_private_key = PrivateKey::try_from(&Scalar::from(1337)).unwrap();
 
         let signed_msg = msg
             .sign_ecdsa(&bruce_wayne_private_key)
@@ -161,7 +161,7 @@ mod tests {
     #[test]
     fn verify_should_return_false_given_tampered_data() {
         let msg = SignableStr("I'm Batman");
-        let bruce_wayne_private_key = Scalar::from(1337);
+        let bruce_wayne_private_key = PrivateKey::try_from(&Scalar::from(1337)).unwrap();
 
         let mut signed_msg = msg
             .sign_ecdsa(&bruce_wayne_private_key)
@@ -176,14 +176,14 @@ mod tests {
     #[test]
     fn verify_should_return_false_given_the_wrong_public_key() {
         let msg = SignableStr("I'm Batman");
-        let bruce_wayne_private_key = Scalar::from(1337);
-        let craig_wright_public_key = ecdsa::PublicKey::new(&Scalar::from(1338)).unwrap();
+        let bruce_wayne_private_key = PrivateKey::try_from(&Scalar::from(1337)).unwrap();
+        let craig_wright_public_key = p256k1::ecdsa::PublicKey::new(&Scalar::from(1338)).unwrap();
 
         let mut signed_msg = msg
             .sign_ecdsa(&bruce_wayne_private_key)
             .expect("Failed to sign message");
 
-        signed_msg.signer_pub_key = craig_wright_public_key;
+        signed_msg.signer_pub_key = craig_wright_public_key.into();
 
         // Craig Wright is not Batman.
         assert!(!signed_msg.verify());
@@ -192,7 +192,7 @@ mod tests {
     #[test]
     fn signed_should_deref_to_the_underlying_type() {
         let msg = SignableStr("I'm Batman");
-        let bruce_wayne_private_key = Scalar::from(1337);
+        let bruce_wayne_private_key = PrivateKey::try_from(&Scalar::from(1337)).unwrap();
 
         let signed_msg = msg
             .sign_ecdsa(&bruce_wayne_private_key)

--- a/signer/src/ecdsa.rs
+++ b/signer/src/ecdsa.rs
@@ -19,6 +19,7 @@
 //! ```
 //! use sha2::Digest;
 //! use signer::ecdsa::SignEcdsa;
+//! use signer::keys::PrivateKey;
 //!
 //! struct SignableStr(&'static str);
 //!
@@ -30,7 +31,7 @@
 //! }
 //!
 //! let msg = SignableStr("Sign me please!");
-//! let private_key = p256k1::scalar::Scalar::from(1337);
+//! let private_key = PrivateKey::try_from(&p256k1::scalar::Scalar::from(1337)).unwrap();
 //!
 //! // Sign the message.
 //! let signed_msg = msg
@@ -42,7 +43,7 @@
 
 use crate::keys::PrivateKey;
 use crate::keys::PublicKey;
-use sha2::Digest;
+use sha2::Digest as _;
 
 /// Wraps an inner type with a public key and a signature,
 /// allowing easy verification of the integrity of the inner data.
@@ -133,7 +134,7 @@ impl Signed<crate::message::SignerMessage> {
     ) -> Self {
         let inner = crate::message::SignerMessage::random(rng);
         inner
-            .sign_ecdsa(&private_key)
+            .sign_ecdsa(private_key)
             .expect("Failed to sign message")
     }
 }

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -210,7 +210,7 @@ pub enum Error {
     /// Thrown when the recoverable signature has a public key that is
     /// unexpected.
     #[error("unexpected public key from signature. key {0}; digest: {1}")]
-    UnknownPublicKey(secp256k1::PublicKey, secp256k1::Message),
+    UnknownPublicKey(crate::keys::PublicKey, secp256k1::Message),
 
     /// WSTS error.
     #[error("WSTS error: {0}")]

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -9,7 +9,7 @@ use crate::{codec, ecdsa, network};
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     /// Error when breaking out the ZeroMQ message into three parts.
-    #[error("bitcoin messages should have a three part layout, receieved {0} parts")]
+    #[error("bitcoin messages should have a three part layout, received {0} parts")]
     BitcoinCoreZmqMessageLayout(usize),
 
     /// Happens when the bitcoin block hash in the ZeroMQ message is not 32
@@ -76,6 +76,16 @@ pub enum Error {
     /// type, which is a thin wrapper around the secp256k1::PublicKey.
     #[error("{0}")]
     InvalidPublicKey(#[source] secp256k1::Error),
+
+    /// This happens when we tweak our public key by a scalar, and the
+    /// result is an invalid public key. I think It is very unlikely that
+    /// we will see this one by chance, since the probability that this
+    /// happens is something like: 1 / (2^256 - 2^32^ - 977), where the
+    /// denominator is the order of the secp256k1 curve. This is because
+    /// for a given public key, the there is only one tweak that will lead
+    /// to an invalid public key.
+    #[error("invalid tweak? seriously? {0}")]
+    InvalidPublicKeyTweak(#[source] secp256k1::Error),
 
     /// This occurs when converting a byte slice to our internal public key
     /// type, which is a thin wrapper around the secp256k1::SecretKey.

--- a/signer/src/keys.rs
+++ b/signer/src/keys.rs
@@ -202,11 +202,23 @@ impl<'r> sqlx::Decode<'r, sqlx::Postgres> for PublicKey {
     }
 }
 
+impl<'r> sqlx::Type<sqlx::Postgres> for PublicKey {
+    fn type_info() -> sqlx::postgres::PgTypeInfo {
+        <Vec<u8> as sqlx::Type<sqlx::Postgres>>::type_info()
+    }
+}
+
 /// We write the compressed public key bytes to the database
 impl<'r> sqlx::Encode<'r, sqlx::Postgres> for PublicKey {
     fn encode_by_ref(&self, buf: &mut sqlx::postgres::PgArgumentBuffer) -> sqlx::encode::IsNull {
         let bytes = self.serialize();
         <[u8; 33] as sqlx::Encode<'r, sqlx::Postgres>>::encode_by_ref(&bytes, buf)
+    }
+}
+#[cfg(feature = "testing")]
+impl fake::Dummy<fake::Faker> for PublicKey {
+    fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &fake::Faker, rng: &mut R) -> Self {
+        Self(secp256k1::PublicKey::from_secret_key_global(&secp256k1::SecretKey::new(rng)))
     }
 }
 

--- a/signer/src/message.rs
+++ b/signer/src/message.rs
@@ -3,6 +3,8 @@
 use blockstack_lib::chainstate::stacks;
 use sha2::Digest;
 
+use crate::keys::PublicKey;
+
 /// Messages exchanged between signers
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct SignerMessage {
@@ -128,7 +130,7 @@ pub struct BitcoinTransactionSignRequest {
     /// The transaction.
     pub tx: bitcoin::Transaction,
     /// The aggregate key used to sign the transaction,
-    pub aggregate_key: p256k1::point::Point,
+    pub aggregate_key: PublicKey,
 }
 
 /// Represents an acknowledgment of a signed Bitcoin transaction.
@@ -233,9 +235,9 @@ mod tests {
     use super::*;
     use crate::codec::{Decode, Encode};
     use crate::ecdsa::{SignEcdsa, Signed};
+    use crate::keys::PrivateKey;
 
-    use p256k1::scalar::Scalar;
-    use rand::{RngCore, SeedableRng};
+    use rand::SeedableRng;
 
     #[test]
     fn signer_messages_should_be_signable() {
@@ -264,7 +266,7 @@ mod tests {
         P: fake::Dummy<fake::Faker> + Into<Payload>,
     {
         let rng = &mut rand::rngs::StdRng::seed_from_u64(1337);
-        let private_key = Scalar::from(rng.next_u32());
+        let private_key = PrivateKey::new(rng);
 
         let signed_message = SignerMessage::random_with_payload_type::<P, _>(rng)
             .sign_ecdsa(&private_key)
@@ -278,7 +280,7 @@ mod tests {
         P: fake::Dummy<fake::Faker> + Into<Payload>,
     {
         let rng = &mut rand::rngs::StdRng::seed_from_u64(42);
-        let private_key = Scalar::from(rng.next_u32());
+        let private_key = PrivateKey::new(rng);
 
         let signed_message = SignerMessage::random_with_payload_type::<P, _>(rng)
             .sign_ecdsa(&private_key)

--- a/signer/src/stacks/contracts.rs
+++ b/signer/src/stacks/contracts.rs
@@ -37,8 +37,8 @@ use blockstack_lib::clarity::vm::ClarityName;
 use blockstack_lib::clarity::vm::ContractName;
 use blockstack_lib::clarity::vm::Value;
 use blockstack_lib::types::chainstate::StacksAddress;
-use secp256k1::PublicKey;
 
+use crate::keys::PublicKey;
 use crate::stacks::wallet::SignerWallet;
 
 /// A struct describing any transaction post-execution conditions that we'd
@@ -310,7 +310,7 @@ impl RotateKeysV1 {
     pub fn new(wallet: &SignerWallet, deployer: StacksAddress) -> Self {
         Self {
             aggregate_key: wallet.aggregate_key(),
-            new_keys: wallet.public_keys().iter().copied().collect(),
+            new_keys: wallet.public_keys().clone(),
             deployer,
         }
     }
@@ -442,7 +442,7 @@ mod tests {
             SecretKey::new(&mut rng),
             SecretKey::new(&mut rng),
         ];
-        let public_keys = secret_keys.map(|sk| sk.public_key(SECP256K1));
+        let public_keys = secret_keys.map(|sk| sk.public_key(SECP256K1).into());
         let wallet = SignerWallet::new(&public_keys, 2, NetworkKind::Testnet, 0).unwrap();
         let deployer = StacksAddress::burn_address(false);
 

--- a/signer/src/stacks/wallet.rs
+++ b/signer/src/stacks/wallet.rs
@@ -303,14 +303,7 @@ impl MultisigTx {
                     let signature = from_secp256k1_recoverable(&sig);
                     cond.push_signature(key_encoding, signature);
                 }
-                None => {
-                    let compressed_data = public_key.serialize();
-                    let public_key = Secp256k1PublicKey::from_slice(&compressed_data)
-                        .expect("we know this is a valid public key");
-
-                    debug_assert!(public_key.compressed());
-                    cond.push_public_key(public_key);
-                }
+                None => cond.push_public_key(Secp256k1PublicKey::from(&public_key)),
             });
 
         self.tx

--- a/signer/src/storage/in_memory.rs
+++ b/signer/src/storage/in_memory.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
+use crate::keys::PublicKey;
 use crate::storage::model;
 
 /// A store wrapped in an Arc<Mutex<...>> for interior mutability
@@ -34,7 +35,7 @@ pub struct Store {
     pub deposit_request_to_signers: HashMap<DepositRequestPk, Vec<model::DepositSigner>>,
 
     /// Deposit signer to request
-    pub signer_to_deposit_request: HashMap<model::PubKey, Vec<DepositRequestPk>>,
+    pub signer_to_deposit_request: HashMap<PublicKey, Vec<DepositRequestPk>>,
 
     /// Withdraw signers
     pub withdraw_request_to_signers: HashMap<WithdrawRequestPk, Vec<model::WithdrawSigner>>,
@@ -58,7 +59,7 @@ pub struct Store {
     pub stacks_nakamoto_blocks: HashMap<model::StacksBlockHash, model::StacksBlock>,
 
     /// Encrypted DKG shares
-    pub encrypted_dkg_shares: HashMap<model::PubKey, model::EncryptedDkgShares>,
+    pub encrypted_dkg_shares: HashMap<PublicKey, model::EncryptedDkgShares>,
 
     /// Rotate keys transactions
     pub rotate_keys_transactions: HashMap<model::StacksTxId, model::RotateKeysTransaction>,
@@ -184,7 +185,7 @@ impl super::DbRead for SharedStore {
 
     async fn get_accepted_deposit_requests(
         &self,
-        signer: &model::PubKey,
+        signer: &PublicKey,
     ) -> Result<Vec<model::DepositRequest>, Self::Error> {
         let store = self.lock().await;
 
@@ -343,7 +344,7 @@ impl super::DbRead for SharedStore {
 
     async fn get_encrypted_dkg_shares(
         &self,
-        aggregate_key: &model::PubKey,
+        aggregate_key: &PublicKey,
     ) -> Result<Option<model::EncryptedDkgShares>, Self::Error> {
         Ok(self
             .lock()
@@ -489,7 +490,7 @@ impl super::DbWrite for SharedStore {
 
         store
             .signer_to_deposit_request
-            .entry(decision.signer_pub_key.clone())
+            .entry(decision.signer_pub_key)
             .or_default()
             .push(deposit_request_pk);
 
@@ -596,7 +597,7 @@ impl super::DbWrite for SharedStore {
         self.lock()
             .await
             .encrypted_dkg_shares
-            .insert(shares.aggregate_key.clone(), shares.clone());
+            .insert(shares.aggregate_key, shares.clone());
 
         Ok(())
     }

--- a/signer/src/storage/mod.rs
+++ b/signer/src/storage/mod.rs
@@ -14,6 +14,8 @@ use std::future::Future;
 
 use blockstack_lib::types::chainstate::StacksBlockId;
 
+use crate::keys::PublicKey;
+
 /// Represents the ability to read data from the signer storage.
 pub trait DbRead {
     /// Read error.
@@ -61,7 +63,7 @@ pub trait DbRead {
     /// Get the deposit requests that the signer has accepted to sign
     fn get_accepted_deposit_requests(
         &self,
-        signer: &model::PubKey,
+        signer: &PublicKey,
     ) -> impl Future<Output = Result<Vec<model::DepositRequest>, Self::Error>> + Send;
 
     /// Get signer decisions for a deposit request
@@ -109,7 +111,7 @@ pub trait DbRead {
     /// given aggregate key
     fn get_encrypted_dkg_shares(
         &self,
-        aggregate_key: &model::PubKey,
+        aggregate_key: &PublicKey,
     ) -> impl Future<Output = Result<Option<model::EncryptedDkgShares>, Self::Error>> + Send;
 
     /// Return the latest rotate-keys transaction confirmed by the given `chain-tip`.

--- a/signer/src/storage/model.rs
+++ b/signer/src/storage/model.rs
@@ -254,7 +254,7 @@ pub struct EncryptedDkgShares {
     /// The aggregate key for these shares
     pub aggregate_key: PublicKey,
     /// The tweaked aggregate key for these shares
-    pub tweaked_aggregate_key: PubKey,
+    pub tweaked_aggregate_key: [u8; 32],
     /// The `scriptPubKey` for the aggregate public key.
     pub script_pubkey: Bytes,
     /// The encrypted DKG shares
@@ -275,7 +275,7 @@ pub struct RotateKeysTransaction {
     /// The aggregate key for these shares.
     pub aggregate_key: PublicKey,
     /// The public keys of the signers.
-    pub signer_set: Vec<Bytes>,
+    pub signer_set: Vec<PublicKey>,
 }
 
 /// The types of transactions the signer is interested in.

--- a/signer/src/storage/model.rs
+++ b/signer/src/storage/model.rs
@@ -254,7 +254,7 @@ pub struct EncryptedDkgShares {
     /// The aggregate key for these shares
     pub aggregate_key: PublicKey,
     /// The tweaked aggregate key for these shares
-    pub tweaked_aggregate_key: [u8; 32],
+    pub tweaked_aggregate_key: PublicKey,
     /// The `scriptPubKey` for the aggregate public key.
     pub script_pubkey: Bytes,
     /// The encrypted DKG shares

--- a/signer/src/storage/model.rs
+++ b/signer/src/storage/model.rs
@@ -8,6 +8,8 @@ use bitcoin::Network;
 use rand::seq::IteratorRandom as _;
 use sbtc::deposits::Deposit;
 
+use crate::keys::PublicKey;
+
 #[cfg(feature = "testing")]
 use fake::faker::time::en::DateTimeAfter;
 
@@ -134,7 +136,7 @@ impl DepositRequest {
 }
 
 /// A signer acknowledging a deposit request.
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, sqlx::FromRow)]
 #[cfg_attr(feature = "testing", derive(fake::Dummy))]
 pub struct DepositSigner {
     /// TxID of the deposit request.
@@ -144,8 +146,7 @@ pub struct DepositSigner {
     #[cfg_attr(feature = "testing", dummy(faker = "0..100"))]
     pub output_index: i32,
     /// Public key of the signer.
-    #[cfg_attr(feature = "testing", dummy(expr = "fake::vec![u8; 32]"))]
-    pub signer_pub_key: PubKey,
+    pub signer_pub_key: PublicKey,
     /// Signals if the signer is prepared to sign for this request.
     pub is_accepted: bool,
     /// The time this block entry was created by the signer.
@@ -183,7 +184,7 @@ pub struct WithdrawRequest {
 }
 
 /// A signer acknowledging a withdrawal request.
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, sqlx::FromRow)]
 #[cfg_attr(feature = "testing", derive(fake::Dummy))]
 pub struct WithdrawSigner {
     /// Request ID of the withdrawal request.
@@ -192,8 +193,7 @@ pub struct WithdrawSigner {
     #[cfg_attr(feature = "testing", dummy(expr = "fake::vec![u8; 32]"))]
     pub block_hash: StacksBlockHash,
     /// Public key of the signer.
-    #[cfg_attr(feature = "testing", dummy(expr = "fake::vec![u8; 32]"))]
-    pub signer_pub_key: PubKey,
+    pub signer_pub_key: PublicKey,
     /// Signals if the signer is prepared to sign for this request.
     pub is_accepted: bool,
     /// The time this block entry was created by the signer.
@@ -252,7 +252,7 @@ pub struct Transaction {
 #[cfg_attr(feature = "testing", derive(fake::Dummy))]
 pub struct EncryptedDkgShares {
     /// The aggregate key for these shares
-    pub aggregate_key: PubKey,
+    pub aggregate_key: PublicKey,
     /// The tweaked aggregate key for these shares
     pub tweaked_aggregate_key: PubKey,
     /// The `scriptPubKey` for the aggregate public key.
@@ -273,7 +273,7 @@ pub struct RotateKeysTransaction {
     #[cfg_attr(feature = "testing", dummy(expr = "fake::vec![u8; 32]"))]
     pub txid: Bytes,
     /// The aggregate key for these shares.
-    pub aggregate_key: PubKey,
+    pub aggregate_key: PublicKey,
     /// The public keys of the signers.
     pub signer_set: Vec<Bytes>,
 }

--- a/signer/src/testing/dummy.rs
+++ b/signer/src/testing/dummy.rs
@@ -8,6 +8,7 @@ use fake::faker::time::en::DateTimeAfter;
 use fake::Fake;
 use rand::Rng;
 
+use crate::keys::PublicKey;
 use crate::keys::SignerScriptPubkey as _;
 use crate::storage::model;
 
@@ -166,10 +167,8 @@ pub fn encrypted_dkg_shares<R: rand::RngCore + rand::CryptoRng>(
     _config: &fake::Faker,
     rng: &mut R,
     signer_private_key: &[u8; 32],
-    group_key: p256k1::point::Point,
+    group_key: PublicKey,
 ) -> model::EncryptedDkgShares {
-    let aggregate_key = group_key.x().to_bytes().to_vec();
-    let tweaked_aggregate_key = wsts::compute::tweaked_public_key(&group_key, None);
     let party_state = wsts::traits::PartyState {
         polynomial: None,
         private_keys: vec![],
@@ -182,7 +181,7 @@ pub fn encrypted_dkg_shares<R: rand::RngCore + rand::CryptoRng>(
         num_keys: 1,
         num_parties: 1,
         threshold: 1,
-        group_key,
+        group_key: group_key.into(),
         parties: vec![(0, party_state)],
     };
 
@@ -200,11 +199,11 @@ pub fn encrypted_dkg_shares<R: rand::RngCore + rand::CryptoRng>(
     let created_at = DateTimeAfter(time::OffsetDateTime::UNIX_EPOCH).fake_with_rng(rng);
 
     model::EncryptedDkgShares {
-        aggregate_key,
+        aggregate_key: group_key,
         encrypted_private_shares,
         public_shares,
-        tweaked_aggregate_key: tweaked_aggregate_key.x().to_bytes().to_vec(),
-        script_pubkey: tweaked_aggregate_key.signers_script_pubkey().into_bytes(),
+        tweaked_aggregate_key: group_key.tweaked_public_key().serialize(),
+        script_pubkey: group_key.signers_script_pubkey().into_bytes(),
         created_at,
     }
 }

--- a/signer/src/testing/dummy.rs
+++ b/signer/src/testing/dummy.rs
@@ -9,7 +9,7 @@ use fake::Fake;
 use rand::Rng;
 
 use crate::keys::PublicKey;
-use crate::keys::SignerScriptPubkey as _;
+use crate::keys::SignerScriptPubKey as _;
 use crate::storage::model;
 
 use crate::codec::Encode;
@@ -202,7 +202,7 @@ pub fn encrypted_dkg_shares<R: rand::RngCore + rand::CryptoRng>(
         aggregate_key: group_key,
         encrypted_private_shares,
         public_shares,
-        tweaked_aggregate_key: group_key.tweaked_public_key().serialize(),
+        tweaked_aggregate_key: group_key.signers_tweaked_pubkey().unwrap(),
         script_pubkey: group_key.signers_script_pubkey().into_bytes(),
         created_at,
     }

--- a/signer/src/testing/dummy.rs
+++ b/signer/src/testing/dummy.rs
@@ -8,7 +8,7 @@ use fake::faker::time::en::DateTimeAfter;
 use fake::Fake;
 use rand::Rng;
 
-use crate::bitcoin::utxo::SignerScriptPubkey as _;
+use crate::keys::SignerScriptPubkey as _;
 use crate::storage::model;
 
 use crate::codec::Encode;

--- a/signer/src/testing/message.rs
+++ b/signer/src/testing/message.rs
@@ -4,6 +4,7 @@ use bitcoin::hashes::Hash;
 use fake::Fake;
 use rand::seq::SliceRandom;
 
+use crate::keys::{PrivateKey, PublicKey};
 use crate::message;
 use crate::testing::dummy;
 
@@ -71,12 +72,11 @@ impl fake::Dummy<fake::Faker> for message::BitcoinTransactionSignRequest {
     fn dummy_with_rng<R: rand::RngCore + ?Sized>(config: &fake::Faker, rng: &mut R) -> Self {
         let mut bytes: [u8; 32] = [0; 32];
         rng.fill_bytes(&mut bytes);
-        let scalar = p256k1::scalar::Scalar::from(bytes);
-        let aggregate_key = p256k1::point::Point::from(&scalar);
+        let private_key = PrivateKey::new(rng);
 
         Self {
             tx: dummy::tx(config, rng),
-            aggregate_key,
+            aggregate_key: PublicKey::from_private_key(&private_key),
         }
     }
 }

--- a/signer/src/testing/transaction_signer.rs
+++ b/signer/src/testing/transaction_signer.rs
@@ -465,7 +465,7 @@ where
                     self.context_window,
                     signer_info.signer_private_key,
                     self.signing_threshold,
-                    rand::rngs::OsRng,
+                    rng.clone(),
                 );
 
                 event_loop_harness.start()

--- a/signer/src/testing/wallet.rs
+++ b/signer/src/testing/wallet.rs
@@ -24,7 +24,7 @@ pub fn generate_wallet() -> (SignerWallet, [Keypair; 3]) {
         Keypair::new_global(&mut rng),
     ];
 
-    let public_keys = key_pairs.map(|kp| kp.public_key());
+    let public_keys = key_pairs.map(|kp| kp.public_key().into());
     let wallet = SignerWallet::new(&public_keys, 2, NetworkKind::Testnet, 0).unwrap();
 
     (wallet, key_pairs)

--- a/signer/src/wsts_state_machine.rs
+++ b/signer/src/wsts_state_machine.rs
@@ -6,6 +6,8 @@ use crate::codec::Decode as _;
 use crate::codec::Encode as _;
 use crate::error;
 use crate::error::Error;
+use crate::keys::PrivateKey;
+use crate::keys::PublicKey;
 use crate::keys::SignerScriptPubkey;
 use crate::storage;
 use crate::storage::model;
@@ -24,20 +26,16 @@ type WstsStateMachine = wsts::state_machine::signer::Signer<wsts::v2::Party>;
 impl SignerStateMachine {
     /// Create a new state machine
     pub fn new(
-        signers: impl IntoIterator<Item = p256k1::ecdsa::PublicKey>,
+        signers: impl IntoIterator<Item = PublicKey>,
         threshold: u32,
-        signer_private_key: p256k1::scalar::Scalar,
+        signer_private_key: PrivateKey,
     ) -> Result<Self, error::Error> {
-        let signer_pub_key = p256k1::ecdsa::PublicKey::new(&signer_private_key)?;
+        let signer_pub_key = PublicKey::from_private_key(&signer_private_key);
         let signers: hashbrown::HashMap<u32, _> = signers
             .into_iter()
             .enumerate()
-            .map(|(id, key)| {
-                id.try_into()
-                    .map(|id| (id, key))
-                    .map_err(|_| error::Error::TypeConversion)
-            })
-            .collect::<Result<_, _>>()?;
+            .map(|(id, key)| (id as u32, p256k1::keys::PublicKey::from(&key)))
+            .collect();
 
         let key_ids = signers
             .clone()
@@ -51,9 +49,10 @@ impl SignerStateMachine {
             .map_err(|_| error::Error::TypeConversion)?;
         let num_keys = num_parties;
 
+        let p256k1_public_key = p256k1::keys::PublicKey::from(&signer_pub_key);
         let id: u32 = *signers
             .iter()
-            .find(|(_, key)| *key == &signer_pub_key)
+            .find(|(_, key)| *key == &p256k1_public_key)
             .ok_or_else(|| error::Error::MissingPublicKey)?
             .0;
 
@@ -71,7 +70,7 @@ impl SignerStateMachine {
             num_keys,
             id,
             key_ids,
-            signer_private_key,
+            signer_private_key.into(),
             public_keys,
         );
 
@@ -81,10 +80,10 @@ impl SignerStateMachine {
     /// Create a state machine from loaded DKG shares for the given aggregate key
     pub async fn load<S>(
         storage: &mut S,
-        aggregate_key: p256k1::point::Point,
-        signers: impl IntoIterator<Item = p256k1::ecdsa::PublicKey>,
+        aggregate_key: PublicKey,
+        signers: impl IntoIterator<Item = PublicKey>,
         threshold: u32,
-        signer_private_key: p256k1::scalar::Scalar,
+        signer_private_key: PrivateKey,
     ) -> Result<Self, error::Error>
     where
         S: storage::DbRead + storage::DbWrite,
@@ -92,7 +91,7 @@ impl SignerStateMachine {
         error::Error: From<<S as storage::DbWrite>::Error>,
     {
         let encrypted_shares = storage
-            .get_encrypted_dkg_shares(&aggregate_key.x().to_bytes().to_vec())
+            .get_encrypted_dkg_shares(&aggregate_key)
             .await?
             .ok_or(error::Error::MissingDkgShares)?;
 
@@ -123,8 +122,8 @@ impl SignerStateMachine {
         rng: &mut Rng,
     ) -> Result<model::EncryptedDkgShares, error::Error> {
         let saved_state = self.signer.save();
-        let aggregate_key = saved_state.group_key.x().to_bytes().to_vec();
-        let tweaked_aggregate_key = wsts::compute::tweaked_public_key(&saved_state.group_key, None);
+        let aggregate_key = PublicKey::try_from(&saved_state.group_key)?;
+        let tweaked_aggregate_key = aggregate_key.tweaked_public_key();
 
         let encoded = saved_state.encode_to_vec().map_err(error::Error::Codec)?;
         let public_shares = self
@@ -139,9 +138,9 @@ impl SignerStateMachine {
         let created_at = time::OffsetDateTime::now_utc();
 
         Ok(model::EncryptedDkgShares {
-            aggregate_key: aggregate_key.clone(),
-            tweaked_aggregate_key: tweaked_aggregate_key.x().to_bytes().to_vec(),
-            script_pubkey: tweaked_aggregate_key.signers_script_pubkey().to_bytes(),
+            aggregate_key,
+            tweaked_aggregate_key: tweaked_aggregate_key.serialize(),
+            script_pubkey: aggregate_key.signers_script_pubkey().to_bytes(),
             encrypted_private_shares,
             public_shares,
             created_at,
@@ -171,21 +170,14 @@ type WstsCoordinator = wsts::state_machine::coordinator::frost::Coordinator<wsts
 
 impl CoordinatorStateMachine {
     /// Create a new state machine
-    pub fn new<I>(signers: I, threshold: u32, message_private_key: p256k1::scalar::Scalar) -> Self
+    pub fn new<I>(signers: I, threshold: u32, message_private_key: PrivateKey) -> Self
     where
-        I: IntoIterator<Item = p256k1::ecdsa::PublicKey>,
+        I: IntoIterator<Item = PublicKey>,
     {
         let signer_public_keys: hashbrown::HashMap<u32, _> = signers
             .into_iter()
             .enumerate()
-            .map(|(idx, key)| {
-                (
-                    idx.try_into().unwrap(),
-                    (&p256k1::point::Compressed::from(key.to_bytes()))
-                        .try_into()
-                        .expect("failed to convert public key"),
-                )
-            })
+            .map(|(idx, key)| (idx as u32, key.into()))
             .collect();
 
         // The number of possible signers is capped at a number well below
@@ -202,7 +194,7 @@ impl CoordinatorStateMachine {
             num_keys: num_signers,
             threshold,
             dkg_threshold: num_signers,
-            message_private_key,
+            message_private_key: message_private_key.into(),
             dkg_public_timeout: None,
             dkg_private_timeout: None,
             dkg_end_timeout: None,
@@ -229,19 +221,19 @@ impl CoordinatorStateMachine {
     /// already been successfully completed.
     pub async fn load<I, S>(
         storage: &mut S,
-        aggregate_key: p256k1::point::Point,
+        aggregate_key: PublicKey,
         signers: I,
         threshold: u32,
-        message_private_key: p256k1::scalar::Scalar,
+        message_private_key: PrivateKey,
     ) -> Result<Self, Error>
     where
-        I: IntoIterator<Item = p256k1::ecdsa::PublicKey>,
+        I: IntoIterator<Item = PublicKey>,
         S: storage::DbRead + storage::DbWrite,
         Error: From<<S as storage::DbRead>::Error>,
         Error: From<<S as storage::DbWrite>::Error>,
     {
         let encrypted_shares = storage
-            .get_encrypted_dkg_shares(&aggregate_key.x().to_bytes().to_vec())
+            .get_encrypted_dkg_shares(&aggregate_key)
             .await?
             .ok_or(Error::MissingDkgShares)?;
 
@@ -305,7 +297,7 @@ impl CoordinatorStateMachine {
         // `party_polynomials` variable in the `WstsCoordinator`. Now we
         // can just set the aggregate key and move the state to the `IDLE`,
         // which is the state after a successful DKG round.
-        coordinator.set_aggregate_public_key(Some(aggregate_key));
+        coordinator.set_aggregate_public_key(Some(aggregate_key.into()));
 
         coordinator
             .move_to(WstsState::Idle)

--- a/signer/src/wsts_state_machine.rs
+++ b/signer/src/wsts_state_machine.rs
@@ -8,7 +8,7 @@ use crate::error;
 use crate::error::Error;
 use crate::keys::PrivateKey;
 use crate::keys::PublicKey;
-use crate::keys::SignerScriptPubkey;
+use crate::keys::SignerScriptPubKey;
 use crate::storage;
 use crate::storage::model;
 
@@ -123,7 +123,6 @@ impl SignerStateMachine {
     ) -> Result<model::EncryptedDkgShares, error::Error> {
         let saved_state = self.signer.save();
         let aggregate_key = PublicKey::try_from(&saved_state.group_key)?;
-        let tweaked_aggregate_key = aggregate_key.tweaked_public_key();
 
         let encoded = saved_state.encode_to_vec().map_err(error::Error::Codec)?;
         let public_shares = self
@@ -139,7 +138,7 @@ impl SignerStateMachine {
 
         Ok(model::EncryptedDkgShares {
             aggregate_key,
-            tweaked_aggregate_key: tweaked_aggregate_key.serialize(),
+            tweaked_aggregate_key: aggregate_key.signers_tweaked_pubkey()?,
             script_pubkey: aggregate_key.signers_script_pubkey().to_bytes(),
             encrypted_private_shares,
             public_shares,

--- a/signer/src/wsts_state_machine.rs
+++ b/signer/src/wsts_state_machine.rs
@@ -2,11 +2,11 @@
 
 use std::collections::BTreeMap;
 
-use crate::bitcoin::utxo::SignerScriptPubkey;
 use crate::codec::Decode as _;
 use crate::codec::Encode as _;
 use crate::error;
 use crate::error::Error;
+use crate::keys::SignerScriptPubkey;
 use crate::storage;
 use crate::storage::model;
 

--- a/signer/tests/integration/contracts.rs
+++ b/signer/tests/integration/contracts.rs
@@ -77,7 +77,7 @@ impl AsContractDeploy for SbtcBootstrapContract {
 
 fn make_signatures(tx: &StacksTransaction, keys: &[Keypair]) -> Vec<RecoverableSignature> {
     keys.iter()
-        .map(|kp| stacks::wallet::sign_ecdsa(tx, &kp.secret_key()))
+        .map(|kp| stacks::wallet::sign_ecdsa(tx, &kp.secret_key().into()))
         .collect()
 }
 


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/417.

## Changes

* Use the new `PublicKey` and `PrivateKey` types throughout.
* The tweaked public key is generated from the same source throughout.
* Add implementations for sending and receiving these types to and from the database.
* Fixed a bunch of typos in the comments.

## Testing Information

If the existing tests pass then these changes should be fine.

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
