### PR TITLE
feat: Emily server cli args + remove "/local" path prefix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1539,6 +1539,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-dynamodb",
  "base64 0.22.1",
+ "clap",
  "config 0.11.0",
  "fake",
  "mockall",

--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ emily-integration-env-down:
 emily-integration-test-full: emily-integration-env-up emily-integration-test emily-integration-env-down
 
 emily-server-watch:
-	cargo watch -d 1.5 -x 'run --bin emily-server'
+	cargo watch -d 1.5 -x 'run --bin emily-server -- --pretty-logs'
 
 emily-integration-test-watch:
 	cargo watch -d 3 -x 'test --package emily-handler --test integration --features integration-tests -- \

--- a/devenv/service-test/curl-test.sh
+++ b/devenv/service-test/curl-test.sh
@@ -4,7 +4,7 @@
 HOSTNAME="$1"
 PORT="$2"
 
-ENDPOINT="http://$HOSTNAME:$PORT/local"
+ENDPOINT="http://$HOSTNAME:$PORT"
 
 banner() {
     echo

--- a/emily/handler/Cargo.toml
+++ b/emily/handler/Cargo.toml
@@ -20,6 +20,7 @@ aws-config.workspace = true
 aws-sdk-dynamodb.workspace = true
 base64.workspace = true
 config.workspace = true
+clap.workspace = true
 openssl.workspace = true
 reqwest.workspace = true
 serde = { workspace = true, features = ["derive"] }

--- a/emily/handler/src/api/routes/mod.rs
+++ b/emily/handler/src/api/routes/mod.rs
@@ -21,29 +21,25 @@ mod withdrawal;
 #[cfg(feature = "testing")]
 pub fn routes(
     context: EmilyContext,
-) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
-    // TODO(273):  Remove the "local" prefix once we figure out why all local
-    // testing calls seem to forcibly start with `local`.
-    warp::path("local").and(
-        health::routes()
-            .or(chainstate::routes(context.clone()))
-            .or(deposit::routes(context.clone()))
-            .or(withdrawal::routes(context.clone()))
-            .or(testing::routes(context)),
-    )
+) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
+    health::routes()
+        .or(chainstate::routes(context.clone()))
+        .or(deposit::routes(context.clone()))
+        .or(withdrawal::routes(context.clone()))
+        .or(testing::routes(context))
+        // Convert reply to tuple to that more routes can be added to the returned filter.
+        .map(|reply| (reply,))
 }
 
 /// This function sets the Warp filters for handling all requests.
 #[cfg(not(feature = "testing"))]
 pub fn routes(
     context: EmilyContext,
-) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
-    // TODO(273):  Remove the "local" prefix once we figure out why all local
-    // testing calls seem to forcibly start with `local`.
-    warp::path("local").and(
-        health::routes()
-            .or(chainstate::routes(context.clone()))
-            .or(deposit::routes(context.clone()))
-            .or(withdrawal::routes(context)),
-    )
+) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
+    health::routes()
+        .or(chainstate::routes(context.clone()))
+        .or(deposit::routes(context.clone()))
+        .or(withdrawal::routes(context))
+        // Convert reply to tuple to that more routes can be added to the returned filter.
+        .map(|reply| (reply,))
 }

--- a/emily/handler/src/bin/emily-lambda.rs
+++ b/emily/handler/src/bin/emily-lambda.rs
@@ -2,6 +2,7 @@
 
 use emily_handler::context::EmilyContext;
 use tracing::info;
+use tracing::warn;
 use warp::Filter;
 
 use emily_handler::api;
