### PR TITLE
refactor: refine smart contract print events

### DIFF
--- a/contracts/contracts/sbtc-registry.clar
+++ b/contracts/contracts/sbtc-registry.clar
@@ -166,7 +166,7 @@
     (request-id uint) 
     (bitcoin-txid (buff 32))
     (signer-bitmap uint)
-    (output-index uint)
+    (vout-index uint)
     (fee uint)
   )
   (begin 
@@ -178,7 +178,7 @@
       request-id: request-id,
       bitcoin-txid: bitcoin-txid,
       signer-bitmap: signer-bitmap,
-      output-index: output-index,
+      vout-index: vout-index,
       fee: fee
     })
     (ok true)
@@ -230,7 +230,7 @@
     })
     (print {
       topic: "completed-deposit",
-      txid: txid,
+      bitcoin-txid: txid,
       vout-index: vout-index,
       amount: amount
     })

--- a/contracts/contracts/sbtc-registry.clar
+++ b/contracts/contracts/sbtc-registry.clar
@@ -165,8 +165,8 @@
 (define-public (complete-withdrawal-accept
     (request-id uint) 
     (bitcoin-txid (buff 32))
+    (output-index uint)
     (signer-bitmap uint)
-    (vout-index uint)
     (fee uint)
   )
   (begin 
@@ -178,7 +178,7 @@
       request-id: request-id,
       bitcoin-txid: bitcoin-txid,
       signer-bitmap: signer-bitmap,
-      vout-index: vout-index,
+      output-index: output-index,
       fee: fee
     })
     (ok true)
@@ -231,7 +231,7 @@
     (print {
       topic: "completed-deposit",
       bitcoin-txid: txid,
-      vout-index: vout-index,
+      output-index: vout-index,
       amount: amount
     })
     (ok true)

