### PR TITLE
refactor: automatically set created_at columns

### DIFF
--- a/signer/migrations/0003__create_tables.sql
+++ b/signer/migrations/0003__create_tables.sql
@@ -13,14 +13,14 @@ CREATE TABLE sbtc_signer.bitcoin_blocks (
     block_height BIGINT NOT NULL,
     parent_hash BYTEA NOT NULL,
     confirms BYTEA[] NOT NULL,
-    created_at TIMESTAMPTZ NOT NULL
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL
 );
 
 CREATE TABLE sbtc_signer.stacks_blocks (
     block_hash BYTEA PRIMARY KEY,
     block_height BIGINT NOT NULL,
     parent_hash BYTEA NOT NULL,
-    created_at TIMESTAMPTZ NOT NULL
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL
 );
 
 CREATE TABLE sbtc_signer.deposit_requests (
@@ -32,7 +32,7 @@ CREATE TABLE sbtc_signer.deposit_requests (
     amount BIGINT NOT NULL,
     max_fee BIGINT NOT NULL,
     sender_addresses TEXT[] NOT NULL,
-    created_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
     PRIMARY KEY (txid, output_index)
 );
 
@@ -41,7 +41,7 @@ CREATE TABLE sbtc_signer.deposit_signers (
     output_index INTEGER NOT NULL,
     signer_pub_key BYTEA NOT NULL,
     is_accepted BOOL NOT NULL,
-    created_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
     PRIMARY KEY (txid, output_index, signer_pub_key),
     FOREIGN KEY (txid, output_index) REFERENCES sbtc_signer.deposit_requests(txid, output_index) ON DELETE CASCADE
 );
@@ -53,7 +53,7 @@ CREATE TABLE sbtc_signer.withdraw_requests (
     amount BIGINT NOT NULL,
     max_fee BIGINT NOT NULL,
     sender_address TEXT NOT NULL,
-    created_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
     PRIMARY KEY (request_id, block_hash),
     FOREIGN KEY (block_hash) REFERENCES sbtc_signer.stacks_blocks(block_hash) ON DELETE CASCADE
 );
@@ -63,7 +63,7 @@ CREATE TABLE sbtc_signer.withdraw_signers (
     block_hash BYTEA NOT NULL,
     signer_pub_key BYTEA NOT NULL,
     is_accepted BOOL NOT NULL,
-    created_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
     PRIMARY KEY (request_id, block_hash, signer_pub_key),
     FOREIGN KEY (request_id, block_hash) REFERENCES sbtc_signer.withdraw_requests(request_id, block_hash) ON DELETE CASCADE
 );
@@ -72,7 +72,7 @@ CREATE TABLE sbtc_signer.transactions (
     txid BYTEA PRIMARY KEY,
     tx BYTEA NOT NULL,
     tx_type sbtc_signer.transaction_type NOT NULL,
-    created_at TIMESTAMPTZ NOT NULL
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL
 );
 
 CREATE TABLE sbtc_signer.dkg_shares (
@@ -81,7 +81,7 @@ CREATE TABLE sbtc_signer.dkg_shares (
     encrypted_private_shares BYTEA NOT NULL,
     public_shares BYTEA NOT NULL,
     script_pubkey BYTEA NOT NULL,
-    created_at TIMESTAMPTZ NOT NULL
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL
 );
 
 CREATE TABLE sbtc_signer.coordinator_broadcasts (
@@ -89,7 +89,7 @@ CREATE TABLE sbtc_signer.coordinator_broadcasts (
     txid BYTEA NOT NULL,
     broadcast_block_height INTEGER NOT NULL,
     market_fee_rate INTEGER NOT NULL,
-    created_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
     FOREIGN KEY (txid) REFERENCES sbtc_signer.transactions(txid) ON DELETE CASCADE
 );
 

--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -263,7 +263,6 @@ where
                 .expect("Failed to get block height") as i64,
             parent_hash: block.header.prev_blockhash.to_byte_array().to_vec(),
             confirms: Vec::new(),
-            created_at: time::OffsetDateTime::now_utc(),
         };
 
         self.storage.write_bitcoin_block(&db_block).await?;
@@ -558,7 +557,6 @@ mod tests {
             aggregate_key,
             tweaked_aggregate_key: aggregate_key.signers_tweaked_pubkey().unwrap(),
             script_pubkey: signers_script_pubkey.clone(),
-            created_at: time::OffsetDateTime::now_utc(),
             encrypted_private_shares: Vec::new(),
             public_shares: Vec::new(),
         };

--- a/signer/src/stacks/contracts.rs
+++ b/signer/src/stacks/contracts.rs
@@ -134,7 +134,7 @@ pub trait AsContractCall {
         Error: From<<S as DbRead>::Error>;
 }
 
-/// Thing
+/// An enum representing all contract calls that the signers can make.
 #[derive(Clone, Debug, Hash, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum ContractCall {
     /// Call the `complete-deposit-wrapper` function in the `sbtc-deposit`

--- a/signer/src/storage/model.rs
+++ b/signer/src/storage/model.rs
@@ -10,11 +10,8 @@ use sbtc::deposits::Deposit;
 
 use crate::keys::PublicKey;
 
-#[cfg(feature = "testing")]
-use fake::faker::time::en::DateTimeAfter;
-
 /// Bitcoin block.
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, sqlx::FromRow)]
 #[cfg_attr(feature = "testing", derive(fake::Dummy))]
 pub struct BitcoinBlock {
     /// Block hash.
@@ -28,16 +25,10 @@ pub struct BitcoinBlock {
     /// Stacks block confirmed by this block.
     #[cfg_attr(feature = "testing", dummy(default))]
     pub confirms: Vec<StacksBlockHash>,
-    /// The time this block entry was created by the signer.
-    #[cfg_attr(
-        feature = "testing",
-        dummy(faker = "DateTimeAfter(time::OffsetDateTime::UNIX_EPOCH)")
-    )]
-    pub created_at: time::OffsetDateTime,
 }
 
 /// Stacks block.
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, sqlx::FromRow)]
 #[cfg_attr(feature = "testing", derive(fake::Dummy))]
 pub struct StacksBlock {
     /// Block hash.
@@ -48,16 +39,10 @@ pub struct StacksBlock {
     /// Hash of the parent block.
     #[cfg_attr(feature = "testing", dummy(expr = "fake::vec![u8; 32]"))]
     pub parent_hash: StacksBlockHash,
-    /// The time this block entry was created by the signer.
-    #[cfg_attr(
-        feature = "testing",
-        dummy(faker = "DateTimeAfter(time::OffsetDateTime::UNIX_EPOCH)")
-    )]
-    pub created_at: time::OffsetDateTime,
 }
 
 /// Deposit request.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, sqlx::FromRow)]
 #[cfg_attr(feature = "testing", derive(fake::Dummy))]
 pub struct DepositRequest {
     /// Transaction ID of the deposit request transaction.
@@ -81,12 +66,6 @@ pub struct DepositRequest {
     /// The addresses of the input UTXOs funding the deposit request.
     #[cfg_attr(feature = "testing", dummy(faker = "BitcoinAddresses(1..5)"))]
     pub sender_addresses: Vec<BitcoinAddress>,
-    /// The time this block entry was created by the signer.
-    #[cfg_attr(
-        feature = "testing",
-        dummy(faker = "DateTimeAfter(time::OffsetDateTime::UNIX_EPOCH)")
-    )]
-    pub created_at: time::OffsetDateTime,
 }
 
 /// Used to for fine-grained control of generating fake testing addresses.