@@ -9,29 +10,44 @@ use emily_handler::logging;
 
 #[tokio::main]
 async fn main() {
+    // Setup logging.
     logging::setup_logging("info,emily-handler=debug", false);
 
+    // Setup context.
     // TODO(389 + 358): Handle config pickup in a way that will only fail for the relevant call.
-    let emily_context: EmilyContext = EmilyContext::from_env()
+    let context: EmilyContext = EmilyContext::from_env()
         .await
         .unwrap_or_else(|e| panic!("{e}"));
+    info!("Lambda Context:\n{context:?}");
 
-    // Print configuration.
-    info!("Emily context setup for Emily Lambda.");
-    let emily_context_string =
-        serde_json::to_string_pretty(&emily_context).expect("Context must be serializable.");
-    info!(emily_context_string);
-
-    // Make routes.
-    let routes = api::routes::routes(emily_context)
+    // Setup service filters.
+    let service_filter = routes(context)
         .recover(api::handlers::handle_rejection)
         .with(warp::log("api"));
 
     // Create warp service.
-    let warp_service = warp::service(routes);
-
     // TODO(276): Remove warp_lambda in Emily API and use different library.
+    let warp_service = warp::service(service_filter);
     warp_lambda::run(warp_service)
         .await
         .expect("An error occurred");
+}
+
+/// Makes the routes.
+#[cfg(not(feature = "testing"))]
+fn routes(
+    context: EmilyContext,
+) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
+    api::routes::routes(context)
+}
+
+/// Makes the routes.
+#[cfg(feature = "testing")]
+fn routes(
+    context: EmilyContext,
+) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
+    warn!(
+        "Running lambda server with testing features - all paths will be prefixed with \"/local\""
+    );
+    warp::path("local").and(api::routes::routes(context))
 }

--- a/emily/handler/src/bin/emily-server.rs
+++ b/emily/handler/src/bin/emily-server.rs
@@ -1,5 +1,7 @@
 //! Emily Warp Service Binary.
 
+use clap::Args;
+use clap::Parser;
 use emily_handler::context::EmilyContext;
 use tracing::info;
 use warp::Filter;
@@ -7,37 +9,73 @@ use warp::Filter;
 use emily_handler::api;
 use emily_handler::logging;
 
+/// The arguments for the Emily server.
+#[derive(Parser, Debug)]
+#[command(
+    name = "EmilyServer",
+    version = "1.0",
+    author = "Ashton Stephens <ashton@trustmachines.co>",
+    about = "Local emily server binary"
+)]
+pub struct Cli {
+    /// Server arguments.
+    #[command(flatten)]
+    pub server: ServerArgs,
+    /// General arguments.
+    #[command(flatten)]
+    pub general: GeneralArgs,
+}
+
+/// General arguments.
+#[derive(Args, Debug)]
+pub struct GeneralArgs {
+    /// Whether to use pretty log printing.
+    #[arg(long, default_value = "false")]
+    pub pretty_logs: bool,
+    /// Log directives.
+    #[arg(long, default_value = "info,emily-handler=debug")]
+    pub log_directives: String,
+}
+
+/// Server related arguments.
+#[derive(Args, Debug)]
+pub struct ServerArgs {
+    /// Host.
+    #[arg(long, default_value = "127.0.0.1")]
+    pub host: String,
+    /// Port to run on.
+    #[arg(long, default_value = "3031")]
+    pub port: u64,
+}
+
+/// Main program.
 #[tokio::main]
 async fn main() {
-    #[cfg(feature = "testing")]
-    logging::setup_logging("info,emily-handler=debug", true);
+    // Get command line arguments.
+    let Cli {
+        server: ServerArgs { host, port },
+        general: GeneralArgs { pretty_logs, log_directives },
+    } = Cli::parse();
 
-    #[cfg(not(feature = "testing"))]
-    logging::setup_logging("info,emily-handler=debug", false);
+    // Setup logging.
+    logging::setup_logging(&log_directives, pretty_logs);
 
+    // Setup context.
     // TODO(389 + 358): Handle config pickup in a way that will only fail for the relevant call.
-    let emily_context: EmilyContext = EmilyContext::local_test_instance()
+    let context: EmilyContext = EmilyContext::local_test_instance()
         .await
         .unwrap_or_else(|e| panic!("{e}"));
+    info!("Lambda Context:\n{context:?}");
 
-    // Print configuration.
-    info!("Emily context setup for Emily local server.");
-    let emily_context_string =
-        serde_json::to_string_pretty(&emily_context).expect("Context must be serializable.");
-    info!("emily_context:\n{}", emily_context_string);
-
-    let routes = api::routes::routes(emily_context)
+    let routes = api::routes::routes(context)
         .recover(api::handlers::handle_rejection)
         .with(warp::log("api"));
 
-    // Create warp service as a local service.
-    // TODO(TBD): Make these fields configurable.
-    let host: &str = "127.0.0.1";
-    let port: i32 = 3031;
-    let addr_str = format!("{}:{}", host, port);
-
+    // Create address.
+    let addr_str = format!("{host}:{port}");
     info!("Server will run locally on {}", addr_str);
     let addr: std::net::SocketAddr = addr_str.parse().expect("Failed to parse address");
 
+    // Create warp service as a local service and listen at the address.
     warp::serve(routes).run(addr).await;
 }

