### PR TITLE
feat: transform print events into proper types

### DIFF
--- a/signer/src/config.rs
+++ b/signer/src/config.rs
@@ -27,6 +27,27 @@ pub enum NetworkKind {
     Mainnet,
     /// The testnet network
     Testnet,
+    /// The regtest network.
+    Regtest,
+}
+
+impl From<NetworkKind> for bitcoin::NetworkKind {
+    fn from(value: NetworkKind) -> Self {
+        match value {
+            NetworkKind::Mainnet => bitcoin::NetworkKind::Main,
+            _ => bitcoin::NetworkKind::Test,
+        }
+    }
+}
+
+impl From<NetworkKind> for bitcoin::KnownHrp {
+    fn from(value: NetworkKind) -> Self {
+        match value {
+            NetworkKind::Mainnet => bitcoin::KnownHrp::Mainnet,
+            NetworkKind::Testnet => bitcoin::KnownHrp::Testnets,
+            NetworkKind::Regtest => bitcoin::KnownHrp::Regtest,
+        }
+    }
 }
 
 /// Top-level configuration for the signer

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -36,6 +36,20 @@ pub enum Error {
     #[error("Could not convert an integer in clarity event into the expected integer {0}")]
     ClarityIntConversion(#[source] std::num::TryFromIntError),
 
+    /// This happens when we attempt to create s String from the raw bytes
+    /// returned in a Clarity [`Value`](clarity::vm::Value).
+    #[error("Could not convert ASCII or UTF8 bytes into a String: {0}")]
+    ClarityStringConversion(#[source] std::string::FromUtf8Error),
+
+    /// This happens when we expect one clarity variant but got another.
+    #[error("Got an unexpected clarity value: {0:?}")]
+    ClarityUnexpectedValue(clarity::vm::Value),
+
+    /// This should never happen, but happens when one of the given topics
+    /// is not on the list of expected topics.
+    #[error("Got an unexpected event topic: {0}")]
+    ClarityUnexpectedEventTopic(String),
+
     /// This a programmer error bug that should never be thrown.
     #[error("The field {0} was missing from the print event for topic")]
     TupleEventField(&'static str),

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -31,6 +31,20 @@ pub enum Error {
     #[error("could not serialize bitcoin transaction into bytes.")]
     BitcoinEncodeTransaction(#[source] bitcoin::io::Error),
 
+    /// This error is thrown when converting a u128 some other smaller
+    /// type. It should never be thrown
+    #[error("Could not convert an integer in clarity event into the expected integer {0}")]
+    ClarityIntConversion(#[source] std::num::TryFromIntError),
+
+    /// This a programmer error bug that should never be thrown.
+    #[error("The field {0} was missing from the print event for topic")]
+    TupleEventField(&'static str),
+
+    /// This can only be thrown when the number of bytes for a txid field
+    /// is not exactly equal to 32. This should never occur.
+    #[error("Could not convert an integer in clarity event into the expected integer {0}")]
+    ClarityTxidConversion(#[source] bitcoin::hashes::FromSliceError),
+
     /// Invalid amount
     #[error("the change amounts for the transaction is negative: {0}")]
     InvalidAmount(i64),

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -31,8 +31,8 @@ pub enum Error {
     #[error("could not serialize bitcoin transaction into bytes.")]
     BitcoinEncodeTransaction(#[source] bitcoin::io::Error),
 
-    /// This error is thrown when converting a u128 some other smaller
-    /// type. It should never be thrown
+    /// This error is thrown when trying to convert an u128 into some other
+    /// smaller type. It should never be thrown
     #[error("Could not convert an integer in clarity event into the expected integer {0}")]
     ClarityIntConversion(#[source] std::num::TryFromIntError),
 
@@ -77,7 +77,7 @@ pub enum Error {
 
     /// Thrown when doing [`i64::try_from`] or [`i32::try_from`] before
     /// inserting a value into the database. This only happens if the value
-    /// is creater than MAX for the signed type.
+    /// is greater than MAX for the signed type.
     #[error("could not convert integer type to the signed version for storing in postgres {0}")]
     ConversionDatabaseInt(#[source] std::num::TryFromIntError),
 

--- a/signer/src/stacks/contracts.rs
+++ b/signer/src/stacks/contracts.rs
@@ -266,7 +266,7 @@ impl AsContractCall for AcceptWithdrawalV1 {
         vec![
             ClarityValue::UInt(self.request_id as u128),
             ClarityValue::Sequence(SequenceData::Buffer(txid)),
-            ClarityValue::UInt(self.signer_bitmap.load()),
+            ClarityValue::UInt(self.signer_bitmap.load_le()),
             ClarityValue::UInt(self.outpoint.vout as u128),
             ClarityValue::UInt(self.tx_fee as u128),
         ]
@@ -318,7 +318,7 @@ impl AsContractCall for RejectWithdrawalV1 {
     fn as_contract_args(&self) -> Vec<ClarityValue> {
         vec![
             ClarityValue::UInt(self.request_id as u128),
-            ClarityValue::UInt(self.signer_bitmap.load()),
+            ClarityValue::UInt(self.signer_bitmap.load_le()),
         ]
     }
     /// Validates that the reject-withdrawal-request satisfies the

--- a/signer/src/stacks/events.rs
+++ b/signer/src/stacks/events.rs
@@ -1,0 +1,344 @@
+//! For deconstructing print events emitted from in the sbtc-registry smart
+//! contract.
+//!
+//! Print events from the sBTC registry come in as [`TupleData`] clarity
+//! values. Each tuple has a topic field that takes one of four values. We
+//! deconstruct the tuple data based on the topic.
+
+use std::collections::BTreeMap;
+
+use bitcoin::hashes::Hash;
+use bitcoin::Address;
+use bitcoin::OutPoint;
+use bitcoin::ScriptBuf;
+use bitcoin::Txid;
+use bitvec::array::BitArray;
+use clarity::vm::types::PrincipalData;
+use clarity::vm::types::SequenceData;
+use clarity::vm::types::TupleData;
+use clarity::vm::ClarityName;
+use clarity::vm::Value as ClarityValue;
+
+use crate::config::NetworkKind;
+use crate::error::Error;
+
+/// The print events emitted by the sbtc-registry clarity smart contract.
+pub enum RegistryEvent {
+    /// For the `completed-deposit` topic
+    CompletedDeposit(CompletedDepositEvent),
+    /// For the `withdrawal-accept` topic
+    WithdrawalAccept(WithdrawalAcceptEvent),
+    /// For the `withdrawal-reject` topic
+    WithdrawalReject(WithdrawalRejectEvent),
+    /// For the `withdrawal-create` topic
+    WithdrawalCreate(WithdrawalCreateEvent),
+}
+
+#[derive(Debug)]
+struct RawTupleData(BTreeMap<ClarityName, ClarityValue>);
+
+impl RawTupleData {
+    /// Extract the u128 value from the given field
+    fn remove_u128(&mut self, field: &'static str) -> Result<u128, Error> {
+        match self.0.remove(field) {
+            Some(ClarityValue::UInt(val)) => Ok(val),
+            _ => Err(Error::TupleEventField(field)),
+        }
+    }
+    /// Extract the buff value from the given field
+    fn remove_buff(&mut self, field: &'static str) -> Result<Vec<u8>, Error> {
+        match self.0.remove(field) {
+            Some(ClarityValue::Sequence(SequenceData::Buffer(buf))) => Ok(buf.data),
+            _ => Err(Error::TupleEventField(field)),
+        }
+    }
+    /// Extract the principal value from the given field
+    fn remove_principal(&mut self, field: &'static str) -> Result<PrincipalData, Error> {
+        match self.0.remove(field) {
+            Some(ClarityValue::Principal(principal)) => Ok(principal),
+            _ => Err(Error::TupleEventField(field)),
+        }
+    }
+    /// Extract the tuple value from the given field
+    fn remove_tuple(&mut self, field: &'static str) -> Result<Self, Error> {
+        match self.0.remove(field) {
+            Some(ClarityValue::Tuple(TupleData { data_map, .. })) => Ok(Self(data_map)),
+            _ => Err(Error::TupleEventField(field)),
+        }
+    }
+}
+
+/// Transform the [`ClarityValue`] from the sbtc-registry event into a
+/// proper type.
+pub fn deconstruct(value: ClarityValue, network: NetworkKind) -> Result<RegistryEvent, Error> {
+    match value {
+        ClarityValue::Tuple(TupleData { mut data_map, .. }) => {
+            // Lucky for us, each sBTC print event in the sbtc-registry
+            // smart contract has a topic. We use that to match on what to
+            // expect when decomposing the event from a [`ClarityValue`]
+            // into a proper type.
+            let topic = match data_map.remove("topic") {
+                Some(ClarityValue::Sequence(SequenceData::String(val))) => val.to_string(),
+                _ => return Err(Error::TupleEventField("topic")),
+            };
+
+            let event_map = RawTupleData(data_map);
+
+            match topic.as_str() {
+                "completed-deposit" => completed_deposit(event_map),
+                "withdrawal-reject" => withdrawal_reject(event_map),
+                "withdrawal-accept" => withdrawal_accept(event_map),
+                "withdrawal-create" => withdrawal_create(event_map, network),
+                _ => Err(Error::TupleEventField("topic")),
+            }
+        }
+        _ => Err(Error::TupleEventField("topic")),
+    }
+}
+
+/// This is the event that is emitted from the `create-withdrawal-request`
+/// public function in sbtc-registry smart contract.
+#[derive(Debug)]
+pub struct CompletedDepositEvent {
+    /// This is the amount of sBTC to mint to the intended recipient.
+    pub amount: u64,
+    /// This is the outpoint of the original bitcoin deposit transaction.
+    pub outpoint: OutPoint,
+}
+
+/// This function if for transforming the print events of the
+/// complete-deposit function in the sbtc-registry.
+///
+/// # Notes
+///
+/// The print events for complete-deposit calls are structured like so:
+///
+/// ```clarity
+/// (print {
+///   topic: "completed-deposit",
+///   bitcoin-txid: (buff 32),
+///   output-index: uint,
+///   amount: uint
+/// })
+/// ```
+///
+/// The above event is emitted after the indicated amount of sBTC has been
+/// emitted to the recipient.
+fn completed_deposit(mut map: RawTupleData) -> Result<RegistryEvent, Error> {
+    let amount = map.remove_u128("amount")?;
+    let vout = map.remove_u128("output-index")?;
+    let txid_bytes = map.remove_buff("bitcoin-txid")?;
+
+    Ok(RegistryEvent::CompletedDeposit(CompletedDepositEvent {
+        // This shouldn't error, since this amount is set from the u64
+        // amount of sats by us.
+        amount: u64::try_from(amount).map_err(Error::ClarityIntConversion)?,
+        outpoint: OutPoint {
+            // This shouldn't error, this is set from a proper [`Txid`] in
+            // a contract call.
+            txid: Txid::from_slice(&txid_bytes).map_err(Error::ClarityTxidConversion)?,
+            // This shouldn't actually error, we cast u32s to u128s before
+            // making the contract call, and that is the value that gets
+            // emitted here.
+            vout: u32::try_from(vout).map_err(Error::ClarityIntConversion)?,
+        },
+    }))
+}
+
+/// This is the event that is emitted from the `create-withdrawal-request`
+/// public function in sbtc-registry smart contract.
+#[derive(Debug)]
+pub struct WithdrawalCreateEvent {
+    /// This is the unique identifier of the withdrawal request.
+    pub request_id: u64,
+    /// This is the amount of sBTC that is locked and requested to be
+    /// withdrawal as sBTC.
+    pub amount: u64,
+    /// This is the principal who has their sBTC locked up.
+    pub sender: PrincipalData,
+    /// This is the address to send the BTC to when fulfilling the
+    /// withdrawal request.
+    pub recipient: Address,
+    /// This is the maximum amount of BTC "spent" to the miners for the
+    /// transaction fee.
+    pub max_fee: u64,
+    /// The block height of the bitcoin blockchain when the stacks
+    /// transaction that emitted this event was executed.
+    pub block_height: u64,
+}
+
+/// This function if for transforming the print events of the
+/// `complete-withdrawal-accept` function in the sbtc-registry.
+///
+/// # Notes
+///
+/// The print events for `create-withdrawal-request` calls are structured
+/// like so:
+///
+/// ```clarity
+/// (print {
+///   topic: "withdrawal-create",
+///   amount: uint,
+///   request-id: uint,
+///   sender: principal,
+///   recipient: { version: (buff 1), hashbytes: (buff 32) },
+///   block-height: uint,
+///   max-fee: uint,
+/// })
+/// ```
+fn withdrawal_create(mut map: RawTupleData, network: NetworkKind) -> Result<RegistryEvent, Error> {
+    let request_id = map.remove_u128("request-id")?;
+    let amount = map.remove_u128("amount")?;
+    let max_fee = map.remove_u128("max-fee")?;
+    let block_height = map.remove_u128("block-height")?;
+    let sender = map.remove_principal("sender")?;
+    let recipient = map.remove_tuple("recipient")?;
+
+    Ok(RegistryEvent::WithdrawalCreate(WithdrawalCreateEvent {
+        // This shouldn't error, practically speaking. Each withdrawal
+        // request increments the integer by one, so we'd have to do many
+        // orders of magnitude more requests than there are bitcoin
+        // transactions, ever.
+        request_id: u64::try_from(request_id).map_err(Error::ClarityIntConversion)?,
+        amount: u64::try_from(amount).map_err(Error::ClarityIntConversion)?,
+        max_fee: u64::try_from(max_fee).map_err(Error::ClarityIntConversion)?,
+        block_height: u64::try_from(block_height).map_err(Error::ClarityIntConversion)?,
+        recipient: recipient_to_address(recipient, network)?,
+        sender,
+    }))
+}
+
+fn recipient_to_address(_map: RawTupleData, network: NetworkKind) -> Result<Address, Error> {
+    Ok(Address::p2shwsh(&ScriptBuf::new_op_return([1, 2]), network))
+}
+
+
+/// This is the event that is emitted from the `complete-withdrawal-accept`
+/// public function in sbtc-registry smart contract.
+#[derive(Debug)]
+pub struct WithdrawalAcceptEvent {
+    /// This is the unique identifier of the withdrawal request.
+    pub request_id: u64,
+    /// The bitmap of how the signers voted for the withdrawal request.
+    /// Here, a 1 (or true) implies that the signer did *not* vote to
+    /// accept the request.
+    pub signer_bitmap: BitArray<[u8; 16]>,
+    /// This is the outpoint for the bitcoin transaction that serviced the
+    /// request.
+    pub outpoint: OutPoint,
+    /// This is the fee that was spent to the bitcoin miners to confirm the
+    /// withdrawal request.
+    pub fee: u64,
+}
+
+/// This function if for transforming the print events of the
+/// `complete-withdrawal-accept` function in the sbtc-registry.
+///
+/// # Notes
+///
+/// The print events for `complete-withdrawal-accept` calls are structured
+/// like so:
+///
+/// ```clarity
+/// (print {
+///   topic: "withdrawal-accept",
+///   request-id: uint,
+///   bitcoin-txid: (buff 32),
+///   signer-bitmap: uint,
+///   bitcoin-index: uint,
+///   fee: fee
+/// })
+/// ```
+fn withdrawal_accept(mut map: RawTupleData) -> Result<RegistryEvent, Error> {
+    let request_id = map.remove_u128("request-id")?;
+    let bitmap = map.remove_u128("signer-bitmap")?;
+    let fee = map.remove_u128("fee")?;
+    let vout = map.remove_u128("output-index")?;
+    let txid_bytes = map.remove_buff("bitcoin-txid")?;
+
+    Ok(RegistryEvent::WithdrawalAccept(WithdrawalAcceptEvent {
+        // This shouldn't error for the reasons noted in
+        // [`withdrawal_create`].
+        request_id: u64::try_from(request_id).map_err(Error::ClarityIntConversion)?,
+        signer_bitmap: BitArray::new(bitmap.to_be_bytes()),
+        outpoint: OutPoint {
+            // This shouldn't error, this is set from a proper [`Txid`] in
+            // a contract call.
+            txid: Txid::from_slice(&txid_bytes).map_err(Error::ClarityTxidConversion)?,
+            // This shouldn't actually error, we cast u32s to u128s before
+            // making the contract call, and that is the value that gets
+            // emitted here.
+            vout: u32::try_from(vout).map_err(Error::ClarityIntConversion)?,
+        },
+        // This shouldn't error, since this amount is set from the u64
+        // amount of sats by us.
+        fee: u64::try_from(fee).map_err(Error::ClarityIntConversion)?,
+    }))
+}
+
+/// This is the event that is emitted from the `complete-withdrawal-reject`
+/// public function in sbtc-registry smart contract.
+pub struct WithdrawalRejectEvent {
+    /// This is the unique identifier of user created the withdrawal
+    /// request.
+    pub request_id: u64,
+    /// The bitmap of how the signers voted for the withdrawal request.
+    /// Here, a 1 (or true) implies that the signer did *not* vote to
+    /// accept the request.
+    pub signer_bitmap: BitArray<[u8; 16]>,
+}
+
+/// This function if for transforming the print events of the
+/// `complete-withdrawal-reject` function in the sbtc-registry.
+///
+/// # Notes
+///
+/// The print events for `complete-withdrawal-reject` calls are structured
+/// like so:
+///
+/// ```clarity
+/// (print {
+///   topic: "withdrawal-reject",
+///   request-id: uint,
+///   signer-bitmap: uint,
+/// })
+/// ```
+///
+/// The above event is emitted after the locked sBTC has been unlocked back
+/// to the account that initiated the request.
+fn withdrawal_reject(mut map: RawTupleData) -> Result<RegistryEvent, Error> {
+    let request_id = map.remove_u128("request-id")?;
+    let bitmap = map.remove_u128("signer-bitmap")?;
+
+    Ok(RegistryEvent::WithdrawalReject(WithdrawalRejectEvent {
+        // This shouldn't error for the reasons noted in
+        // [`withdrawal_create`].
+        request_id: u64::try_from(request_id).map_err(Error::ClarityIntConversion)?,
+        signer_bitmap: BitArray::new(bitmap.to_le_bytes()),
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use bitvec::field::BitField as _;
+
+    use super::*;
+
+    #[test]
+    fn signer_bitmap_conversion() {
+        // This test checks that converting from an integer to the bitmap
+        // works the way that we expect.
+        let bitmap_number: u128 = 3;
+        let bitmap: BitArray<[u8; 16]> = BitArray::new(bitmap_number.to_le_bytes());
+
+        assert_eq!(bitmap.load_le::<u128>(), bitmap_number);
+
+        // This is basically a test of the same thing as the above, except
+        // that we explicitly create the signer bitmap.
+        let mut bitmap: BitArray<[u8; 16]> = BitArray::ZERO;
+        bitmap.set(0, true);
+        bitmap.set(1, true);
+
+        assert_eq!(bitmap.load_le::<u128>(), bitmap_number);
+    }
+}

--- a/signer/src/stacks/mod.rs
+++ b/signer/src/stacks/mod.rs
@@ -3,6 +3,7 @@
 /// Contains an interface for interacting with a stacks node.
 pub mod api;
 pub mod contracts;
+pub mod events;
 /// Contains structs for signing stacks transactions using the signers'
 /// multi-sig wallet.
 pub mod wallet;

--- a/signer/src/stacks/wallet.rs
+++ b/signer/src/stacks/wallet.rs
@@ -121,7 +121,7 @@ impl SignerWallet {
         let hash_mode = Self::hash_mode().to_address_hash_mode();
         let version = match network_kind {
             NetworkKind::Mainnet => C32_ADDRESS_VERSION_MAINNET_MULTISIG,
-            NetworkKind::Testnet => C32_ADDRESS_VERSION_TESTNET_MULTISIG,
+            _ => C32_ADDRESS_VERSION_TESTNET_MULTISIG,
         };
 
         // The [`StacksAddress::from_public_keys`] call below should never
@@ -220,7 +220,7 @@ impl MultisigTx {
         // https://docs.stacks.co/clarity/keywords#chain-id-clarity2:
         let (version, chain_id) = match wallet.network_kind {
             NetworkKind::Mainnet => (TransactionVersion::Mainnet, CHAIN_ID_MAINNET),
-            NetworkKind::Testnet => (TransactionVersion::Testnet, CHAIN_ID_TESTNET),
+            _ => (TransactionVersion::Testnet, CHAIN_ID_TESTNET),
         };
 
         let conditions = payload.post_conditions();


### PR DESCRIPTION
## Description

Closes part of https://github.com/stacks-network/sbtc/issues/448. There is a small part left out of this PR, where I do not parse the recipient into a proper type. That will be done in a subsequent PR.

## Changes

1. Add functions for deconstructing print event Clarity `Values` into regular types.
2. Be explicit about the endianness of the signer bitmap when converting it into an integer.

## Testing Information

I did some local testing, but ran into an issue with my local stacks-node not confirming my contract call transaction after the first. Not sure what the issue is. When I get that sorted I think this can be considered "well-tested".

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
