### PR TITLE
feat: modify signature threshold rotate keys

### DIFF
--- a/contracts/contracts/sbtc-bootstrap-signers.clar
+++ b/contracts/contracts/sbtc-bootstrap-signers.clar
@@ -14,7 +14,7 @@
 ;; The function caller is not the current signer principal
 (define-constant ERR_INVALID_CALLER (err u201))
 ;; The given signature threshold must be greater than 50% and less than or
-;; equal to 100% of the total number signer keys.
+;; equal to 100% of the total number of signer keys.
 (define-constant ERR_SIGNATURE_THRESHOLD (err u202))
 
 ;; data vars
@@ -38,7 +38,7 @@
             (current-signer-data (contract-call? .sbtc-registry get-current-signer-data))   
             (new-signer-principal (pubkeys-to-principal new-keys new-signature-threshold))
         )
-        ;; Checkc that the signature threshold is valid
+        ;; Check that the signature threshold is valid
         (asserts! (and (> new-signature-threshold (/ (len new-keys) u2))
                        (<= new-signature-threshold (len new-keys))) ERR_SIGNATURE_THRESHOLD)
 

--- a/contracts/contracts/sbtc-bootstrap-signers.clar
+++ b/contracts/contracts/sbtc-bootstrap-signers.clar
@@ -2,8 +2,6 @@
 
 ;; constants
 
-;; The number of signatures required to sign a transaction
-(define-constant signature-threshold u8)
 ;; The required length of public keys
 (define-constant key-size u33)
 
@@ -15,6 +13,9 @@
 (define-constant ERR_KEY_SIZE (err u200))
 ;; The function caller is not the current signer principal
 (define-constant ERR_INVALID_CALLER (err u201))
+;; The given signature threshold must be greater than 50% and less than or
+;; equal to 100% of the total number signer keys.
+(define-constant ERR_SIGNATURE_THRESHOLD (err u202))
 
 ;; data vars
 ;;
@@ -27,12 +28,20 @@
 ;; Rotate keys
 ;; Used to rotate the keys of the signers. This is called whenever
 ;; the signer set is updated.
-(define-public (rotate-keys-wrapper (new-keys (list 128 (buff 33))) (new-aggregate-pubkey (buff 33)))
+(define-public (rotate-keys-wrapper 
+    (new-keys (list 128 (buff 33)))
+    (new-aggregate-pubkey (buff 33))
+    (new-signature-threshold uint)
+  )
     (let 
         (
             (current-signer-data (contract-call? .sbtc-registry get-current-signer-data))   
-            (new-signer-principal (pubkeys-to-principal new-keys signature-threshold))
+            (new-signer-principal (pubkeys-to-principal new-keys new-signature-threshold))
         )
+        ;; Checkc that the signature threshold is valid
+        (asserts! (and (> new-signature-threshold (/ (len new-keys) u2))
+                       (<= new-signature-threshold (len new-keys))) ERR_SIGNATURE_THRESHOLD)
+
         ;; Check that the caller is the current signer principal
         (asserts! (is-eq (get current-signer-principal current-signer-data) tx-sender) ERR_INVALID_CALLER)
 
@@ -43,7 +52,7 @@
         (asserts! (is-eq (len new-aggregate-pubkey) key-size) ERR_KEY_SIZE)
 
         ;; Call into .sbtc-registry to update the keys & address
-        (ok (try! (contract-call? .sbtc-registry rotate-keys new-keys new-signer-principal new-aggregate-pubkey)))
+        (ok (try! (contract-call? .sbtc-registry rotate-keys new-keys new-signer-principal new-aggregate-pubkey new-signature-threshold)))
     )
 )
 

--- a/contracts/contracts/sbtc-registry.clar
+++ b/contracts/contracts/sbtc-registry.clar
@@ -10,6 +10,7 @@
 ;; Variables
 
 (define-data-var last-withdrawal-request-id uint u0)
+(define-data-var current-signature-threshold uint u0)
 (define-data-var current-signer-set (list 128 (buff 33)) (list))
 (define-data-var current-aggregate-pubkey (buff 33) 0x00)
 (define-data-var current-signer-principal principal tx-sender)
@@ -91,7 +92,8 @@
   {
     current-signer-set: (var-get current-signer-set),
     current-aggregate-pubkey: (var-get current-aggregate-pubkey),
-    current-signer-principal: (var-get current-signer-principal)
+    current-signer-principal: (var-get current-signer-principal),
+    current-signature-threshold: (var-get current-signature-threshold),
   }
 )
 