--- a/emily/handler/src/context.rs
+++ b/emily/handler/src/context.rs
@@ -6,6 +6,7 @@
 //! toml and potentially overwrites the fields with environment values.
 
 use std::env;
+use std::fmt;
 
 use aws_config::BehaviorVersion;
 use aws_sdk_dynamodb::Client;
@@ -26,14 +27,26 @@ pub struct Settings {
     pub chainstate_table_name: String,
 }
 
-/// Lambda Context
-#[derive(Clone, Debug, Serialize)]
+/// Emily Context
+#[derive(Clone, Serialize)]
 pub struct EmilyContext {
     /// Lambda settings.
     pub settings: Settings,
     /// DynamoDB Client.
     #[serde(skip_serializing)]
     pub dynamodb_client: Client,
+}
+
+/// Implement debug print for the context struct.
+impl fmt::Debug for EmilyContext {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            serde_json::to_string_pretty(self)
+                .expect("Failed to serialize Emily Context in debug print.")
+        )
+    }
 }
 
 // Implementations -------------------------------------------------------------

--- a/emily/handler/tests/integration/util/constants.rs
+++ b/emily/handler/tests/integration/util/constants.rs
@@ -2,13 +2,11 @@
 
 use emily_handler::api::models::{common::Status, withdrawal::WithdrawalParameters};
 
-// TODO(273):  Remove the "local" prefix once we figure out why all local
-// testing calls seem to forcibly start with `local`.
-pub const EMILY_ENDPOINT: &'static str = "http://localhost:3031/local";
-pub const EMILY_WITHDRAWAL_ENDPOINT: &'static str = "http://localhost:3031/local/withdrawal";
-pub const EMILY_DEPOSIT_ENDPOINT: &'static str = "http://localhost:3031/local/deposit";
-pub const EMILY_CHAINSTATE_ENDPOINT: &'static str = "http://localhost:3031/local/chainstate";
-pub const EMILY_TESTING_ENDPOINT: &'static str = "http://localhost:3031/local/testing";
+pub const EMILY_ENDPOINT: &'static str = "http://localhost:3031";
+pub const EMILY_WITHDRAWAL_ENDPOINT: &'static str = "http://localhost:3031/withdrawal";
+pub const EMILY_DEPOSIT_ENDPOINT: &'static str = "http://localhost:3031/deposit";
+pub const EMILY_CHAINSTATE_ENDPOINT: &'static str = "http://localhost:3031/chainstate";
+pub const EMILY_TESTING_ENDPOINT: &'static str = "http://localhost:3031/testing";
 
 pub const TEST_WITHDRAWAL_PARAMETERS: WithdrawalParameters = WithdrawalParameters { max_fee: 1234 };
 


### PR DESCRIPTION
## Description

Closes: #273

This ticket closes the local prefix issue by only adding the prefix on the lambda binary configuration with the `testing` feature. The `sam` cli that's used to run the lambda locally forcibly includes the `/local` prefix to prevent any accidental running of the `sam` development environment in the cloud, so the only way to get around this is to make adding the path conditional.

## Changes

The `route` commands needed to change to return tuples of replies because the output of the filters needs to be a tuple in order to continue composing the filter with `and` warp filters - this is because it needs to be possible to convert the output into function arguments for the next filter to receive.

It's a bit wonky, but necessary.

## Testing Information

Tested with integration tests and also on local make commands.

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
