### PR TITLE
feat: Update requests for deposit and withdrawals

### DIFF
--- a/.generated-sources/emily/openapi/emily-openapi-spec.json
+++ b/.generated-sources/emily/openapi/emily-openapi-spec.json
@@ -1244,7 +1244,7 @@
       },
       "WithdrawalUpdate": {
         "type": "object",
-        "description": "Withdrawals where only the fields to update are defined.",
+        "description": "A singlular Withdrawal update that contains only the fields pertinent\nto updating the status of a withdrawal. This includes the key related\ndata in addition to status history related data.",
         "required": [
           "requestId",
           "lastUpdateHeight",

--- a/.generated-sources/emily/openapi/emily-openapi-spec.json
+++ b/.generated-sources/emily/openapi/emily-openapi-spec.json
@@ -942,31 +942,21 @@
       },
       "DepositUpdate": {
         "type": "object",
-        "description": "A Deposit where only the fields that need updating are set.",
+        "description": "A singlular Deposit update that contains only the fields pertinent\nto updating the status of a deposit. This includes the key related\ndata in addition to status history related data.",
+        "required": [
+          "bitcoinTxid",
+          "bitcoinTxOutputIndex",
+          "lastUpdateHeight",
+          "lastUpdateBlockHash",
+          "status",
+          "statusMessage"
+        ],
         "properties": {
-          "amount": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Satoshis"
-              }
-            ],
-            "nullable": true
-          },
           "bitcoinTxOutputIndex": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BitcoinTransactionOutputIndex"
-              }
-            ],
-            "nullable": true
+            "$ref": "#/components/schemas/BitcoinTransactionOutputIndex"
           },
           "bitcoinTxid": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BitcoinTransactionId"
-              }
-            ],
-            "nullable": true
+            "$ref": "#/components/schemas/BitcoinTransactionId"
           },
           "fulfillment": {
             "allOf": [
@@ -977,49 +967,17 @@
             "nullable": true
           },
           "lastUpdateBlockHash": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/StacksBlockHash"
-              }
-            ],
-            "nullable": true
+            "$ref": "#/components/schemas/StacksBlockHash"
           },
           "lastUpdateHeight": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BlockHeight"
-              }
-            ],
-            "nullable": true
-          },
-          "parameters": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/super.DepositParameters"
-              }
-            ],
-            "nullable": true
-          },
-          "recipient": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/StacksPrinciple"
-              }
-            ],
-            "nullable": true
+            "$ref": "#/components/schemas/BlockHeight"
           },
           "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Status"
-              }
-            ],
-            "nullable": true
+            "$ref": "#/components/schemas/Status"
           },
           "statusMessage": {
             "type": "string",
-            "description": "The status message of the deposit.",
-            "nullable": true
+            "description": "The status message of the deposit."
           }
         }
       },
@@ -1287,31 +1245,14 @@
       "WithdrawalUpdate": {
         "type": "object",
         "description": "Withdrawals where only the fields to update are defined.",
+        "required": [
+          "requestId",
+          "lastUpdateHeight",
+          "lastUpdateBlockHash",
+          "status",
+          "statusMessage"
+        ],
         "properties": {
-          "amount": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Satoshis"
-              }
-            ],
-            "nullable": true
-          },
-          "blockHash": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/StacksBlockHash"
-              }
-            ],
-            "nullable": true
-          },
-          "blockHeight": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BlockHeight"
-              }
-            ],
-            "nullable": true
-          },
           "fulfillment": {
             "allOf": [
               {
@@ -1321,57 +1262,20 @@
             "nullable": true
           },
           "lastUpdateBlockHash": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/StacksBlockHash"
-              }
-            ],
-            "nullable": true
+            "$ref": "#/components/schemas/StacksBlockHash"
           },
           "lastUpdateHeight": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BlockHeight"
-              }
-            ],
-            "nullable": true
-          },
-          "parameters": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/WithdrawalParameters"
-              }
-            ],
-            "nullable": true
-          },
-          "recipient": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BitcoinAddress"
-              }
-            ],
-            "nullable": true
+            "$ref": "#/components/schemas/BlockHeight"
           },
           "requestId": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/WithdrawalId"
-              }
-            ],
-            "nullable": true
+            "$ref": "#/components/schemas/WithdrawalId"
           },
           "status": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Status"
-              }
-            ],
-            "nullable": true
+            "$ref": "#/components/schemas/Status"
           },
           "statusMessage": {
             "type": "string",
-            "description": "The status message of the withdrawal.",
-            "nullable": true
+            "description": "The status message of the withdrawal."
           }
         }
       }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1539,6 +1539,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-dynamodb",
  "base64 0.22.1",
+ "clap",
  "config 0.11.0",
  "fake",
  "mockall",

--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,14 @@ emily-integration-env-down:
 
 emily-integration-test-full: emily-integration-env-up emily-integration-test emily-integration-env-down
 
+emily-server-watch:
+	cargo watch -d 1.5 -x 'run --bin emily-server'
+
+emily-integration-test-watch:
+	cargo watch -d 3 -x 'test --package emily-handler --test integration --features integration-tests -- \
+		--test-threads=1 \
+		--nocapture'
+
 .PHONY: emily-integration-env-up emily-integration-test emily-integration-env-up emily-integration-test-full
 
 # Builds all dockerfiles that need to be built for the dev environment.

--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ emily-integration-env-down:
 emily-integration-test-full: emily-integration-env-up emily-integration-test emily-integration-env-down
 
 emily-server-watch:
-	cargo watch -d 1.5 -x 'run --bin emily-server'
+	cargo watch -d 1.5 -x 'run --bin emily-server -- --pretty-logs'
 
 emily-integration-test-watch:
 	cargo watch -d 3 -x 'test --package emily-handler --test integration --features integration-tests -- \

--- a/devenv/service-test/curl-test.sh
+++ b/devenv/service-test/curl-test.sh
@@ -4,7 +4,7 @@
 HOSTNAME="$1"
 PORT="$2"
 
