### PR TITLE
Sort key ordered dynamodb access (reorg part 3/4)

### DIFF
--- a/emily/handler/src/database/accessors.rs
+++ b/emily/handler/src/database/accessors.rs
@@ -2,7 +2,7 @@
 
 use aws_sdk_dynamodb::types::AttributeValue;
 use serde_dynamo::Item;
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::{
     api::models::{common::BlockHeight, withdrawal::WithdrawalId},
@@ -72,6 +72,55 @@ pub async fn get_deposit_entries(
         context,
         status,
         maybe_next_token,
+        maybe_page_size,
+    )
+    .await
+}
+
+/// Hacky exhasutive list of all statuses that we will iterate over in order to
+/// get every deposit present.
+const ALL_STATUSES: &[Status] = &[
+    Status::Accepted,
+    Status::Confirmed,
+    Status::Failed,
+    Status::Pending,
+    Status::Reprocessing,
+];
+
+/// Gets all deposit entries modified after a given height.
+pub async fn get_all_deposit_entries_modified_after_height(
+    context: &EmilyContext,
+    minimum_height: u64,
+    maybe_page_size: Option<i32>,
+) -> Result<Vec<DepositInfoEntry>, Error> {
+    let mut all = Vec::new();
+    for status in ALL_STATUSES {
+        let mut received = get_all_deposit_entries_modified_after_height_with_status(
+            context,
+            status,
+            minimum_height,
+            maybe_page_size,
+        )
+        .await?;
+        all.append(&mut received);
+    }
+    // Return.
+    Ok(all)
+}
+
+/// Gets all deposit entries modified after a given height.
+pub async fn get_all_deposit_entries_modified_after_height_with_status(
+    context: &EmilyContext,
+    status: &Status,
+    minimum_height: u64,
+    maybe_page_size: Option<i32>,
+) -> Result<Vec<DepositInfoEntry>, Error> {
+    // Make the query.
+    query_all_with_partition_and_sort_key::<DepositTableSecondaryIndex>(
+        context,
+        status,
+        &minimum_height,
+        ">=",
         maybe_page_size,
     )
     .await
@@ -191,9 +240,15 @@ pub async fn get_withdrawal_entry(
             );
             Ok(withdrawal.clone())
         }
-        _ => Err(Error::Debug(format!(
-            "Found too many withdrawals for id {key}: {entries:?}"
-        ))),
+        _ => {
+            warn!(
+                "Found too many withdrawals for id {key}: {}",
+                serde_json::to_string_pretty(&entries)?
+            );
+            Err(Error::Debug(format!(
+                "Found too many withdrawals for id {key}: {entries:?}"
+            )))
+        }
     }
 }
 
