### PR TITLE
Emily as Local Warp Service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ endif
 # Runs a version of the emily integration environment with a pre-populated database. This is intended
 # to be used for testing the sbtc bridge website, and is not intended to be used for running code that
 # alters the API - though it could be used for that.
-emily-integration-env-up-populated-database: devenv $(EMILY_LAMBDA_BINARY) $(EMILY_CDK_TEMPLATE) $(EMILY_DOCKER_COMPOSE)
+emily-integration-env-up-populated-database: $(EMILY_CDK_TEMPLATE) $(EMILY_DOCKER_COMPOSE) # devenv
 	DYNAMODB_DB_DIR=./devenv/dynamodb/populated \
 		CONTAINER_HOST=$(_CONTAINER_HOST) \
 		docker compose --file $(EMILY_DOCKER_COMPOSE) up --remove-orphans # --detach
@@ -111,7 +111,7 @@ emily-populate-database:
 	@echo "Populating populated database"
 	cargo test --package emily-handler --test integration --features populate -- --test-threads=1 --nocapture
 
-emily-integration-env-up: devenv $(EMILY_LAMBDA_BINARY) $(EMILY_CDK_TEMPLATE) $(EMILY_DOCKER_COMPOSE)
+emily-integration-env-up: $(EMILY_DOCKER_COMPOSE) $(EMILY_CDK_TEMPLATE) $(EMILY_DOCKER_COMPOSE) devenv
 	rm -rf ./devenv/dynamodb/dynamic/shared-local-instance.db
 	DYNAMODB_DB_DIR=./devenv/dynamodb/dynamic \
 		CONTAINER_HOST=$(_CONTAINER_HOST) \
@@ -173,10 +173,12 @@ $(EMILY_LAMBDA_BINARY): $(EMILY_HANDLER_SOURCE_FILES)
 emily-lambda: $(EMILY_LAMBDA_BINARY)
 emily-cdk-synth: $(EMILY_CDK_TEMPLATE)
 emily-openapi-spec: $(EMILY_OPENAPI_SPEC)
-emily-curl-test: $(EMILY_LAMBDA_BINARY)
-	./devenv/service-test/curl-test.sh localhost 3000 0
+emily-curl-test:
+	./devenv/service-test/curl-test.sh localhost 3031 0
+emily-server:
+	cargo run --bin emily-server
 
-.PHONY: emily-lambda emily-cdk-synth emily-openapi-spec emily-curl-test
+.PHONY: emily-lambda emily-cdk-synth emily-openapi-spec emily-curl-test emily-server
 
 # Blocklist Client API
 # ----------------------------------------------------

--- a/blocklist-client/src/main.rs
+++ b/blocklist-client/src/main.rs
@@ -1,7 +1,6 @@
 use crate::config::SETTINGS;
 use reqwest::Client;
-use std::net::ToSocketAddrs;
-use tracing::{error, info};
+use tracing::info;
 use warp::Filter;
 
 mod api;
@@ -22,13 +21,7 @@ async fn main() {
     let addr_str = format!("{}:{}", SETTINGS.server.host, SETTINGS.server.port);
     info!("Server will run on {}", addr_str);
 
-    let addr = match addr_str.to_socket_addrs() {
-        Ok(mut addrs) => addrs.next().expect("No addresses found"),
-        Err(e) => {
-            error!("Failed to resolve address: {}", e);
-            return;
-        }
-    };
+    let addr: std::net::SocketAddr = addr_str.parse().expect("Failed to parse address");
 
     warp::serve(routes).run(addr).await;
 }

--- a/devenv/service-test/curl-test.sh
+++ b/devenv/service-test/curl-test.sh
@@ -4,7 +4,7 @@
 HOSTNAME="$1"
 PORT="$2"
 
