### PR TITLE
feat: Emily reorg handling. (reorg part 4/4)

### DIFF
--- a/emily/handler/src/api/handlers/chainstate.rs
+++ b/emily/handler/src/api/handlers/chainstate.rs
@@ -1,17 +1,21 @@
 //! Handlers for chainstate endpoints.
 use crate::{
-    api::models::{
-        chainstate::{
-            requests::{SetChainstateRequestBody, UpdateChainstateRequestBody},
-            responses::{GetChainstateResponse, SetChainstateResponse},
-            Chainstate,
+    api::{
+        handlers::internal::{execute_reorg_handler, ExecuteReorgRequest},
+        models::{
+            chainstate::{
+                requests::{SetChainstateRequestBody, UpdateChainstateRequestBody},
+                responses::{GetChainstateResponse, SetChainstateResponse},
+                Chainstate,
+            },
+            common::BlockHeight,
         },
-        common::BlockHeight,
     },
-    common::error::Error,
+    common::error::{Error, Inconsistency},
     context::EmilyContext,
     database::{accessors, entries::chainstate::ChainstateEntry},
 };
+use tracing::warn;
 use warp::http::StatusCode;
 use warp::reply::{json, with_status, Reply};
 
@@ -36,7 +40,7 @@ pub async fn get_chain_tip(context: EmilyContext) -> impl warp::reply::Reply {
     async fn handler(context: EmilyContext) -> Result<impl warp::reply::Reply, Error> {
         // TODO(390): Handle multiple being in the tip list here.
         let api_state = accessors::get_api_state(&context).await?;
-        let chaintip: Chainstate = api_state.chaintip.into();
+        let chaintip: Chainstate = api_state.chaintip().into();
         Ok(with_status(
             json(&(chaintip as GetChainstateResponse)),
             StatusCode::OK,
@@ -75,31 +79,15 @@ pub async fn get_chainstate_at_height(
         context: EmilyContext,
         height: BlockHeight,
     ) -> Result<impl warp::reply::Reply, Error> {
-        // Get chainstate at height - hopefully just one.
-        //
-        // If there is more than one then there is a state inconsistency. This is potentially
-        // okay but the hope then is that the database is actively being repaired.
-        let num_to_retrieve_if_multiple = 5;
-        let (entries, _) = accessors::get_chainstate_entries_for_height(
-            &context,
-            &height,
-            None,
-            Some(num_to_retrieve_if_multiple),
-        )
-        .await?;
-        // Convert data into resource types.
-        let chainstates: Vec<Chainstate> = entries.into_iter().map(|entry| entry.into()).collect();
+        // Get chainstate at height.
+        let chainstate: Chainstate = accessors::get_chainstate_entry_at_height(&context, &height)
+            .await?
+            .into();
         // Respond.
-        match &chainstates[..] {
-            [] => Err(Error::NotFound),
-            [chainstate] => Ok(with_status(
-                json(chainstate as &GetChainstateResponse),
-                StatusCode::OK,
-            )),
-            _ => Err(Error::Debug(format!(
-                "Found too many withdrawals: {chainstates:?}"
-            ))),
-        }
+        Ok(with_status(
+            json(&(chainstate as GetChainstateResponse)),
+            StatusCode::OK,
+        ))
     }
     // Handle and respond.
     handler(context, height)
@@ -134,9 +122,7 @@ pub async fn set_chainstate(
     ) -> Result<impl warp::reply::Reply, Error> {
         // Convert body to the correct type.
         let chainstate: Chainstate = body;
-        let chainstate_entry: ChainstateEntry = chainstate.clone().into();
-        // TODO(TBD): handle a conflicting internal state error.
-        accessors::add_chainstate_entry(&context, &chainstate_entry).await?;
+        add_chainstate_entry_or_reorg(&context, &chainstate).await?;
         // Respond.
         Ok(with_status(
             json(&(chainstate as SetChainstateResponse)),
@@ -166,10 +152,57 @@ pub async fn set_chainstate(
     )
 )]
 pub async fn update_chainstate(
-    _context: EmilyContext,
-    _request: UpdateChainstateRequestBody,
+    context: EmilyContext,
+    request: UpdateChainstateRequestBody,
 ) -> impl warp::reply::Reply {
-    Error::NotImplemented
+    // Internal handler so `?` can be used correctly while still returning a reply.
+    async fn handler(
+        context: EmilyContext,
+        body: SetChainstateRequestBody,
+    ) -> Result<impl warp::reply::Reply, Error> {
+        // Convert body to the correct type.
+        let chainstate: Chainstate = body;
+        add_chainstate_entry_or_reorg(&context, &chainstate).await?;
+        // Respond.
+        Ok(with_status(
+            json(&(chainstate as SetChainstateResponse)),
+            StatusCode::CREATED,
+        ))
+    }
+    // Handle and respond.
+    handler(context, request)
+        .await
+        .map_or_else(Reply::into_response, Reply::into_response)
+}
+
+/// Adds the chainstate to the table, and reorganizes the API if there's a
+/// conflict that suggests it needs a reorg in order for this entry to be
+/// consistent.
+async fn add_chainstate_entry_or_reorg(
+    context: &EmilyContext,
+    chainstate: &Chainstate,
+) -> Result<(), Error> {
+    // Get chainstate as entry.
+    let entry: ChainstateEntry = chainstate.clone().into();
+    match accessors::add_chainstate_entry(context, &entry).await {
+        Err(Error::InconsistentState(Inconsistency::Chainstate(conflicting_chainstates))) => {
+            let execute_reorg_request = ExecuteReorgRequest {
+                canonical_tip: chainstate.clone(),
+                conflicting_chainstates,
+            };
+            // Execute the reorg.
+            execute_reorg_handler(context, execute_reorg_request)
+                .await
+                .map_err(|e| {
+                    warn!("Failed executing reorg with error {}", e);
+                    e
+                })?;
+        }
+        Err(e) => Err(e)?,
+        _ => {}
+    };
+    // Return.
+    Ok(())
 }
 
 // TODO(393): Add handler unit tests.

--- a/emily/handler/src/api/handlers/chainstate.rs
+++ b/emily/handler/src/api/handlers/chainstate.rs
@@ -193,12 +193,9 @@ async fn add_chainstate_entry_or_reorg(
             // Execute the reorg.
             execute_reorg_handler(context, execute_reorg_request)
                 .await
-                .map_err(|e| {
-                    warn!("Failed executing reorg with error {}", e);
-                    e
-                })?;
+                .inspect_err(|e| warn!("Failed executing reorg with error {}", e))?;
         }
-        Err(e) => Err(e)?,
+        e @ Err(_) => return e,
         _ => {}
     };
     // Return.

--- a/emily/handler/src/api/handlers/deposit.rs
+++ b/emily/handler/src/api/handlers/deposit.rs
@@ -271,6 +271,10 @@ pub async fn update_deposits(
         body: UpdateDepositsRequestBody,
     ) -> Result<impl warp::reply::Reply, Error> {
         // Get the api state and error if the api state is claimed by a reorg.
+        //
+        // Note: This may not be necessary due to the implied order of events
+        // that the API can receive from stacks nodes, but it's being added here
+        // in order to enforce added stability to the API during a reorg.
         let api_state = accessors::get_api_state(&context).await?;
         api_state.error_if_reorganizing()?;
         // Validate request.

--- a/emily/handler/src/api/handlers/internal.rs
+++ b/emily/handler/src/api/handlers/internal.rs
@@ -1,0 +1,220 @@
+//! Handlers for internal endpoints.
+
+use reqwest::StatusCode;
+use serde::{Deserialize, Serialize};
+use tracing::{debug, info, warn};
+
+use crate::api::models::chainstate::Chainstate;
+use crate::common::error::{Error, Inconsistency};
+use crate::context::EmilyContext;
+use crate::database::accessors;
+use crate::database::entries::chainstate::{ApiStateEntry, ApiStatus};
+use crate::database::entries::deposit::DepositEntry;
+use crate::database::entries::withdrawal::WithdrawalEntry;
+
+const MAX_SET_API_STATE_ATTEMPTS_DURING_REORG: u32 = 20;
+const ENTRY_UPDATE_RETRIES: u32 = 4;
+
+/// Request for executing a reorg.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ExecuteReorgRequest {
+    /// New canonical chainstate tip.
+    pub canonical_tip: Chainstate,
+    /// Conflicting chainstates.
+    pub conflicting_chainstates: Vec<Chainstate>,
+}
+
+/// Sets the api status to the provided status.
+///
+/// Return meanings:
+/// - Err(e):
+///     Something went wrong.
+/// - Ok(None):
+///     The API status is already what we wanted it to be, so there's
+///     no action required.
+/// - Ok(Some(ApiStateEntry)):
+///     We have successfully converted the api to the state returned.
+async fn set_api_state_status(
+    context: &EmilyContext,
+    new_status: &ApiStatus,
+) -> Result<Option<ApiStateEntry>, Error> {
+    let mut update_attempts = 0;
+    let mut api_state: ApiStateEntry;
+    loop {
+        update_attempts += 1;
+        let original_api_state = accessors::get_api_state(context).await?;
+        api_state = original_api_state.clone();
+
+        // Update the api status.
+        api_state.api_status = match (new_status, &original_api_state.api_status) {
+            // Handle trying to set the api status to reorganizing.
+            (ApiStatus::Reorg(_), ApiStatus::Stable(_)) => new_status.clone(),
+            (ApiStatus::Reorg(new_reorg_tip), ApiStatus::Reorg(current_reorg_tip)) => {
+                if new_reorg_tip == current_reorg_tip {
+                    return Ok(None);
+                } else {
+                    warn!(
+                        "Trying to reorg with new chaintip {:?} while the api is reorganizing around the chaintip {:?}",
+                        new_reorg_tip,
+                        current_reorg_tip,
+                    );
+                    return Err(Error::InconsistentState(Inconsistency::ItemUpdate(
+                        format!("Trying to reorg with new chaintip {:?} while the api is reorganizing around the chaintip {:?}",
+                        new_reorg_tip,
+                        current_reorg_tip,
+                        ))));
+                }
+            }
+            (ApiStatus::Stable(new_tip), ApiStatus::Stable(old_tip)) => {
+                if new_tip == old_tip {
+                    return Ok(None);
+                } else {
+                    new_status.clone()
+                }
+            }
+            (ApiStatus::Stable(_), ApiStatus::Reorg(_)) => new_status.clone(),
+        };
+
+        debug!(
+            "Changing Api state from [{:?}] to [{:?}]. Attempt {} of maximum {}.",
+            original_api_state, api_state, update_attempts, MAX_SET_API_STATE_ATTEMPTS_DURING_REORG,
+        );
+
+        // Attempt to set the API state.
+        match accessors::set_api_state(context, &api_state).await {
+            // Retry if there was a version conflict.
+            Err(Error::VersionConflict) => {
+                if update_attempts >= MAX_SET_API_STATE_ATTEMPTS_DURING_REORG {
+                    debug!("Failed to update API state {:?}", api_state);
+                    return Err(Error::InternalServer);
+                } else {
+                    debug!("Failed to update API state - retrying: {:?}", api_state);
+                }
+            }
+            // If it was okay then we successfully control the API.
+            Ok(()) => {
+                info!("Successfully set api state: {:?}.", api_state);
+                break;
+            }
+            // If some other error occured then return from here; this shouldn't
+            // happen and something has actually gone wrong.
+            Err(e) => Err(e)?,
+        }
+    }
+    // Return.
+    Ok(Some(api_state))
+}
+
+/// Handler that executes a reorg.
+///
+/// This function isn't intendeded to be exposed into any specific endpoint
+/// outside of what could maybe be a testing endpoint one day. It handles
+/// the internal requests to execute a reorg.
+pub async fn execute_reorg_handler(
+    context: &EmilyContext,
+    request: ExecuteReorgRequest,
+) -> Result<impl warp::reply::Reply, Error> {
+    info!("Executing a reorg with request {request:?}.");
+    let empty_reply = warp::reply::with_status(warp::reply(), StatusCode::NO_CONTENT);
+
+    let new_status = ApiStatus::Reorg(request.canonical_tip.clone().into());
+    match set_api_state_status(context, &new_status).await {
+        // Do nothing if we claimed the api correctly.
+        Ok(Some(_)) => {}
+        Ok(None) => {
+            return Ok(empty_reply);
+        }
+        Err(e) => {
+            return Err(e);
+        }
+    };
+
+    // Assume that we have control of the API at this point. For each entry of the deposit
+    // and withdrawal table we'll wipe out all the history after the latest reorg.
+
+    // Get all deposits that would be impacted by this reorg.
+    let all_deposits = accessors::get_all_deposit_entries_modified_after_height(
+        context,
+        request.canonical_tip.stacks_block_height,
+        None,
+    )
+    .await?;
+
+    // Setup debug modified deposit list.
+    let mut debug_modified_deposit_entries: Vec<DepositEntry> =
+        Vec::with_capacity(all_deposits.len());
+
+    // Kill the history from all the deposits.
+    for deposit in all_deposits {
+        for attempt in 0..ENTRY_UPDATE_RETRIES {
+            let mut entry =
+                accessors::get_deposit_entry(context, &deposit.primary_index_key).await?;
+            entry.reorganize_around(&request.canonical_tip)?;
+            match accessors::set_deposit_entry(context, &mut entry).await {
+                Ok(_) => break,
+                Err(Error::VersionConflict) => {
+                    debug!(
+                        "Encountered race condition in updating entry {:?}. Attempt {}/{}",
+                        entry, attempt, ENTRY_UPDATE_RETRIES
+                    );
+                }
+                Err(e) => Err(e)?,
+            }
+            // Add modified deposit entries.
+            debug_modified_deposit_entries.push(entry);
+        }
+    }
+
+    // Show updated deposits.
+    debug!(
+        "Reorganized deposits: {}",
+        serde_json::to_string_pretty(&debug_modified_deposit_entries)?
+    );
+
+    // Get all withdrawals that would be impacted by this reorg.
+    let all_withdrawals = accessors::get_all_withdrawal_entries_modified_after_height(
+        context,
+        request.canonical_tip.stacks_block_height,
+        None,
+    )
+    .await?;
+
+    // Setup debug modified withdrawal list.
+    let mut debug_modified_withdrawal_entries: Vec<WithdrawalEntry> =
+        Vec::with_capacity(all_withdrawals.len());
+
+    // Kill the history from all the withdrawals.
+    for withdrawal in all_withdrawals {
+        for attempt in 0..ENTRY_UPDATE_RETRIES {
+            let request_id = withdrawal.primary_index_key.request_id;
+            let mut entry = accessors::get_withdrawal_entry(context, &request_id).await?;
+            entry.reorganize_around(&request.canonical_tip)?;
+            match accessors::set_withdrawal_entry(context, &mut entry).await {
+                Ok(_) => break,
+                Err(Error::VersionConflict) => {
+                    debug!(
+                        "Encountered race condition in updating entry {:?}. Attempt {}/{}",
+                        entry, attempt, ENTRY_UPDATE_RETRIES
+                    );
+                }
+                Err(e) => Err(e)?,
+            }
+            // Add modified withdrawal entries.
+            debug_modified_withdrawal_entries.push(entry);
+        }
+    }
+
+    // Show updated withdrawals.
+    debug!(
+        "Reorganized withdrawals: {}",
+        serde_json::to_string_pretty(&debug_modified_withdrawal_entries)?
+    );
+
+    // Cleanup API state.
+    set_api_state_status(context, &ApiStatus::Stable(request.canonical_tip.into())).await?;
+
+    // All good.
+    Ok(empty_reply)
+}
+
+// TODO: Unit tests.

--- a/emily/handler/src/api/handlers/mod.rs
+++ b/emily/handler/src/api/handlers/mod.rs
@@ -12,6 +12,8 @@ pub mod chainstate;
 pub mod deposit;
 /// Health handlers.
 pub mod health;
+/// Internal handlers.
+pub mod internal;
 /// Testing handlers.
 #[cfg(feature = "testing")]
 pub mod testing;

--- a/emily/handler/src/api/handlers/withdrawal.rs
+++ b/emily/handler/src/api/handlers/withdrawal.rs
@@ -140,8 +140,9 @@ pub async fn create_withdrawal(
         context: EmilyContext,
         body: CreateWithdrawalRequestBody,
     ) -> Result<impl warp::reply::Reply, Error> {
-        // Set variables.
-        // TODO(396): Remove dummy hash; take hash from request.
+        // Get the api state and error if the api state is claimed by a reorg.
+        let api_state = accessors::get_api_state(&context).await?;
+        api_state.error_if_reorganizing()?;
 
         let CreateWithdrawalRequestBody {
             request_id,
@@ -213,6 +214,9 @@ pub async fn update_withdrawals(
         context: EmilyContext,
         body: UpdateWithdrawalsRequestBody,
     ) -> Result<impl warp::reply::Reply, Error> {
+        // Get the api state and error if the api state is claimed by a reorg.
+        let api_state = accessors::get_api_state(&context).await?;
+        api_state.error_if_reorganizing()?;
         // Validate request.
         let validated_request: ValidatedUpdateWithdrawalRequest = body.try_into()?;
         // Create aggregator.

--- a/emily/handler/src/api/handlers/withdrawal.rs
+++ b/emily/handler/src/api/handlers/withdrawal.rs
@@ -141,6 +141,10 @@ pub async fn create_withdrawal(
         body: CreateWithdrawalRequestBody,
     ) -> Result<impl warp::reply::Reply, Error> {
         // Get the api state and error if the api state is claimed by a reorg.
+        //
+        // Note: This may not be necessary due to the implied order of events
+        // that the API can receive from stacks nodes, but it's being added here
+        // in order to enforce added stability to the API during a reorg.
         let api_state = accessors::get_api_state(&context).await?;
         api_state.error_if_reorganizing()?;
 
@@ -215,6 +219,10 @@ pub async fn update_withdrawals(
         body: UpdateWithdrawalsRequestBody,
     ) -> Result<impl warp::reply::Reply, Error> {
         // Get the api state and error if the api state is claimed by a reorg.
+        //
+        // Note: This may not be necessary due to the implied order of events
+        // that the API can receive from stacks nodes, but it's being added here
+        // in order to enforce added stability to the API during a reorg.
         let api_state = accessors::get_api_state(&context).await?;
         api_state.error_if_reorganizing()?;
         // Validate request.

--- a/emily/handler/src/common/error.rs
+++ b/emily/handler/src/common/error.rs
@@ -15,13 +15,16 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use warp::{reject::Reject, reply::Reply};
 
-use crate::database::entries::chainstate::ChainstateEntry;
+use crate::{api::models::chainstate::Chainstate, database::entries::chainstate::ChainstateEntry};
 
 /// State inconsistency representations.
 #[derive(Debug)]
 pub enum Inconsistency {
-    /// There is a chainstate inconsistency.
-    Chainstate(Vec<ChainstateEntry>),
+    /// There is a chainstate inconsistency, and all the chainstates
+    /// in the vector are the chainstates that are present in the API
+    /// but are not known to be correct. All chainstates in the vector
+    /// are considered equally cannonical.
+    Chainstate(Vec<Chainstate>),
     /// There is an inconsistency in the way an item is being updated.
     ItemUpdate(String),
 }
@@ -90,6 +93,10 @@ pub enum Error {
     #[error("Inconsistent internal state: {0:?}")]
     InconsistentState(Inconsistency),
 
+    /// API is reorganizing.
+    #[error("Api is reorganizing around new chain tip {0:?}")]
+    Reorganzing(Chainstate),
+
     /// An entry update version conflict in a resource update resulted
     /// in an update not being performed.
     #[error("Version conflict")]
@@ -115,6 +122,7 @@ impl Error {
             Error::ServiceUnavailable => StatusCode::SERVICE_UNAVAILABLE,
             Error::RequestTimeout => StatusCode::REQUEST_TIMEOUT,
             Error::InconsistentState(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            Error::Reorganzing(_) => StatusCode::INTERNAL_SERVER_ERROR,
             Error::VersionConflict => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
@@ -141,9 +149,20 @@ impl Error {
             | Error::Network(_)
             | Error::ServiceUnavailable
             | Error::VersionConflict
+            | Error::Reorganzing(_)
             | Error::InternalServer => Error::InternalServer,
             err => err,
         }
+    }
+    /// Makes an inconsistency error from a vector of chainstate entries.
+    pub fn from_inconsistent_chainstate_entries(entries: Vec<ChainstateEntry>) -> Self {
+        Error::InconsistentState(Inconsistency::Chainstate(
+            entries.into_iter().map(|entry| entry.into()).collect(),
+        ))
+    }
+    /// Makes an inconsistency error from a single chainstate entry.
+    pub fn from_inconsistent_chainstate_entry(entry: ChainstateEntry) -> Self {
+        Error::InconsistentState(Inconsistency::Chainstate(vec![entry.into()]))
     }
 }
 

--- a/emily/handler/src/common/error.rs
+++ b/emily/handler/src/common/error.rs
@@ -23,7 +23,7 @@ pub enum Inconsistency {
     /// There is a chainstate inconsistency, and all the chainstates
     /// in the vector are the chainstates that are present in the API
     /// but are not known to be correct. All chainstates in the vector
-    /// are considered equally cannonical.
+    /// are considered equally canonical.
     Chainstate(Vec<Chainstate>),
     /// There is an inconsistency in the way an item is being updated.
     ItemUpdate(String),

--- a/emily/handler/src/database/accessors.rs
+++ b/emily/handler/src/database/accessors.rs
@@ -16,7 +16,8 @@ use crate::{
 
 use super::entries::{
     chainstate::{
-        ApiStateEntry, ChainstateEntry, ChainstateTablePrimaryIndex, SpecialApiStateIndex,
+        ApiStateEntry, ApiStatus, ChainstateEntry, ChainstateTablePrimaryIndex,
+        SpecialApiStateIndex,
     },
     deposit::{
         DepositEntry, DepositEntryKey, DepositInfoEntry, DepositTablePrimaryIndex,
@@ -369,17 +370,24 @@ pub async fn add_chainstate_entry(
     context: &EmilyContext,
     entry: &ChainstateEntry,
 ) -> Result<(), Error> {
+    // Get the current api state and give up if reorging.
+    let mut api_state = get_api_state(context).await?;
+    if let ApiStatus::Reorg(reorg_chaintip) = &api_state.api_status {
+        if reorg_chaintip != entry {
+            return Err(Error::InconsistentState(Inconsistency::ItemUpdate(
+                "Attempting to update chainstate during a reorg.".to_string(),
+            )));
+        }
+    }
+
     // Get the existing chainstate entry for height. If there's a conflict
     // then propagate it back to the caller.
     let current_chainstate_entry_result =
         get_chainstate_entry_at_height(context, &entry.key.height)
             .await
-            .and_then(|existing_entry| {
+            .and_then(|existing_entry: ChainstateEntry| {
                 if &existing_entry != entry {
-                    Err(Error::InconsistentState(Inconsistency::Chainstate(vec![
-                        entry.clone(),
-                        existing_entry,
-                    ])))
+                    Err(Error::from_inconsistent_chainstate_entry(existing_entry))
                 } else {
                     Ok(())
                 }
@@ -395,16 +403,11 @@ pub async fn add_chainstate_entry(
         }
     };
 
-    // TODO(390): Determine whether the order for these operations is correct
-    // given the eventual consistency guarantees of dynamodb.
-    //
-    // TODO(TBD): Handle api status being "Reorg" during this period.
-    let mut api_state = get_api_state(context).await?;
-    let blocks_higher_than_current_tip =
-        (entry.key.height as i128) - (api_state.chaintip.key.height as i128);
+    let chaintip: ChainstateEntry = api_state.chaintip();
+    let blocks_higher_than_current_tip = (entry.key.height as i128) - (chaintip.key.height as i128);
 
-    if blocks_higher_than_current_tip == 1 || api_state.chaintip.key.height == 0 {
-        api_state.chaintip = entry.clone();
+    if blocks_higher_than_current_tip == 1 || chaintip.key.height == 0 {
+        api_state.api_status = ApiStatus::Stable(entry.clone());
         // Put the chainstate entry into the table. If two lambdas get exactly here at the same time
         // and have different views of the block hash at this height it would result in two hashes
         // for the same height. This will be explicitly handled when the api attempts to retrieve the
@@ -415,7 +418,9 @@ pub async fn add_chainstate_entry(
     } else if blocks_higher_than_current_tip > 1 {
         // Attempting to put an entry into the table that's significantly higher than the current
         // known chain tip.
-        Err(Error::NotAcceptable)
+        Err(Error::InconsistentState(Inconsistency::ItemUpdate("
+            Attempting to put an entry into the table that's significantly higher than the current known chain tip.".to_string(),
+        )))
     } else {
         // Current tip is higher than the entry we attempted to emplace
         // but there is no record of the chainstate at the current height.
@@ -427,7 +432,7 @@ pub async fn add_chainstate_entry(
         // reorg has reset the knowledge of the API maintainer to an earlier time.
         //
         // Worst case this causes an unnecessary reorg.
-        Err(Error::InconsistentState(Inconsistency::Chainstate(vec![])))
+        Err(Error::from_inconsistent_chainstate_entry(chaintip))
     }
 }
 
@@ -445,7 +450,7 @@ pub async fn get_chainstate_entry_at_height(
     match entries.as_slice() {
         [] => Err(Error::NotFound),
         [single_entry] => Ok(single_entry.clone()),
-        [_, ..] => Err(Error::InconsistentState(Inconsistency::Chainstate(entries))),
+        [_, ..] => Err(Error::from_inconsistent_chainstate_entries(entries)),
     }
 }
 

--- a/emily/handler/src/database/accessors.rs
+++ b/emily/handler/src/database/accessors.rs
@@ -121,7 +121,7 @@ pub async fn get_all_deposit_entries_modified_after_height_with_status(
         context,
         status,
         &minimum_height,
-        ">=",
+        ">",
         maybe_page_size,
     )
     .await
@@ -302,7 +302,7 @@ pub async fn get_all_withdrawal_entries_modified_after_height_with_status(
         context,
         status,
         &minimum_height,
-        ">=",
+        ">",
         maybe_page_size,
     )
     .await

--- a/emily/handler/src/database/entries/deposit.rs
+++ b/emily/handler/src/database/entries/deposit.rs
@@ -164,11 +164,11 @@ impl DepositEntry {
         self.history.retain(|event| {
             // The event is younger than the reorg...
             (chainstate.stacks_block_height > event.stacks_block_height)
-                // Or the event is as old as the reorg but has a different block hash...
+                // Or the event is as old as the reorg and has the same block hash...
                 || ((chainstate.stacks_block_height == event.stacks_block_height)
                     && (chainstate.stacks_block_hash == event.stacks_block_hash))
         });
-        // If the history is empty add a reassessing event.
+        // If the history is empty add a reprocessing event.
         if self.history.is_empty() {
             self.history = vec![DepositEvent {
                 status: StatusEntry::Reprocessing,
@@ -183,7 +183,19 @@ impl DepositEntry {
         Ok(())
     }
 
-    /// Synchronize the entry with its history.
+    /// Synchronizes the entry with its history.
+    ///
+    /// These entries contain an internal vector of history entries in chronological order.
+    /// The last entry in the history vector is the latest entry, meaning the most up-to-date data.
+    /// Within this last history are some fields that we want to be able to index into the
+    /// table with; at the moment of writing this it's `status` and `last_update_height`.
+    ///
+    /// DynamoDB can only be sorted and indexed by top level fields, so in order to allow the table
+    /// to be searchable by `status`` or ordered by `last_update_height`` there needs to be a top
+    /// level field for it.
+    ///
+    /// This function takes the entry and then synchronizes the top level fields that should
+    /// reflect the latest data in the history vector with the latest entry in the history vector.
     pub fn synchronize_with_history(&mut self) -> Result<(), Error> {
         // Get latest event.
         let latest_event = self.latest_event()?;

--- a/emily/handler/src/database/entries/withdrawal.rs
+++ b/emily/handler/src/database/entries/withdrawal.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     api::models::{
+        chainstate::Chainstate,
         common::{BitcoinAddress, BlockHeight, Satoshis, StacksBlockHash, StacksPrinciple, Status},
         withdrawal::{
             requests::{UpdateWithdrawalsRequestBody, WithdrawalUpdate},
@@ -113,6 +114,46 @@ impl WithdrawalEntry {
             "Withdrawal entry must always have at least one event, but entry with id {:?} did not.",
             self.key(),
         )))
+    }
+
+    /// Reorgs around a given chainstate.
+    /// TODO(TBD): Remove duplicate code around deposits and withdrawals if possible.
+    pub fn reorganize_around(&mut self, chainstate: &Chainstate) -> Result<(), Error> {
+        // Update the history to have the histories wiped after the reorg.
+        self.history.retain(|event| {
+            // The event is younger than the reorg...
+            (chainstate.stacks_block_height > event.stacks_block_height)
+                // Or the event is as old as the reorg but has a different block hash...
+                || ((chainstate.stacks_block_height == event.stacks_block_height)
+                    && (chainstate.stacks_block_hash == event.stacks_block_hash))
+        });
+        // If the history is empty add a reassessing event.
+        if self.history.is_empty() {
+            self.history = vec![WithdrawalEvent {
+                status: StatusEntry::Reprocessing,
+                message: "Reprocessing withdrawal status after reorg.".to_string(),
+                stacks_block_height: chainstate.stacks_block_height,
+                stacks_block_hash: chainstate.stacks_block_hash.clone(),
+            }]
+        }
+        // Synchronize self with the new history.
+        self.synchronize_with_history()?;
+        // Return.
+        Ok(())
+    }
+
+    /// Synchronize the entry with its history.
+    pub fn synchronize_with_history(&mut self) -> Result<(), Error> {
+        // Get latest event.
+        let latest_event = self.latest_event()?;
+        // Calculate the new values.
+        let new_status: Status = (&latest_event.status).into();
+        let new_last_update_height: u64 = latest_event.stacks_block_height;
+        // Set variables.
+        self.status = new_status;
+        self.last_update_height = new_last_update_height;
+        // Return.
+        Ok(())
     }
 }
 

--- a/emily/handler/tests/integration/accessors.rs
+++ b/emily/handler/tests/integration/accessors.rs
@@ -135,7 +135,7 @@ async fn get_deposits_modified_after_height() {
         accessors::get_all_deposit_entries_modified_after_height_with_status(
             &context,
             &status,
-            minimum_height,
+            minimum_height - 1,
             None,
         )
         .await

--- a/emily/handler/tests/integration/complex/reorg.rs
+++ b/emily/handler/tests/integration/complex/reorg.rs
@@ -146,9 +146,8 @@ async fn simple_reorg_test_base(scenario: ReorgScenario) {
         util::test_chainstate(initial_chain_length - 1, fork_id),
     );
 
-    // Do the reorg part of the test.
+    // Do the reorg part of the test if specified.
     if do_reorg {
-        // TODO(348): Uncomment once updates are supported.
         // Step 2: Create a conflicting fork.
         // -------------------------------------------------------------------------
         fork_id += 1;

--- a/emily/handler/tests/integration/complex/reorg.rs
+++ b/emily/handler/tests/integration/complex/reorg.rs
@@ -75,7 +75,6 @@ pub async fn simple_no_reorg() {
 /// of those chainstates were re-written.
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
-// #[ignore = "Because reorg is not implemented."]
 pub async fn simple_reorg() {
     // Setup client.
     simple_reorg_test_base(ReorgScenario {
@@ -167,6 +166,7 @@ async fn simple_reorg_test_base(scenario: ReorgScenario) {
         let all_reevaluating_deposits = client
             .get_all_deposits_with_status(&Status::Reprocessing)
             .await;
+
         assert_eq!(
             all_reevaluating_deposits.len(),
             reorganized_chainstates.len(),

--- a/emily/handler/tests/integration/complex/reorg.rs
+++ b/emily/handler/tests/integration/complex/reorg.rs
@@ -1,5 +1,5 @@
 use emily_handler::api::models::{
-    chainstate::Chainstate, deposit::requests::CreateDepositRequestBody,
+    chainstate::Chainstate, common::Status, deposit::requests::CreateDepositRequestBody,
     withdrawal::requests::CreateWithdrawalRequestBody,
 };
 
@@ -19,6 +19,8 @@ struct ReorgScenario {
     initial_chain_length: u64,
     /// The depth of the reorg.
     reorg_depth: u64,
+    /// Whether to do a reorg.
+    do_reorg: bool,
 }
 
 /// Reorg validate implementation.
@@ -53,6 +55,19 @@ impl ReorgScenario {
     }
 }
 
+/// Tests a simple blockchain setup without a reorg.
+#[cfg_attr(not(feature = "integration-tests"), ignore)]
+#[tokio::test]
+pub async fn simple_no_reorg() {
+    // Setup client.
+    simple_reorg_test_base(ReorgScenario {
+        initial_chain_length: 10,
+        reorg_depth: 5,
+        do_reorg: false,
+    })
+    .await;
+}
+
 /// Tests a simple blockchain reorg.
 ///
 /// To test a simple reorg we create a single deposit and withdrawal for a number
@@ -60,11 +75,13 @@ impl ReorgScenario {
 /// of those chainstates were re-written.
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
+// #[ignore = "Because reorg is not implemented."]
 pub async fn simple_reorg() {
     // Setup client.
     simple_reorg_test_base(ReorgScenario {
         initial_chain_length: 10,
         reorg_depth: 5,
+        do_reorg: true,
     })
     .await;
 }
@@ -76,6 +93,7 @@ async fn simple_reorg_test_base(scenario: ReorgScenario) {
     let ReorgScenario {
         initial_chain_length,
         reorg_depth: _,
+        do_reorg,
     } = scenario;
 
     // Setup the test client and environment.
@@ -83,7 +101,7 @@ async fn simple_reorg_test_base(scenario: ReorgScenario) {
     client.setup_test().await;
 
     // Identifier for the current fork.
-    let fork_id: u32 = 0;
+    let mut fork_id: u32 = 0;
 
     // Step 1: Make an initial fork.
     // -------------------------------------------------------------------------
@@ -128,32 +146,33 @@ async fn simple_reorg_test_base(scenario: ReorgScenario) {
         util::test_chainstate(initial_chain_length - 1, fork_id),
     );
 
-    // // TODO(348): Uncomment once updates are supported.
-    // // Step 2: Create a conflicting fork.
-    // // -------------------------------------------------------------------------
-    // fork_id += 1;
+    // Do the reorg part of the test.
+    if do_reorg {
+        // TODO(348): Uncomment once updates are supported.
+        // Step 2: Create a conflicting fork.
+        // -------------------------------------------------------------------------
+        fork_id += 1;
 
-    // // Set a conflicting chainstate for a lower than top depth to initiate an internal reorg.
-    // let reorganized_chainstates = scenario.reorganized_chainstates(fork_id);
-    // let lowest_reorganized_block: Chainstate = reorganized_chainstates.first().unwrap().clone();
-    // client.update_chainstate(&lowest_reorganized_block).await;
+        // Set a conflicting chainstate for a lower than top depth to initiate an internal reorg.
+        let reorganized_chainstates = scenario.reorganized_chainstates(fork_id);
+        let lowest_reorganized_block: Chainstate = reorganized_chainstates.first().unwrap().clone();
+        client.update_chainstate(&lowest_reorganized_block).await;
 
-    // // Verify that the chain tip is updated to be the new reorg height.
-    // let chain_tip: Chainstate = client.get_chaintip().await;
-    // assert_eq!(chain_tip, lowest_reorganized_block);
+        // Verify that the chain tip is updated to be the new reorg height.
+        let chain_tip: Chainstate = client.get_chaintip().await;
+        assert_eq!(chain_tip, lowest_reorganized_block);
 
-    // // Description:
-    // //
-    // // Now that there's a conflicting fork we should see that all the withdrawals created
-    // // within the span of the reorged blocks are effectively "wiped". Because we created one
-    // // withdrawal per block, we should only see as many withdrawals as there were un-reorged
-    // // blocks.
+        let all_deposits = client.get_all_deposits().await;
 
-    // let all_deposits = client.get_all_deposits().await;
-    // let all_withdrawals = client.get_all_withdrawals().await;
-
-    // assert_eq!(all_deposits.len(), initial_chain_length as usize);
-    // assert_eq!(all_withdrawals.len(), reorganized_chainstates.len());
+        assert_eq!(all_deposits.len(), initial_chain_length as usize);
+        let all_reevaluating_deposits = client
+            .get_all_deposits_with_status(&Status::Reprocessing)
+            .await;
+        assert_eq!(
+            all_reevaluating_deposits.len(),
+            reorganized_chainstates.len(),
+        );
+    }
 
     // Setup for the next test.
     client.reset_environment().await;


### PR DESCRIPTION
## Description

Closes: #348 

Handles reorgs when the chainstate updates.

Also adds a gate to other modifying API requests that prevents state alteration when the api is reorganizing. We can likely remove this gate long term but for now I'm adding it for stability.

## Changes

Adds reorganization handling.

## Testing Information

Tested with unit tests.

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
