### PR TITLE
fix: event emitting bug

### DIFF
--- a/contracts/contracts/sbtc-withdrawal.clar
+++ b/contracts/contracts/sbtc-withdrawal.clar
@@ -158,7 +158,7 @@
       )
 
       ;; Call into registry to confirm accepted withdrawal
-      (try! (contract-call? .sbtc-registry complete-withdrawal-accept request-id bitcoin-txid signer-bitmap output-index fee))
+      (try! (contract-call? .sbtc-registry complete-withdrawal-accept request-id bitcoin-txid output-index signer-bitmap fee))
 
       (ok true)
   )


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/468.

## Changes

1. Swap the order of the inputs into the `complete-withdrawal-accept` public function.
2. Add test cases for the print events.

## Testing Information

The new checks should prevent further regression.

## Checklist:

- [x] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