-ENDPOINT="http://$HOSTNAME:$PORT/local"
+ENDPOINT="http://$HOSTNAME:$PORT"
 
 banner() {
     echo

--- a/emily/handler/Cargo.toml
+++ b/emily/handler/Cargo.toml
@@ -20,6 +20,7 @@ aws-config.workspace = true
 aws-sdk-dynamodb.workspace = true
 base64.workspace = true
 config.workspace = true
+clap.workspace = true
 openssl.workspace = true
 reqwest.workspace = true
 serde = { workspace = true, features = ["derive"] }

--- a/emily/handler/src/api/handlers/deposit.rs
+++ b/emily/handler/src/api/handlers/deposit.rs
@@ -276,7 +276,7 @@ pub async fn update_deposits(
             // Get original deposit entry.
             let deposit_entry = accessors::get_deposit_entry(&context, &update.key).await?;
             // Make the update package.
-            let update_package = DepositUpdatePackage::from(&deposit_entry, update)?;
+            let update_package = DepositUpdatePackage::try_from(&deposit_entry, update)?;
             let updated_deposit = accessors::update_deposit(&context, &update_package)
                 .await?
                 .try_into()?;

--- a/emily/handler/src/api/handlers/withdrawal.rs
+++ b/emily/handler/src/api/handlers/withdrawal.rs
@@ -224,7 +224,7 @@ pub async fn update_withdrawals(
             let withdrawal_entry =
                 accessors::get_withdrawal_entry(&context, &update.request_id).await?;
             // Make the update package.
-            let update_package = WithdrawalUpdatePackage::from(&withdrawal_entry, update)?;
+            let update_package = WithdrawalUpdatePackage::try_from(&withdrawal_entry, update)?;
             let updated_withdrawal = accessors::update_withdrawal(&context, &update_package)
                 .await?
                 .try_into()?;

--- a/emily/handler/src/api/handlers/withdrawal.rs
+++ b/emily/handler/src/api/handlers/withdrawal.rs
@@ -1,4 +1,5 @@
 //! Handlers for withdrawal endpoints.
+use serde_dynamo::Item;
 use warp::reply::{json, with_status, Reply};
 
 use crate::api::models::common::{BlockHeight, Status};
@@ -15,8 +16,10 @@ use crate::common::error::Error;
 use crate::context::EmilyContext;
 use crate::database::accessors;
 use crate::database::entries::withdrawal::{
-    WithdrawalEntry, WithdrawalEntryKey, WithdrawalEvent, WithdrawalParametersEntry,
+    build_withdrawal_update, ValidatedUpdateWithdrawalRequest, WithdrawalEntry, WithdrawalEntryKey,
+    WithdrawalEvent, WithdrawalParametersEntry, WithdrawalUpdatePackage,
 };
+use crate::database::entries::StatusEntry;
 use warp::http::StatusCode;
 
 /// Get withdrawal handler.
@@ -46,36 +49,16 @@ pub async fn get_withdrawal(
         context: EmilyContext,
         request_id: WithdrawalId,
     ) -> Result<impl warp::reply::Reply, Error> {
-        // Get withdrawals - hopefully just one.
-        // If there is more than one withdrawal then there is a state inconsistency. This
-        // is potentially okay but the hope then is that the database is actively being
-        // repaired.
-        let num_to_retrieve_if_multiple = 5;
-        let (entries, _) = accessors::get_withdrawal_entries_for_id(
-            &context,
-            &request_id,
-            None,
-            Some(num_to_retrieve_if_multiple),
-        )
-        .await?;
-
-        // Convert data into resource types.
-        let withdrawals: Vec<Withdrawal> = entries
-            .into_iter()
-            .map(|entry| entry.try_into())
-            .collect::<Result<_, _>>()?;
+        // Get withdrawal.
+        let withdrawal: Withdrawal = accessors::get_withdrawal_entry(&context, &request_id)
+            .await?
+            .try_into()?;
 
         // Respond.
-        match &withdrawals[..] {
-            [] => Err(Error::NotFound),
-            [withdrawal] => Ok(with_status(
-                json(withdrawal as &GetWithdrawalResponse),
-                StatusCode::OK,
-            )),
-            _ => Err(Error::Debug(format!(
-                "Found too many withdrawals: {withdrawals:?}"
-            ))),
-        }
+        Ok(with_status(
+            json(&(withdrawal as GetWithdrawalResponse)),
+            StatusCode::OK,
+        ))
     }
     // Handle and respond.
     handler(context, request_id)
@@ -183,7 +166,7 @@ pub async fn create_withdrawal(
             amount,
             parameters: WithdrawalParametersEntry { max_fee: parameters.max_fee },
             history: vec![WithdrawalEvent {
-                status: Status::Pending,
+                status: StatusEntry::Pending,
                 message: "Just received withdrawal".to_string(),
                 stacks_block_hash: stacks_block_hash.clone(),
                 stacks_block_height,
@@ -223,11 +206,50 @@ pub async fn create_withdrawal(
     )
 )]
 pub async fn update_withdrawals(
-    _context: EmilyContext,
-    _body: UpdateWithdrawalsRequestBody,
+    context: EmilyContext,
+    body: UpdateWithdrawalsRequestBody,
 ) -> impl warp::reply::Reply {
-    let response = UpdateWithdrawalsResponse { ..Default::default() };
-    with_status(json(&response), StatusCode::CREATED)
+    // Internal handler so `?` can be used correctly while still returning a reply.
+    async fn handler(
+        context: EmilyContext,
+        body: UpdateWithdrawalsRequestBody,
+    ) -> Result<impl warp::reply::Reply, Error> {
+        // Validate request.
+        let validated_request: ValidatedUpdateWithdrawalRequest = body.try_into()?;
+        // Create aggregator.
+        let mut updated_withdrawals: Vec<Withdrawal> =
+            Vec::with_capacity(validated_request.withdrawals.len());
+        // Loop through all updates and execute.
+        for update in validated_request.withdrawals {
+            // Get original withdrawal entry.
+            let withdrawal_entry =
+                accessors::get_withdrawal_entry(&context, &update.request_id).await?;
+            // Make the update package.
+            let update_package = WithdrawalUpdatePackage::from(&withdrawal_entry, update)?;
+            let update_output = build_withdrawal_update(&context, &update_package)?
+                .send()
+                .await?;
+            // Get the updated withdrawal.
+            let updated_withdrawal: Withdrawal = update_output
+                .attributes
+                .ok_or(Error::InternalServer)
+                .and_then(|fields| {
+                    serde_dynamo::from_item::<Item, WithdrawalEntry>(fields.into())
+                        .map_err(Error::from)
+                })
+                .and_then(|entry| entry.try_into())?;
+            // Append the updated withdrawal to the list.
+            updated_withdrawals.push(updated_withdrawal);
+        }
+        let response = UpdateWithdrawalsResponse {
+            withdrawals: updated_withdrawals,
+        };
+        Ok(with_status(json(&response), StatusCode::CREATED))
+    }
+    // Handle and respond.
+    handler(context, body)
+        .await
+        .map_or_else(Reply::into_response, Reply::into_response)
 }
 
 // TODO(393): Add handler unit tests.

--- a/emily/handler/src/api/models/common/mod.rs
+++ b/emily/handler/src/api/models/common/mod.rs
@@ -51,8 +51,8 @@ pub enum Status {
     #[default]
     Pending,
     /// Transaction was dealt with by the signers at one point but is now being
-    /// reevaluated. The Signers are aware of the operation request.
-    Reevaluating,
+    /// reprocessed. The Signers are aware of the operation request.
+    Reprocessing,
     /// Transaction has been seen and accepted by the sBTC Signers, but is not
     /// yet included in any on chain artifact. The transaction can still fail
     /// at this point if the Signers fail to include the transaciton in an on

--- a/emily/handler/src/api/models/common/mod.rs
+++ b/emily/handler/src/api/models/common/mod.rs
@@ -87,6 +87,7 @@ pub enum Status {
     ToSchema,
     ToResponse,
 )]
+#[serde(rename_all = "PascalCase")]
 pub struct Fulfillment {
     /// Bitcoin transaction id of the Bitcoin transaction that fulfilled the operation.
     pub bitcoin_txid: BitcoinTransactionId,

--- a/emily/handler/src/api/models/deposit/requests.rs
+++ b/emily/handler/src/api/models/deposit/requests.rs
@@ -45,44 +45,31 @@ pub struct CreateDepositRequestBody {
     pub deposit: BitcoinScript,
 }
 
-/// A Deposit where only the fields that need updating are set.
+/// A singlular Deposit update that contains only the fields pertinent
+/// to updating the status of a deposit. This includes the key related
+/// data in addition to status history related data.
 #[derive(Clone, Default, Debug, PartialEq, Hash, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct DepositUpdate {
     /// Bitcoin transaction id.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub bitcoin_txid: Option<BitcoinTransactionId>,
+    pub bitcoin_txid: BitcoinTransactionId,
     /// Output index on the bitcoin transaction associated with this specific deposit.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub bitcoin_tx_output_index: Option<BitcoinTransactionOutputIndex>,
-    /// Stacks address to received the deposited sBTC.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub recipient: Option<StacksPrinciple>,
-    /// Amount of BTC being deposited.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub amount: Option<Satoshis>,
+    pub bitcoin_tx_output_index: BitcoinTransactionOutputIndex,
     /// The most recent Stacks block height the API was aware of when the deposit was last
     /// updated. If the most recent update is tied to an artifact on the Stacks blockchain
     /// then this height is the Stacks block height that contains that artifact.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub last_update_height: Option<BlockHeight>,
+    pub last_update_height: BlockHeight,
     /// The most recent Stacks block hash the API was aware of when the deposit was last
     /// updated. If the most recent update is tied to an artifact on the Stacks blockchain
     /// then this hash is the Stacks block hash that contains that artifact.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub last_update_block_hash: Option<StacksBlockHash>,
+    pub last_update_block_hash: StacksBlockHash,
     /// The status of the deposit.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub status: Option<Status>,
+    pub status: Status,
     /// The status message of the deposit.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub status_message: Option<String>,
-    /// Deposit parameters
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub parameters: Option<super::DepositParameters>,
+    pub status_message: String,
     /// Details about the on chain artifacts that fulfilled the deposit.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub fulfillment: Option<Option<Fulfillment>>,
+    pub fulfillment: Option<Fulfillment>,
 }
 
 /// Request structure for update deposit request.

--- a/emily/handler/src/api/models/withdrawal/requests.rs
+++ b/emily/handler/src/api/models/withdrawal/requests.rs
@@ -36,7 +36,9 @@ pub struct CreateWithdrawalRequestBody {
     pub parameters: WithdrawalParameters,
 }
 
-/// Withdrawals where only the fields to update are defined.
+/// A singlular Withdrawal update that contains only the fields pertinent
+/// to updating the status of a withdrawal. This includes the key related
+/// data in addition to status history related data.
 #[derive(Clone, Default, Debug, PartialEq, Hash, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct WithdrawalUpdate {

--- a/emily/handler/src/api/models/withdrawal/requests.rs
+++ b/emily/handler/src/api/models/withdrawal/requests.rs
@@ -41,42 +41,22 @@ pub struct CreateWithdrawalRequestBody {
 #[serde(rename_all = "camelCase")]
 pub struct WithdrawalUpdate {
     /// The id of the Stacks withdrawal request that initiated the sBTC operation.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub request_id: Option<WithdrawalId>,
-    /// The stacks block hash in which this request id was initiated.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub block_hash: Option<StacksBlockHash>,
-    /// The height of the Stacks block in which this request id was initiated.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub block_height: Option<BlockHeight>,
-    /// The recipient Bitcoin address.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub recipient: Option<BitcoinAddress>,
-    /// Amount of BTC being withdrawn.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub amount: Option<Satoshis>,
+    pub request_id: WithdrawalId,
     /// The most recent Stacks block height the API was aware of when the withdrawal was last
     /// updated. If the most recent update is tied to an artifact on the Stacks blockchain
     /// then this height is the Stacks block height that contains that artifact.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub last_update_height: Option<BlockHeight>,
+    pub last_update_height: BlockHeight,
     /// The most recent Stacks block hash the API was aware of when the withdrawal was last
     /// updated. If the most recent update is tied to an artifact on the Stacks blockchain
     /// then this hash is the Stacks block hash that contains that artifact.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub last_update_block_hash: Option<StacksBlockHash>,
+    pub last_update_block_hash: StacksBlockHash,
     /// The status of the withdrawal.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub status: Option<Status>,
+    pub status: Status,
     /// The status message of the withdrawal.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub status_message: Option<String>,
-    /// Withdrawal request parameters.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub parameters: Option<WithdrawalParameters>,
+    pub status_message: String,
     /// Details about the on chain artifacts that fulfilled the withdrawal.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub fulfillment: Option<Option<Fulfillment>>,
+    pub fulfillment: Option<Fulfillment>,
 }
 
 /// Request structure for the create withdrawal request.
@@ -84,5 +64,5 @@ pub struct WithdrawalUpdate {
 #[serde(rename_all = "camelCase")]
 pub struct UpdateWithdrawalsRequestBody {
     /// Withdrawal updates to execute.
-    withdrawals: Vec<WithdrawalUpdate>,
+    pub withdrawals: Vec<WithdrawalUpdate>,
 }

--- a/emily/handler/src/api/routes/deposit.rs
+++ b/emily/handler/src/api/routes/deposit.rs
@@ -72,7 +72,7 @@ fn update_deposits(
     warp::any()
         .map(move || context.clone())
         .and(warp::path!("deposit"))
-        .and(warp::post())
+        .and(warp::put())
         .and(warp::body::json())
         .then(handlers::deposit::update_deposits)
 }

--- a/emily/handler/src/api/routes/mod.rs
+++ b/emily/handler/src/api/routes/mod.rs
@@ -21,29 +21,25 @@ mod withdrawal;
 #[cfg(feature = "testing")]
 pub fn routes(
     context: EmilyContext,
-) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
-    // TODO(273):  Remove the "local" prefix once we figure out why all local
-    // testing calls seem to forcibly start with `local`.
-    warp::path("local").and(
-        health::routes()
-            .or(chainstate::routes(context.clone()))
-            .or(deposit::routes(context.clone()))
-            .or(withdrawal::routes(context.clone()))
-            .or(testing::routes(context)),
-    )
+) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
+    health::routes()
+        .or(chainstate::routes(context.clone()))
+        .or(deposit::routes(context.clone()))
+        .or(withdrawal::routes(context.clone()))
+        .or(testing::routes(context))
+        // Convert reply to tuple to that more routes can be added to the returned filter.
+        .map(|reply| (reply,))
 }
 
 /// This function sets the Warp filters for handling all requests.
 #[cfg(not(feature = "testing"))]
 pub fn routes(
     context: EmilyContext,
-) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
-    // TODO(273):  Remove the "local" prefix once we figure out why all local
-    // testing calls seem to forcibly start with `local`.
-    warp::path("local").and(
-        health::routes()
-            .or(chainstate::routes(context.clone()))
-            .or(deposit::routes(context.clone()))
-            .or(withdrawal::routes(context)),
-    )
+) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
+    health::routes()
+        .or(chainstate::routes(context.clone()))
+        .or(deposit::routes(context.clone()))
+        .or(withdrawal::routes(context))
+        // Convert reply to tuple to that more routes can be added to the returned filter.
+        .map(|reply| (reply,))
 }

--- a/emily/handler/src/bin/emily-lambda.rs
+++ b/emily/handler/src/bin/emily-lambda.rs
@@ -2,6 +2,7 @@
 
 use emily_handler::context::EmilyContext;
 use tracing::info;
+use tracing::warn;
 use warp::Filter;
 
 use emily_handler::api;
@@ -9,29 +10,44 @@ use emily_handler::logging;
 
 #[tokio::main]
 async fn main() {
+    // Setup logging.
     logging::setup_logging("info,emily-handler=debug", false);
 
+    // Setup context.
     // TODO(389 + 358): Handle config pickup in a way that will only fail for the relevant call.
-    let emily_context: EmilyContext = EmilyContext::from_env()
+    let context: EmilyContext = EmilyContext::from_env()
         .await
         .unwrap_or_else(|e| panic!("{e}"));
+    info!("Lambda Context:\n{context:?}");
 
-    // Print configuration.
-    info!("Emily context setup for Emily Lambda.");
-    let emily_context_string =
-        serde_json::to_string_pretty(&emily_context).expect("Context must be serializable.");
-    info!(emily_context_string);
-
-    // Make routes.
-    let routes = api::routes::routes(emily_context)
+    // Setup service filters.
+    let service_filter = routes(context)
         .recover(api::handlers::handle_rejection)
         .with(warp::log("api"));
 
     // Create warp service.
-    let warp_service = warp::service(routes);
-
     // TODO(276): Remove warp_lambda in Emily API and use different library.
+    let warp_service = warp::service(service_filter);
     warp_lambda::run(warp_service)
         .await
         .expect("An error occurred");
+}
+
+/// Makes the routes.
+#[cfg(not(feature = "testing"))]
+fn routes(
+    context: EmilyContext,
+) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
+    api::routes::routes(context)
+}
+
+/// Makes the routes.
+#[cfg(feature = "testing")]
+fn routes(
+    context: EmilyContext,
+) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
+    warn!(
+        "Running lambda server with testing features - all paths will be prefixed with \"/local\""
+    );
+    warp::path("local").and(api::routes::routes(context))
 }