-ENDPOINT="http://$HOSTNAME:$PORT"
+ENDPOINT="http://$HOSTNAME:$PORT/local"
 
 banner() {
     echo

--- a/docker-compose.emily.yml
+++ b/docker-compose.emily.yml
@@ -11,7 +11,6 @@ services:
     networks:
       - aws-local-vpc
 
-
   # Modifies the CDK template and creates DynamoDB Tables if necessary.
   aws-setup:
     build: devenv/aws-setup
@@ -33,6 +32,8 @@ services:
   # Hosts the SAM CLI
   apigateway:
     build: devenv/apigateway
+    profiles:
+      - apigateway
     depends_on:
       aws-setup:
         condition: service_completed_successfully
@@ -63,20 +64,6 @@ services:
         --warm-containers LAZY
         --env-vars /lambda/env.json
         -t /cdk.out/EmilyStack.devenv.template.json
-    networks:
-      - aws-local-vpc
-
-  service-test:
-    build: devenv/service-test
-    image: "debian:12.5"
-    profiles:
-      - test
-    depends_on:
-      apigateway:
-        condition: service_started
-    volumes:
-      - "./devenv/service-test:/service-test:ro"
-    command: bash /service-test/curl-test.sh apigateway 3000 5
     networks:
       - aws-local-vpc
 

--- a/emily/handler/Cargo.toml
+++ b/emily/handler/Cargo.toml
@@ -8,7 +8,6 @@ name = "emily-lambda"
 
 [[bin]]
 name = "emily-server"
-features = ["testing"]
 
 [features]
 default = ["testing"]

--- a/emily/handler/Cargo.toml
+++ b/emily/handler/Cargo.toml
@@ -4,7 +4,11 @@ version = "0.1.0"
 edition = "2021"
 
 [[bin]]
-name = "emily-handler"
+name = "emily-lambda"
+
+[[bin]]
+name = "emily-server"
+features = ["testing"]
 
 [features]
 default = ["testing"]

--- a/emily/handler/src/bin/emily-lambda.rs
+++ b/emily/handler/src/bin/emily-lambda.rs
@@ -1,0 +1,37 @@
+//! Emily API entrypoint.
+
+use emily_handler::context::EmilyContext;
+use tracing::info;
+use warp::Filter;
+
+use emily_handler::api;
+use emily_handler::logging;
+
+#[tokio::main]
+async fn main() {
+    crate::logging::setup_logging("info,emily-handler=debug", false);
+
+    // TODO(389 + 358): Handle config pickup in a way that will only fail for the relevant call.
+    let emily_context: EmilyContext = EmilyContext::from_env()
+        .await
+        .unwrap_or_else(|e| panic!("{e}"));
+
+    // Print configuration.
+    info!("Emily context setup for Emily Lambda.");
+    let emily_context_string =
+        serde_json::to_string_pretty(&emily_context).expect("Context must be serializable.");
+    info!(emily_context_string);
+
+    // Make routes.
+    let routes = api::routes::routes(emily_context)
+        .recover(api::handlers::handle_rejection)
+        .with(warp::log("api"));
+
+    // Create warp service.
+    let warp_service = warp::service(routes);
+
+    // TODO(276): Remove warp_lambda in Emily API and use different library.
+    warp_lambda::run(warp_service)
+        .await
+        .expect("An error occurred");
+}

--- a/emily/handler/src/bin/emily-lambda.rs
+++ b/emily/handler/src/bin/emily-lambda.rs
@@ -9,7 +9,7 @@ use emily_handler::logging;
 
 #[tokio::main]
 async fn main() {
-    crate::logging::setup_logging("info,emily-handler=debug", false);
+    logging::setup_logging("info,emily-handler=debug", false);
 
     // TODO(389 + 358): Handle config pickup in a way that will only fail for the relevant call.
     let emily_context: EmilyContext = EmilyContext::from_env()

--- a/emily/handler/src/bin/emily-server.rs
+++ b/emily/handler/src/bin/emily-server.rs
@@ -1,10 +1,10 @@
 //! Emily Warp Service Binary.
 
 use emily_handler::context::EmilyContext;
+use std::net::ToSocketAddrs;
 use tracing::error;
 use tracing::info;
 use warp::Filter;
-use std::net::ToSocketAddrs;
 
 use emily_handler::api;
 use emily_handler::logging;

--- a/emily/handler/src/bin/emily-server.rs
+++ b/emily/handler/src/bin/emily-server.rs
@@ -1,8 +1,6 @@
 //! Emily Warp Service Binary.
 
 use emily_handler::context::EmilyContext;
-use std::net::ToSocketAddrs;
-use tracing::error;
 use tracing::info;
 use warp::Filter;
 
@@ -35,13 +33,7 @@ async fn main() {
     let addr_str = format!("{}:{}", host, port);
 
     info!("Server will run locally on {}", addr_str);
-    let addr = match addr_str.to_socket_addrs() {
-        Ok(mut addrs) => addrs.next().expect("No addresses found"),
-        Err(e) => {
-            error!("Failed to resolve address: {}", e);
-            return;
-        }
-    };
+    let addr: std::net::SocketAddr = addr_str.parse().expect("Failed to parse address");
 
     warp::serve(routes).run(addr).await;
 }

--- a/emily/handler/src/bin/emily-server.rs
+++ b/emily/handler/src/bin/emily-server.rs
@@ -1,0 +1,47 @@
+//! Emily Warp Service Binary.
+
+use emily_handler::context::EmilyContext;
+use tracing::error;
+use tracing::info;
+use warp::Filter;
+use std::net::ToSocketAddrs;
+
+use emily_handler::api;
+use emily_handler::logging;
+
+#[tokio::main]
+async fn main() {
+    logging::setup_logging("info,emily-handler=debug", false);
+
+    // TODO(389 + 358): Handle config pickup in a way that will only fail for the relevant call.
+    let emily_context: EmilyContext = EmilyContext::local_test_instance()
+        .await
+        .unwrap_or_else(|e| panic!("{e}"));
+
+    // Print configuration.
+    info!("Emily context setup for Emily local server.");
+    let emily_context_string =
+        serde_json::to_string_pretty(&emily_context).expect("Context must be serializable.");
+    info!(emily_context_string);
+
+    let routes = api::routes::routes(emily_context)
+        .recover(api::handlers::handle_rejection)
+        .with(warp::log("api"));
+
+    // Create warp service as a local service.
+    // TODO(TBD): Make these fields configurable.
+    let host: &str = "127.0.0.1";
+    let port: i32 = 3031;
+    let addr_str = format!("{}:{}", host, port);
+
+    info!("Server will run locally on {}", addr_str);
+    let addr = match addr_str.to_socket_addrs() {
+        Ok(mut addrs) => addrs.next().expect("No addresses found"),
+        Err(e) => {
+            error!("Failed to resolve address: {}", e);
+            return;
+        }
+    };
+
+    warp::serve(routes).run(addr).await;
+}

--- a/emily/handler/src/context.rs
+++ b/emily/handler/src/context.rs
@@ -80,13 +80,12 @@ impl EmilyContext {
 
         // Get config that always points to the dynamodb table directly
         // from outside of a docker compose setup.
-        let dynamodb_client = Client::new(
-            &aws_config::load_defaults(BehaviorVersion::latest())
-                .await
-                .into_builder()
-                .endpoint_url("http://localhost:8000")
-                .build(),
-        );
+        let sdk_config = aws_config::load_defaults(BehaviorVersion::latest())
+            .await
+            .into_builder()
+            .endpoint_url("http://localhost:8000")
+            .build();
+        let dynamodb_client = Client::new(&sdk_config);
 
         // Get the names of the existing tables so we can populate from them.
         let table_names = dynamodb_client
@@ -95,11 +94,7 @@ impl EmilyContext {
             .limit(20)
             .send()
             .await
-            .map_err(|err| {
-                Error::Debug(format!(
-                    "Failed setting up settings from table names - {err:?}"
-                ))
-            })?
+            .expect("Failed setting up settings from table names")
             .table_names
             .unwrap_or_default();
 

--- a/emily/handler/src/database/accessors.rs
+++ b/emily/handler/src/database/accessors.rs
@@ -280,7 +280,7 @@ async fn wipe_withdrawal_table(context: &EmilyContext) -> Result<(), Error> {
 #[cfg(feature = "testing")]
 async fn wipe_chainstate_table(context: &EmilyContext) -> Result<(), Error> {
     delete_entry::<SpecialApiStateIndex>(context, &ApiStateEntry::key()).await?;
-    wipe::<SpecialApiStateIndex>(context).await
+    wipe::<ChainstateTablePrimaryIndex>(context).await
 }
 
 // Generics --------------------------------------------------------------------

--- a/emily/handler/src/lib.rs
+++ b/emily/handler/src/lib.rs
@@ -5,3 +5,4 @@ pub mod api;
 pub mod common;
 pub mod context;
 pub mod database;
+pub mod logging;

--- a/emily/handler/src/main.rs
+++ b/emily/handler/src/main.rs
@@ -1,4 +1,3 @@
 //! Dummy Emily entrypoint.
 
 fn main() {}
-

--- a/emily/handler/src/main.rs
+++ b/emily/handler/src/main.rs
@@ -1,39 +1,4 @@
-//! Emily API entrypoint.
+//! Dummy Emily entrypoint.
 
-use api::handlers;
-use context::EmilyContext;
-use tracing::info;
-use warp::Filter;
+fn main() {}
 
-mod api;
-mod common;
-mod context;
-mod database;
-mod logging;
-
-#[tokio::main]
-async fn main() {
-    crate::logging::setup_logging("info,emily-handler=debug", false);
-
-    // TODO(389 + 358): Handle config pickup in a way that will only fail for the relevant call.
-    let emily_context: EmilyContext = EmilyContext::from_env()
-        .await
-        .unwrap_or_else(|e| panic!("{e}"));
-
-    // Print configuration.
-    info!("Emily Context Setup.");
-    let emily_context_string =
-        serde_json::to_string_pretty(&emily_context).expect("Context must be serializable.");
-    info!(emily_context_string);
-
-    let routes = api::routes::routes(emily_context)
-        .recover(handlers::handle_rejection)
-        .with(warp::log("api"));
-
-    let warp_service = warp::service(routes);
-
-    // TODO(276): Remove warp_lambda in Emily API and use different library.
-    warp_lambda::run(warp_service)
-        .await
-        .expect("An error occured");
-}

--- a/emily/handler/tests/integration/accessors.rs
+++ b/emily/handler/tests/integration/accessors.rs
@@ -1,8 +1,6 @@
 //! Integration tests for the database accessors
 
-use aws_sdk_dynamodb::operation::update_item::builders::UpdateItemFluentBuilder;
 use emily_handler::{
-    api::models::deposit::requests::DepositUpdate,
     context::EmilyContext,
     database::{accessors, entries::deposit::DepositEntryKey},
 };
@@ -41,9 +39,8 @@ async fn test_update() {
             .await;
     }
     // Make a new deposit.
-    let deposit = client
-        .create_deposit(&util::test_create_deposit_request(5, 0))
-        .await;
+    let create_deposit_request = util::test_create_deposit_request(5, 0);
+    let deposit = client.create_deposit(&create_deposit_request).await;
     // Get the corresponding deposit entry.
     let deposit_entry = accessors::get_deposit_entry(
         &context,
@@ -54,4 +51,13 @@ async fn test_update() {
     )
     .await
     .expect("Get deposit entry for newly created deposit should work.");
+    // Assert.
+    assert_eq!(
+        deposit_entry.key.bitcoin_txid,
+        create_deposit_request.bitcoin_txid
+    );
+    assert_eq!(
+        deposit_entry.key.bitcoin_tx_output_index,
+        create_deposit_request.bitcoin_tx_output_index
+    );
 }

--- a/emily/handler/tests/integration/accessors.rs
+++ b/emily/handler/tests/integration/accessors.rs
@@ -2,7 +2,9 @@
 
 use aws_sdk_dynamodb::operation::update_item::builders::UpdateItemFluentBuilder;
 use emily_handler::{
-    api::models::deposit::requests::DepositUpdate, context::EmilyContext, database::{accessors, entries::deposit::DepositEntryKey}
+    api::models::deposit::requests::DepositUpdate,
+    context::EmilyContext,
+    database::{accessors, entries::deposit::DepositEntryKey},
 };
 
 use crate::util::{self, TestClient};

--- a/emily/handler/tests/integration/accessors.rs
+++ b/emily/handler/tests/integration/accessors.rs
@@ -1,0 +1,55 @@
+//! Integration tests for the database accessors
+
+use aws_sdk_dynamodb::operation::update_item::builders::UpdateItemFluentBuilder;
+use emily_handler::{
+    api::models::deposit::requests::DepositUpdate, context::EmilyContext, database::{accessors, entries::deposit::DepositEntryKey}
+};
+
+use crate::util::{self, TestClient};
+
+/// Test environment.
+struct TestEnvironment {
+    client: TestClient,
+    context: EmilyContext,
+}
+
+/// Setup accessor test.
+async fn setup_accessor_test() -> TestEnvironment {
+    // Get client and wipe the API.
+    let client = TestClient::new();
+    client.setup_test().await;
+    // Setup context.
+    let context = util::test_context().await;
+    // Return test environment.
+    TestEnvironment { client, context }
+}
+
+/// Get all deposits for each transaction using a page size large enough to get all entries.
+#[cfg_attr(not(feature = "integration-tests"), ignore)]
+#[tokio::test]
+async fn test_update() {
+    // Setup test environment.
+    let TestEnvironment { client, context } = setup_accessor_test().await;
+    // Make a bunch of chainstates.
+
+    let fork_id = 0;
+    for height in 0..10 {
+        client
+            .create_chainstate(&util::test_chainstate(height, fork_id))
+            .await;
+    }
+    // Make a new deposit.
+    let deposit = client
+        .create_deposit(&util::test_create_deposit_request(5, 0))
+        .await;
+    // Get the corresponding deposit entry.
+    let deposit_entry = accessors::get_deposit_entry(
+        &context,
+        &DepositEntryKey {
+            bitcoin_txid: deposit.bitcoin_txid.clone(),
+            bitcoin_tx_output_index: deposit.bitcoin_tx_output_index,
+        },
+    )
+    .await
+    .expect("Get deposit entry for newly created deposit should work.");
+}

--- a/emily/handler/tests/integration/main.rs
+++ b/emily/handler/tests/integration/main.rs
@@ -1,3 +1,5 @@
+/// Database accessor tests.
+pub mod accessors;
 /// Complex tests.
 pub mod complex;
 /// Endpoint tests.

--- a/emily/handler/tests/integration/util/constants.rs
+++ b/emily/handler/tests/integration/util/constants.rs
@@ -2,11 +2,13 @@
 
 use emily_handler::api::models::{common::Status, withdrawal::WithdrawalParameters};
 
-pub const EMILY_ENDPOINT: &'static str = "http://localhost:3000";
-pub const EMILY_WITHDRAWAL_ENDPOINT: &'static str = "http://localhost:3000/withdrawal";
-pub const EMILY_DEPOSIT_ENDPOINT: &'static str = "http://localhost:3000/deposit";
-pub const EMILY_CHAINSTATE_ENDPOINT: &'static str = "http://localhost:3000/chainstate";
-pub const EMILY_TESTING_ENDPOINT: &'static str = "http://localhost:3000/testing";
+// TODO(273):  Remove the "local" prefix once we figure out why all local
+// testing calls seem to forcibly start with `local`.
+pub const EMILY_ENDPOINT: &'static str = "http://localhost:3031/local";
+pub const EMILY_WITHDRAWAL_ENDPOINT: &'static str = "http://localhost:3031/local/withdrawal";
+pub const EMILY_DEPOSIT_ENDPOINT: &'static str = "http://localhost:3031/local/deposit";
+pub const EMILY_CHAINSTATE_ENDPOINT: &'static str = "http://localhost:3031/local/chainstate";
+pub const EMILY_TESTING_ENDPOINT: &'static str = "http://localhost:3031/local/testing";
 
 pub const TEST_WITHDRAWAL_PARAMETERS: WithdrawalParameters = WithdrawalParameters { max_fee: 1234 };
 


### PR DESCRIPTION
## Description

Closes: #N/A

I added this change because iterating on the update command was taking too long with the 30 seconds of recompile and run time for emily running in a docker container with the apigateway wrapper. This change adds the ability to run emily as a warp service locally.

Note that this is required for https://github.com/stacks-network/sbtc/issues/360 because running the apigateway container locally won't be feasible for `arm64` chips once the `sbtc` library is imported. This isn't going to be an issue in production because it will only use `intel x86` processors for which this library is fine.

## Changes

- Changes the Makefile to have slightly better commands
- Changes the emily docker compose to not always include the apigateway container
- Creates two binary files for the emily handler - one for prod and one for local warp service
- Changes the integration tests to expect to point to the new warp service
- Adds new emily context option to automatically detect locally running tables. 
- Adds the beginnings of a test for just the table accessor

## Testing Information

Tested with the integration tests. Unfortunately this now requires 3 terminals, but this won't last long.

1. Terminal 1: `make emily-integration-env-up`
2. Terminal 2: `make emily-server`
3. Terminal 3: `make emily-integration-test`

Variations that require a single or two terminals created odd error scenarios for the database that were not remotely obvious to debug; this inconvenience saves a lot of debug time.

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