@@ -241,7 +243,12 @@
 ;; Rotate the signer set, multi-sig principal, & aggregate pubkey
 ;; This function can only be called by the bootstrap-signers contract.
 ;; #[allow(unchecked_data)]
-(define-public (rotate-keys (new-keys (list 128 (buff 33))) (new-address principal) (new-aggregate-pubkey (buff 33)))
+(define-public (rotate-keys 
+    (new-keys (list 128 (buff 33)))
+    (new-address principal)
+    (new-aggregate-pubkey (buff 33))
+    (new-signature-threshold uint)
+  )
   (begin
     ;; Check that caller is protocol contract
     (try! (is-protocol-caller))
@@ -253,6 +260,8 @@
     (var-set current-signer-set new-keys)
     ;; Update the current multi-sig address
     (var-set current-signer-principal new-address)
+    ;; Update the current signature threshold
+    (var-set current-signature-threshold new-signature-threshold)
     ;; Update the current aggregate pubkey
     (ok (var-set current-aggregate-pubkey new-aggregate-pubkey))
   )

--- a/contracts/docs/sbtc-bootstrap-signers.md
+++ b/contracts/docs/sbtc-bootstrap-signers.md
@@ -28,20 +28,20 @@ sBTC Bootstrap Signers contract
 
 **Constants**
 
-- [`signature-threshold`](#signature-threshold)
 - [`key-size`](#key-size)
 - [`ERR_KEY_SIZE_PREFIX`](#err_key_size_prefix)
 - [`ERR_KEY_SIZE`](#err_key_size)
 - [`ERR_INVALID_CALLER`](#err_invalid_caller)
+- [`ERR_SIGNATURE_THRESHOLD`](#err_signature_threshold)
 - [`BUFF_TO_BYTE`](#buff_to_byte)
 
 ## Functions
 
 ### rotate-keys-wrapper
 
-[View in file](../contracts/sbtc-bootstrap-signers.clar#L30)
+[View in file](../contracts/sbtc-bootstrap-signers.clar#L31)
 
-`(define-public (rotate-keys-wrapper ((new-keys (list 128 (buff 33))) (new-aggregate-pubkey (buff 33))) (response bool uint))`
+`(define-public (rotate-keys-wrapper ((new-keys (list 128 (buff 33))) (new-aggregate-pubkey (buff 33)) (new-signature-threshold uint)) (response bool uint))`
 
 Rotate keys
 Used to rotate the keys of the signers. This is called whenever
@@ -51,12 +51,20 @@ the signer set is updated.
   <summary>Source code:</summary>
 
 ```clarity
-(define-public (rotate-keys-wrapper (new-keys (list 128 (buff 33))) (new-aggregate-pubkey (buff 33)))
+(define-public (rotate-keys-wrapper
+    (new-keys (list 128 (buff 33)))
+    (new-aggregate-pubkey (buff 33))
+    (new-signature-threshold uint)
+  )
     (let
         (
             (current-signer-data (contract-call? .sbtc-registry get-current-signer-data))
-            (new-signer-principal (pubkeys-to-principal new-keys signature-threshold))
+            (new-signer-principal (pubkeys-to-principal new-keys new-signature-threshold))
         )
+        ;; Checkc that the signature threshold is valid
+        (asserts! (and (> new-signature-threshold (/ (len new-keys) u2))
+                       (<= new-signature-threshold (len new-keys))) ERR_SIGNATURE_THRESHOLD)
+
         ;; Check that the caller is the current signer principal
         (asserts! (is-eq (get current-signer-principal current-signer-data) tx-sender) ERR_INVALID_CALLER)
 
@@ -67,7 +75,7 @@ the signer set is updated.
         (asserts! (is-eq (len new-aggregate-pubkey) key-size) ERR_KEY_SIZE)
 
         ;; Call into .sbtc-registry to update the keys & address
-        (ok (try! (contract-call? .sbtc-registry rotate-keys new-keys new-signer-principal new-aggregate-pubkey)))
+        (ok (try! (contract-call? .sbtc-registry rotate-keys new-keys new-signer-principal new-aggregate-pubkey new-signature-threshold)))
     )
 )
 ```
@@ -76,14 +84,15 @@ the signer set is updated.
 
 **Parameters:**
 
-| Name                 | Type                 |
-| -------------------- | -------------------- |
-| new-keys             | (list 128 (buff 33)) |
-| new-aggregate-pubkey | (buff 33)            |
+| Name                    | Type                 |
+| ----------------------- | -------------------- |
+| new-keys                | (list 128 (buff 33)) |
+| new-aggregate-pubkey    | (buff 33)            |
+| new-signature-threshold | uint                 |
 
 ### signer-key-length-check
 
-[View in file](../contracts/sbtc-bootstrap-signers.clar#L57)
+[View in file](../contracts/sbtc-bootstrap-signers.clar#L66)
 
 `(define-private (signer-key-length-check ((current-key (buff 33)) (helper-response (response uint uint))) (response uint uint))`
 
@@ -118,7 +127,7 @@ Checks that the length of each key is exactly 33 bytes #[allow(unchecked_data)]
 
 ### pubkeys-to-spend-script
 
-[View in file](../contracts/sbtc-bootstrap-signers.clar#L72)
+[View in file](../contracts/sbtc-bootstrap-signers.clar#L81)
 
 `(define-read-only (pubkeys-to-spend-script ((pubkeys (list 128 (buff 33))) (m uint)) (buff 513))`
 
@@ -151,7 +160,7 @@ Generate the p2sh redeem script for a multisig
 
 ### pubkeys-to-hash
 
-[View in file](../contracts/sbtc-bootstrap-signers.clar#L84)
+[View in file](../contracts/sbtc-bootstrap-signers.clar#L93)
 
 `(define-read-only (pubkeys-to-hash ((pubkeys (list 128 (buff 33))) (m uint)) (buff 20))`
 
@@ -180,7 +189,7 @@ hash160 of the p2sh redeem script
 
 ### pubkeys-to-principal
 
-[View in file](../contracts/sbtc-bootstrap-signers.clar#L92)
+[View in file](../contracts/sbtc-bootstrap-signers.clar#L101)
 
 `(define-read-only (pubkeys-to-principal ((pubkeys (list 128 (buff 33))) (m uint)) principal)`
 
@@ -212,7 +221,7 @@ Given a set of pubkeys and an m-of-n, generate a principal
 
 ### pubkeys-to-bytes
 
-[View in file](../contracts/sbtc-bootstrap-signers.clar#L103)
+[View in file](../contracts/sbtc-bootstrap-signers.clar#L112)
 
 `(define-read-only (pubkeys-to-bytes ((pubkeys (list 128 (buff 33)))) (buff 510))`
 
@@ -237,7 +246,7 @@ Concat a list of pubkeys into a buffer with length prefixes
 
 ### concat-pubkeys-fold
 
-[View in file](../contracts/sbtc-bootstrap-signers.clar#L110)
+[View in file](../contracts/sbtc-bootstrap-signers.clar#L119)
 
 `(define-read-only (concat-pubkeys-fold ((pubkey (buff 33)) (iterator (buff 510))) (buff 510))`
 
@@ -271,7 +280,7 @@ for the public keys and 15 bytes for the length prefixes.
 
 ### bytes-len
 
-[View in file](../contracts/sbtc-bootstrap-signers.clar#L122)
+[View in file](../contracts/sbtc-bootstrap-signers.clar#L131)
 
 `(define-read-only (bytes-len ((bytes (buff 33))) (buff 1))`
 
@@ -294,7 +303,7 @@ for the public keys and 15 bytes for the length prefixes.
 
 ### uint-to-byte
 
-[View in file](../contracts/sbtc-bootstrap-signers.clar#L126)
+[View in file](../contracts/sbtc-bootstrap-signers.clar#L135)
 
 `(define-read-only (uint-to-byte ((n uint)) (buff 1))`
 
@@ -321,16 +330,6 @@ for the public keys and 15 bytes for the length prefixes.
 
 ## Constants
 
-### signature-threshold
-
-The number of signatures required to sign a transaction
-
-```clarity
-(define-constant signature-threshold u8)
-```
-
-[View in file](../contracts/sbtc-bootstrap-signers.clar#L6)
-
 ### key-size
 
 The required length of public keys
@@ -339,7 +338,7 @@ The required length of public keys
 (define-constant key-size u33)
 ```
 
-[View in file](../contracts/sbtc-bootstrap-signers.clar#L8)
+[View in file](../contracts/sbtc-bootstrap-signers.clar#L6)
 
 ### ERR_KEY_SIZE_PREFIX
 
@@ -350,7 +349,7 @@ if err is u210>, it's the key at index (err - 210)
 (define-constant ERR_KEY_SIZE_PREFIX (unwrap-err! ERR_KEY_SIZE (err true)))
 ```
 
-[View in file](../contracts/sbtc-bootstrap-signers.clar#L14)
+[View in file](../contracts/sbtc-bootstrap-signers.clar#L12)
 
 ### ERR_KEY_SIZE
 
@@ -358,7 +357,7 @@ if err is u210>, it's the key at index (err - 210)
 (define-constant ERR_KEY_SIZE (err u200))
 ```
 
-[View in file](../contracts/sbtc-bootstrap-signers.clar#L15)
+[View in file](../contracts/sbtc-bootstrap-signers.clar#L13)
 
 ### ERR_INVALID_CALLER
 
@@ -368,7 +367,18 @@ The function caller is not the current signer principal
 (define-constant ERR_INVALID_CALLER (err u201))
 ```
 
-[View in file](../contracts/sbtc-bootstrap-signers.clar#L17)
+[View in file](../contracts/sbtc-bootstrap-signers.clar#L15)
+
+### ERR_SIGNATURE_THRESHOLD
+
+The given signature threshold must be greater than 50% and less than or
+equal to 100% of the total number signer keys.
+
+```clarity
+(define-constant ERR_SIGNATURE_THRESHOLD (err u202))
+```
+
+[View in file](../contracts/sbtc-bootstrap-signers.clar#L18)
 
 ### BUFF_TO_BYTE
 
@@ -393,4 +403,4 @@ The function caller is not the current signer principal
 ))
 ```
 
-[View in file](../contracts/sbtc-bootstrap-signers.clar#L130)
+[View in file](../contracts/sbtc-bootstrap-signers.clar#L139)

--- a/contracts/docs/sbtc-bootstrap-signers.md
+++ b/contracts/docs/sbtc-bootstrap-signers.md
@@ -61,7 +61,7 @@ the signer set is updated.
             (current-signer-data (contract-call? .sbtc-registry get-current-signer-data))
             (new-signer-principal (pubkeys-to-principal new-keys new-signature-threshold))
         )
-        ;; Checkc that the signature threshold is valid
+        ;; Check that the signature threshold is valid
         (asserts! (and (> new-signature-threshold (/ (len new-keys) u2))
                        (<= new-signature-threshold (len new-keys))) ERR_SIGNATURE_THRESHOLD)
 
@@ -372,7 +372,7 @@ The function caller is not the current signer principal
 ### ERR_SIGNATURE_THRESHOLD
 
 The given signature threshold must be greater than 50% and less than or
-equal to 100% of the total number signer keys.
+equal to 100% of the total number of signer keys.
 
 ```clarity
 (define-constant ERR_SIGNATURE_THRESHOLD (err u202))

--- a/contracts/tests/clarigen-types.ts
+++ b/contracts/tests/clarigen-types.ts
@@ -39,12 +39,17 @@ export const contracts = {
             type: { list: { type: { buffer: { length: 33 } }, length: 128 } },
           },
           { name: "new-aggregate-pubkey", type: { buffer: { length: 33 } } },
+          { name: "new-signature-threshold", type: "uint128" },
         ],
         outputs: { type: { response: { ok: "bool", error: "uint128" } } },
       } as TypedAbiFunction<
         [
           newKeys: TypedAbiArg<Uint8Array[], "newKeys">,
           newAggregatePubkey: TypedAbiArg<Uint8Array, "newAggregatePubkey">,
+          newSignatureThreshold: TypedAbiArg<
+            number | bigint,
+            "newSignatureThreshold"
+          >,
         ],
         Response<boolean, bigint>
       >,
@@ -188,13 +193,18 @@ export const contracts = {
         type: "uint128",
         access: "constant",
       } as TypedAbiVariable<bigint>,
+      ERR_SIGNATURE_THRESHOLD: {
+        name: "ERR_SIGNATURE_THRESHOLD",
+        type: {
+          response: {
+            ok: "none",
+            error: "uint128",
+          },
+        },
+        access: "constant",
+      } as TypedAbiVariable<Response<null, bigint>>,
       keySize: {
         name: "key-size",
-        type: "uint128",
-        access: "constant",
-      } as TypedAbiVariable<bigint>,
-      signatureThreshold: {
-        name: "signature-threshold",
         type: "uint128",
         access: "constant",
       } as TypedAbiVariable<bigint>,
@@ -467,8 +477,11 @@ export const contracts = {
         value: 200n,
       },
       ERR_KEY_SIZE_PREFIX: 200n,
+      ERR_SIGNATURE_THRESHOLD: {
+        isOk: false,
+        value: 202n,
+      },
       keySize: 33n,
-      signatureThreshold: 8n,
     },
     non_fungible_tokens: [],
     fungible_tokens: [],
@@ -787,6 +800,7 @@ export const contracts = {
           },
           { name: "new-address", type: "principal" },
           { name: "new-aggregate-pubkey", type: { buffer: { length: 33 } } },
+          { name: "new-signature-threshold", type: "uint128" },
         ],
         outputs: { type: { response: { ok: "bool", error: "uint128" } } },
       } as TypedAbiFunction<
@@ -794,6 +808,10 @@ export const contracts = {
           newKeys: TypedAbiArg<Uint8Array[], "newKeys">,
           newAddress: TypedAbiArg<string, "newAddress">,
           newAggregatePubkey: TypedAbiArg<Uint8Array, "newAggregatePubkey">,
+          newSignatureThreshold: TypedAbiArg<
+            number | bigint,
+            "newSignatureThreshold"
+          >,
         ],
         Response<boolean, bigint>
       >,
@@ -841,6 +859,7 @@ export const contracts = {
                 name: "current-aggregate-pubkey",
                 type: { buffer: { length: 33 } },
               },
+              { name: "current-signature-threshold", type: "uint128" },
               { name: "current-signer-principal", type: "principal" },
               {
                 name: "current-signer-set",
@@ -855,6 +874,7 @@ export const contracts = {
         [],
         {
           currentAggregatePubkey: Uint8Array;
+          currentSignatureThreshold: bigint;
           currentSignerPrincipal: string;
           currentSignerSet: Uint8Array[];
         }
@@ -1058,6 +1078,11 @@ export const contracts = {
         },
         access: "variable",
       } as TypedAbiVariable<Uint8Array>,
+      currentSignatureThreshold: {
+        name: "current-signature-threshold",
+        type: "uint128",
+        access: "variable",
+      } as TypedAbiVariable<bigint>,
       currentSignerPrincipal: {
         name: "current-signer-principal",
         type: "principal",
@@ -1101,6 +1126,7 @@ export const contracts = {
         value: 400n,
       },
       currentAggregatePubkey: Uint8Array.from([0]),
+      currentSignatureThreshold: 0n,
       currentSignerPrincipal: "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM",
       currentSignerSet: [],
       lastWithdrawalRequestId: 0n,

--- a/contracts/tests/sbtc-registry.test.ts
+++ b/contracts/tests/sbtc-registry.test.ts
@@ -127,6 +127,7 @@ describe("sBTC registry contract", () => {
         signers.rotateKeysWrapper({
           newKeys: [new Uint8Array(33).fill(0), new Uint8Array(33).fill(0)],
           newAggregatePubkey: new Uint8Array(33).fill(0),
+          newSignatureThreshold: 2n,
         }),
         deployer
       );
@@ -137,6 +138,7 @@ describe("sBTC registry contract", () => {
         signers.rotateKeysWrapper({
           newKeys: [new Uint8Array(33).fill(0), new Uint8Array(31).fill(0)],
           newAggregatePubkey: new Uint8Array(33).fill(0),
+          newSignatureThreshold: 2n,
         }),
         deployer
       );
@@ -147,6 +149,7 @@ describe("sBTC registry contract", () => {
         signers.rotateKeysWrapper({
           newKeys: [new Uint8Array(33).fill(0), new Uint8Array(33).fill(0)],
           newAggregatePubkey: new Uint8Array(31).fill(0),
+          newSignatureThreshold: 2n,
         }),
         deployer
       );

--- a/signer/src/stacks/contracts.rs
+++ b/signer/src/stacks/contracts.rs
@@ -351,7 +351,6 @@ pub struct RotateKeysV1 {
     /// The address that deployed the contract.
     deployer: StacksAddress,
     /// The number of signatures required for the multi-sig wallet.
-    #[allow(dead_code)]
     signatures_required: u16,
 }
 
@@ -423,6 +422,7 @@ impl AsContractCall for RotateKeysV1 {
         vec![
             ClarityValue::Sequence(SequenceData::List(new_keys)),
             ClarityValue::Sequence(SequenceData::Buffer(BuffData { data: key.to_vec() })),
+            ClarityValue::UInt(self.signatures_required as u128),
         ]
     }
     /// Validates that the rotate-keys-wrapper satisfies the following


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/424

## Changes

* Allow the signature threshold be changed during rotate-keys contract calls.
* Add new tests given the new behavior.

## Testing Information

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