--- a/contracts/contracts/sbtc-registry.clar
+++ b/contracts/contracts/sbtc-registry.clar
@@ -170,7 +170,7 @@
     ;; Mark the withdrawal as completed
     (map-insert withdrawal-status request-id true)
     (print {
-      topic: "accepted-withdrawal",
+      topic: "withdrawal-accept",
       request-id: request-id,
       bitcoin-txid: bitcoin-txid,
       signer-bitmap: signer-bitmap,
@@ -192,7 +192,7 @@
     ;; Mark the withdrawal as completed
     (map-insert withdrawal-status request-id false)
     (print {
-      topic: "rejected-withdrawal",
+      topic: "withdrawal-reject",
       request-id: request-id,
       signer-bitmap: signer-bitmap,
     })

--- a/contracts/contracts/sbtc-registry.clar
+++ b/contracts/contracts/sbtc-registry.clar
@@ -121,7 +121,7 @@
 ;; This function does not handle validation or moving the funds.
 ;; Instead, it is purely for the purpose of storing the request.
 ;; 
-;; The function will emit a print event with the topic "withdrawal-request"
+;; The function will emit a print event with the topic "withdrawal-create"
 ;; and the data of the request.
 (define-public (create-withdrawal-request
     (amount uint)
@@ -144,7 +144,7 @@
       block-height: height,
     })
     (print {
-      topic: "withdrawal-request",
+      topic: "withdrawal-create",
       amount: amount,
       request-id: id,
       sender: sender,

--- a/contracts/contracts/sbtc-registry.clar
+++ b/contracts/contracts/sbtc-registry.clar
@@ -156,7 +156,11 @@
   )
 )
 
-;; Complete withdrawal request by noting the acceptance
+;; Complete withdrawal request by noting the acceptance in the
+;; withdrawal-status state map.
+;;
+;; This function will emit a print event with the topic
+;; "withdrawal-accept".
 ;; #[allow(unchecked_data)]
 (define-public (complete-withdrawal-accept
     (request-id uint) 
@@ -181,7 +185,11 @@
   )
 )
 
-;; Complete withdrawal request by noting the rejection
+;; Complete withdrawal request by noting the rejection in the 
+;; withdrawal-status state map.
+;;
+;; This function will emit a print event with the topic
+;; "withdrawal-reject".
 ;; #[allow(unchecked_data)]
 (define-public (complete-withdrawal-reject
     (request-id uint) 

--- a/contracts/contracts/sbtc-registry.clar
+++ b/contracts/contracts/sbtc-registry.clar
@@ -156,28 +156,45 @@
   )
 )
 
-;; Complete withdrawal request
+;; Complete withdrawal request by noting the acceptance
 ;; #[allow(unchecked_data)]
-(define-public (complete-withdrawal
+(define-public (complete-withdrawal-accept
     (request-id uint) 
-    (status bool)
-    (bitcoin-txid (optional (buff 32))) 
-    (signer-bitmap (optional uint))
-    (output-index (optional uint))
-    (fee (optional uint))
+    (bitcoin-txid (buff 32))
+    (signer-bitmap uint)
+    (output-index uint)
+    (fee uint)
   )
   (begin 
     (try! (is-protocol-caller))
     ;; Mark the withdrawal as completed
-    (map-insert withdrawal-status request-id status)
+    (map-insert withdrawal-status request-id true)
     (print {
-      topic: "completed-withdrawal",
+      topic: "accepted-withdrawal",
       request-id: request-id,
-      request-status: status,
       bitcoin-txid: bitcoin-txid,
       signer-bitmap: signer-bitmap,
       output-index: output-index,
       fee: fee
+    })
+    (ok true)
+  )
+)
+
+;; Complete withdrawal request by noting the rejection
+;; #[allow(unchecked_data)]
+(define-public (complete-withdrawal-reject
+    (request-id uint) 
+    (signer-bitmap uint)
+  )
+  (begin 
+    (try! (is-protocol-caller))
+    ;; Mark the withdrawal as completed
+    (map-insert withdrawal-status request-id false)
+    (print {
+      topic: "rejected-withdrawal",
+      request-id: request-id,
+      signer-bitmap: signer-bitmap,
     })
     (ok true)
   )

--- a/contracts/contracts/sbtc-withdrawal.clar
+++ b/contracts/contracts/sbtc-withdrawal.clar
@@ -77,7 +77,7 @@
       )
 
       ;; Call into registry to confirm accepted withdrawal
-      (try! (contract-call? .sbtc-registry complete-withdrawal request-id true (some bitcoin-txid) (some signer-bitmap) (some output-index) (some fee)))
+      (try! (contract-call? .sbtc-registry complete-withdrawal-accept request-id bitcoin-txid signer-bitmap output-index fee))
 
       (ok true)
   )
@@ -101,7 +101,7 @@
     (try! (contract-call? .sbtc-token protocol-unlock (get amount withdrawal) (get sender withdrawal)))
 
     ;; Call into registry to confirm accepted withdrawal
-    (try! (contract-call? .sbtc-registry complete-withdrawal request-id false none (some signer-bitmap) none none))
+    (try! (contract-call? .sbtc-registry complete-withdrawal-reject request-id signer-bitmap))
 
     (ok true)
   )

--- a/contracts/tests/clarigen-types.ts
+++ b/contracts/tests/clarigen-types.ts
@@ -706,29 +706,39 @@ export const contracts = {
         ],
         Response<boolean, bigint>
       >,
-      completeWithdrawal: {
-        name: "complete-withdrawal",
+      completeWithdrawalAccept: {
+        name: "complete-withdrawal-accept",
         access: "public",
         args: [
           { name: "request-id", type: "uint128" },
-          { name: "status", type: "bool" },
-          {
-            name: "bitcoin-txid",
-            type: { optional: { buffer: { length: 32 } } },
-          },
-          { name: "signer-bitmap", type: { optional: "uint128" } },
-          { name: "output-index", type: { optional: "uint128" } },
-          { name: "fee", type: { optional: "uint128" } },
+          { name: "bitcoin-txid", type: { buffer: { length: 32 } } },
+          { name: "signer-bitmap", type: "uint128" },
+          { name: "output-index", type: "uint128" },
+          { name: "fee", type: "uint128" },
         ],
         outputs: { type: { response: { ok: "bool", error: "uint128" } } },
       } as TypedAbiFunction<
         [
           requestId: TypedAbiArg<number | bigint, "requestId">,
-          status: TypedAbiArg<boolean, "status">,
-          bitcoinTxid: TypedAbiArg<Uint8Array | null, "bitcoinTxid">,
-          signerBitmap: TypedAbiArg<number | bigint | null, "signerBitmap">,
-          outputIndex: TypedAbiArg<number | bigint | null, "outputIndex">,
-          fee: TypedAbiArg<number | bigint | null, "fee">,
+          bitcoinTxid: TypedAbiArg<Uint8Array, "bitcoinTxid">,
+          signerBitmap: TypedAbiArg<number | bigint, "signerBitmap">,
+          outputIndex: TypedAbiArg<number | bigint, "outputIndex">,
+          fee: TypedAbiArg<number | bigint, "fee">,
+        ],
+        Response<boolean, bigint>
+      >,
+      completeWithdrawalReject: {
+        name: "complete-withdrawal-reject",
+        access: "public",
+        args: [
+          { name: "request-id", type: "uint128" },
+          { name: "signer-bitmap", type: "uint128" },
+        ],
+        outputs: { type: { response: { ok: "bool", error: "uint128" } } },
+      } as TypedAbiFunction<
+        [
+          requestId: TypedAbiArg<number | bigint, "requestId">,
+          signerBitmap: TypedAbiArg<number | bigint, "signerBitmap">,
         ],
         Response<boolean, bigint>
       >,

--- a/contracts/tests/clarigen-types.ts
+++ b/contracts/tests/clarigen-types.ts
@@ -713,7 +713,7 @@ export const contracts = {
           { name: "request-id", type: "uint128" },
           { name: "bitcoin-txid", type: { buffer: { length: 32 } } },
           { name: "signer-bitmap", type: "uint128" },
-          { name: "output-index", type: "uint128" },
+          { name: "vout-index", type: "uint128" },
           { name: "fee", type: "uint128" },
         ],
         outputs: { type: { response: { ok: "bool", error: "uint128" } } },
@@ -722,7 +722,7 @@ export const contracts = {
           requestId: TypedAbiArg<number | bigint, "requestId">,
           bitcoinTxid: TypedAbiArg<Uint8Array, "bitcoinTxid">,
           signerBitmap: TypedAbiArg<number | bigint, "signerBitmap">,
-          outputIndex: TypedAbiArg<number | bigint, "outputIndex">,
+          voutIndex: TypedAbiArg<number | bigint, "voutIndex">,
           fee: TypedAbiArg<number | bigint, "fee">,
         ],
         Response<boolean, bigint>

--- a/contracts/tests/clarigen-types.ts
+++ b/contracts/tests/clarigen-types.ts
@@ -712,8 +712,8 @@ export const contracts = {
         args: [
           { name: "request-id", type: "uint128" },
           { name: "bitcoin-txid", type: { buffer: { length: 32 } } },
+          { name: "output-index", type: "uint128" },
           { name: "signer-bitmap", type: "uint128" },
-          { name: "vout-index", type: "uint128" },
           { name: "fee", type: "uint128" },
         ],
         outputs: { type: { response: { ok: "bool", error: "uint128" } } },
@@ -721,8 +721,8 @@ export const contracts = {
         [
           requestId: TypedAbiArg<number | bigint, "requestId">,
           bitcoinTxid: TypedAbiArg<Uint8Array, "bitcoinTxid">,
+          outputIndex: TypedAbiArg<number | bigint, "outputIndex">,
           signerBitmap: TypedAbiArg<number | bigint, "signerBitmap">,
-          voutIndex: TypedAbiArg<number | bigint, "voutIndex">,
           fee: TypedAbiArg<number | bigint, "fee">,
         ],
         Response<boolean, bigint>

--- a/contracts/tests/sbtc-deposit.test.ts
+++ b/contracts/tests/sbtc-deposit.test.ts
@@ -86,7 +86,7 @@ describe("sBTC deposit contract", () => {
       }>(print.data.value);
       expect(printData).toStrictEqual({
         topic: "completed-deposit",
-        txid: new Uint8Array(32).fill(0),
+        bitcoinTxid: new Uint8Array(32).fill(0),
         voutIndex: 0n,
         amount: 1000n,
       });

--- a/contracts/tests/sbtc-deposit.test.ts
+++ b/contracts/tests/sbtc-deposit.test.ts
@@ -87,7 +87,7 @@ describe("sBTC deposit contract", () => {
       expect(printData).toStrictEqual({
         topic: "completed-deposit",
         bitcoinTxid: new Uint8Array(32).fill(0),
-        voutIndex: 0n,
+        outputIndex: 0n,
         amount: 1000n,
       });
     });

--- a/contracts/tests/sbtc-registry.test.ts
+++ b/contracts/tests/sbtc-registry.test.ts
@@ -89,7 +89,7 @@ describe("sBTC registry contract", () => {
         amount: 100n,
         maxFee: 10n,
         blockHeight: request.blockHeight,
-        topic: "withdrawal-request",
+        topic: "withdrawal-create",
         requestId: 1n,
       });
     });

--- a/contracts/tests/sbtc-token.test.ts
+++ b/contracts/tests/sbtc-token.test.ts
@@ -29,7 +29,7 @@ describe("sBTC token contract", () => {
       expect(printData).toStrictEqual({
         topic: "completed-deposit",
         bitcoinTxid: new Uint8Array(32).fill(0),
-        voutIndex: 0n,
+        outputIndex: 0n,
         amount: 1000n,
       });
       const receipt1 = rov(
@@ -65,7 +65,7 @@ describe("sBTC token contract", () => {
       expect(printData).toStrictEqual({
         topic: "completed-deposit",
         bitcoinTxid: new Uint8Array(32).fill(0),
-        voutIndex: 0n,
+        outputIndex: 0n,
         amount: 1000n,
       });
       const receipt1 = txOk(

--- a/contracts/tests/sbtc-token.test.ts
+++ b/contracts/tests/sbtc-token.test.ts
@@ -28,7 +28,7 @@ describe("sBTC token contract", () => {
       }>(print.data.value);
       expect(printData).toStrictEqual({
         topic: "completed-deposit",
-        txid: new Uint8Array(32).fill(0),
+        bitcoinTxid: new Uint8Array(32).fill(0),
         voutIndex: 0n,
         amount: 1000n,
       });
@@ -64,7 +64,7 @@ describe("sBTC token contract", () => {
       }>(print.data.value);
       expect(printData).toStrictEqual({
         topic: "completed-deposit",
-        txid: new Uint8Array(32).fill(0),
+        bitcoinTxid: new Uint8Array(32).fill(0),
         voutIndex: 0n,
         amount: 1000n,
       });

--- a/contracts/tests/sbtc-withdrawal.test.ts
+++ b/contracts/tests/sbtc-withdrawal.test.ts
@@ -399,6 +399,94 @@ describe("Accepting a withdrawal request", () => {
     );
     expect(rovOk(token.getBalance(alice))).toEqual(0n);
   });
+  test("accept withdrawal sets withdrawal-status to true", () => {
+    // Alice initiates withdrawalrequest
+    txOk(
+      deposit.completeDepositWrapper({
+        txid: new Uint8Array(32).fill(0),
+        voutIndex: 0,
+        amount: 1000n,
+        recipient: alice,
+      }),
+      deployer
+    );
+    txOk(
+      withdrawal.initiateWithdrawalRequest({
+        amount: 1000n,
+        recipient: alicePoxAddr,
+        maxFee: 10n,
+      }),
+      alice
+    );
+    txOk(
+      withdrawal.acceptWithdrawalRequest({
+        requestId: 1n,
+        bitcoinTxid: new Uint8Array(32).fill(0),
+        signerBitmap: 0n,
+        outputIndex: 10n,
+        fee: 10n,
+      }),
+      deployer
+    );
+    expect(rovOk(token.getBalance(alice))).toEqual(0n);
+
+    // Check that the request was stored correctly with the correct status
+    const request = rov(registry.getWithdrawalRequest(1n));
+    if (!request) {
+      throw new Error("Request not stored");
+    }
+    expect(request).toStrictEqual({
+      sender: alice,
+      recipient: alicePoxAddr,
+      amount: 1000n,
+      maxFee: 10n,
+      blockHeight: 2n,
+      status: true,
+    });
+  });
+  test("reject withdrawal sets withdrawal-status to false", () => {
+    // Alice initiates withdrawalrequest
+    txOk(
+      deposit.completeDepositWrapper({
+        txid: new Uint8Array(32).fill(0),
+        voutIndex: 0,
+        amount: 1000n,
+        recipient: alice,
+      }),
+      deployer
+    );
+    txOk(
+      withdrawal.initiateWithdrawalRequest({
+        amount: 1000n,
+        recipient: alicePoxAddr,
+        maxFee: 10n,
+      }),
+      alice
+    );
+    txOk(
+      withdrawal.rejectWithdrawalRequest({
+        requestId: 1n,
+        signerBitmap: 0n,
+      }),
+      deployer
+    );
+    // This is the original balance, rejecting the request restores it.
+    expect(rovOk(token.getBalance(alice))).toEqual(1000n);
+
+    // Check that the request was stored correctly with the correct status
+    const request = rov(registry.getWithdrawalRequest(1n));
+    if (!request) {
+      throw new Error("Request not stored");
+    }
+    expect(request).toStrictEqual({
+      sender: alice,
+      recipient: alicePoxAddr,
+      amount: 1000n,
+      maxFee: 10n,
+      blockHeight: 2n,
+      status: false,
+    });
+  });
   test("Request is successfully accepted with fee less than max", () => {
     // Alice initiates withdrawalrequest
     txOk(

--- a/contracts/tests/sbtc-withdrawal.test.ts
+++ b/contracts/tests/sbtc-withdrawal.test.ts
@@ -130,7 +130,7 @@ describe("initiating a withdrawal request", () => {
       amount: 1000n,
       maxFee: 10n,
       blockHeight: 2n,
-      topic: "withdrawal-request",
+      topic: "withdrawal-create",
       requestId: 1n,
     });
   });


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/449.

## Changes

* Break up the `complete-withdrawal` function into two; one for accepts and another for rejects. Make all function arguments for both non-optional.
* Change the topics to match accept and reject.

## Testing Information

This is a minor refactor to the last step of the withdrawal contract calls, but I added two more tests just to be extra sure that this is okay.

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
