### PR TITLE
suggestion for signer runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4522,6 +4522,7 @@ dependencies = [
  "bitcoincore-rpc",
  "bitvec",
  "blocklist-api",
+ "cfg-if 1.0.0",
  "clap",
  "clarity",
  "config 0.14.0",

--- a/emily/handler/src/api/handlers/chainstate.rs
+++ b/emily/handler/src/api/handlers/chainstate.rs
@@ -71,10 +71,7 @@ pub async fn get_chainstate_at_height(
             .await?
             .into();
         // Respond.
-        Ok(with_status(
-            json(&chainstate),
-            StatusCode::OK,
-        ))
+        Ok(with_status(json(&chainstate), StatusCode::OK))
     }
     // Handle and respond.
     handler(context, height)
@@ -108,10 +105,7 @@ pub async fn set_chainstate(context: EmilyContext, body: Chainstate) -> impl war
         let chainstate: Chainstate = body;
         add_chainstate_entry_or_reorg(&context, &chainstate).await?;
         // Respond.
-        Ok(with_status(
-            json(&chainstate),
-            StatusCode::CREATED,
-        ))
+        Ok(with_status(json(&chainstate), StatusCode::CREATED))
     }
     // Handle and respond.
     handler(context, body)
@@ -148,10 +142,7 @@ pub async fn update_chainstate(
         let chainstate: Chainstate = body;
         add_chainstate_entry_or_reorg(&context, &chainstate).await?;
         // Respond.
-        Ok(with_status(
-            json(&chainstate),
-            StatusCode::CREATED,
-        ))
+        Ok(with_status(json(&chainstate), StatusCode::CREATED))
     }
     // Handle and respond.
     handler(context, request)

--- a/emily/handler/src/api/handlers/withdrawal.rs
+++ b/emily/handler/src/api/handlers/withdrawal.rs
@@ -47,10 +47,7 @@ pub async fn get_withdrawal(context: EmilyContext, request_id: u64) -> impl warp
             .try_into()?;
 
         // Respond.
-        Ok(with_status(
-            json(&withdrawal),
-            StatusCode::OK,
-        ))
+        Ok(with_status(json(&withdrawal), StatusCode::OK))
     }
     // Handle and respond.
     handler(context, request_id)

--- a/signer/Cargo.toml
+++ b/signer/Cargo.toml
@@ -55,6 +55,7 @@ url.workspace = true
 wsts.workspace = true
 zeromq.workspace = true
 hex.workspace = true
+cfg-if = "1.0"
 
 # Only for testing
 fake = { version = "2.9.2", features = ["derive", "time"], optional = true }

--- a/signer/src/blocklist_client.rs
+++ b/signer/src/blocklist_client.rs
@@ -5,12 +5,13 @@
 //! include querying the blocklist API and interpreting the responses to determine if a given
 //! address is blocklisted, along with its associated risk severity.
 
-use crate::config::SETTINGS;
 use blocklist_api::apis::address_api::{check_address, CheckAddressError};
 use blocklist_api::apis::configuration::Configuration;
 use blocklist_api::apis::Error as ClientError;
 use blocklist_api::models::BlocklistStatus;
 use std::future::Future;
