### PR TITLE
feat: add types for smart contract events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -611,7 +611,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.3.4",
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
@@ -626,10 +626,43 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde 1.0.203",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "tower",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "axum"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf"
+dependencies = [
+ "async-trait",
+ "axum-core 0.4.3",
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.3.1",
+ "hyper-util",
+ "itoa 1.0.11",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde 1.0.203",
+ "serde_json",
+ "serde_path_to_error",
+ "sync_wrapper 1.0.1",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -647,6 +680,27 @@ dependencies = [
  "rustversion",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15c63fd72d41492dc4f497196f5da1fb04fb7529e631d73630d1b491e47a2e3"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper 0.1.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2229,6 +2283,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.0",
  "httparse",
+ "httpdate",
  "itoa 1.0.11",
  "pin-project-lite",
  "smallvec",
@@ -3814,7 +3869,7 @@ dependencies = [
  "serde 1.0.203",
  "serde_json",
  "serde_urlencoded 0.7.1",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
@@ -3857,7 +3912,7 @@ dependencies = [
  "serde 1.0.203",
  "serde_json",
  "serde_urlencoded 0.7.1",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
@@ -4340,6 +4395,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
+dependencies = [
+ "itoa 1.0.11",
+ "serde 1.0.203",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4508,6 +4573,7 @@ name = "signer"
 version = "0.1.0"
 dependencies = [
  "aquamarine",
+ "axum 0.7.5",
  "backoff",
  "bincode",
  "bitcoin",
@@ -5068,6 +5134,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+
+[[package]]
 name = "system-configuration"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5459,7 +5531,7 @@ checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum",
+ "axum 0.6.20",
  "base64 0.21.7",
  "bytes",
  "h2 0.3.26",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,11 @@ wsts = "9.1.0"
 zeromq = { version = "0.4.0", default-features = false, features = ["tokio-runtime", "all-transport"] }
 hex = "0.4.3"
 
+[workspace.dependencies.axum]
+version = "0.7"
+default-features = false
+features = ["http1", "json", "tracing", "tokio", "tower-log"]
+
 [workspace.dependencies.tracing-subscriber]
 version = "0.3"
 default-features = false

--- a/signer/Cargo.toml
+++ b/signer/Cargo.toml
@@ -19,6 +19,7 @@ testing = ["fake"]
 
 [dependencies]
 aquamarine.workspace = true
+axum.workspace = true
 backoff.workspace = true
 bincode.workspace = true
 bitcoin = { workspace = true, features = ["rand-std"] }

--- a/signer/src/api/mod.rs
+++ b/signer/src/api/mod.rs
@@ -1,0 +1,8 @@
+//! This module contains functions and structs for the Signer API.
+//!
+
+pub mod new_block;
+pub mod status;
+
+pub use new_block::new_block_handler;
+pub use status::status_handler;

--- a/signer/src/api/new_block.rs
+++ b/signer/src/api/new_block.rs
@@ -1,0 +1,21 @@
+//! This module is contains the handler for the POST /new_block endpoint,
+//! which is for processing new block webhooks from a stacks node.
+
+use axum::http::StatusCode;
+
+/// A basic handler that responds with 200 OK
+pub async fn new_block_handler() -> StatusCode {
+    StatusCode::OK
+}
+
+/// The Schema for new block events are defined in the source here:
+/// https://github.com/stacks-network/stacks-core/blob/09c4b066e25104be8b066e8f7530ff0c6df4ccd5/testnet/stacks-node/src/event_dispatcher.rs#L644-L687
+pub struct NewBlockEvent {
+
+}
+
+/// https://github.com/stacks-network/stacks-core/blob/develop/clarity/src/vm/events.rs#L358-L363
+/// https://github.com/stacks-network/stacks-core/blob/develop/clarity/src/vm/events.rs#L45-L51
+pub struct SmartContractEvent {
+
+}

--- a/signer/src/api/new_block.rs
+++ b/signer/src/api/new_block.rs
@@ -11,10 +11,11 @@ use crate::stacks::webhooks::NewBlockEvent;
 use crate::storage::DbWrite;
 
 /// We denote the stacks node payload by this type so that our handler
-/// always gets to handle the request, regardless of if there is a failure
-/// deserializing or not. This is so that we can return a `200 OK` status
-/// code on deserialization errors.
-pub type NewBlockPayload = Result<Json<serde_json::Value>, JsonRejection>;
+/// always gets to handle the request, regardless of whether there is a
+/// failure deserializing or not. This is so that we can return a `200 OK`
+/// status code on deserialization errors, so that the stacks node does not
+/// retry them.
+pub type StacksNodePayload = Result<Json<serde_json::Value>, JsonRejection>;
 
 /// A handler of `POST /new_block` webhook events.
 ///
@@ -24,17 +25,19 @@ pub type NewBlockPayload = Result<Json<serde_json::Value>, JsonRejection>;
 /// the payload to all interested observers, one-by-one. If the node fails
 /// to connect to one of the observers, or if the response from the
 /// observer is not a 200-299 response code, then it sleeps for 1 second
-/// and tries again[^1]. From the looks of it, the node will not stop
-/// trying to send the webhook when there is a success response of if we've
+/// and tries again[^1]. From the looks of it, the node will stop trying to
+/// send the webhook when it receives a success response or if we've
 /// reached the `retry_count` that is configured in the stacks node config.
-/// Because of this, unless we encounter an error where retrying in a
+/// Because of this, unless we encounter an error where retrying it a
 /// second might succeed, we will return a 200 OK status code.
 ///
 /// [^1]: <https://github.com/stacks-network/stacks-core/blob/09c4b066e25104be8b066e8f7530ff0c6df4ccd5/testnet/stacks-node/src/event_dispatcher.rs#L317-L385>
-pub async fn new_block_handler<S>(_state: State<S>, body: NewBlockPayload) -> StatusCode
+pub async fn new_block_handler<S>(_state: State<S>, body: StacksNodePayload) -> StatusCode
 where
     S: DbWrite,
 {
+    tracing::info!("Received a new block event from stacks-core");
+
     let _event: NewBlockEvent = match body {
         Ok(Json(value)) => {
             // We print out the raw string if there are any errors during
@@ -55,8 +58,8 @@ where
         }
         // If we are here, then we failed to deserialize the webhook body
         // into the expected type. It's unlikely that retying this webhook
-        // will lead to any success, so we log the error and keep things
-        // moving.
+        // will lead to success, so we log the error and return `200 OK` so
+        // that the node does not retry the webhook.
         Err(error) => {
             tracing::error!("could not deserialize POST /new_block webhook: {error:?}");
             return StatusCode::OK;

--- a/signer/src/api/new_block.rs
+++ b/signer/src/api/new_block.rs
@@ -1,21 +1,35 @@
-//! This module is contains the handler for the POST /new_block endpoint,
+//! This module contains the handler for the `POST /new_block` endpoint,
 //! which is for processing new block webhooks from a stacks node.
+//!
 
+use axum::extract::State;
 use axum::http::StatusCode;
+use axum::Json;
 
-/// A basic handler that responds with 200 OK
-pub async fn new_block_handler() -> StatusCode {
+use crate::stacks::webhooks::NewBlockEvent;
+use crate::storage::DbWrite;
+
+/// A handler of `POST /new_block` webhook events.
+///
+/// # Notes
+///
+/// The event dispatcher functionality in a stacks node attempts to send
+/// the payload to all interested observers, sequentially one-by-one. If
+/// the node fails to connect to one of the observers, or if the response
+/// from the observer is not a 200-299 response code, then it sleeps for 1
+/// second and tries again[^1]. From the looks of it, the node will not
+/// stop trying to send the webhook until there is a success. Because of
+/// this, unless we encounter an error where retrying in a second might
+/// succeed, we will return a 200 OK status code. Also, we will only return
+/// a Non-success status a maximum of 3 times.
+///
+/// I need to find out what happens if we continually return 400 for
+/// webhooks.
+///
+/// [^1]: https://github.com/stacks-network/stacks-core/blob/09c4b066e25104be8b066e8f7530ff0c6df4ccd5/testnet/stacks-node/src/event_dispatcher.rs#L317-L385
+pub async fn new_block_handler<S>(_state: State<S>, _body: Json<NewBlockEvent>) -> StatusCode
+where
+    S: DbWrite,
+{
     StatusCode::OK
-}
-
-/// The Schema for new block events are defined in the source here:
-/// https://github.com/stacks-network/stacks-core/blob/09c4b066e25104be8b066e8f7530ff0c6df4ccd5/testnet/stacks-node/src/event_dispatcher.rs#L644-L687
-pub struct NewBlockEvent {
-
-}
-
-/// https://github.com/stacks-network/stacks-core/blob/develop/clarity/src/vm/events.rs#L358-L363
-/// https://github.com/stacks-network/stacks-core/blob/develop/clarity/src/vm/events.rs#L45-L51
-pub struct SmartContractEvent {
-
 }

--- a/signer/src/api/status.rs
+++ b/signer/src/api/status.rs
@@ -1,0 +1,8 @@
+//! This module is for the `GET /` endpoint, which just returns the status.
+
+use axum::http::StatusCode;
+
+/// A basic handler that responds with 200 OK
+pub async fn status_handler() -> StatusCode {
+    StatusCode::OK
+}

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -142,6 +142,11 @@ pub enum Error {
     #[error("received an error when attempting to query the database: {0}")]
     SqlxQuery(#[source] sqlx::Error),
 
+    /// An error when attempting to generically decode bytes using the
+    /// trait implementation.
+    #[error("got an error wen attempting to call StacksMessageCodec::consensus_deserialize {0}")]
+    StacksCodec(#[source] blockstack_lib::codec::Error),
+
     /// An error for the case where we cannot create a multi-sig
     /// StacksAddress using given public keys.
     #[error("could not create a StacksAddress from the public keys: threshold {0}, keys {1}")]

--- a/signer/src/lib.rs
+++ b/signer/src/lib.rs
@@ -1,6 +1,7 @@
 #![doc = include_str!("../README.md")]
 #![deny(missing_docs)]
 
+pub mod api;
 pub mod bitcoin;
 pub mod block_observer;
 pub mod blocklist_client;

--- a/signer/src/main.rs
+++ b/signer/src/main.rs
@@ -14,6 +14,8 @@ fn get_connection_pool() -> sqlx::PgPool {
 
 #[tokio::main]
 async fn main() {
+    sbtc::logging::setup_logging("info,signer=debug", false);
+
     let pool = get_connection_pool();
     let pool_store = PgStore::from(pool);
     // Build the signer API application

--- a/signer/src/main.rs
+++ b/signer/src/main.rs
@@ -1,1 +1,15 @@
-fn main() {}
+use axum::routing::get;
+use axum::routing::post;
+use axum::Router;
+
+#[tokio::main]
+async fn main() {
+    // Build the signer API application
+    let app = Router::new()
+        .route("/", get(signer::api::status_handler))
+        .route("/new_block", post(signer::api::new_block_handler));
+
+    // run our app with hyper
+    let listener = tokio::net::TcpListener::bind("0.0.0.0:8800").await.unwrap();
+    axum::serve(listener, app).await.unwrap();
+}

--- a/signer/src/main.rs
+++ b/signer/src/main.rs
@@ -1,15 +1,28 @@
 use axum::routing::get;
 use axum::routing::post;
 use axum::Router;
+use signer::api;
+use signer::storage::postgres::PgStore;
+
+const DATABASE_URL: &str = "postgres://user:password@localhost:5432/signer";
+
+fn get_connection_pool() -> sqlx::PgPool {
+    sqlx::postgres::PgPoolOptions::new()
+        .connect_lazy(DATABASE_URL)
+        .unwrap()
+}
 
 #[tokio::main]
 async fn main() {
+    let pool = get_connection_pool();
+    let pool_store = PgStore::from(pool);
     // Build the signer API application
     let app = Router::new()
-        .route("/", get(signer::api::status_handler))
-        .route("/new_block", post(signer::api::new_block_handler));
+        .route("/", get(api::status_handler))
+        .route("/new_block", post(api::new_block_handler::<PgStore>))
+        .with_state(pool_store);
 
     // run our app with hyper
-    let listener = tokio::net::TcpListener::bind("0.0.0.0:8800").await.unwrap();
+    let listener = tokio::net::TcpListener::bind("0.0.0.0:8801").await.unwrap();
     axum::serve(listener, app).await.unwrap();
 }

--- a/signer/src/stacks/contracts.rs
+++ b/signer/src/stacks/contracts.rs
@@ -36,7 +36,7 @@ use blockstack_lib::clarity::vm::types::SequenceData;
 use blockstack_lib::clarity::vm::types::BUFF_33;
 use blockstack_lib::clarity::vm::ClarityName;
 use blockstack_lib::clarity::vm::ContractName;
-use blockstack_lib::clarity::vm::Value;
+use blockstack_lib::clarity::vm::Value as ClarityValue;
 use blockstack_lib::types::chainstate::StacksAddress;
 
 use crate::error::Error;
@@ -100,7 +100,7 @@ pub trait AsContractCall {
     /// The stacks address that deployed the contract.
     fn deployer_address(&self) -> StacksAddress;
     /// The arguments to the clarity function.
-    fn as_contract_args(&self) -> Vec<Value>;
+    fn as_contract_args(&self) -> Vec<ClarityValue>;
     /// Convert this struct to a Stacks contract call.
     fn as_contract_call(&self) -> TransactionContractCall {
         TransactionContractCall {
@@ -196,15 +196,15 @@ impl AsContractCall for CompleteDepositV1 {
     }
     /// Construct the input arguments to the complete-deposit-wrapper
     /// contract call.
-    fn as_contract_args(&self) -> Vec<Value> {
+    fn as_contract_args(&self) -> Vec<ClarityValue> {
         let txid_data = self.outpoint.txid.to_byte_array().to_vec();
         let txid = BuffData { data: txid_data };
 
         vec![
-            Value::Sequence(SequenceData::Buffer(txid)),
-            Value::UInt(self.outpoint.vout as u128),
-            Value::UInt(self.amount as u128),
-            Value::Principal(self.recipient.clone()),
+            ClarityValue::Sequence(SequenceData::Buffer(txid)),
+            ClarityValue::UInt(self.outpoint.vout as u128),
+            ClarityValue::UInt(self.amount as u128),
+            ClarityValue::Principal(self.recipient.clone()),
         ]
     }
     /// Validates that the Complete deposit request satisfies the following
@@ -259,16 +259,16 @@ impl AsContractCall for AcceptWithdrawalV1 {
     fn deployer_address(&self) -> StacksAddress {
         self.deployer
     }
-    fn as_contract_args(&self) -> Vec<Value> {
+    fn as_contract_args(&self) -> Vec<ClarityValue> {
         let txid_data = self.outpoint.txid.to_byte_array().to_vec();
         let txid = BuffData { data: txid_data };
 
         vec![
-            Value::UInt(self.request_id as u128),
-            Value::Sequence(SequenceData::Buffer(txid)),
-            Value::UInt(self.signer_bitmap.load()),
-            Value::UInt(self.outpoint.vout as u128),
-            Value::UInt(self.tx_fee as u128),
+            ClarityValue::UInt(self.request_id as u128),
+            ClarityValue::Sequence(SequenceData::Buffer(txid)),
+            ClarityValue::UInt(self.signer_bitmap.load()),
+            ClarityValue::UInt(self.outpoint.vout as u128),
+            ClarityValue::UInt(self.tx_fee as u128),
         ]
     }
     /// Validates that the accept-withdrawal-request satisfies the
@@ -315,10 +315,10 @@ impl AsContractCall for RejectWithdrawalV1 {
     fn deployer_address(&self) -> StacksAddress {
         self.deployer
     }
-    fn as_contract_args(&self) -> Vec<Value> {
+    fn as_contract_args(&self) -> Vec<ClarityValue> {
         vec![
-            Value::UInt(self.request_id as u128),
-            Value::UInt(self.signer_bitmap.load()),
+            ClarityValue::UInt(self.request_id as u128),
+            ClarityValue::UInt(self.signer_bitmap.load()),
         ]
     }
     /// Validates that the reject-withdrawal-request satisfies the
@@ -401,13 +401,13 @@ impl AsContractCall for RotateKeysV1 {
     /// The signature to this function is:
     ///
     ///   (new-keys (list 128 (buff 33))) (new-aggregate-pubkey (buff 33))
-    fn as_contract_args(&self) -> Vec<Value> {
-        let new_key_data: Vec<Value> = self
+    fn as_contract_args(&self) -> Vec<ClarityValue> {
+        let new_key_data: Vec<ClarityValue> = self
             .new_keys
             .iter()
             .map(|pk| {
                 let data = pk.serialize().to_vec();
-                Value::Sequence(SequenceData::Buffer(BuffData { data }))
+                ClarityValue::Sequence(SequenceData::Buffer(BuffData { data }))
             })
             .collect();
 
@@ -421,8 +421,8 @@ impl AsContractCall for RotateKeysV1 {
         let key: [u8; 33] = self.aggregate_key.serialize();
 
         vec![
-            Value::Sequence(SequenceData::List(new_keys)),
-            Value::Sequence(SequenceData::Buffer(BuffData { data: key.to_vec() })),
+            ClarityValue::Sequence(SequenceData::List(new_keys)),
+            ClarityValue::Sequence(SequenceData::Buffer(BuffData { data: key.to_vec() })),
         ]
     }
     /// Validates that the rotate-keys-wrapper satisfies the following

--- a/signer/src/stacks/mod.rs
+++ b/signer/src/stacks/mod.rs
@@ -6,3 +6,4 @@ pub mod contracts;
 /// Contains structs for signing stacks transactions using the signers'
 /// multi-sig wallet.
 pub mod wallet;
+pub mod webhooks;

--- a/signer/src/stacks/wallet.rs
+++ b/signer/src/stacks/wallet.rs
@@ -305,7 +305,7 @@ impl MultisigTx {
 
 #[cfg(test)]
 mod tests {
-    use blockstack_lib::clarity::vm::Value;
+    use blockstack_lib::clarity::vm::Value as ClarityValue;
     use rand::rngs::OsRng;
     use rand::seq::SliceRandom;
     use secp256k1::Keypair;
@@ -329,7 +329,7 @@ mod tests {
         fn deployer_address(&self) -> StacksAddress {
             StacksAddress::burn_address(false)
         }
-        fn as_contract_args(&self) -> Vec<Value> {
+        fn as_contract_args(&self) -> Vec<ClarityValue> {
             Vec::new()
         }
         async fn validate<S>(&self, _: &S) -> Result<bool, Error>

--- a/signer/src/stacks/webhooks.rs
+++ b/signer/src/stacks/webhooks.rs
@@ -40,7 +40,7 @@ use crate::error::Error;
 ///
 /// This struct leaves out some of the fields that are included. For the
 /// full payload, see the source here:
-/// https://github.com/stacks-network/stacks-core/blob/09c4b066e25104be8b066e8f7530ff0c6df4ccd5/testnet/stacks-node/src/event_dispatcher.rs#L644-L687
+/// <https://github.com/stacks-network/stacks-core/blob/09c4b066e25104be8b066e8f7530ff0c6df4ccd5/testnet/stacks-node/src/event_dispatcher.rs#L644-L687>
 #[derive(Debug, Deserialize)]
 pub struct NewBlockEvent {
     /// The hash of the stacks block
@@ -83,7 +83,10 @@ pub struct NewBlockEvent {
     pub parent_burn_block_timestamp: u64,
 }
 
-/// https://github.com/stacks-network/stacks-core/blob/09c4b066e25104be8b066e8f7530ff0c6df4ccd5/testnet/stacks-node/src/event_dispatcher.rs#L499-L511
+/// This matches the json value that is defined in stacks-core[^1]. It
+/// contains the raw tranaction and the result of the transaction.
+/// 
+/// <https://github.com/stacks-network/stacks-core/blob/09c4b066e25104be8b066e8f7530ff0c6df4ccd5/testnet/stacks-node/src/event_dispatcher.rs#L499-L511>
 #[derive(Debug, Deserialize)]
 pub struct TransactionReceipt {
     /// The id of this transaction .
@@ -132,8 +135,9 @@ pub enum TransactionEventType {
     FtBurnEvent,
 }
 
-/// https://github.com/stacks-network/stacks-core/blob/09c4b066e25104be8b066e8f7530ff0c6df4ccd5/clarity/src/vm/events.rs#L358-L363
-/// https://github.com/stacks-network/stacks-core/blob/09c4b066e25104be8b066e8f7530ff0c6df4ccd5/clarity/src/vm/events.rs#L45-L51
+/// An event that was emitted during the execution of the transaction. It
+/// is defined in [^1].
+/// [^1]: <https://github.com/stacks-network/stacks-core/blob/09c4b066e25104be8b066e8f7530ff0c6df4ccd5/clarity/src/vm/events.rs#L45-L51>
 #[derive(Debug, Deserialize)]
 pub struct TransactionEvent {
     /// The id of the transaction that generated the event.
@@ -153,7 +157,9 @@ pub struct TransactionEvent {
 }
 
 /// Smart contracts emit events when they are executed. This represents
-/// such an event.
+/// such an event. The expected type is taken from stackss-core[^1].
+/// 
+/// [^1]: <https://github.com/stacks-network/stacks-core/blob/09c4b066e25104be8b066e8f7530ff0c6df4ccd5/clarity/src/vm/events.rs#L358-L363>
 #[derive(Debug, Deserialize)]
 pub struct SmartContractEvent {
     /// Identifies the smart contract that generated event.
@@ -183,7 +189,7 @@ pub struct SmartContractEvent {
 /// the types that we use here that implement [`HexDeser`] here follow that
 /// same pattern.
 ///
-/// [^1]: https://github.com/stacks-network/stacks-core/blob/09c4b066e25104be8b066e8f7530ff0c6df4ccd5/testnet/stacks-node/src/event_dispatcher.rs#L645
+/// [^1]: <https://github.com/stacks-network/stacks-core/blob/09c4b066e25104be8b066e8f7530ff0c6df4ccd5/testnet/stacks-node/src/event_dispatcher.rs#L645>
 pub fn deserialize_hex<'de, D, T>(deserializer: D) -> Result<T, D::Error>
 where
     D: serde::Deserializer<'de>,

--- a/signer/src/stacks/webhooks.rs
+++ b/signer/src/stacks/webhooks.rs
@@ -85,7 +85,7 @@ pub struct NewBlockEvent {
 
 /// This matches the json value that is defined in stacks-core[^1]. It
 /// contains the raw tranaction and the result of the transaction.
-/// 
+///
 /// <https://github.com/stacks-network/stacks-core/blob/09c4b066e25104be8b066e8f7530ff0c6df4ccd5/testnet/stacks-node/src/event_dispatcher.rs#L499-L511>
 #[derive(Debug, Deserialize)]
 pub struct TransactionReceipt {
@@ -137,6 +137,7 @@ pub enum TransactionEventType {
 
 /// An event that was emitted during the execution of the transaction. It
 /// is defined in [^1].
+///
 /// [^1]: <https://github.com/stacks-network/stacks-core/blob/09c4b066e25104be8b066e8f7530ff0c6df4ccd5/clarity/src/vm/events.rs#L45-L51>
 #[derive(Debug, Deserialize)]
 pub struct TransactionEvent {
@@ -158,7 +159,7 @@ pub struct TransactionEvent {
 
 /// Smart contracts emit events when they are executed. This represents
 /// such an event. The expected type is taken from stackss-core[^1].
-/// 
+///
 /// [^1]: <https://github.com/stacks-network/stacks-core/blob/09c4b066e25104be8b066e8f7530ff0c6df4ccd5/clarity/src/vm/events.rs#L358-L363>
 #[derive(Debug, Deserialize)]
 pub struct SmartContractEvent {
@@ -178,16 +179,13 @@ pub struct SmartContractEvent {
 ///
 /// # Notes
 ///
-/// A good example of how why this works is with the `block_hash` field in
-/// the `POST /new_block` webhook[^1]. It's set using the
-/// [`std::fmt::Display`] implementation of a [`BlockHeaderHash`] type. The
-/// [`std::fmt::Display`] implementation is done using the
-/// [`stacks_common::util::macros::impl_byte_array_newtype!`] macro, which
-/// is implemented using the [`BlockHeaderHash::to_hex`] function. That
-/// type also implements [`HexDeser`], with the implementation of
-/// [`HexDeser::try_from`] done using the types `from_hex` function. All
-/// the types that we use here that implement [`HexDeser`] here follow that
-/// same pattern.
+/// A good example of how this works is with the `block_hash` field in the
+/// `POST /new_block` webhook[^1]. It's set using the [`std::fmt::Display`]
+/// implementation of a [`BlockHeaderHash`] type. The [`std::fmt::Display`]
+/// implementation uses the [`BlockHeaderHash::to_hex`] function. That type
+/// also implements [`HexDeser`], where the [`HexDeser::try_from`]
+/// implementation uses the types `from_hex` function. All the types that
+/// we use here that implement [`HexDeser`] follow this same pattern.
 ///
 /// [^1]: <https://github.com/stacks-network/stacks-core/blob/09c4b066e25104be8b066e8f7530ff0c6df4ccd5/testnet/stacks-node/src/event_dispatcher.rs#L645>
 pub fn deserialize_hex<'de, D, T>(deserializer: D) -> Result<T, D::Error>
@@ -224,7 +222,8 @@ where
 ///
 /// # Notes
 ///
-/// This returns [`Ok(None)`] whenever the "raw_tx" is "0x00".
+/// This returns [`Ok(None)`] whenever the "raw_tx" is "0x00", which
+/// corresponds to a burnchain operation.
 pub fn deserialize_tx<'de, D>(deserializer: D) -> Result<Option<StacksTransaction>, D::Error>
 where
     D: serde::Deserializer<'de>,

--- a/signer/src/stacks/webhooks.rs
+++ b/signer/src/stacks/webhooks.rs
@@ -1,0 +1,229 @@
+//! This module contains structs that represent the payload for new block
+//! webhooks from a stacks node.
+//!
+//! The payload of a Stacks node webhooks is really defined in the source.
+//! Here we attempt to follow the source and deserialize them using the
+//! internal methods that are built for deserialization, which is typically
+//! not their [`serde::Deserialize`] implementation.
+//!
+//! Fields in a stacks-node webhook, the types fall into three categories
+//! 1. Types that are sent as hex encoded binary, where the binary is
+//!    serialized using the type's `T::to_hex` implementation (implemented
+//!    using the [`stacks_common::util::macros::impl_byte_array_newtype!`]
+//!    macro).
+//! 2. Types that are sent as hex encoded binary, where the binary is
+//!    serialized using the type's
+//!    [`StacksMessageCodec::consensus_serialize`] implementation.
+//! 3. Types that are serialized using the type's serde::Serialized
+//!    implementation.
+//!
+//! Unfortunately, sometimes the same type is serialized using two
+//! different methods for two different parts of the same payload.
+
+use blockstack_lib::burnchains::Txid;
+use blockstack_lib::chainstate::stacks::StacksTransaction;
+use blockstack_lib::net::api::HexDeser;
+use clarity::vm::types::QualifiedContractIdentifier;
+use clarity::vm::types::Value as ClarityValue;
+use serde::Deserialize;
+use stacks_common::codec::StacksMessageCodec;
+use stacks_common::types::chainstate::BlockHeaderHash;
+use stacks_common::types::chainstate::BurnchainHeaderHash;
+use stacks_common::types::chainstate::StacksBlockId;
+
+/// This struct represents the body of POST /new_block events from a stacks
+/// node.
+///
+/// # Note
+///
+/// This struct leaves out some of the fields that are included. For the
+/// full payload, see the source here:
+/// https://github.com/stacks-network/stacks-core/blob/09c4b066e25104be8b066e8f7530ff0c6df4ccd5/testnet/stacks-node/src/event_dispatcher.rs#L644-L687
+#[derive(Debug, Deserialize)]
+pub struct NewBlockEvent {
+    /// The hash of the stacks block
+    #[serde(deserialize_with = "deserialize_hex")]
+    pub block_hash: BlockHeaderHash,
+    /// The height of the stacks block
+    pub block_height: u64,
+    /// The hash of the bitcoin block associated with the stacks block.
+    #[serde(deserialize_with = "deserialize_hex")]
+    pub burn_block_hash: BurnchainHeaderHash,
+    /// The height of the bitcoin block associated with the stacks block.
+    pub burn_block_height: u32,
+    /// The timestamp in the header of the burn block. This corresponds to
+    /// the `burn_header_timestamp` field in the
+    /// [`blockstack_lib::chainstate::stacks::db::StacksHeaderInfo`]
+    pub burn_block_time: u64,
+    /// The timestamp in the header of the burn block. This corresponds to
+    /// [`blockstack_lib::chainstate::stacks::db::StacksHeaderInfo::index_block_hash`]
+    /// function.
+    #[serde(deserialize_with = "deserialize_hex")]
+    pub index_block_hash: StacksBlockId,
+    /// The events associated with transactions within the block. These are
+    /// only the events that we have configured our stacks node to send.
+    pub events: Vec<TransactionEvent>,
+    /// The transactions and their results that included within the block.
+    pub transactions: Vec<TransactionReceipt>,
+    /// The block hash of the parent Stacks block in the blockchain.
+    #[serde(deserialize_with = "deserialize_hex")]
+    pub parent_block_hash: BlockHeaderHash,
+    /// The block id of the parent Stacks block in the blockchain.
+    #[serde(deserialize_with = "deserialize_hex")]
+    pub parent_index_block_hash: StacksBlockId,
+    /// The block hash of the parent bitcoin block associated with this new
+    /// Stacks block.
+    #[serde(deserialize_with = "deserialize_hex")]
+    pub parent_burn_block_hash: BurnchainHeaderHash,
+    /// The height of the parent of the bitcoin burn block.
+    pub parent_burn_block_height: u32,
+    /// The timestamp in the header of the parent bitcoin burn block.
+    pub parent_burn_block_timestamp: u64,
+}
+
+/// https://github.com/stacks-network/stacks-core/blob/09c4b066e25104be8b066e8f7530ff0c6df4ccd5/testnet/stacks-node/src/event_dispatcher.rs#L499-L511
+#[derive(Debug, Deserialize)]
+pub struct TransactionReceipt {
+    /// The id of this transaction .
+    #[serde(deserialize_with = "deserialize_codec")]
+    pub txid: Txid,
+    /// Can drop, just a sequence
+    pub tx_index: u32,
+    /// Probably should be an enum
+    pub status: String,
+    /// These are probably bytes as hex
+    #[serde(rename = "raw_result", deserialize_with = "deserialize_codec")]
+    pub result: ClarityValue,
+    /// These are bytes as hex
+    #[serde(rename = "raw_tx", deserialize_with = "deserialize_codec")]
+    pub tx: StacksTransaction,
+}
+
+/// The type of event that occurred within the transaction.
+#[derive(Debug, Deserialize)]
+#[serde(rename = "lower_camel_case")]
+pub enum TransactionEventType {
+    /// A smart contract event
+    ContractEvent,
+    /// A STX transfer event
+    StxTransferEvent,
+    /// An STX mint event
+    StxMintEvent,
+    /// An STX burn event
+    StxBurnEvent,
+    /// An STX lock event
+    StxLockEvent,
+    /// A transfer event for a NFT
+    NftTransferEvent,
+    /// A non-fungible-token mint event
+    NftMintEvent,
+    /// A non-fungible-token burn event
+    NftBurnEvent,
+    /// A fungible-token transfer event
+    FtTransferEvent,
+    /// A fungible-token mint event
+    FtMintEvent,
+    /// A fungible-token burn event
+    FtBurnEvent,
+}
+
+/// https://github.com/stacks-network/stacks-core/blob/09c4b066e25104be8b066e8f7530ff0c6df4ccd5/clarity/src/vm/events.rs#L358-L363
+/// https://github.com/stacks-network/stacks-core/blob/09c4b066e25104be8b066e8f7530ff0c6df4ccd5/clarity/src/vm/events.rs#L45-L51
+#[derive(Debug, Deserialize)]
+pub struct TransactionEvent {
+    /// The id of the transaction that generated the event.
+    #[serde(deserialize_with = "deserialize_codec")]
+    pub txid: Txid,
+    /// can drop, just a sequence
+    pub event_index: u64,
+    /// This corresponds to the negation of the value in the
+    /// [`StacksTransactionReceipt.post_condition_aborted`] field.
+    pub committed: bool,
+    /// The type of event that this is. We only care about contract events,
+    /// so we only have the corresponding fields for it.
+    #[serde(rename = "type")]
+    pub event_type: TransactionEventType,
+    /// The actual event
+    pub contract_event: Option<SmartContractEvent>,
+}
+
+/// Smart contracts emit events when they are executed. This represents
+/// such an event.
+#[derive(Debug, Deserialize)]
+pub struct SmartContractEvent {
+    /// Identifies the smart contract that generated event.
+    #[serde(deserialize_with = "parse_contract_name")]
+    pub contract_identifier: QualifiedContractIdentifier,
+    /// The specific topic of the event. This is placed in the stacks node
+    /// config when specifying events.
+    pub topic: String,
+    /// The actual event
+    pub value: ClarityValue,
+}
+
+/// This is for deserializing fields that were effectively serialized the
+/// type's `to_hex` function, which they implemented through the
+/// [`stacks_common::util::macros::impl_byte_array_newtype!`] macro.
+///
+/// # Notes
+///
+/// A good example of how why this works is with the `block_hash` field in
+/// the `POST /new_block` webhook[^1]. It's set using the
+/// [`std::fmt::Display`] implementation of a [`BlockHeaderHash`] type. The
+/// [`std::fmt::Display`] implementation is done using the
+/// [`stacks_common::util::macros::impl_byte_array_newtype!`] macro, which
+/// is implemented using the [`BlockHeaderHash::to_hex`] function. That
+/// type also implements [`HexDeser`], with the implementation of
+/// [`HexDeser::try_from`] done using the types `from_hex` function. All
+/// the types that we use here that implement [`HexDeser`] here follow that
+/// same pattern.
+///
+/// [^1]: https://github.com/stacks-network/stacks-core/blob/09c4b066e25104be8b066e8f7530ff0c6df4ccd5/testnet/stacks-node/src/event_dispatcher.rs#L645
+pub fn deserialize_hex<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: HexDeser,
+{
+    let hex_str = <&str>::deserialize(deserializer)?;
+    let hex_str = hex_str.trim_start_matches("0x");
+    <T as HexDeser>::try_from(hex_str).map_err(serde::de::Error::custom)
+}
+
+/// This is for deserializing fields that were effectively serialized using
+/// [`StacksMessageCodec::consensus_serialize`].
+///
+/// # Notes
+///
+/// Fields deserialized with this function were serialized by "effectively"
+/// calling [`StacksMessageCodec::consensus_serialize`] followed by
+/// [`bytes_to_hex`] on the output and prepending "0x".
+pub fn deserialize_codec<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: StacksMessageCodec,
+{
+    let hex_str = <&str>::deserialize(deserializer)?;
+    let hex_str = hex_str.trim_start_matches("0x");
+    let bytes = stacks_common::util::hash::hex_bytes(hex_str).map_err(serde::de::Error::custom)?;
+    let fd = &mut bytes.as_slice();
+    <T as StacksMessageCodec>::consensus_deserialize(fd).map_err(serde::de::Error::custom)
+}
+
+/// The [`QualifiedContractIdentifier::parse`] function inverts the
+/// [`<QualifiedContractIdentifier as std::fmt::Display>::fmt`] call that
+/// was used to generate the fields that use this function for
+/// deserialization.
+pub fn parse_contract_name<'de, D>(des: D) -> Result<QualifiedContractIdentifier, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let literal = <&str>::deserialize(des)?;
+    QualifiedContractIdentifier::parse(literal).map_err(serde::de::Error::custom)
+}
+
+#[cfg(test)]
+mod tests {
+
+    #[test]
+    fn test_me() {}
+}

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -4,7 +4,7 @@ use bitcoin::hashes::Hash as _;
 use bitvec::array::BitArray;
 use blockstack_lib::chainstate::nakamoto::NakamotoBlock;
 use blockstack_lib::clarity::vm::types::PrincipalData;
-use blockstack_lib::clarity::vm::Value;
+use blockstack_lib::clarity::vm::Value as ClarityValue;
 use blockstack_lib::codec::StacksMessageCodec;
 use blockstack_lib::types::chainstate::StacksAddress;
 use futures::StreamExt;
@@ -95,7 +95,7 @@ impl AsContractCall for InitiateWithdrawalRequest {
         StacksAddress::burn_address(false)
     }
     /// The arguments to the clarity function.
-    fn as_contract_args(&self) -> Vec<Value> {
+    fn as_contract_args(&self) -> Vec<ClarityValue> {
         Vec::new()
     }
     async fn validate<S>(&self, _: &S) -> Result<bool, Error>


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/441.

## Changes

* Add concrete types for `POST /new_block` webhooks with types that match on smart contract events. There are a few other kinds of events by this PR only adds types for smart contract events.
* Set up a basic web server with two endpoints, one for the webhooks and another for the application status.
* Rename `Value` to `ClarityValue` where appropriate.

## Testing Information

This includes a unit test that checks the deserialization of the webhooks emitted from stacks core. This payload was sent from a stacks core node under Nakamoto on commit https://github.com/stacks-network/stacks-core/commit/cbf0c52fb7a0b8ac55badadcf3773ca0848a25cf which was made on 2024-08-20. The testing setup here followed the same testing setup as in https://github.com/stacks-network/sbtc/pull/303.

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