--- a/emily/handler/src/bin/emily-server.rs
+++ b/emily/handler/src/bin/emily-server.rs
@@ -1,5 +1,7 @@
 //! Emily Warp Service Binary.
 
+use clap::Args;
+use clap::Parser;
 use emily_handler::context::EmilyContext;
 use tracing::info;
 use warp::Filter;
@@ -7,37 +9,73 @@ use warp::Filter;
 use emily_handler::api;
 use emily_handler::logging;
 
+/// The arguments for the Emily server.
+#[derive(Parser, Debug)]
+#[command(
+    name = "EmilyServer",
+    version = "1.0",
+    author = "Ashton Stephens <ashton@trustmachines.co>",
+    about = "Local emily server binary"
+)]
+pub struct Cli {
+    /// Server arguments.
+    #[command(flatten)]
+    pub server: ServerArgs,
+    /// General arguments.
+    #[command(flatten)]
+    pub general: GeneralArgs,
+}
+
+/// General arguments.
+#[derive(Args, Debug)]
+pub struct GeneralArgs {
+    /// Whether to use pretty log printing.
+    #[arg(long, default_value = "false")]
+    pub pretty_logs: bool,
+    /// Log directives.
+    #[arg(long, default_value = "info,emily-handler=debug")]
+    pub log_directives: String,
+}
+
+/// Server related arguments.
+#[derive(Args, Debug)]
+pub struct ServerArgs {
+    /// Host.
+    #[arg(long, default_value = "127.0.0.1")]
+    pub host: String,
+    /// Port to run on.
+    #[arg(long, default_value = "3031")]
+    pub port: u64,
+}
+
+/// Main program.
 #[tokio::main]
 async fn main() {
-    #[cfg(feature = "testing")]
-    logging::setup_logging("info,emily-handler=debug", true);
+    // Get command line arguments.
+    let Cli {
+        server: ServerArgs { host, port },
+        general: GeneralArgs { pretty_logs, log_directives },
+    } = Cli::parse();
 
-    #[cfg(not(feature = "testing"))]
-    logging::setup_logging("info,emily-handler=debug", false);
+    // Setup logging.
+    logging::setup_logging(&log_directives, pretty_logs);
 
+    // Setup context.
     // TODO(389 + 358): Handle config pickup in a way that will only fail for the relevant call.
-    let emily_context: EmilyContext = EmilyContext::local_test_instance()
+    let context: EmilyContext = EmilyContext::local_test_instance()
         .await
         .unwrap_or_else(|e| panic!("{e}"));
+    info!("Lambda Context:\n{context:?}");
 
-    // Print configuration.
-    info!("Emily context setup for Emily local server.");
-    let emily_context_string =
-        serde_json::to_string_pretty(&emily_context).expect("Context must be serializable.");
-    info!("emily_context:\n{}", emily_context_string);
-
-    let routes = api::routes::routes(emily_context)
+    let routes = api::routes::routes(context)
         .recover(api::handlers::handle_rejection)
         .with(warp::log("api"));
 
-    // Create warp service as a local service.
-    // TODO(TBD): Make these fields configurable.
-    let host: &str = "127.0.0.1";
-    let port: i32 = 3031;
-    let addr_str = format!("{}:{}", host, port);
-
+    // Create address.
+    let addr_str = format!("{host}:{port}");
     info!("Server will run locally on {}", addr_str);
     let addr: std::net::SocketAddr = addr_str.parse().expect("Failed to parse address");
 
+    // Create warp service as a local service and listen at the address.
     warp::serve(routes).run(addr).await;
 }