+
+use crate::context::Context;
 
 /// A trait for checking if an address is blocklisted.
 pub trait BlocklistChecker {
@@ -40,10 +41,11 @@ impl BlocklistChecker for BlocklistClient {
 
 impl BlocklistClient {
     /// Construct a new [`BlocklistClient`]
-    pub fn new() -> Self {
+    pub fn new(ctx: &impl Context) -> Self {
         let base_url = format!(
             "http://{}:{}",
-            SETTINGS.blocklist_client.host, SETTINGS.blocklist_client.port
+            ctx.config().blocklist_client.host,
+            ctx.config().blocklist_client.port
         );
 
         let config = Configuration {
@@ -62,12 +64,6 @@ impl BlocklistClient {
         };
 
         BlocklistClient { config }
-    }
-}
-
-impl Default for BlocklistClient {
-    fn default() -> Self {
-        Self::new()
     }
 }
 

--- a/signer/src/config.rs
+++ b/signer/src/config.rs
@@ -3,7 +3,7 @@
 use config::{Config, ConfigError, Environment, File};
 use serde::Deserialize;
 use serde::Deserializer;
-use std::sync::LazyLock;
+use std::path::Path;
 
 use crate::error::Error;
 use crate::keys::PrivateKey;
@@ -188,10 +188,6 @@ pub struct StacksAccountConfig {
     pub private_key: PrivateKey,
 }
 
-/// Statically configured settings for the signer
-pub static SETTINGS: LazyLock<Settings> =
-    LazyLock::new(|| Settings::new().expect("Failed to load configuration"));
-
 impl Settings {
     /// Initializing the global config first with default values and then with
     /// provided/overwritten environment variables. The explicit separator with
@@ -214,7 +210,7 @@ impl Settings {
     ///    │  └ prefix_separator("_")
     ///    └ with_prefix("SIGNER")
     /// ```
-    pub fn new() -> Result<Self, ConfigError> {
+    pub fn new(config_path: Option<impl AsRef<Path>>) -> Result<Self, ConfigError> {
         // To properly parse lists from both environment and config files while
         // using a custom deserializer, we need to specify the list separator,
         // enable try_parsing and specify the keys which should be parsed as lists.
@@ -228,10 +224,11 @@ impl Settings {
             .with_list_parse_key("signer.p2p.listen_on")
             .with_list_parse_key("signer.p2p.public_endpoints")
             .prefix_separator("_");
-        let cfg = Config::builder()
-            .add_source(File::with_name("./src/config/default"))
-            .add_source(env)
-            .build()?;
+        let mut cfg_builder = Config::builder();
+        if let Some(path) = config_path {
+            cfg_builder = cfg_builder.add_source(File::from(path.as_ref()));
+        }
+        let cfg = cfg_builder.add_source(env).build()?;
 
         let settings: Settings = cfg.try_deserialize()?;
 
@@ -337,6 +334,8 @@ mod tests {
 
     use super::*;
 
+    const DEFAULT_CONFIG_PATH: Option<&str> = Some("./src/config/default");
+
     /// Helper function to quickly create a URL from a string in tests.
     fn url(s: &str) -> url::Url {
         s.parse().unwrap()
@@ -350,7 +349,7 @@ mod tests {
     // !! default.toml file are changed.
     #[test]
     fn default_config_toml_loads() {
-        let settings = Settings::new().unwrap();
+        let settings = Settings::new(DEFAULT_CONFIG_PATH).unwrap();
         assert_eq!(settings.blocklist_client.host, "127.0.0.1");
         assert_eq!(settings.blocklist_client.port, 8080);
         assert_eq!(settings.block_notifier.server, "tcp://localhost:60401");
@@ -380,7 +379,7 @@ mod tests {
         );
         std::env::set_var("SIGNER_SIGNER__P2P__LISTEN_ON", "tcp://1.2.3.4:1234");
 
-        let settings = Settings::new().unwrap();
+        let settings = Settings::new(DEFAULT_CONFIG_PATH).unwrap();
 
         assert_eq!(
             settings.signer.p2p.seeds,
@@ -397,7 +396,7 @@ mod tests {
         let new = "a1a6fcf2de80dcde3e0e4251eae8c69adf57b88613b2dcb79332cc325fa439bd";
         std::env::set_var("SIGNER_SIGNER__STACKS_ACCOUNT__PRIVATE_KEY", new);
 
-        let settings = Settings::new().unwrap();
+        let settings = Settings::new(DEFAULT_CONFIG_PATH).unwrap();
 
         assert_eq!(
             settings.signer.stacks_account.private_key,
@@ -446,7 +445,7 @@ mod tests {
     fn invalid_private_key_length_returns_correct_error() {
         std::env::set_var("SIGNER_SIGNER__STACKS_ACCOUNT__PRIVATE_KEY", "1234");
 
-        let settings = Settings::new();
+        let settings = Settings::new(DEFAULT_CONFIG_PATH);
         assert!(settings.is_err());
         assert!(matches!(
             settings.unwrap_err(),
@@ -459,7 +458,7 @@ mod tests {
         std::env::set_var("SIGNER_SIGNER__STACKS_ACCOUNT__PRIVATE_KEY", "zz");
         let hex_err = hex::decode("zz").unwrap_err();
 
-        let settings = Settings::new();
+        let settings = Settings::new(DEFAULT_CONFIG_PATH);
         assert!(settings.is_err());
         assert!(matches!(
             settings.unwrap_err(),

--- a/signer/src/context.rs
+++ b/signer/src/context.rs
@@ -1,0 +1,76 @@
+//! Context module for the signer binary.
+
+use std::path::Path;
+
+use tokio::sync::broadcast::Sender;
+
+use crate::{config::Settings, error::Error};
+
+/// Context trait that is implemented by the [`SignerContext`].
+pub trait Context {
+    /// Initialize a new signer context.
+    fn init(config_path: Option<impl AsRef<Path>>) -> Result<Self, crate::error::Error>
+    where
+        Self: Sized;
+    /// Get the current configuration for the signer.
+    fn config(&self) -> &Settings;
+    /// Subscribe to the application signalling channel, returning a receiver
+    /// which can be used to listen for events.
+    fn signal_subscribe(&self) -> tokio::sync::broadcast::Receiver<SignerSignal>;
+    /// Send a signal to the application signalling channel.
+    fn signal_send(&self, signal: SignerSignal) -> Result<usize, crate::error::Error>;
+    /// Signal the application to shutdown.
+    fn signal_shutdown(&self) -> Result<usize, Error>;
+}
+
+/// Signer context which is passed to different components within the
+/// signer binary.
+pub struct SignerContext {
+    config: Settings,
+    signal_tx: Sender<SignerSignal>,
+    // Would be used if we wanted to listen for any events in the context,
+    // for example if we wanted a subroutine to be able to trigger a config
+    // refresh:
+    // signal_rx: Receiver<SignerSignal>,
+
+    // Example if we wanted to have a database pool in the context:
+    // db_pool: sqlx::PgPool,
+}
+
+/// Signals that can be sent within the signer binary.
+#[derive(Debug, Clone)]
+pub enum SignerSignal {
+    /// Signals to the application to shut down.
+    Shutdown,
+}
+
+impl Context for SignerContext {
+    /// Create a new signer context.
+    fn init(config_path: Option<impl AsRef<Path>>) -> Result<Self, Error> {
+        let config = Settings::new(config_path).map_err(Error::SignerConfig)?;
+
+        let (signal_tx, _) = tokio::sync::broadcast::channel(10);
+
+        Ok(Self { config, signal_tx })
+    }
+
+    fn config(&self) -> &Settings {
+        &self.config
+    }
+
+    fn signal_subscribe(&self) -> tokio::sync::broadcast::Receiver<SignerSignal> {
+        self.signal_tx.subscribe()
+    }
+
+    /// Send a signal to the application signalling channel.
+    fn signal_send(&self, signal: SignerSignal) -> Result<usize, Error> {
+        self.signal_tx
+            .send(signal)
+            .map_err(Error::ApplicationSignal)
+    }
+
+    /// Signal the application to shutdown.
+    fn signal_shutdown(&self) -> Result<usize, Error> {
+        self.signal_send(SignerSignal::Shutdown)
+    }
+}

--- a/signer/src/context.rs
+++ b/signer/src/context.rs
@@ -1,6 +1,6 @@
 //! Context module for the signer binary.
 
-use std::{path::Path, sync::Arc};
+use std::path::Path;
 
 use tokio::sync::broadcast::Sender;
 
@@ -25,7 +25,7 @@ pub trait Context {
 /// signer binary.
 pub struct SignerContext {
     config: Settings,
-    signal_tx: Arc<Sender<SignerSignal>>,
+    signal_tx: Sender<SignerSignal>,
     // Would be used if we wanted to listen for any events in the context,
     // for example if we wanted a subroutine to be able to trigger a config
     // refresh:
@@ -49,10 +49,7 @@ impl Context for SignerContext {
 
         let (signal_tx, _) = tokio::sync::broadcast::channel(10);
 
-        Ok(Self {
-            config,
-            signal_tx: Arc::new(signal_tx),
-        })
+        Ok(Self { config, signal_tx })
     }
 
     fn config(&self) -> &Settings {

--- a/signer/src/context.rs
+++ b/signer/src/context.rs
@@ -18,7 +18,7 @@ pub trait Context {
     /// which can be used to listen for events.
     fn get_signal_receiver(&self) -> tokio::sync::broadcast::Receiver<SignerSignal>;
     /// Send a signal to the application signalling channel.
-    fn signal_send(&self, signal: SignerSignal) -> Result<usize, crate::error::Error>;
+    fn signal(&self, signal: SignerSignal) -> Result<usize, crate::error::Error>;
 }
 
 /// Signer context which is passed to different components within the
@@ -64,7 +64,7 @@ impl Context for SignerContext {
     }
 
     /// Send a signal to the application signalling channel.
-    fn signal_send(&self, signal: SignerSignal) -> Result<usize, Error> {
+    fn signal(&self, signal: SignerSignal) -> Result<usize, Error> {
         self.signal_tx
             .send(signal)
             .map_err(Error::ApplicationSignal)

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -8,6 +8,21 @@ use crate::{codec, ecdsa, network};
 /// Top-level signer error
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
+    /// Stacks event observer terminated prematurely.
+    #[error("stacks event observer terminated prematurely")]
+    StacksEventObserverAborted,
+
+    /// I/O Error raised by the Tokio runtime.
+    #[error("tokio i/o error: {0}")]
+    TokioIo(#[from] tokio::io::Error),
+
+    /// Error when attempting to send a signal to the application's signalling
+    /// channel.
+    #[error("failed to send signal to the application: {0}")]
+    ApplicationSignal(
+        #[source] tokio::sync::broadcast::error::SendError<crate::context::SignerSignal>,
+    ),
+
     /// Error when breaking out the ZeroMQ message into three parts.
     #[error("bitcoin messages should have a three part layout, received {0} parts")]
     BitcoinCoreZmqMessageLayout(usize),

--- a/signer/src/lib.rs
+++ b/signer/src/lib.rs
@@ -7,6 +7,7 @@ pub mod block_observer;
 pub mod blocklist_client;
 pub mod codec;
 pub mod config;
+pub mod context;
 pub mod ecdsa;
 pub mod error;
 pub mod keys;

--- a/signer/src/main.rs
+++ b/signer/src/main.rs
@@ -87,7 +87,7 @@ async fn run_shutdown_signal_watcher(ctx: &impl Context) -> Result<(), Error> {
 
     // Send the shutdown signal to the rest of the application.
     tracing::info!("Sending shutdown signal to the application");
-    ctx.signal_send(SignerSignal::Shutdown)?;
+    ctx.signal(SignerSignal::Shutdown)?;
 
     Ok(())
 }
@@ -133,7 +133,7 @@ async fn run_stacks_event_observer(ctx: &impl Context) -> Result<(), Error> {
     tokio::select! {
         _ = handle => {
             tracing::info!("Stacks event observer server aborted");
-            ctx.signal_send(SignerSignal::Shutdown)?;
+            ctx.signal(SignerSignal::Shutdown)?;
             Err(Error::StacksEventObserverAborted)
         }
         Ok(SignerSignal::Shutdown) = signal.recv() => {

--- a/signer/src/main.rs
+++ b/signer/src/main.rs
@@ -1,9 +1,17 @@
+use std::path::PathBuf;
+
 use axum::routing::get;
 use axum::routing::post;
 use axum::Router;
+use clap::Parser;
 use signer::api;
+use signer::context::Context;
+use signer::context::SignerContext;
+use signer::context::SignerSignal;
+use signer::error::Error;
 use signer::storage::postgres::PgStore;
 
+// TODO: This should be read from configuration
 const DATABASE_URL: &str = "postgres://user:password@localhost:5432/signer";
 
 fn get_connection_pool() -> sqlx::PgPool {
@@ -12,10 +20,61 @@ fn get_connection_pool() -> sqlx::PgPool {
         .unwrap()
 }
 
+/// Command line arguments for the signer.
+#[derive(Debug, Parser)]
+#[clap(name = "sBTC Signer")]
+struct SignerArgs {
+    /// Optional path to the configuration file. If not provided, it is expected
+    /// that all parameters are provided via environment variables.
+    #[clap(short = 'c', long, required = false)]
+    config: Option<PathBuf>,
+}
+
 #[tokio::main]
-async fn main() {
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Initialize logging
     sbtc::logging::setup_logging("info,signer=debug", false);
 
+    // Parse the command line arguments.
+    let args = SignerArgs::parse();
+
+    // Initialize the signer context.
+    let context = SignerContext::init(args.config)?;
+
+    // Run the Stacks event observer and Ctrl-C watcher concurrently.
+    let _ = tokio::join!(
+        run_stacks_event_observer(&context),
+        run_ctrl_c_watcher(&context),
+        run_libp2p_swarm(&context),
+    );
+
+    Ok(())
+}
+
+/// Runs the Ctrl-C watcher.
+async fn run_ctrl_c_watcher(ctx: &impl Context) -> Result<(), Error> {
+    tokio::signal::ctrl_c().await?;
+    ctx.signal_shutdown()?;
+    Ok(())
+}
+
+/// Runs the libp2p swarm.
+async fn run_libp2p_swarm(ctx: &impl Context) -> Result<(), Error> {
+    // Subscribe to the signal channel so that we can catch shutdown events.
+    let mut signal = ctx.signal_subscribe();
+
+    // TODO(409): Add libp2p swarm initialization here.
+
+    tokio::select! {
+        Ok(SignerSignal::Shutdown) = signal.recv() => {
+            tracing::info!("Received shutdown signal, stopping libp2p swarm");
+            Ok(())
+        }
+    }
+}
+
+/// Runs the Stacks event observer server.
+async fn run_stacks_event_observer(ctx: &impl Context) -> Result<(), Error> {
     let pool = get_connection_pool();
     let pool_store = PgStore::from(pool);
     // Build the signer API application
@@ -26,5 +85,25 @@ async fn main() {
 
     // run our app with hyper
     let listener = tokio::net::TcpListener::bind("0.0.0.0:8801").await.unwrap();
-    axum::serve(listener, app).await.unwrap();
+
+    // Subscribe to the signal channel so that we can catch shutdown events.
+    let mut signal = ctx.signal_subscribe();
+
+    // Start the server in its own task.
+    let handle = tokio::spawn(async { axum::serve(listener, app).await });
+
+    // Wait for either the server to stop or a shutdown signal. If the server
+    // stops on its own, this is probably a premature termination of some sort,
+    // so return an error.
+    tokio::select! {
+        _ = handle => {
+            tracing::info!("Stacks event observer server aborted");
+            ctx.signal_shutdown()?;
+            Err(Error::StacksEventObserverAborted)
+        }
+        Ok(SignerSignal::Shutdown) = signal.recv() => {
+            tracing::info!("Received shutdown signal, stopping Stacks event observer server");
+            Ok(())
+        }
+    }
 }


### PR DESCRIPTION
## Description

Closes: #467

## Changes

Was looking into the wire-up of config, runloop, etc. with libp2p and thought I'd come with a boilerplate suggestion for the signer binary runtime since it's very basic atm.

- I removed the `LazyLock` static configuration in favor of a `SignerContext` object which can be passed down from `main` into subroutines (a better pattern, imo).
- Added application signalling (for ctrl+c, SIGHUP, SIGTERM, SIGINT) but can be expanded to other things like "ConfigReload" or whatever. This uses a broadcast channel which each component can subscribe to to receive shutdown events and shut itself down gracefully (if necessary).
EDIT: This might actually be a better option for communication between components, i.e. when a p2p message is received, or a p2p broadcast should be sent.
- Changed `Settings` to accept an optional file path, which can now be passed to the signer using `-c`/`--config`.
- `cargo fmt` touched a couple of unrelated files, guess that would have happened sooner or later regardless.

## Testing Information
You can run the binary now by using:
```
cargo run --bin signer -- -c ./signer/src/config/default.toml
```

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