@@ -130,7 +109,6 @@ impl DepositRequest {
             amount: deposit.info.amount as i64,
             max_fee: deposit.info.max_fee as i64,
             sender_addresses: sender_addresses.into_iter().collect(),
-            created_at: time::OffsetDateTime::now_utc(),
         }
     }
 }
@@ -149,16 +127,10 @@ pub struct DepositSigner {
     pub signer_pub_key: PublicKey,
     /// Signals if the signer is prepared to sign for this request.
     pub is_accepted: bool,
-    /// The time this block entry was created by the signer.
-    #[cfg_attr(
-        feature = "testing",
-        dummy(faker = "DateTimeAfter(time::OffsetDateTime::UNIX_EPOCH)")
-    )]
-    pub created_at: time::OffsetDateTime,
 }
 
 /// Withdraw request.
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, sqlx::FromRow)]
 #[cfg_attr(feature = "testing", derive(fake::Dummy))]
 pub struct WithdrawRequest {
     /// Request ID of the withdrawal request.
@@ -175,12 +147,6 @@ pub struct WithdrawRequest {
     pub max_fee: i64,
     /// The address that initiated the request.
     pub sender_address: StacksAddress,
-    /// The time this block entry was created by the signer.
-    #[cfg_attr(
-        feature = "testing",
-        dummy(faker = "DateTimeAfter(time::OffsetDateTime::UNIX_EPOCH)")
-    )]
-    pub created_at: time::OffsetDateTime,
 }
 
 /// A signer acknowledging a withdrawal request.
@@ -196,16 +162,10 @@ pub struct WithdrawSigner {
     pub signer_pub_key: PublicKey,
     /// Signals if the signer is prepared to sign for this request.
     pub is_accepted: bool,
-    /// The time this block entry was created by the signer.
-    #[cfg_attr(
-        feature = "testing",
-        dummy(faker = "DateTimeAfter(time::OffsetDateTime::UNIX_EPOCH)")
-    )]
-    pub created_at: time::OffsetDateTime,
 }
 
 /// A connection between a bitcoin block and a bitcoin transaction.
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, sqlx::FromRow)]
 pub struct BitcoinTransaction {
     /// Transaction ID.
     pub txid: BitcoinTxId,
@@ -261,8 +221,6 @@ pub struct EncryptedDkgShares {
     pub encrypted_private_shares: Bytes,
     /// The public DKG shares
     pub public_shares: Bytes,
-    /// The time this entry was created by the signer.
-    pub created_at: time::OffsetDateTime,
 }
 
 /// Persisted public DKG shares from other signers

--- a/signer/src/testing/dummy.rs
+++ b/signer/src/testing/dummy.rs
@@ -4,7 +4,6 @@ use std::collections::BTreeMap;
 
 use bitcoin::hashes::Hash as _;
 use blockstack_lib::chainstate::{nakamoto, stacks};
-use fake::faker::time::en::DateTimeAfter;
 use fake::Fake;
 use rand::Rng;
 use secp256k1::ecdsa::RecoverableSignature;
@@ -197,15 +196,12 @@ pub fn encrypted_dkg_shares<R: rand::RngCore + rand::CryptoRng>(
         .encode_to_vec()
         .expect("encoding to vec failed");
 
-    let created_at = DateTimeAfter(time::OffsetDateTime::UNIX_EPOCH).fake_with_rng(rng);
-
     model::EncryptedDkgShares {
         aggregate_key: group_key,
         encrypted_private_shares,
         public_shares,
         tweaked_aggregate_key: group_key.signers_tweaked_pubkey().unwrap(),
         script_pubkey: group_key.signers_script_pubkey().into_bytes(),
-        created_at,
     }
 }
 

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -531,8 +531,6 @@ where
             })
             .await;
 