@@ -208,6 +263,45 @@ pub async fn get_withdrawal_entries(
         context,
         status,
         maybe_next_token,
+        maybe_page_size,
+    )
+    .await
+}
+
+/// Gets all withdrawal entries modified after a given height.
+pub async fn get_all_withdrawal_entries_modified_after_height(
+    context: &EmilyContext,
+    minimum_height: u64,
+    maybe_page_size: Option<i32>,
+) -> Result<Vec<WithdrawalInfoEntry>, Error> {
+    let mut all = Vec::new();
+    for status in ALL_STATUSES {
+        let mut received = get_all_withdrawal_entries_modified_after_height_with_status(
+            context,
+            status,
+            minimum_height,
+            maybe_page_size,
+        )
+        .await?;
+        all.append(&mut received);
+    }
+    // Return.
+    Ok(all)
+}
+
+/// Gets all withdrawal entries modified after a given height.
+pub async fn get_all_withdrawal_entries_modified_after_height_with_status(
+    context: &EmilyContext,
+    status: &Status,
+    minimum_height: u64,
+    maybe_page_size: Option<i32>,
+) -> Result<Vec<WithdrawalInfoEntry>, Error> {
+    // Make the query.
+    query_all_with_partition_and_sort_key::<WithdrawalTableSecondaryIndex>(
+        context,
+        status,
+        &minimum_height,
+        ">=",
         maybe_page_size,
     )
     .await
@@ -474,6 +568,60 @@ async fn query_with_partition_key<T: TableIndexTrait>(
         &context.dynamodb_client,
         &context.settings,
         parition_key,
+        maybe_next_token,
+        maybe_page_size,
+    )
+    .await
+}
+
+async fn query_all_with_partition_and_sort_key<T: TableIndexTrait>(
+    context: &EmilyContext,
+    parition_key: &<<<T as TableIndexTrait>::Entry as EntryTrait>::Key as KeyTrait>::PartitionKey,
+    sort_key: &<<<T as TableIndexTrait>::Entry as EntryTrait>::Key as KeyTrait>::SortKey,
+    sort_key_operator: &str,
+    maybe_page_size: Option<i32>,
+) -> Result<Vec<<T as TableIndexTrait>::Entry>, Error> {
+    // item aggregator.
+    let mut items: Vec<<T as TableIndexTrait>::Entry> = Vec::new();
+    // Next token.
+    let mut next_token: Option<String> = None;
+    // Loop over all items.
+    loop {
+        let mut new_items: Vec<<T as TableIndexTrait>::Entry>;
+        (new_items, next_token) = query_with_partition_and_sort_key::<T>(
+            context,
+            parition_key,
+            sort_key,
+            sort_key_operator,
+            next_token,
+            maybe_page_size,
+        )
+        .await?;
+        // add new items.
+        items.append(&mut new_items);
+        if next_token.is_none() {
+            // If there are no more entries then end the loop.
+            break;
+        }
+    }
+    // Return the items.
+    Ok(items)
+}
+
+async fn query_with_partition_and_sort_key<T: TableIndexTrait>(
+    context: &EmilyContext,
+    parition_key: &<<<T as TableIndexTrait>::Entry as EntryTrait>::Key as KeyTrait>::PartitionKey,
+    sort_key: &<<<T as TableIndexTrait>::Entry as EntryTrait>::Key as KeyTrait>::SortKey,
+    sort_key_operator: &str,
+    maybe_next_token: Option<String>,
+    maybe_page_size: Option<i32>,
+) -> Result<(Vec<<T as TableIndexTrait>::Entry>, Option<String>), Error> {
+    <T as TableIndexTrait>::query_with_partition_and_sort_key(
+        &context.dynamodb_client,
+        &context.settings,
+        parition_key,
+        sort_key,
+        sort_key_operator,
         maybe_next_token,
         maybe_page_size,
     )

--- a/emily/handler/src/database/accessors.rs
+++ b/emily/handler/src/database/accessors.rs
@@ -588,8 +588,9 @@ async fn query_all_with_partition_and_sort_key<T: TableIndexTrait>(
     // Loop over all items.
     loop {
         let mut new_items: Vec<<T as TableIndexTrait>::Entry>;
-        (new_items, next_token) = query_with_partition_and_sort_key::<T>(
-            context,
+        (new_items, next_token) = <T as TableIndexTrait>::query_with_partition_and_sort_key(
+            &context.dynamodb_client,
+            &context.settings,
             parition_key,
             sort_key,
             sort_key_operator,
@@ -606,26 +607,6 @@ async fn query_all_with_partition_and_sort_key<T: TableIndexTrait>(
     }
     // Return the items.
     Ok(items)
-}
-
-async fn query_with_partition_and_sort_key<T: TableIndexTrait>(
-    context: &EmilyContext,
-    parition_key: &<<<T as TableIndexTrait>::Entry as EntryTrait>::Key as KeyTrait>::PartitionKey,
-    sort_key: &<<<T as TableIndexTrait>::Entry as EntryTrait>::Key as KeyTrait>::SortKey,
-    sort_key_operator: &str,
-    maybe_next_token: Option<String>,
-    maybe_page_size: Option<i32>,
-) -> Result<(Vec<<T as TableIndexTrait>::Entry>, Option<String>), Error> {
-    <T as TableIndexTrait>::query_with_partition_and_sort_key(
-        &context.dynamodb_client,
-        &context.settings,
-        parition_key,
-        sort_key,
-        sort_key_operator,
-        maybe_next_token,
-        maybe_page_size,
-    )
-    .await
 }
 
 #[cfg(feature = "testing")]

--- a/emily/handler/src/database/entries/chainstate.rs
+++ b/emily/handler/src/database/entries/chainstate.rs
@@ -63,7 +63,7 @@ impl KeyTrait for ChainstateEntryKey {
     /// The table field name of the partition key.
     const PARTITION_KEY_NAME: &'static str = "Height";
     /// The table field name of the sort key.
-    const _SORT_KEY_NAME: &'static str = "Hash";
+    const SORT_KEY_NAME: &'static str = "Hash";
 }
 
 /// Implements the entry trait for the deposit entry.
@@ -178,7 +178,7 @@ impl KeyTrait for SpecialApiStateKey {
     /// The table field name of the partition key.
     const PARTITION_KEY_NAME: &'static str = "Height";
     /// The table field name of the sort key.
-    const _SORT_KEY_NAME: &'static str = "Hash";
+    const SORT_KEY_NAME: &'static str = "Hash";
 }
 
 /// Implements the entry trait for the deposit entry.

--- a/emily/handler/src/database/entries/deposit.rs
+++ b/emily/handler/src/database/entries/deposit.rs
@@ -90,7 +90,7 @@ impl KeyTrait for DepositEntryKey {
     /// The table field name of the partition key.
     const PARTITION_KEY_NAME: &'static str = "BitcoinTxid";
     /// The table field name of the sort key.
-    const _SORT_KEY_NAME: &'static str = "BitcoinTxOutputIndex";
+    const SORT_KEY_NAME: &'static str = "BitcoinTxOutputIndex";
 }
 
 /// Implements the entry trait for the deposit entry.
@@ -299,7 +299,7 @@ impl KeyTrait for DepositInfoEntryKey {
     /// The table field name of the partition key.
     const PARTITION_KEY_NAME: &'static str = "OpStatus";
     /// The table field name of the sort key.
-    const _SORT_KEY_NAME: &'static str = "LastUpdateHeight";
+    const SORT_KEY_NAME: &'static str = "LastUpdateHeight";
 }
 
 /// Implements the entry trait for the deposit entry.

--- a/emily/handler/src/database/entries/withdrawal.rs
+++ b/emily/handler/src/database/entries/withdrawal.rs
@@ -209,7 +209,7 @@ impl KeyTrait for WithdrawalEntryKey {
     /// The table field name of the partition key.
     const PARTITION_KEY_NAME: &'static str = "RequestId";
     /// The table field name of the sort key.
-    const _SORT_KEY_NAME: &'static str = "StacksBlockHash";
+    const SORT_KEY_NAME: &'static str = "StacksBlockHash";
 }
 
 /// Implements the entry trait for the withdrawal entry.
@@ -295,7 +295,7 @@ impl KeyTrait for WithdrawalInfoEntryKey {
     /// The table field name of the partition key.
     const PARTITION_KEY_NAME: &'static str = "OpStatus";
     /// The table field name of the sort key.
-    const _SORT_KEY_NAME: &'static str = "LastUpdateHeight";
+    const SORT_KEY_NAME: &'static str = "LastUpdateHeight";
 }
 
 /// Implements the entry trait for the withdrawal info entry.

--- a/emily/handler/tests/integration/endpoints/withdrawal.rs
+++ b/emily/handler/tests/integration/endpoints/withdrawal.rs
@@ -350,7 +350,7 @@ async fn update_withdrawal() {
             status: StatusEntry::Pending,
             message: "Just received withdrawal".to_string(),
             stacks_block_height: 0,
-            stacks_block_hash: "test_stacks_block_hash_5".to_string(),
+            stacks_block_hash: "test_stacks_block_hash_1".to_string(),
         },
         WithdrawalEvent {
             status: StatusEntry::Accepted(fulfillment.clone()),

--- a/emily/handler/tests/integration/util/mod.rs
+++ b/emily/handler/tests/integration/util/mod.rs
@@ -21,6 +21,7 @@ use emily_handler::{
         },
     },
     context::EmilyContext,
+    database::entries::deposit::DepositEntryKey,
 };
 use error::TestError;
 use reqwest::{Client, RequestBuilder};
@@ -74,6 +75,14 @@ pub async fn test_context() -> EmilyContext {
     EmilyContext::local_test_instance()
         .await
         .expect("Failed to setup local test context for Emily integration test.")
+}
+
+/// Gets key from deposit.
+pub fn entry_key_from_deposit(deposit: &Deposit) -> DepositEntryKey {
+    return DepositEntryKey {
+        bitcoin_txid: deposit.bitcoin_txid.clone(),
+        bitcoin_tx_output_index: deposit.bitcoin_tx_output_index,
+    };
 }
 
 /// Test client to make API calls within integration tests. This takes the place of what


### PR DESCRIPTION
## Description

Closes: #N/A

Part of the reorg handling PR but broken up.

## Changes

- Adds sort key ordered queries. 
- Adds specific functions for querying by last modified height for deposit and withdrawal entries.
- Additionally makes the output of the operation by status queries in sorted order by last modified height.

## Testing Information

Integration and unit tests.

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