--- a/emily/handler/src/bin/emily-server.rs
+++ b/emily/handler/src/bin/emily-server.rs
@@ -9,7 +9,7 @@ use emily_handler::logging;
 
 #[tokio::main]
 async fn main() {
-    logging::setup_logging("info,emily-handler=debug", false);
+    logging::setup_logging("info,emily-handler=debug", true);
 
     // TODO(389 + 358): Handle config pickup in a way that will only fail for the relevant call.
     let emily_context: EmilyContext = EmilyContext::local_test_instance()
@@ -20,7 +20,7 @@ async fn main() {
     info!("Emily context setup for Emily local server.");
     let emily_context_string =
         serde_json::to_string_pretty(&emily_context).expect("Context must be serializable.");
-    info!(emily_context_string);
+    info!("emily_context:\n{}", emily_context_string);
 
     let routes = api::routes::routes(emily_context)
         .recover(api::handlers::handle_rejection)

--- a/emily/handler/src/bin/emily-server.rs
+++ b/emily/handler/src/bin/emily-server.rs
@@ -9,7 +9,7 @@ use emily_handler::logging;
 
 #[tokio::main]
 async fn main() {
-    logging::setup_logging("info,emily-handler=debug", true);
+    logging::setup_logging("info,emily-handler=debug", false);
 
     // TODO(389 + 358): Handle config pickup in a way that will only fail for the relevant call.
     let emily_context: EmilyContext = EmilyContext::local_test_instance()

--- a/emily/handler/src/bin/emily-server.rs
+++ b/emily/handler/src/bin/emily-server.rs
@@ -9,6 +9,10 @@ use emily_handler::logging;
 
 #[tokio::main]
 async fn main() {
+    #[cfg(feature = "testing")]
+    logging::setup_logging("info,emily-handler=debug", true);
+
+    #[cfg(not(feature = "testing"))]
     logging::setup_logging("info,emily-handler=debug", false);
 
     // TODO(389 + 358): Handle config pickup in a way that will only fail for the relevant call.

--- a/emily/handler/src/context.rs
+++ b/emily/handler/src/context.rs
@@ -6,6 +6,7 @@
 //! toml and potentially overwrites the fields with environment values.
 
 use std::env;
+use std::fmt;
 
 use aws_config::BehaviorVersion;
 use aws_sdk_dynamodb::Client;
@@ -26,14 +27,26 @@ pub struct Settings {
     pub chainstate_table_name: String,
 }
 
-/// Lambda Context
-#[derive(Clone, Debug, Serialize)]
+/// Emily Context
+#[derive(Clone, Serialize)]
 pub struct EmilyContext {
     /// Lambda settings.
     pub settings: Settings,
     /// DynamoDB Client.
     #[serde(skip_serializing)]
     pub dynamodb_client: Client,
+}
+
+/// Implement debug print for the context struct.
+impl fmt::Debug for EmilyContext {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            serde_json::to_string_pretty(self)
+                .expect("Failed to serialize Emily Context in debug print.")
+        )
+    }
 }
 
 // Implementations -------------------------------------------------------------

--- a/emily/handler/src/database/accessors.rs
+++ b/emily/handler/src/database/accessors.rs
@@ -45,6 +45,7 @@ pub async fn get_deposit_entry(
     key: &DepositEntryKey,
 ) -> Result<DepositEntry, Error> {
     let entry = get_entry::<DepositTablePrimaryIndex>(context, key).await?;
+    #[cfg(feature = "testing")]
     info!(
         "Received deposit entry {}",
         serde_json::to_string_pretty(&entry)?
@@ -172,6 +173,7 @@ pub async fn get_withdrawal_entry(
     match entries.as_slice() {
         [] => Err(Error::NotFound),
         [withdrawal] => {
+            #[cfg(feature = "testing")]
             info!(
                 "Received withdrawal entry {}",
                 serde_json::to_string_pretty(withdrawal)?

--- a/emily/handler/src/database/accessors.rs
+++ b/emily/handler/src/database/accessors.rs
@@ -92,14 +92,14 @@ pub async fn update_deposit(
 ) -> Result<DepositEntry, Error> {
     // Setup the update procedure.
     let update_expression: &str = " SET
-        #history = list_append(#history, :new_event),
-        #version = #version + :one,
-        #op_status = :new_op_status,
-        #height = :new_height,
-        #hash = :new_hash
+        History = list_append(History, :new_event),
+        Version = Version + :one,
+        OpStatus = :new_op_status,
+        LastUpdateHeight = :new_height,
+        LastUpdateBlockHash = :new_hash
     ";
     // Ensure the version field is what we expect it to be.
-    let condition_expression = "attribute_exists(#version) AND #version = :expected_version";
+    let condition_expression = "attribute_exists(Version) AND Version = :expected_version";
     // Make the key item.
     let key_item: Item = serde_dynamo::to_item(&update.key)?;
     // Get simplified status enum.
@@ -110,11 +110,6 @@ pub async fn update_deposit(
         .update_item()
         .table_name(&context.settings.deposit_table_name)
         .set_key(Some(key_item.into()))
-        .expression_attribute_names("#history", "History")
-        .expression_attribute_names("#version", "Version")
-        .expression_attribute_names("#op_status", "OpStatus")
-        .expression_attribute_names("#height", "LastUpdateHeight")
-        .expression_attribute_names("#hash", "LastUpdateBlockHash")
         .expression_attribute_values(":new_op_status", serde_dynamo::to_attribute_value(&status)?)
         .expression_attribute_values(
             ":new_height",
@@ -209,14 +204,14 @@ pub async fn update_withdrawal(
 ) -> Result<WithdrawalEntry, Error> {
     // Setup the update procedure.
     let update_expression: &str = " SET
-        #history = list_append(#history, :new_event),
-        #version = #version + :one,
-        #op_status = :new_op_status,
-        #height = :new_height,
-        #hash = :new_hash
+        History = list_append(History, :new_event),
+        Version = Version + :one,
+        OpStatus = :new_op_status,
+        LastUpdateHeight = :new_height,
+        LastUpdateBlockHash = :new_hash
     ";
     // Ensure the version field is what we expect it to be.
-    let condition_expression = "attribute_exists(#version) AND #version = :expected_version";
+    let condition_expression = "attribute_exists(Version) AND Version = :expected_version";
     // Make the key item.
     let key_item: Item = serde_dynamo::to_item(&update.key)?;
     // Get simplified status enum.
@@ -227,11 +222,6 @@ pub async fn update_withdrawal(
         .update_item()
         .table_name(&context.settings.withdrawal_table_name)
         .set_key(Some(key_item.into()))
-        .expression_attribute_names("#history", "History")
-        .expression_attribute_names("#version", "Version")
-        .expression_attribute_names("#op_status", "OpStatus")
-        .expression_attribute_names("#height", "LastUpdateHeight")
-        .expression_attribute_names("#hash", "LastUpdateBlockHash")
         .expression_attribute_values(":new_op_status", serde_dynamo::to_attribute_value(&status)?)
         .expression_attribute_values(
             ":new_height",

--- a/emily/handler/src/database/entries/deposit.rs
+++ b/emily/handler/src/database/entries/deposit.rs
@@ -1,6 +1,10 @@
 //! Entries into the deposit table.
 
+use aws_sdk_dynamodb::{
+    operation::update_item::builders::UpdateItemFluentBuilder, types::AttributeValue,
+};
 use serde::{Deserialize, Serialize};
+use serde_dynamo::Item;
 
 use crate::{
     api::models::{
@@ -8,13 +12,18 @@ use crate::{
             BitcoinScript, BitcoinTransactionId, BitcoinTransactionOutputIndex, BlockHeight,
             Fulfillment, Satoshis, StacksBlockHash, StacksPrinciple, Status,
         },
-        deposit::{Deposit, DepositInfo, DepositParameters},
+        deposit::{
+            requests::{DepositUpdate, UpdateDepositsRequestBody},
+            Deposit, DepositInfo, DepositParameters,
+        },
     },
-    common::error::Error,
+    common::error::{Error, Inconsistency},
+    context::EmilyContext,
 };
 
 use super::{
     EntryTrait, KeyTrait, PrimaryIndex, PrimaryIndexTrait, SecondaryIndex, SecondaryIndexTrait,
+    StatusEntry,
 };
 
 // Deposit entry ---------------------------------------------------------------
@@ -57,7 +66,7 @@ pub struct DepositEntry {
     /// then this hash is the Stacks block hash that contains that artifact.
     pub last_update_block_hash: StacksBlockHash,
     /// Data about the fulfillment of the sBTC Operation.
-    #[serde(flatten, skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub fulfillment: Option<Fulfillment>,
     /// History of this deposit transaction.
     pub history: Vec<DepositEvent>,
@@ -122,12 +131,19 @@ impl DepositEntry {
                 format!("last update block height is inconsistent between history and top level data. {stringy_self:?}")
             ));
         }
-        if self.status != latest_event.status {
+        if self.status != (&latest_event.status).into() {
             return Err(Error::Debug(
                 format!("most recent status is inconsistent between history and top level data. {stringy_self:?}")
             ));
         }
         Ok(())
+    }
+
+    /// Gets the latest event.
+    pub fn latest_event(&self) -> &DepositEvent {
+        self.history
+            .last()
+            .expect("Deposit entry must always have at least one event.")
     }
 }
 
@@ -136,11 +152,16 @@ impl TryFrom<DepositEntry> for Deposit {
     fn try_from(deposit_entry: DepositEntry) -> Result<Self, Self::Error> {
         // Ensure entry is valid.
         deposit_entry.validate()?;
-        // Get the latest event.
-        let latest_event: &DepositEvent = deposit_entry
-            .history
-            .last()
-            .expect("Deposit history is invalid but was just validate.");
+
+        // Extract data from the latest event.
+        let latest_event = deposit_entry.latest_event();
+        let status_message = latest_event.message.clone();
+        let status: Status = (&latest_event.status).into();
+        let fulfillment = match &latest_event.status {
+            StatusEntry::Accepted(fulfillment) => Some(fulfillment.clone()),
+            _ => None,
+        };
+
         // Create deposit from table entry.
         Ok(Deposit {
             bitcoin_txid: deposit_entry.key.bitcoin_txid,
@@ -149,14 +170,14 @@ impl TryFrom<DepositEntry> for Deposit {
             amount: deposit_entry.amount,
             last_update_height: deposit_entry.last_update_height,
             last_update_block_hash: deposit_entry.last_update_block_hash,
-            status: deposit_entry.status,
-            status_message: latest_event.message.clone(),
+            status,
+            status_message,
             parameters: DepositParameters {
                 max_fee: deposit_entry.parameters.max_fee,
                 lock_time: deposit_entry.parameters.lock_time,
                 reclaim_script: deposit_entry.parameters.reclaim_script,
             },
-            fulfillment: deposit_entry.fulfillment,
+            fulfillment,
         })
     }
 }
@@ -180,13 +201,36 @@ pub struct DepositParametersEntry {
 pub struct DepositEvent {
     /// Status code.
     #[serde(rename = "OpStatus")]
-    pub status: Status,
+    pub status: StatusEntry,
     /// Status message.
     pub message: String,
     /// Stacks block heigh at the time of this update.
     pub stacks_block_height: BlockHeight,
     /// Stacks block hash associated with the height of this update.
     pub stacks_block_hash: StacksBlockHash,
+}
+
+/// Implementation of deposit event.
+impl DepositEvent {
+    /// Errors if the next event provided could not follow the current one.
+    pub fn ensure_following_event_is_valid(&self, next_event: &DepositEvent) -> Result<(), Error> {
+        // Determine if event is valid.
+        if self.stacks_block_height > next_event.stacks_block_height {
+            return Err(Error::InconsistentState(Inconsistency::ItemUpdate(
+                "Attempting to update a deposit with a block height earlier than it should be."
+                    .into(),
+            )));
+        } else if self.stacks_block_height == next_event.stacks_block_height
+            && self.stacks_block_hash != next_event.stacks_block_hash
+        {
+            return Err(Error::InconsistentState(Inconsistency::ItemUpdate(
+                "Attempting to update a deposit with a block height and hash that conflicts with the current history."
+                    .into(),
+            )));
+        }
+
+        Ok(())
+    }
 }
 
 // Deposit info entry ----------------------------------------------------------
@@ -285,4 +329,151 @@ impl From<DepositInfoEntry> for DepositInfo {
             status: deposit_info_entry.key.status,
         }
     }
+}
+
+/// Validated version of the update deposit request.
+pub struct ValidatedUpdateDepositsRequest {
+    /// Validated deposit update requests.
+    pub deposits: Vec<ValidatedDepositUpdate>,
+}
+
+/// Implement try from for the validated depoit requests.
+impl TryFrom<UpdateDepositsRequestBody> for ValidatedUpdateDepositsRequest {
+    type Error = Error;
+    fn try_from(update_request: UpdateDepositsRequestBody) -> Result<Self, Self::Error> {
+        // Validate all the depoit updates.
+        let deposits = update_request
+            .deposits
+            .into_iter()
+            .map(|i| i.try_into())
+            .collect::<Result<_, Error>>()?;
+        Ok(ValidatedUpdateDepositsRequest { deposits })
+    }
+}
+
+/// Validated deposit update.
+pub struct ValidatedDepositUpdate {
+    /// Key.
+    pub key: DepositEntryKey,
+    /// Deposit event.
+    pub event: DepositEvent,
+}
+
+impl TryFrom<DepositUpdate> for ValidatedDepositUpdate {
+    type Error = Error;
+    fn try_from(update: DepositUpdate) -> Result<Self, Self::Error> {
+        // Make key.
+        let key = DepositEntryKey {
+            bitcoin_tx_output_index: update.bitcoin_tx_output_index,
+            bitcoin_txid: update.bitcoin_txid,
+        };
+        // Make status entry.
+        let status_entry: StatusEntry = match update.status {
+            Status::Accepted => {
+                let fulfillment = update.fulfillment.ok_or(Error::InternalServer)?;
+                StatusEntry::Accepted(fulfillment)
+            }
+            Status::Confirmed => StatusEntry::Confirmed,
+            Status::Pending => StatusEntry::Pending,
+            Status::Reevaluating => StatusEntry::Reevaluating,
+            Status::Failed => StatusEntry::Failed,
+        };
+        // Make the new event.
+        let event = DepositEvent {
+            status: status_entry,
+            message: update.status_message,
+            stacks_block_height: update.last_update_height,
+            stacks_block_hash: update.last_update_block_hash,
+        };
+        // Return the validated update.
+        Ok(ValidatedDepositUpdate { key, event })
+    }
+}
+
+/// Packaged deposit update.
+pub struct DepositUpdatePackage {
+    /// Key.
+    pub key: DepositEntryKey,
+    /// Version.
+    pub version: u64,
+    /// Deposit event.
+    pub event: DepositEvent,
+}
+
+/// Implementation of deposit update package.
+impl DepositUpdatePackage {
+    /// Implements from.
+    pub fn from(entry: &DepositEntry, update: ValidatedDepositUpdate) -> Result<Self, Error> {
+        // Ensure the keys are equal.
+        if update.key != entry.key {
+            return Err(Error::Debug(
+                "Attempted to update deposit txid + output index combo".into(),
+            ));
+        }
+        // Ensure that this event is valid if it follows the current latest event.
+        entry
+            .latest_event()
+            .ensure_following_event_is_valid(&update.event)?;
+        // Create the deposit update package.
+        Ok(DepositUpdatePackage {
+            key: entry.key.clone(),
+            version: entry.version,
+            event: update.event,
+        })
+    }
+}
+
+/// All but sends a packaged deposit update.
+pub fn build_deposit_update(
+    context: &EmilyContext,
+    update: &DepositUpdatePackage,
+) -> Result<UpdateItemFluentBuilder, Error> {
+    // Setup the update procedure.
+    let update_expression: &str = " SET
+        #history = list_append(#history, :new_event),
+        #version = #version + :one,
+        #op_status = :new_op_status,
+        #height = :new_height,
+        #hash = :new_hash
+    ";
+    // Ensure the version field is what we expect it to be.
+    let condition_expression = "attribute_exists(#version) AND #version = :expected_version";
+    // Make the key item.
+    let key_item: Item = serde_dynamo::to_item(&update.key)?;
+    // Get simplified status enum.
+    let status: Status = (&update.event.status).into();
+    // Build the update.
+    let builder = context
+        .dynamodb_client
+        .update_item()
+        .table_name(&context.settings.deposit_table_name)
+        .set_key(Some(key_item.into()))
+        .expression_attribute_names("#history", "History")
+        .expression_attribute_names("#version", "Version")
+        .expression_attribute_names("#op_status", "OpStatus")
+        .expression_attribute_names("#height", "LastUpdateHeight")
+        .expression_attribute_names("#hash", "LastUpdateBlockHash")
+        .expression_attribute_values(":new_op_status", serde_dynamo::to_attribute_value(&status)?)
+        .expression_attribute_values(
+            ":new_height",
+            serde_dynamo::to_attribute_value(update.event.stacks_block_height)?,
+        )
+        .expression_attribute_values(
+            ":new_hash",
+            serde_dynamo::to_attribute_value(&update.event.stacks_block_hash)?,
+        )
+        .expression_attribute_values(
+            ":new_event",
+            serde_dynamo::to_attribute_value(vec![update.event.clone()])?,
+        )
+        .expression_attribute_values(
+            ":expected_version",
+            serde_dynamo::to_attribute_value(update.version)?,
+        )
+        .expression_attribute_values(":one", AttributeValue::N(1.to_string()))
+        .condition_expression(condition_expression)
+        .return_values(aws_sdk_dynamodb::types::ReturnValue::AllNew)
+        .update_expression(update_expression);
+    // Return.
+    Ok(builder)
 }

--- a/emily/handler/src/database/entries/mod.rs
+++ b/emily/handler/src/database/entries/mod.rs
@@ -75,8 +75,8 @@ pub enum StatusEntry {
     #[default]
     Pending,
     /// Transaction was dealt with by the signers at one point but is now being
-    /// reevaluated. The Signers are aware of the operation request.
-    Reevaluating,
+    /// reprocessed. The Signers are aware of the operation request.
+    Reprocessing,
     /// Transaction has been seen and accepted by the sBTC Signers, but is not
     /// yet included in any on chain artifact. The transaction can still fail
     /// at this point if the Signers fail to include the transaciton in an on
@@ -100,7 +100,7 @@ impl From<&StatusEntry> for Status {
     fn from(value: &StatusEntry) -> Self {
         match value {
             StatusEntry::Pending => Status::Pending,
-            StatusEntry::Reevaluating => Status::Reevaluating,
+            StatusEntry::Reprocessing => Status::Reprocessing,
             StatusEntry::Accepted(_) => Status::Accepted,
             StatusEntry::Confirmed => Status::Confirmed,
             StatusEntry::Failed => Status::Failed,

--- a/emily/handler/src/database/entries/mod.rs
+++ b/emily/handler/src/database/entries/mod.rs
@@ -51,7 +51,11 @@ use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use serde::{Deserialize, Serialize};
 use serde_dynamo::Item;
 
-use crate::{common::error::Error, context::Settings};
+use crate::{
+    api::models::common::{Fulfillment, Status},
+    common::error::Error,
+    context::Settings,
+};
 
 /// Chainstate table entries.
 pub mod chainstate;
@@ -59,6 +63,50 @@ pub mod chainstate;
 pub mod deposit;
 /// Withdrawal table entries.
 pub mod withdrawal;
+
+// Event structure
+// -----------------------------------------------------------------------------
+
+/// Status entry.
+#[derive(Clone, Default, Debug, Eq, PartialEq, PartialOrd, Ord, Serialize, Deserialize, Hash)]
+#[serde(rename_all = "PascalCase")]
+pub enum StatusEntry {
+    /// Transaction hasn't yet been addressed by the sBTC Signers.
+    #[default]
+    Pending,
+    /// Transaction was dealt with by the signers at one point but is now being
+    /// reevaluated. The Signers are aware of the operation request.
+    Reevaluating,
+    /// Transaction has been seen and accepted by the sBTC Signers, but is not
+    /// yet included in any on chain artifact. The transaction can still fail
+    /// at this point if the Signers fail to include the transaciton in an on
+    /// chain artifact.
+    ///
+    /// For example, a deposit or withdrawal that has specified too low of a
+    /// BTC fee may fail after being accepted.
+    Accepted(Fulfillment),
+    /// The articacts that fulill the operation have been observed in a valid fork of
+    /// both the Stacks blockchain and the Bitcoin blockchain by at least one signer.
+    ///
+    /// Note that if the signers detect a conflicting chainstate in which the operation
+    /// is not confirmed this status will be reverted to either ACCEPTED or REEVALUATING
+    /// depending on whether the conflicting chainstate calls the acceptance into question.
+    Confirmed,
+    /// The operation was not fulfilled.
+    Failed,
+}
+
+impl From<&StatusEntry> for Status {
+    fn from(value: &StatusEntry) -> Self {
+        match value {
+            StatusEntry::Pending => Status::Pending,
+            StatusEntry::Reevaluating => Status::Reevaluating,
+            StatusEntry::Accepted(_) => Status::Accepted,
+            StatusEntry::Confirmed => Status::Confirmed,
+            StatusEntry::Failed => Status::Failed,
+        }
+    }
+}
 
 // Structures
 // -----------------------------------------------------------------------------

--- a/emily/handler/src/database/entries/withdrawal.rs
+++ b/emily/handler/src/database/entries/withdrawal.rs
@@ -185,7 +185,7 @@ impl WithdrawalEvent {
     }
 }
 
-/// Implements the key trait for the deposit entry key.
+/// Implements the key trait for the withdrawal entry key.
 impl KeyTrait for WithdrawalEntryKey {
     /// The type of the partition key.
     type PartitionKey = u64;
@@ -197,11 +197,11 @@ impl KeyTrait for WithdrawalEntryKey {
     const _SORT_KEY_NAME: &'static str = "StacksBlockHash";
 }
 
-/// Implements the entry trait for the deposit entry.
+/// Implements the entry trait for the withdrawal entry.
 impl EntryTrait for WithdrawalEntry {
     /// The type of the key for this entry type.
     type Key = WithdrawalEntryKey;
-    /// Extract the key from the deposit entry.
+    /// Extract the key from the withdrawal entry.
     fn key(&self) -> Self::Key {
         WithdrawalEntryKey {
             request_id: self.key.request_id,
@@ -271,7 +271,7 @@ pub struct WithdrawalInfoEntry {
     pub last_update_block_hash: StacksBlockHash,
 }
 
-/// Implements the key trait for the deposit entry key.
+/// Implements the key trait for the withdrawal info entry key.
 impl KeyTrait for WithdrawalInfoEntryKey {
     /// The type of the partition key.
     type PartitionKey = Status;
@@ -283,11 +283,11 @@ impl KeyTrait for WithdrawalInfoEntryKey {
     const _SORT_KEY_NAME: &'static str = "LastUpdateHeight";
 }
 
-/// Implements the entry trait for the deposit entry.
+/// Implements the entry trait for the withdrawal info entry.
 impl EntryTrait for WithdrawalInfoEntry {
     /// The type of the key for this entry type.
     type Key = WithdrawalInfoEntryKey;
-    /// Extract the key from the deposit info entry.
+    /// Extract the key from the withdrawal info entry.
     fn key(&self) -> Self::Key {
         WithdrawalInfoEntryKey {
             status: self.key.status.clone(),
@@ -298,7 +298,7 @@ impl EntryTrait for WithdrawalInfoEntry {
 
 /// Primary index struct.
 pub struct WithdrawalTableSecondaryIndexInner;
-/// Deposit table primary index type.
+/// Withdrawal table primary index type.
 pub type WithdrawalTableSecondaryIndex = SecondaryIndex<WithdrawalTableSecondaryIndexInner>;
 /// Definition of Primary index trait.
 impl SecondaryIndexTrait for WithdrawalTableSecondaryIndexInner {
@@ -323,7 +323,7 @@ impl From<WithdrawalInfoEntry> for WithdrawalInfo {
     }
 }
 
-/// Validated version of the update deposit request.
+/// Validated version of the update withdrawal request.
 pub struct ValidatedUpdateWithdrawalRequest {
     /// Validated withdrawal update requests.
     pub withdrawals: Vec<ValidatedWithdrawalUpdate>,
@@ -343,11 +343,11 @@ impl TryFrom<UpdateWithdrawalsRequestBody> for ValidatedUpdateWithdrawalRequest 
     }
 }
 
-/// Validated deposit update.
+/// Validated withdrawal update.
 pub struct ValidatedWithdrawalUpdate {
     /// Key.
     pub request_id: WithdrawalId,
-    /// Deposit event.
+    /// Withdrawal event.
     pub event: WithdrawalEvent,
 }
 
@@ -390,7 +390,7 @@ pub struct WithdrawalUpdatePackage {
     pub event: WithdrawalEvent,
 }
 
-/// Implementation of deposit update package.
+/// Implementation of withdrawal update package.
 impl WithdrawalUpdatePackage {
     /// Implements from.
     pub fn from(entry: &WithdrawalEntry, update: ValidatedWithdrawalUpdate) -> Result<Self, Error> {
@@ -404,7 +404,7 @@ impl WithdrawalUpdatePackage {
         entry
             .latest_event()
             .ensure_following_event_is_valid(&update.event)?;
-        // Create the deposit update package.
+        // Create the withdrawal update package.
         Ok(WithdrawalUpdatePackage {
             key: entry.key.clone(),
             version: entry.version,

--- a/emily/handler/src/database/entries/withdrawal.rs
+++ b/emily/handler/src/database/entries/withdrawal.rs
@@ -1,10 +1,6 @@
 //! Entries into the withdrawal table.
 
-use aws_sdk_dynamodb::{
-    operation::update_item::builders::UpdateItemFluentBuilder, types::AttributeValue,
-};
 use serde::{Deserialize, Serialize};
-use serde_dynamo::Item;
 
 use crate::{
     api::models::{
@@ -15,7 +11,6 @@ use crate::{
         },
     },
     common::error::{Error, Inconsistency},
-    context::EmilyContext,
 };
 
 use super::{
@@ -416,59 +411,4 @@ impl WithdrawalUpdatePackage {
             event: update.event,
         })
     }
-}
-
-/// All but sends a packaged withdrawal update.
-pub fn build_withdrawal_update(
-    context: &EmilyContext,
-    update: &WithdrawalUpdatePackage,
-) -> Result<UpdateItemFluentBuilder, Error> {
-    // Setup the update procedure.
-    let update_expression: &str = " SET
-        #history = list_append(#history, :new_event),
-        #version = #version + :one,
-        #op_status = :new_op_status,
-        #height = :new_height,
-        #hash = :new_hash
-    ";
-    // Ensure the version field is what we expect it to be.
-    let condition_expression = "attribute_exists(#version) AND #version = :expected_version";
-    // Make the key item.
-    let key_item: Item = serde_dynamo::to_item(&update.key)?;
-    // Get simplified status enum.
-    let status: Status = (&update.event.status).into();
-    // Build the update.
-    let builder = context
-        .dynamodb_client
-        .update_item()
-        .table_name(&context.settings.withdrawal_table_name)
-        .set_key(Some(key_item.into()))
-        .expression_attribute_names("#history", "History")
-        .expression_attribute_names("#version", "Version")
-        .expression_attribute_names("#op_status", "OpStatus")
-        .expression_attribute_names("#height", "LastUpdateHeight")
-        .expression_attribute_names("#hash", "LastUpdateBlockHash")
-        .expression_attribute_values(":new_op_status", serde_dynamo::to_attribute_value(&status)?)
-        .expression_attribute_values(
-            ":new_height",
-            serde_dynamo::to_attribute_value(update.event.stacks_block_height)?,
-        )
-        .expression_attribute_values(
-            ":new_hash",
-            serde_dynamo::to_attribute_value(&update.event.stacks_block_hash)?,
-        )
-        .expression_attribute_values(
-            ":new_event",
-            serde_dynamo::to_attribute_value(vec![update.event.clone()])?,
-        )
-        .expression_attribute_values(
-            ":expected_version",
-            serde_dynamo::to_attribute_value(update.version)?,
-        )
-        .expression_attribute_values(":one", AttributeValue::N(1.to_string()))
-        .condition_expression(condition_expression)
-        .return_values(aws_sdk_dynamodb::types::ReturnValue::AllNew)
-        .update_expression(update_expression);
-    // Return.
-    Ok(builder)
 }

--- a/emily/handler/tests/integration/endpoints/deposit.rs
+++ b/emily/handler/tests/integration/endpoints/deposit.rs
@@ -1,8 +1,18 @@
 use crate::util::{self, constants::EMILY_DEPOSIT_ENDPOINT, TestClient};
-use emily_handler::api::models::deposit::{
-    requests::CreateDepositRequestBody,
-    responses::{GetDepositsForTransactionResponse, GetDepositsResponse},
-    Deposit, DepositInfo, DepositParameters,
+use emily_handler::{
+    api::models::{
+        common::{Fulfillment, Status},
+        deposit::{
+            requests::{CreateDepositRequestBody, DepositUpdate, UpdateDepositsRequestBody},
+            responses::{GetDepositsForTransactionResponse, GetDepositsResponse},
+            Deposit, DepositInfo, DepositParameters,
+        },
+    },
+    context::EmilyContext,
+    database::{
+        accessors,
+        entries::deposit::{DepositEntry, DepositEntryKey, DepositInfoEntryKey},
+    },
 };
 use serde_json::json;
 use std::sync::LazyLock;
@@ -337,5 +347,140 @@ async fn get_failed_deposits() {
 
     // Assert.
     assert_eq!(response.deposits.len(), 0);
+    client.teardown().await;
+}
+
+/// Update deposits test.
+#[cfg_attr(not(feature = "integration-tests"), ignore)]
+#[tokio::test]
+async fn update_deposit() {
+    // Arrange.
+    let client = setup_deposit_integration_test().await;
+
+    // Get a random deposit info and its identifying fields.
+    let deposit_keys: Vec<DepositEntryKey> = client
+        .get_all_deposits()
+        .await
+        .into_iter()
+        .map(|deposit_info| DepositEntryKey {
+            bitcoin_tx_output_index: deposit_info.bitcoin_tx_output_index,
+            bitcoin_txid: deposit_info.bitcoin_txid,
+        })
+        .collect();
+
+    let key1 = deposit_keys.get(0).unwrap().clone();
+    let key2 = deposit_keys.get(1).unwrap().clone();
+
+    let bitcoin_txid = key1.bitcoin_txid.clone();
+    let bitcoin_tx_output_index = key1.bitcoin_tx_output_index;
+
+    // Get the full deposit.
+    let _original_deposit = client
+        .get_deposit(&bitcoin_txid, bitcoin_tx_output_index)
+        .await;
+
+    // Make some parameters.
+    let updated_hash = "UPDATED_HASH".to_string();
+    let mut updated_height: u64 = 12345;
+    let updated_status: Status = Status::Accepted;
+    let updated_message: String = "UPDATED_MESSAGE".to_string();
+    let fulfillment: Fulfillment = Fulfillment {
+        bitcoin_txid: "FULFILLMENT_BITCOIN_TXID".to_string(),
+        bitcoin_tx_index: 10,
+        stacks_txid: "FULFILLMENT_STACKS_TXID".to_string(),
+        bitcoin_block_hash: "FULFILLMENT_HASH".to_string(),
+        bitcoin_block_height: 10,
+        btc_fee: 12,
+    };
+
+    // Create and make the request.
+    let single_update = UpdateDepositsRequestBody {
+        deposits: vec![
+            DepositUpdate {
+                // Original fields.
+                bitcoin_txid: key1.bitcoin_txid.clone(),
+                bitcoin_tx_output_index: key1.bitcoin_tx_output_index,
+                // New updated height.
+                last_update_height: updated_height,
+                last_update_block_hash: updated_hash.clone(),
+                status: updated_status.clone(),
+                status_message: updated_message.clone(),
+                fulfillment: Some(fulfillment.clone()),
+            },
+            DepositUpdate {
+                // Original fields.
+                bitcoin_txid: key2.bitcoin_txid.clone(),
+                bitcoin_tx_output_index: key2.bitcoin_tx_output_index,
+                // New updated height.
+                last_update_height: updated_height,
+                last_update_block_hash: updated_hash.clone(),
+                status: updated_status.clone(),
+                status_message: updated_message.clone(),
+                fulfillment: Some(fulfillment.clone()),
+            },
+        ],
+    };
+    let response = client.update_deposits(&single_update).await;
+    assert_eq!(response.deposits.len(), 2);
+
+    let updated_deposit = response.deposits.get(0).unwrap().clone();
+    assert_eq!(updated_deposit.last_update_height, updated_height);
+    assert_eq!(updated_deposit.last_update_block_hash, updated_hash);
+    assert_eq!(updated_deposit.status, updated_status);
+    assert_eq!(updated_deposit.status_message, updated_message);
+    assert_eq!(updated_deposit.fulfillment, Some(fulfillment.clone()));
+
+    let updated_deposit = response.deposits.get(1).unwrap().clone();
+    assert_eq!(updated_deposit.last_update_height, updated_height);
+    assert_eq!(updated_deposit.last_update_block_hash, updated_hash);
+    assert_eq!(updated_deposit.status, updated_status);
+    assert_eq!(updated_deposit.status_message, updated_message);
+    assert_eq!(updated_deposit.fulfillment, Some(fulfillment));
+
+    // Update the parameters.
+    let updated_status: Status = Status::Reevaluating;
+    updated_height += 1;
+    // Make the request.
+    let single_update = UpdateDepositsRequestBody {
+        deposits: vec![DepositUpdate {
+            // Original fields.
+            bitcoin_txid: bitcoin_txid,
+            bitcoin_tx_output_index: bitcoin_tx_output_index,
+            // New updated height.
+            last_update_height: updated_height,
+            last_update_block_hash: updated_hash.clone(),
+            status: updated_status.clone(),
+            status_message: updated_message.clone(),
+            fulfillment: None,
+        }],
+    };
+    let response = client.update_deposits(&single_update).await;
+    assert_eq!(response.deposits.len(), 1);
+
+    let updated_deposit = response.deposits.first().unwrap().clone();
+    assert_eq!(updated_deposit.last_update_height, updated_height);
+    assert_eq!(updated_deposit.last_update_block_hash, updated_hash);
+    assert_eq!(updated_deposit.status, updated_status);
+    assert_eq!(updated_deposit.status_message, updated_message);
+    assert_eq!(updated_deposit.fulfillment, None);
+
+    // Now try getting the raw internal entry.
+    let context: EmilyContext = EmilyContext::local_test_instance()
+        .await
+        .expect("Making emily context must succeed in integration test.");
+    let deposit_entry = accessors::get_deposit_entry(
+        &context,
+        &DepositEntryKey {
+            bitcoin_txid: updated_deposit.bitcoin_txid,
+            bitcoin_tx_output_index: updated_deposit.bitcoin_tx_output_index,
+        },
+    )
+    .await
+    .expect("Getting deposit entry in test must succeed.");
+
+    // The history of the deposit should be tracked correctly.
+    assert_eq!(deposit_entry.history.len(), 3);
+
+    // Assert.
     client.teardown().await;
 }

--- a/emily/handler/tests/integration/endpoints/deposit.rs
+++ b/emily/handler/tests/integration/endpoints/deposit.rs
@@ -9,10 +9,7 @@ use emily_handler::{
         },
     },
     context::EmilyContext,
-    database::{
-        accessors,
-        entries::deposit::{DepositEntry, DepositEntryKey, DepositInfoEntryKey},
-    },
+    database::{accessors, entries::deposit::DepositEntryKey},
 };
 use serde_json::json;
 use std::sync::LazyLock;

--- a/emily/handler/tests/integration/endpoints/deposit.rs
+++ b/emily/handler/tests/integration/endpoints/deposit.rs
@@ -397,7 +397,7 @@ async fn update_deposit() {
     };
 
     // Create and make the request.
-    let single_update = UpdateDepositsRequestBody {
+    let update_requests = UpdateDepositsRequestBody {
         deposits: vec![
             DepositUpdate {
                 // Original fields.
@@ -423,8 +423,8 @@ async fn update_deposit() {
             },
         ],
     };
-    let response = client.update_deposits(&single_update).await;
-    assert_eq!(response.deposits.len(), 2);
+    let response = client.update_deposits(&update_requests).await;
+    assert_eq!(response.deposits.len(), update_requests.deposits.len());
 
     let updated_deposit = response.deposits.get(0).unwrap().clone();
     assert_eq!(updated_deposit.last_update_height, updated_height);
@@ -441,9 +441,9 @@ async fn update_deposit() {
     assert_eq!(updated_deposit.fulfillment, Some(fulfillment.clone()));
 
     // Update the parameters.
-    let updated_status: Status = Status::Reevaluating;
+    let updated_status: Status = Status::Reprocessing;
     // Make the request.
-    let single_update = UpdateDepositsRequestBody {
+    let update_requests = UpdateDepositsRequestBody {
         deposits: vec![DepositUpdate {
             // Original fields.
             bitcoin_txid: bitcoin_txid,
@@ -456,8 +456,8 @@ async fn update_deposit() {
             fulfillment: None,
         }],
     };
-    let response = client.update_deposits(&single_update).await;
-    assert_eq!(response.deposits.len(), 1);
+    let response = client.update_deposits(&update_requests).await;
+    assert_eq!(response.deposits.len(), update_requests.deposits.len());
 
     let updated_deposit = response.deposits.first().unwrap().clone();
     assert_eq!(updated_deposit.last_update_height, updated_height + 1);
@@ -495,7 +495,7 @@ async fn update_deposit() {
             stacks_block_hash: updated_hash.clone(),
         },
         DepositEvent {
-            status: StatusEntry::Reevaluating,
+            status: StatusEntry::Reprocessing,
             message: updated_message.clone(),
             stacks_block_height: updated_height + 1,
             stacks_block_hash: updated_hash.clone(),

--- a/emily/handler/tests/integration/endpoints/deposit.rs
+++ b/emily/handler/tests/integration/endpoints/deposit.rs
@@ -11,7 +11,10 @@ use emily_handler::{
     context::EmilyContext,
     database::{
         accessors,
-        entries::{deposit::{DepositEntryKey, DepositEvent}, StatusEntry},
+        entries::{
+            deposit::{DepositEntryKey, DepositEvent},
+            StatusEntry,
+        },
     },
 };
 use serde_json::json;
@@ -499,7 +502,6 @@ async fn update_deposit() {
         },
     ];
     assert_eq!(deposit_entry.history, history);
-
 
     // Assert.
     client.teardown().await;

--- a/emily/handler/tests/integration/endpoints/withdrawal.rs
+++ b/emily/handler/tests/integration/endpoints/withdrawal.rs
@@ -10,7 +10,10 @@ use emily_handler::{
         },
     },
     context::EmilyContext,
-    database::{accessors, entries::{withdrawal::WithdrawalEvent, StatusEntry}},
+    database::{
+        accessors,
+        entries::{withdrawal::WithdrawalEvent, StatusEntry},
+    },
 };
 use serde_json::json;
 use std::sync::LazyLock;

--- a/emily/handler/tests/integration/endpoints/withdrawal.rs
+++ b/emily/handler/tests/integration/endpoints/withdrawal.rs
@@ -1,10 +1,16 @@
-use emily_handler::api::models::{
-    common::Status,
-    withdrawal::{
-        requests::CreateWithdrawalRequestBody,
-        responses::{GetWithdrawalResponse, GetWithdrawalsResponse},
-        Withdrawal, WithdrawalInfo,
+use emily_handler::{
+    api::models::{
+        common::{Fulfillment, Status},
+        withdrawal::{
+            requests::{
+                CreateWithdrawalRequestBody, UpdateWithdrawalsRequestBody, WithdrawalUpdate,
+            },
+            responses::{GetWithdrawalResponse, GetWithdrawalsResponse},
+            Withdrawal, WithdrawalInfo,
+        },
     },
+    context::EmilyContext,
+    database::{accessors, entries::withdrawal::WithdrawalEntryKey},
 };
 use serde_json::json;
 use std::sync::LazyLock;
@@ -47,7 +53,7 @@ static TEST_WITHDRAWAL_DATA: LazyLock<Vec<TestWithdrawalData>> = LazyLock::new(|
 
 /// Setup function that wipes the database and populates it with the necessary
 /// withdrawal data.
-async fn setup_deposit_integration_test() -> TestClient {
+async fn setup_withdrawal_integration_test() -> TestClient {
     let client = TestClient::new();
     client.setup_test().await;
     for test_withdrawal_data in TEST_WITHDRAWAL_DATA.iter() {
@@ -105,7 +111,7 @@ fn just_created_withdrawal(
 async fn create_withdrawals() {
     // The setup function runs what was origninally the create tests by creating the
     // resources and then assessing what was created.
-    let client = setup_deposit_integration_test().await;
+    let client = setup_withdrawal_integration_test().await;
     client.teardown().await;
 }
 
@@ -113,7 +119,7 @@ async fn create_withdrawals() {
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn get_withdrawal() {
-    let client = setup_deposit_integration_test().await;
+    let client = setup_withdrawal_integration_test().await;
     for test_withdrawal_data in TEST_WITHDRAWAL_DATA.iter() {
         // Arrange.
         let TestWithdrawalData {
@@ -151,7 +157,7 @@ async fn get_withdrawal() {
 #[tokio::test]
 async fn get_withdrawals() {
     // Arrange.
-    let client = setup_deposit_integration_test().await;
+    let client = setup_withdrawal_integration_test().await;
     let page_size: i32 = 1;
 
     let mut aggregate_withdrawals: Vec<WithdrawalInfo> = vec![];
@@ -214,5 +220,123 @@ async fn get_withdrawals() {
     aggregate_withdrawals.sort();
     expected_withdrawal_infos.sort();
     assert_eq!(aggregate_withdrawals, expected_withdrawal_infos);
+    client.teardown().await;
+}
+
+/// Update deposits test.
+#[cfg_attr(not(feature = "integration-tests"), ignore)]
+#[tokio::test]
+async fn update_withdrawal() {
+    // Arrange.
+    let client = setup_withdrawal_integration_test().await;
+
+    // Get a random deposit info and its identifying fields.
+    let withdrawal_ids: Vec<u64> = client
+        .get_all_withdrawals()
+        .await
+        .into_iter()
+        .map(|withdrawal_info| withdrawal_info.request_id)
+        .collect();
+
+    let request_id_1 = withdrawal_ids.get(0).unwrap().clone();
+    let request_id_2 = withdrawal_ids.get(1).unwrap().clone();
+
+    // Get the full deposit.
+    let _original_deposit = client.get_withdrawal(&request_id_1).await;
+
+    // Make some parameters.
+    let updated_hash = "UPDATED_HASH".to_string();
+    let mut updated_height: u64 = 12345;
+    let updated_status: Status = Status::Accepted;
+    let updated_message: String = "UPDATED_MESSAGE".to_string();
+    let fulfillment: Fulfillment = Fulfillment {
+        bitcoin_txid: "FULFILLMENT_BITCOIN_TXID".to_string(),
+        bitcoin_tx_index: 10,
+        stacks_txid: "FULFILLMENT_STACKS_TXID".to_string(),
+        bitcoin_block_hash: "FULFILLMENT_HASH".to_string(),
+        bitcoin_block_height: 10,
+        btc_fee: 12,
+    };
+
+    // Create and make the request.
+    let single_update = UpdateWithdrawalsRequestBody {
+        withdrawals: vec![
+            WithdrawalUpdate {
+                // Original fields.
+                request_id: request_id_1,
+                // New updated height.
+                last_update_height: updated_height,
+                last_update_block_hash: updated_hash.clone(),
+                status: updated_status.clone(),
+                status_message: updated_message.clone(),
+                fulfillment: Some(fulfillment.clone()),
+            },
+            WithdrawalUpdate {
+                // Original fields.
+                request_id: request_id_2,
+                // New updated height.
+                last_update_height: updated_height,
+                last_update_block_hash: updated_hash.clone(),
+                status: updated_status.clone(),
+                status_message: updated_message.clone(),
+                fulfillment: Some(fulfillment.clone()),
+            },
+        ],
+    };
+    let response = client.update_withdrawals(&single_update).await;
+    assert_eq!(response.withdrawals.len(), 2);
+
+    let updated_withdrawal = response.withdrawals.get(0).unwrap().clone();
+    assert_eq!(updated_withdrawal.last_update_height, updated_height);
+    assert_eq!(updated_withdrawal.last_update_block_hash, updated_hash);
+    assert_eq!(updated_withdrawal.status, updated_status);
+    assert_eq!(updated_withdrawal.status_message, updated_message);
+    assert_eq!(updated_withdrawal.fulfillment, Some(fulfillment.clone()));
+
+    let updated_withdrawal = response.withdrawals.get(1).unwrap().clone();
+    assert_eq!(updated_withdrawal.last_update_height, updated_height);
+    assert_eq!(updated_withdrawal.last_update_block_hash, updated_hash);
+    assert_eq!(updated_withdrawal.status, updated_status);
+    assert_eq!(updated_withdrawal.status_message, updated_message);
+    assert_eq!(updated_withdrawal.fulfillment, Some(fulfillment));
+
+    // Update the parameters.
+    let updated_status: Status = Status::Reevaluating;
+    updated_height += 1;
+    // Make the request.
+    let single_update = UpdateWithdrawalsRequestBody {
+        withdrawals: vec![WithdrawalUpdate {
+            // Original fields.
+            request_id: request_id_1,
+            // New updated height.
+            last_update_height: updated_height,
+            last_update_block_hash: updated_hash.clone(),
+            status: updated_status.clone(),
+            status_message: updated_message.clone(),
+            fulfillment: None,
+        }],
+    };
+    let response = client.update_withdrawals(&single_update).await;
+    assert_eq!(response.withdrawals.len(), 1);
+
+    let updated_withdrawal = response.withdrawals.first().unwrap().clone();
+    assert_eq!(updated_withdrawal.last_update_height, updated_height);
+    assert_eq!(updated_withdrawal.last_update_block_hash, updated_hash);
+    assert_eq!(updated_withdrawal.status, updated_status);
+    assert_eq!(updated_withdrawal.status_message, updated_message);
+    assert_eq!(updated_withdrawal.fulfillment, None);
+
+    // Now try getting the raw internal entry and ensure that the history is good.
+    let context: EmilyContext = EmilyContext::local_test_instance()
+        .await
+        .expect("Making emily context must succeed in integration test.");
+    let withdrawal_entry = accessors::get_withdrawal_entry(&context, &request_id_1)
+        .await
+        .expect("Getting withdrawal entry in test must succeed.");
+
+    // The history of the withdrawal should be tracked correctly.
+    assert_eq!(withdrawal_entry.history.len(), 3);
+
+    // Assert.
     client.teardown().await;
 }

--- a/emily/handler/tests/integration/endpoints/withdrawal.rs
+++ b/emily/handler/tests/integration/endpoints/withdrawal.rs
@@ -10,7 +10,7 @@ use emily_handler::{
         },
     },
     context::EmilyContext,
-    database::{accessors, entries::withdrawal::WithdrawalEntryKey},
+    database::accessors,
 };
 use serde_json::json;
 use std::sync::LazyLock;

--- a/emily/handler/tests/integration/endpoints/withdrawal.rs
+++ b/emily/handler/tests/integration/endpoints/withdrawal.rs
@@ -262,7 +262,7 @@ async fn update_withdrawal() {
     };
 
     // Create and make the request.
-    let single_update = UpdateWithdrawalsRequestBody {
+    let update_requests = UpdateWithdrawalsRequestBody {
         withdrawals: vec![
             WithdrawalUpdate {
                 // Original fields.
@@ -286,8 +286,11 @@ async fn update_withdrawal() {
             },
         ],
     };
-    let response = client.update_withdrawals(&single_update).await;
-    assert_eq!(response.withdrawals.len(), 2);
+    let response = client.update_withdrawals(&update_requests).await;
+    assert_eq!(
+        response.withdrawals.len(),
+        update_requests.withdrawals.len()
+    );
 
     let updated_withdrawal = response.withdrawals.get(0).unwrap().clone();
     assert_eq!(updated_withdrawal.last_update_height, updated_height);
@@ -304,9 +307,9 @@ async fn update_withdrawal() {
     assert_eq!(updated_withdrawal.fulfillment, Some(fulfillment.clone()));
 
     // Update the parameters.
-    let updated_status: Status = Status::Reevaluating;
+    let updated_status: Status = Status::Reprocessing;
     // Make the request.
-    let single_update = UpdateWithdrawalsRequestBody {
+    let update_requests = UpdateWithdrawalsRequestBody {
         withdrawals: vec![WithdrawalUpdate {
             // Original fields.
             request_id: request_id_1,
@@ -318,8 +321,11 @@ async fn update_withdrawal() {
             fulfillment: None,
         }],
     };
-    let response = client.update_withdrawals(&single_update).await;
-    assert_eq!(response.withdrawals.len(), 1);
+    let response = client.update_withdrawals(&update_requests).await;
+    assert_eq!(
+        response.withdrawals.len(),
+        update_requests.withdrawals.len()
+    );
 
     let updated_withdrawal = response.withdrawals.first().unwrap().clone();
     assert_eq!(updated_withdrawal.last_update_height, updated_height + 1);
@@ -351,7 +357,7 @@ async fn update_withdrawal() {
             stacks_block_hash: updated_hash.clone(),
         },
         WithdrawalEvent {
-            status: StatusEntry::Reevaluating,
+            status: StatusEntry::Reprocessing,
             message: updated_message.clone(),
             stacks_block_height: updated_height + 1,
             stacks_block_hash: updated_hash.clone(),

--- a/emily/handler/tests/integration/util/constants.rs
+++ b/emily/handler/tests/integration/util/constants.rs
@@ -2,13 +2,11 @@
 
 use emily_handler::api::models::{common::Status, withdrawal::WithdrawalParameters};
 
-// TODO(273):  Remove the "local" prefix once we figure out why all local
-// testing calls seem to forcibly start with `local`.
-pub const EMILY_ENDPOINT: &'static str = "http://localhost:3031/local";
-pub const EMILY_WITHDRAWAL_ENDPOINT: &'static str = "http://localhost:3031/local/withdrawal";
-pub const EMILY_DEPOSIT_ENDPOINT: &'static str = "http://localhost:3031/local/deposit";
-pub const EMILY_CHAINSTATE_ENDPOINT: &'static str = "http://localhost:3031/local/chainstate";
-pub const EMILY_TESTING_ENDPOINT: &'static str = "http://localhost:3031/local/testing";
+pub const EMILY_ENDPOINT: &'static str = "http://localhost:3031";
+pub const EMILY_WITHDRAWAL_ENDPOINT: &'static str = "http://localhost:3031/withdrawal";
+pub const EMILY_DEPOSIT_ENDPOINT: &'static str = "http://localhost:3031/deposit";
+pub const EMILY_CHAINSTATE_ENDPOINT: &'static str = "http://localhost:3031/chainstate";
+pub const EMILY_TESTING_ENDPOINT: &'static str = "http://localhost:3031/testing";
 
 pub const TEST_WITHDRAWAL_PARAMETERS: WithdrawalParameters = WithdrawalParameters { max_fee: 1234 };
 

--- a/emily/handler/tests/integration/util/constants.rs
+++ b/emily/handler/tests/integration/util/constants.rs
@@ -22,5 +22,5 @@ pub const ALL_STATUSES: &[Status] = &[
     Status::Confirmed,
     Status::Failed,
     Status::Pending,
-    Status::Reevaluating,
+    Status::Reprocessing,
 ];

--- a/emily/handler/tests/integration/util/mod.rs
+++ b/emily/handler/tests/integration/util/mod.rs
@@ -8,14 +8,16 @@ use emily_handler::{
         chainstate::Chainstate,
         common::Status,
         deposit::{
-            requests::CreateDepositRequestBody,
-            responses::{CreateDepositResponse, GetDepositsResponse},
-            DepositInfo,
+            requests::{CreateDepositRequestBody, UpdateDepositsRequestBody},
+            responses::{CreateDepositResponse, GetDepositsResponse, UpdateDepositsResponse},
+            Deposit, DepositInfo,
         },
         withdrawal::{
-            requests::CreateWithdrawalRequestBody,
-            responses::{CreateWithdrawalResponse, GetWithdrawalsResponse},
-            WithdrawalInfo,
+            requests::{CreateWithdrawalRequestBody, UpdateWithdrawalsRequestBody},
+            responses::{
+                CreateWithdrawalResponse, GetWithdrawalsResponse, UpdateWithdrawalsResponse,
+            },
+            Withdrawal, WithdrawalId, WithdrawalInfo,
         },
     },
     context::EmilyContext,
@@ -121,6 +123,30 @@ impl TestClient {
             .unwrap()
     }
 
+    /// Get a single deposit.
+    pub async fn get_deposit(
+        &self,
+        bitcoin_txid: &String,
+        bitcoin_tx_output_index: u32,
+    ) -> Deposit {
+        get_xyz::<Deposit>(
+            &self.inner,
+            format!("{EMILY_DEPOSIT_ENDPOINT}/{bitcoin_txid}/{bitcoin_tx_output_index}").as_str(),
+        )
+        .await
+        .expect("Get deposit in test failed.")
+    }
+
+    /// Executes an update deposits request.
+    pub async fn update_deposits(
+        &self,
+        request: &UpdateDepositsRequestBody,
+    ) -> UpdateDepositsResponse {
+        update_xyz(&self.inner, &EMILY_DEPOSIT_ENDPOINT, request)
+            .await
+            .expect("Update deposits in test failed.")
+    }
+
     /// Create withdrawal.
     pub async fn create_withdrawal(
         &self,
@@ -129,6 +155,26 @@ impl TestClient {
         create_xyz(&self.inner, EMILY_WITHDRAWAL_ENDPOINT, request)
             .await
             .unwrap()
+    }
+
+    /// Get a single withdrawal.
+    pub async fn get_withdrawal(&self, request_id: &WithdrawalId) -> Withdrawal {
+        get_xyz::<Withdrawal>(
+            &self.inner,
+            format!("{EMILY_WITHDRAWAL_ENDPOINT}/{request_id}").as_str(),
+        )
+        .await
+        .expect("Get withdrawal in test failed.")
+    }
+
+    /// Executes an update withdrawals request.
+    pub async fn update_withdrawals(
+        &self,
+        request: &UpdateWithdrawalsRequestBody,
+    ) -> UpdateWithdrawalsResponse {
+        update_xyz(&self.inner, &EMILY_WITHDRAWAL_ENDPOINT, request)
+            .await
+            .expect("Update withdrawals in test failed.")
     }
 
     /// Create chainstate.


### PR DESCRIPTION
## Description

Partially closes: #348 

Finishes the put requests for the deposit and withdrawal entries.

The last steps handle are 
- Chainstate update with a reorg.
- Hidden conflicts.

This PR alters the deposit and withdrawal update structures and implements the update api calls for the deposits and withdrawals. 

## Changes

- Makefile
    - Adds two watch commands for emily api
- Deposit and Withdrawal
    - Changed the update request structure to only include fields relevant to an update
    - Added update functionality for deposit and withdrawal entries

## Testing Information

Tested with new integration tests.

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