-        let created_at = time::OffsetDateTime::now_utc();
-
         let msg = message::SignerDepositDecision {
             txid: bitcoin::Txid::from_slice(&deposit_request.txid)
                 .map_err(error::Error::SliceConversion)?,
@@ -548,7 +546,6 @@ where
             output_index: deposit_request.output_index,
             signer_pub_key: self.signer_pub_key(),
             is_accepted,
-            created_at,
         };
 
         self.storage
@@ -571,14 +568,11 @@ where
             .await
             .unwrap_or(false);
 
-        let created_at = time::OffsetDateTime::now_utc();
-
         let signer_decision = model::WithdrawSigner {
             request_id: withdraw_request.request_id,
             block_hash: withdraw_request.block_hash,
             signer_pub_key: self.signer_pub_key(),
             is_accepted,
-            created_at,
         };
 
         self.storage
@@ -600,14 +594,12 @@ where
             .try_into()
             .map_err(|_| error::Error::TypeConversion)?;
         let is_accepted = decision.accepted;
-        let created_at = time::OffsetDateTime::now_utc();
 
         let signer_decision = model::DepositSigner {
             txid,
             output_index,
             signer_pub_key,
             is_accepted,
-            created_at,
         };
 
         self.storage
@@ -637,14 +629,12 @@ where
 
         let block_hash = decision.block_hash.to_vec();
         let is_accepted = decision.accepted;
-        let created_at = time::OffsetDateTime::now_utc();
 
         let signer_decision = model::WithdrawSigner {
             request_id,
             block_hash,
             signer_pub_key,
             is_accepted,
-            created_at,
         };
 
         self.storage

--- a/signer/src/wsts_state_machine.rs
+++ b/signer/src/wsts_state_machine.rs
@@ -134,15 +134,12 @@ impl SignerStateMachine {
             wsts::util::encrypt(&self.0.network_private_key.to_bytes(), &encoded, rng)
                 .map_err(|_| error::Error::Encryption)?;
 
-        let created_at = time::OffsetDateTime::now_utc();
-
         Ok(model::EncryptedDkgShares {
             aggregate_key,
             tweaked_aggregate_key: aggregate_key.signers_tweaked_pubkey()?,
             script_pubkey: aggregate_key.signers_script_pubkey().to_bytes(),
             encrypted_private_shares,
             public_shares,
-            created_at,
         })
     }
 }

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -652,7 +652,6 @@ async fn writing_transactions_postgres(pool: sqlx::PgPool) {
         block_height: 15,
         parent_hash: parent_hash.to_byte_array().to_vec(),
         confirms: Vec::new(),
-        created_at: time::OffsetDateTime::now_utc(),
     };
 
     // We start by writing the bitcoin block because of the foreign key

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -465,7 +465,11 @@ async fn should_return_the_same_pending_accepted_withdraw_requests_as_in_memory_
         num_stacks_blocks_per_bitcoin_block: 3,
         num_deposit_requests_per_block: 5,
         num_withdraw_requests_per_block: 1,
-        num_signers_per_request: 7,
+        // The signers in these tests vote to reject the request with 50%
+        // probability, so the number of signers needs to be a bit above
+        // the threshold in order for the test to succeed with accepted
+        // requests.
+        num_signers_per_request: 15,
     };
     let threshold = 4;
     let test_data = testing::storage::model::TestData::generate(&mut rng, &test_model_params);


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/304.

This isn't really necessary. I just decided to working on something that requires less mental energy while in transit and this fit the bill.

## Changes

* Allow `created_at` fields in all tables to be set automatically on insert with defaults
* Don't set the `created_at` fields when inserting data in the database.
* Remove the `created_at` fields from the model types.
* Don't update the `query!` and `query_as!` macro usage. I don't think this is worth the hassle.

## Testing Information

I had to update one of the parameters in one of the tests since the test now fails due to randomness. Signers randomly reject requests and if enough of them reject the request than the test will fail. So I made sure that there were enough signers so that it was very unlikely by chance that the test will fail. Maybe I should make it even more unlikely.

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
