### PR TITLE
add support for get-data-var stacks node api call

### DIFF
--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -293,6 +293,7 @@ mod tests {
     use blockstack_lib::net::api::gettenureinfo::RPCGetTenureInfo;
     use blockstack_lib::types::chainstate::StacksAddress;
     use blockstack_lib::types::chainstate::StacksBlockId;
+    use clarity::vm::{ClarityName, ContractName, Value};
     use fake::Dummy;
     use rand::seq::IteratorRandom;
     use rand::SeedableRng;
@@ -744,6 +745,15 @@ mod tests {
     }
 
     impl StacksInteract for TestHarness {
+        async fn get_data_var(
+            &mut self,
+            _contract_principal: &StacksAddress,
+            _contract_name: &ContractName,
+            _variable_name: &ClarityName,
+        ) -> Result<Value, Error> {
+            // issue #118
+            todo!()
+        }
         async fn get_account(&mut self, _address: &StacksAddress) -> Result<AccountInfo, Error> {
             // issue #118
             todo!()

--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -293,7 +293,6 @@ mod tests {
     use blockstack_lib::net::api::gettenureinfo::RPCGetTenureInfo;
     use blockstack_lib::types::chainstate::StacksAddress;
     use blockstack_lib::types::chainstate::StacksBlockId;
-    use clarity::vm::{ClarityName, ContractName, Value};
     use fake::Dummy;
     use rand::seq::IteratorRandom;
     use rand::SeedableRng;
@@ -745,12 +744,10 @@ mod tests {
     }
 
     impl StacksInteract for TestHarness {
-        async fn get_data_var(
+        async fn get_current_signer_set(
             &mut self,
             _contract_principal: &StacksAddress,
-            _contract_name: &ContractName,
-            _variable_name: &ClarityName,
-        ) -> Result<Value, Error> {
+        ) -> Result<Vec<PublicKey>, Error> {
             // issue #118
             todo!()
         }

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -163,6 +163,10 @@ pub enum Error {
     #[error("response from stacks node did not conform to the expected schema: {0}")]
     UnexpectedStacksResponse(#[source] reqwest::Error),
 
+    /// The response from the Stacks node was invalid or malformed.
+    #[error("invalid stacks response: {0}")]
+    InvalidStacksResponse(&'static str),
+
     /// Taproot error
     #[error("an error occurred when constructing the taproot signing digest: {0}")]
     Taproot(#[from] bitcoin::sighash::TaprootError),

--- a/signer/src/stacks/api.rs
+++ b/signer/src/stacks/api.rs
@@ -18,9 +18,11 @@ use blockstack_lib::net::api::postfeerate::FeeRateEstimateRequestBody;
 use blockstack_lib::net::api::postfeerate::RPCFeeEstimateResponse;
 use blockstack_lib::types::chainstate::StacksAddress;
 use blockstack_lib::types::chainstate::StacksBlockId;
+use clarity::vm::{ClarityName, ContractName, Value};
 use futures::TryFutureExt;
 use reqwest::header::CONTENT_LENGTH;
 use reqwest::header::CONTENT_TYPE;
+use serde::{Deserialize, Deserializer};
 
 use crate::config::StacksSettings;
 use crate::error::Error;
@@ -71,6 +73,13 @@ pub enum FeePriority {
 
 /// A trait detailing the interface with the Stacks API and Stacks Nodes.
 pub trait StacksInteract {
+    /// Retrieve a data variable from a contract.
+    fn get_data_var(
+        &mut self,
+        contract_principal: &StacksAddress,
+        contract_name: &ContractName,
+        var_name: &ClarityName,
+    ) -> impl Future<Output = Result<Value, Error>>;
     /// Get the latest account info for the given address.
     fn get_account(
         &mut self,
@@ -239,6 +248,14 @@ pub struct AccountInfo {
     pub nonce: u64,
 }
 
+/// The response from a GET /v2/data_var/<contract-principal>/<contract-name>/<var-name> request.
+#[derive(Debug, Deserialize)]
+pub struct DataVarResponse {
+    /// The value of the data variable.
+    #[serde(deserialize_with = "clarity_value_deserializer")]
+    pub data: Value,
+}
+
 /// Helper function for converting a hexidecimal string into an integer.
 fn parse_hex_u128(hex: &str) -> Result<u128, Error> {
     let hex_str = hex.trim_start_matches("0x");
@@ -293,6 +310,47 @@ impl StacksClient {
     /// get the current endpoint
     pub fn get_current_endpoint(&self) -> url::Url {
         self.node_endpoints[self.endpoint_index].clone()
+    }
+
+    /// Retrieve the latest value of a data variable from the specified contract.
+    ///
+    /// This is done by making a
+    /// `GET /v2/data_var/<contract-principal>/<contract-name>/<var-name>`
+    /// request. In the request we specify that the proof should not be included
+    /// in the response.
+    #[tracing::instrument(skip_all)]
+    pub async fn get_data_var(
+        &self,
+        contract_principal: &StacksAddress,
+        contract_name: &ContractName,
+        var_name: &ClarityName,
+    ) -> Result<Value, Error> {
+        let path = format!(
+            "/v2/data_var/{}/{}/{}?proof=0",
+            contract_principal, contract_name, var_name
+        );
+        let base = self.get_current_endpoint();
+        let url = base
+            .join(&path)
+            .map_err(|err| Error::PathJoin(err, base, Cow::Owned(path)))?;
+
+        tracing::debug!(%contract_principal, %contract_name, %var_name, "Fetching contract data variable");
+
+        let response = self
+            .client
+            .get(url)
+            .timeout(REQUEST_TIMEOUT)
+            .send()
+            .await
+            .map_err(Error::StacksNodeRequest)?;
+
+        response
+            .error_for_status()
+            .map_err(Error::StacksNodeResponse)?
+            .json::<DataVarResponse>()
+            .await
+            .map_err(Error::UnexpectedStacksResponse)
+            .map(|x| x.data)
     }
 
     /// Get the latest account info for the given address.
@@ -590,6 +648,17 @@ fn check_result<T>(client: &mut StacksClient, result: Result<T, Error>) -> Resul
 }
 
 impl StacksInteract for StacksClient {
+    async fn get_data_var(
+        &mut self,
+        contract_principal: &StacksAddress,
+        contract_name: &ContractName,
+        var_name: &ClarityName,
+    ) -> Result<Value, Error> {
+        check_result(
+            self,
+            StacksClient::get_data_var(self, contract_principal, contract_name, var_name).await,
+        )
+    }
     async fn get_account(&mut self, address: &StacksAddress) -> Result<AccountInfo, Error> {
         check_result(self, StacksClient::get_account(self, address).await)
     }
@@ -693,13 +762,29 @@ where
     Ok(blocks)
 }
 
+/// A deserializer for Clarity's [`Value`] type that deserializes a hex-encoded
+/// string which was serialized using Clarity's consensus serialization format.
+fn clarity_value_deserializer<'de, D>(deserializer: D) -> Result<Value, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Value::try_deserialize_hex_untyped(&String::deserialize(deserializer)?)
+        .map_err(serde::de::Error::custom)
+}
+
 #[cfg(test)]
 mod tests {
     use crate::config::StacksNodeSettings;
+    use crate::keys::{PrivateKey, PublicKey};
     use crate::storage::in_memory::Store;
     use crate::storage::postgres::PgStore;
     use crate::storage::DbWrite;
 
+    use clarity::types::Address;
+    use clarity::vm::types::{
+        BuffData, BufferLength, ListData, ListTypeData, SequenceData, SequenceSubtype,
+        TypeSignature,
+    };
     use test_case::test_case;
 
     use super::*;
@@ -871,6 +956,87 @@ mod tests {
 
         assert_eq!(resp, expected);
         first_mock.assert();
+    }
+
+    /// Helper method for generating a list of public keys.
+    fn generate_pubkeys(count: u16) -> Vec<PublicKey> {
+        (0..count)
+            .map(|_| PublicKey::from_private_key(&PrivateKey::new(&mut rand::thread_rng())))
+            .collect()
+    }
+
+    /// Helper method for creating a list of public keys as a Clarity [`Value::Sequence`].
+    fn create_clarity_pubkey_list(count: u16) -> Vec<Value> {
+        generate_pubkeys(count)
+            .iter()
+            .map(|pk| {
+                Value::Sequence(SequenceData::Buffer(BuffData {
+                    data: pk.serialize().to_vec(),
+                }))
+            })
+            .collect()
+    }
+
+    #[test_case(0; "empty-list")]
+    #[test_case(128; "list-128")]
+    #[tokio::test]
+    async fn get_data_var_current_signer_set(list_size: u16) {
+        // Create our simulated response JSON. This uses the same method to generate
+        // the serialized list of public keys as the actual Stacks node does.
+        let signer_set = Value::Sequence(SequenceData::List(ListData {
+            data: create_clarity_pubkey_list(list_size),
+            type_signature: ListTypeData::new_list(
+                TypeSignature::list_of(
+                    TypeSignature::SequenceType(SequenceSubtype::BufferType(
+                        BufferLength::try_from(33_usize).unwrap(),
+                    )),
+                    33,
+                )
+                .expect("failed to create sequence type signature"),
+                128,
+            )
+            .expect("failed to create list type signature"),
+        }));
+        // The format of the response JSON is `{"data": "0x<serialized-value>"}` (excluding the proof).
+        let raw_json_response = format!(
+            r#"{{"data":"0x{}"}}"#,
+            Value::serialize_to_hex(&signer_set).expect("failed to serialize value")
+        );
+
+        // Setup our mock server
+        let mut stacks_node_server = mockito::Server::new_async().await;
+        let mock = stacks_node_server
+            .mock("GET", "/v2/data_var/ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM/sbtc-registry/current-signer-set?proof=0")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(&raw_json_response)
+            .expect(1)
+            .create();
+
+        // Setup our Stacks client
+        let settings = StacksSettings {
+            node: StacksNodeSettings {
+                endpoints: vec![url::Url::parse(stacks_node_server.url().as_str()).unwrap()],
+                nakamoto_start_height: 20,
+            },
+        };
+        let client = StacksClient::new(settings);
+
+        // Make the request to the mock server
+        let resp = client
+            .get_data_var(
+                &StacksAddress::from_string("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM")
+                    .expect("failed to parse stacks address"),
+                &ContractName::from("sbtc-registry"),
+                &ClarityName::from("current-signer-set"),
+            )
+            .await
+            .unwrap();
+
+        // Assert that the response is what we expect
+        let expected: DataVarResponse = serde_json::from_str(&raw_json_response).unwrap();
+        assert_eq!(&resp, &expected.data);
+        mock.assert();
     }
 
     /// Check that everything works as expected in the happy path case.


### PR DESCRIPTION
## Description

Closes: #434
Related to: #409 

This took a little longer than I thought as I was trying to get a node with the contracts running where I could see what's actually being output. I really wanted to do this without pulling more dependencies on `stacks-core`, but that turned out to take more time than I think it's worth for right now, so I ended up just using Clarity's own `Value` type for de/serialization so we can get this closed.

## Changes
Adds an additional method to the Stacks API client for calling the `/v2/data_var` endpoint and retrieving the value of a contract `data-var`.

## Testing Information
Added mocked tests. Mocked responses are generated by building up the Clarity type as a `Value`, serializing it and placing it into the API's response JSON format. I added test cases for both empty list and max-size (128).

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
