### PR TITLE
feat: Add stacks block height to withdrawal request (reorg part 1/4)

### DIFF
--- a/.generated-sources/emily/openapi/emily-openapi-spec.json
+++ b/.generated-sources/emily/openapi/emily-openapi-spec.json
@@ -809,6 +809,7 @@
         "required": [
           "requestId",
           "stacksBlockHash",
+          "stacksBlockHeight",
           "recipient",
           "amount",
           "parameters"
@@ -828,6 +829,9 @@
           },
           "stacksBlockHash": {
             "$ref": "#/components/schemas/StacksBlockHash"
+          },
+          "stacksBlockHeight": {
+            "$ref": "#/components/schemas/BlockHeight"
           }
         }
       },

--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,8 @@ emily-integration-env-up: $(EMILY_DOCKER_COMPOSE) $(EMILY_CDK_TEMPLATE) $(EMILY_
 		docker compose --file $(EMILY_DOCKER_COMPOSE) up --remove-orphans # --detach
 
 emily-integration-test:
-	cargo test --package emily-handler --test integration --features integration-tests -- --test-threads=1 --nocapture
+	cargo test --package emily-handler --test integration --features integration-tests -- \
+	--test-threads=1 --nocapture
 
 emily-complex-integration-test:
 	cargo test --package emily-handler --test integration --features integration-tests -- \

--- a/emily/handler/src/api/handlers/deposit.rs
+++ b/emily/handler/src/api/handlers/deposit.rs
@@ -204,8 +204,9 @@ pub async fn create_deposit(
         body: CreateDepositRequestBody,
     ) -> Result<impl warp::reply::Reply, Error> {
         // Set variables.
-        let stacks_block_hash: StacksBlockHash = "DUMMY_HASH".into();
-        let stacks_block_height: BlockHeight = 0;
+        let api_state = accessors::get_api_state(&context).await?;
+        let stacks_block_hash: StacksBlockHash = api_state.chaintip.key.hash;
+        let stacks_block_height: BlockHeight = api_state.chaintip.key.height;
         let status = Status::Pending;
         // Make table entry.
         let deposit_entry: DepositEntry = DepositEntry {

--- a/emily/handler/src/api/handlers/withdrawal.rs
+++ b/emily/handler/src/api/handlers/withdrawal.rs
@@ -1,7 +1,7 @@
 //! Handlers for withdrawal endpoints.
 use warp::reply::{json, with_status, Reply};
 
-use crate::api::models::common::{BlockHeight, Status};
+use crate::api::models::common::Status;
 use crate::api::models::withdrawal::{
     requests::{CreateWithdrawalRequestBody, GetWithdrawalsQuery, UpdateWithdrawalsRequestBody},
     responses::{
@@ -146,12 +146,12 @@ pub async fn create_withdrawal(
         let CreateWithdrawalRequestBody {
             request_id,
             stacks_block_hash,
+            stacks_block_height,
             recipient,
             amount,
             parameters,
         } = body;
 
-        let stacks_block_height: BlockHeight = 0;
         let status = Status::Pending;
 
         // Make table entry.

--- a/emily/handler/src/api/models/withdrawal/requests.rs
+++ b/emily/handler/src/api/models/withdrawal/requests.rs
@@ -28,6 +28,8 @@ pub struct CreateWithdrawalRequestBody {
     pub request_id: WithdrawalId,
     /// The stacks block hash in which this request id was initiated.
     pub stacks_block_hash: StacksBlockHash,
+    /// The stacks block hash in which this request id was initiated.
+    pub stacks_block_height: BlockHeight,
     /// The recipient Bitcoin address.
     pub recipient: BitcoinAddress,
     /// Amount of BTC being withdrawn.

--- a/emily/handler/tests/integration/complex/reorg.rs
+++ b/emily/handler/tests/integration/complex/reorg.rs
@@ -101,12 +101,12 @@ async fn simple_reorg_test_base(scenario: ReorgScenario) {
         };
         let withdrawal_request = CreateWithdrawalRequestBody {
             request_id: stacks_block_height,
-            stacks_block_hash: stacks_block_hash,
+            stacks_block_hash,
+            stacks_block_height,
             recipient: TEST_RECIPIENT.to_string(),
             amount: 1,
             parameters: TEST_WITHDRAWAL_PARAMETERS.clone(),
         };
-
         // Make requests to populate the database.
         client.create_chainstate(&chainstate).await;
         client.create_deposit(&deposit_request).await;

--- a/emily/handler/tests/integration/endpoints/withdrawal.rs
+++ b/emily/handler/tests/integration/endpoints/withdrawal.rs
@@ -59,6 +59,7 @@ static TEST_WITHDRAWAL_DATA: LazyLock<Vec<TestWithdrawalData>> = LazyLock::new(|
 async fn setup_withdrawal_integration_test() -> TestClient {
     let client = TestClient::new();
     client.setup_test().await;
+    let stacks_block_height: u64 = 0;
     for test_withdrawal_data in TEST_WITHDRAWAL_DATA.iter() {
         // Arrange.
         let TestWithdrawalData {
@@ -69,6 +70,7 @@ async fn setup_withdrawal_integration_test() -> TestClient {
         let request: CreateWithdrawalRequestBody = serde_json::from_value(json!({
           "requestId": request_id,
           "stacksBlockHash": stacks_block_hash,
+          "stacksBlockHeight": stacks_block_height,
           "recipient": recipient,
           "amount": 0,
           "parameters": {

--- a/emily/handler/tests/integration/populate/mod.rs
+++ b/emily/handler/tests/integration/populate/mod.rs
@@ -49,6 +49,7 @@ async fn create_withdrawals(client: &TestClient) {
         let create_request = CreateWithdrawalRequestBody {
             request_id: i as u64,
             stacks_block_hash: format!("stacks-block-hash-{i}"),
+            stacks_block_height: i as u64,
             recipient: format!("recipient-{i}"),
             amount: rng.gen_range(1000..=1000000) as u64,
             parameters: WithdrawalParameters {


### PR DESCRIPTION
## Description

Closes: #N/A

Part of the implementation of the reorg handling.

## Changes

Adds stacks block height correctly to operation handling.

## Testing Information

Integration and unit tests.

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
