### PR TITLE
feat: add handler for smart contract events

### DIFF
--- a/signer/migrations/0003__create_tables.sql
+++ b/signer/migrations/0003__create_tables.sql
@@ -134,14 +134,16 @@ CREATE TABLE sbtc_signer.withdraw_responses (
 
 CREATE TABLE sbtc_signer.completed_deposit_events (
     id           BIGSERIAL PRIMARY KEY,
-    amount       BIGINT  NOT NULL,
     txid         BYTEA   NOT NULL,
+    amount       BIGINT  NOT NULL,
+    bitcoin_txid BYTEA   NOT NULL,
     output_index BIGINT  NOT NULL,
     created_at   TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL
 );
 
 CREATE TABLE sbtc_signer.withdrawal_create_events (
     id           BIGSERIAL PRIMARY KEY,
+    txid         BYTEA   NOT NULL,
     request_id   BIGINT  NOT NULL,
     amount       BIGINT  NOT NULL,
     sender       VARCHAR NOT NULL,
@@ -153,9 +155,10 @@ CREATE TABLE sbtc_signer.withdrawal_create_events (
 
 CREATE TABLE sbtc_signer.withdrawal_accept_events (
     id            BIGSERIAL PRIMARY KEY,
+    txid          BYTEA   NOT NULL,
     request_id    BIGINT  NOT NULL,
     signer_bitmap BYTEA   NOT NULL,
-    txid          BYTEA   NOT NULL,
+    bitcoin_txid  BYTEA   NOT NULL,
     output_index  BIGINT  NOT NULL,
     fee           BIGINT  NOT NULL,
     created_at    TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL
@@ -163,6 +166,7 @@ CREATE TABLE sbtc_signer.withdrawal_accept_events (
 
 CREATE TABLE sbtc_signer.withdrawal_reject_events (
     id            BIGSERIAL PRIMARY KEY,
+    txid          BYTEA  NOT NULL,
     request_id    BIGINT NOT NULL,
     signer_bitmap BYTEA  NOT NULL,
     created_at    TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL

--- a/signer/migrations/0003__create_tables.sql
+++ b/signer/migrations/0003__create_tables.sql
@@ -136,7 +136,8 @@ CREATE TABLE sbtc_signer.completed_deposit_events (
     id           BIGSERIAL PRIMARY KEY,
     amount       BIGINT  NOT NULL,
     txid         BYTEA   NOT NULL,
-    output_index BIGINT NOT NULL
+    output_index BIGINT  NOT NULL,
+    created_at   TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL
 );
 
 CREATE TABLE sbtc_signer.withdrawal_create_events (
@@ -146,7 +147,8 @@ CREATE TABLE sbtc_signer.withdrawal_create_events (
     sender       VARCHAR NOT NULL,
     recipient    VARCHAR NOT NULL,
     max_fee      BIGINT  NOT NULL,
-    block_height BIGINT  NOT NULL
+    block_height BIGINT  NOT NULL,
+    created_at   TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL
 );
 
 CREATE TABLE sbtc_signer.withdrawal_accept_events (
@@ -154,13 +156,15 @@ CREATE TABLE sbtc_signer.withdrawal_accept_events (
     request_id    BIGINT  NOT NULL,
     signer_bitmap BYTEA   NOT NULL,
     txid          BYTEA   NOT NULL,
-    output_index  BIGINT NOT NULL,
-    fee           BIGINT  NOT NULL
+    output_index  BIGINT  NOT NULL,
+    fee           BIGINT  NOT NULL,
+    created_at    TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL
 );
 
 CREATE TABLE sbtc_signer.withdrawal_reject_events (
     id            BIGSERIAL PRIMARY KEY,
     request_id    BIGINT NOT NULL,
-    signer_bitmap BYTEA  NOT NULL
+    signer_bitmap BYTEA  NOT NULL,
+    created_at    TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL
 );
 

--- a/signer/migrations/0003__create_tables.sql
+++ b/signer/migrations/0003__create_tables.sql
@@ -131,3 +131,36 @@ CREATE TABLE sbtc_signer.withdraw_responses (
     withdraw_txid BYTEA NOT NULL,
     withdraw_request_id BIGINT NOT NULL
 );
+
+CREATE TABLE sbtc_signer.completed_deposit_events (
+    id           BIGSERIAL PRIMARY KEY,
+    amount       BIGINT  NOT NULL,
+    txid         BYTEA   NOT NULL,
+    output_index BIGINT NOT NULL
+);
+
+CREATE TABLE sbtc_signer.withdrawal_create_events (
+    id           BIGSERIAL PRIMARY KEY,
+    request_id   BIGINT  NOT NULL,
+    amount       BIGINT  NOT NULL,
+    sender       VARCHAR NOT NULL,
+    recipient    VARCHAR NOT NULL,
+    max_fee      BIGINT  NOT NULL,
+    block_height BIGINT  NOT NULL
+);
+
+CREATE TABLE sbtc_signer.withdrawal_accept_events (
+    id            BIGSERIAL PRIMARY KEY,
+    request_id    BIGINT  NOT NULL,
+    signer_bitmap BYTEA   NOT NULL,
+    txid          BYTEA   NOT NULL,
+    output_index  BIGINT NOT NULL,
+    fee           BIGINT  NOT NULL
+);
+
+CREATE TABLE sbtc_signer.withdrawal_reject_events (
+    id            BIGSERIAL PRIMARY KEY,
+    request_id    BIGINT NOT NULL,
+    signer_bitmap BYTEA  NOT NULL
+);
+

--- a/signer/src/api/mod.rs
+++ b/signer/src/api/mod.rs
@@ -6,3 +6,14 @@ pub mod status;
 
 pub use new_block::new_block_handler;
 pub use status::status_handler;
+
+use crate::config::Settings;
+
+/// A struct with state data necessary for runtime operation.
+#[derive(Debug, Clone)]
+pub struct ApiState<S> {
+    /// For writing to the database.
+    pub db: S,
+    /// The runtime settings of the system.
+    pub settings: Settings,
+}

--- a/signer/src/api/new_block.rs
+++ b/signer/src/api/new_block.rs
@@ -75,7 +75,7 @@ where
         // So we return a non success status code so that the node retries
         // in a second.
         if let Err(err) = res {
-            tracing::error!("Got an error when writting event to database: {err}");
+            tracing::error!("Got an error when writing event to database: {err}");
             return StatusCode::INTERNAL_SERVER_ERROR;
         }
     }

--- a/signer/src/api/new_block.rs
+++ b/signer/src/api/new_block.rs
@@ -6,9 +6,12 @@ use axum::extract::rejection::JsonRejection;
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::Json;
+use blockstack_lib::chainstate::stacks::TransactionPayload;
 
+use crate::stacks::events::RegistryEvent;
 use crate::stacks::webhooks::NewBlockEvent;
-use crate::storage::DbWrite;
+use crate::storage::postgres::PgStore;
+// use crate::storage::DbWrite;
 
 /// We denote the stacks node payload by this type so that our handler
 /// always gets to handle the request, regardless of whether there is a
@@ -32,39 +35,62 @@ pub type StacksNodePayload = Result<Json<serde_json::Value>, JsonRejection>;
 /// second might succeed, we will return a 200 OK status code.
 ///
 /// [^1]: <https://github.com/stacks-network/stacks-core/blob/09c4b066e25104be8b066e8f7530ff0c6df4ccd5/testnet/stacks-node/src/event_dispatcher.rs#L317-L385>
-pub async fn new_block_handler<S>(_state: State<S>, body: StacksNodePayload) -> StatusCode
-where
-    S: DbWrite,
-{
+pub async fn new_block_handler(_state: State<PgStore>, body: String) -> StatusCode {
     tracing::info!("Received a new block event from stacks-core");
 
-    let _event: NewBlockEvent = match body {
-        Ok(Json(value)) => {
-            // We print out the raw string if there are any errors during
-            // deserialization, but only for non-release builds.
-            #[cfg(debug_assertions)]
-            let raw_payload = serde_json::to_string(&value).unwrap();
-
-            match serde_json::from_value(value) {
-                Ok(event) => event,
-                Err(error) => {
-                    tracing::error!("could not deserialize POST /new_block webhook: {error}");
-
-                    #[cfg(debug_assertions)]
-                    println!("raw payload: {raw_payload}");
-                    return StatusCode::OK;
-                }
-            }
-        }
+    let mut _event: NewBlockEvent = match serde_json::from_str(&body) {
+        Ok(value) => value,
         // If we are here, then we failed to deserialize the webhook body
         // into the expected type. It's unlikely that retying this webhook
         // will lead to success, so we log the error and return `200 OK` so
         // that the node does not retry the webhook.
         Err(error) => {
-            tracing::error!("could not deserialize POST /new_block webhook: {error:?}");
+            tracing::error!("could not deserialize POST /new_block webhook: {body}, error {error}");
             return StatusCode::OK;
         }
     };
 
+    if !_event.events.is_empty() {
+        let ans = _event
+            .events
+            .into_iter()
+            .filter_map(|x| x.contract_event)
+            .map(|x| {
+                crate::stacks::events::transform_value(x.value, crate::config::NetworkKind::Regtest)
+            })
+            .collect::<Vec<_>>();
+        _event.transactions.retain(|x| x.tx.is_some());
+        _event.transactions.retain(|x| {
+            matches!(
+                x.tx.as_ref().unwrap().payload,
+                TransactionPayload::ContractCall(_)
+            )
+        });
+        if !_event.transactions.is_empty() {
+            let _ = dbg!(&ans);
+            dbg!(&_event.transactions);
+        }
+        for event in ans.into_iter() {
+            let _res = match event {
+                Ok(RegistryEvent::CompletedDeposit(event)) => {
+                    _state.0.write_completed_deposit_event(&event).await
+                }
+                Ok(RegistryEvent::WithdrawalAccept(event)) => {
+                    _state.0.write_withdrawal_accept_event(&event).await
+                }
+                Ok(RegistryEvent::WithdrawalCreate(event)) => {
+                    _state.0.write_withdrawal_create_event(&event).await
+                }
+                Ok(RegistryEvent::WithdrawalReject(event)) => {
+                    _state.0.write_withdrawal_reject_event(&event).await
+                }
+                Err(err) => {
+                    tracing::error!("{err}");
+                    return StatusCode::OK;
+                }
+            };
+            tracing::info!("{_res:?}");
+        }
+    }
     StatusCode::OK
 }

--- a/signer/src/api/new_block.rs
+++ b/signer/src/api/new_block.rs
@@ -128,11 +128,9 @@ mod tests {
             settings: Settings::new(crate::testing::DEFAULT_CONFIG_PATH).unwrap(),
         };
 
-        {
-            // Hey look, there is nothing here!
-            let db = api.db.lock().await;
-            assert!(table_is_empty(db));
-        }
+        // Hey look, there is nothing here!
+        let db = api.db.lock().await;
+        assert!(table_is_empty(db));        
 
         let state = State(api.clone());
         let body = body_str.to_string();

--- a/signer/src/api/new_block.rs
+++ b/signer/src/api/new_block.rs
@@ -119,7 +119,7 @@ mod tests {
     #[test_case(WITHDRAWAL_ACCEPT_WEBHOOK, |db| db.withdrawal_accept_events.get(&1).is_none(); "withdrawal-accept")]
     #[test_case(WITHDRAWAL_REJECT_WEBHOOK, |db| db.withdrawal_reject_events.get(&2).is_none(); "withdrawal-reject")]
     #[tokio::test]
-    async fn test_events<F>(body_str: &str, func: F)
+    async fn test_events<F>(body_str: &str, table_is_empty: F)
     where
         F: Fn(tokio::sync::MutexGuard<'_, Store>) -> bool,
     {
@@ -131,7 +131,7 @@ mod tests {
         {
             // Hey look, there is nothing here!
             let db = api.db.lock().await;
-            assert!(func(db));
+            assert!(table_is_empty(db));
         }
 
         let state = State(api.clone());
@@ -142,6 +142,6 @@ mod tests {
 
         // Now there should be something here
         let db = api.db.lock().await;
-        assert!(!func(db));
+        assert!(!table_is_empty(db));
     }
 }

--- a/signer/src/api/new_block.rs
+++ b/signer/src/api/new_block.rs
@@ -103,7 +103,7 @@ mod tests {
         include_str!("../../tests/fixtures/withdrawal-create-event.json");
 
     const RAW_WITHDRAWAL_REJECT_WEBHOOK: &str =
-        include_str!("../../tests/fixtures/withdrawal-REJECT-event.json");
+        include_str!("../../tests/fixtures/withdrawal-reject-event.json");
 
     #[test_case(RAW_COMPLETED_DEPOSIT_WEBHOOK, |db| db.completed_deposit_events.get(&bitcoin::OutPoint::null()).is_none(); "completed-deposit")]
     #[test_case(RAW_WITHDRAWAL_CREATE_WEBHOOK, |db| db.withdrawal_create_events.get(&1).is_none(); "withdrawal-create")]

--- a/signer/src/api/new_block.rs
+++ b/signer/src/api/new_block.rs
@@ -119,10 +119,9 @@ mod tests {
     where
         F: Fn(tokio::sync::MutexGuard<'_, Store>) -> bool,
     {
-        let config_path = Some("./src/config/default");
         let api = ApiState {
             db: Store::new_shared(),
-            settings: Settings::new(config_path).unwrap(),
+            settings: Settings::new(crate::testing::DEFAULT_CONFIG_PATH).unwrap(),
         };
 
         {

--- a/signer/src/config.rs
+++ b/signer/src/config.rs
@@ -1,4 +1,5 @@
 //! Configuration management for the signer
+use std::str::FromStr as _;
 
 use config::{Config, ConfigError, Environment, File};
 use serde::Deserialize;
@@ -338,19 +339,14 @@ fn private_key_deserializer<'de, D>(deserializer: D) -> Result<PrivateKey, D::Er
 where
     D: Deserializer<'de>,
 {
-    use std::str::FromStr as _;
     PrivateKey::from_str(&String::deserialize(deserializer)?).map_err(serde::de::Error::custom)
 }
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
-
-    use crate::keys::PrivateKey;
-
     use super::*;
 
-    const DEFAULT_CONFIG_PATH: Option<&str> = Some("./src/config/default");
+    use crate::testing::DEFAULT_CONFIG_PATH;
 
     /// Helper function to quickly create a URL from a string in tests.
     fn url(s: &str) -> url::Url {

--- a/signer/src/config.rs
+++ b/signer/src/config.rs
@@ -27,7 +27,7 @@ pub enum NetworkKind {
     Mainnet,
     /// The testnet network
     Testnet,
-    /// The regtest network. This is equivalent to Testnet on when
+    /// The regtest network. This is equivalent to Testnet when
     /// constructing Stacks addresses and transactions.
     Regtest,
 }

--- a/signer/src/config/default.toml
+++ b/signer/src/config/default.toml
@@ -55,6 +55,8 @@ private_key = "8183dc385a7a1fc8353b9e781ee0859a71e57abea478a5bca679334094f7adb5"
 # node.
 #
 # Required: true
+# Possible values: mainnet, testnet, regtest
+# Environment: SIGNER_SIGNER__NETWORK
 network = "regtest"
 # !! ==============================================================================
 # !! Signer P2P Networking Configuration

--- a/signer/src/config/default.toml
+++ b/signer/src/config/default.toml
@@ -40,14 +40,22 @@ endpoints = ["http://localhost:20443"]
 nakamoto_start_height = 31
 
 # !! ==============================================================================
-# !! Signer Stacks Account Configuration
+# !! Signer Configuration
 # !! ==============================================================================
-[signer.stacks_account]
-# The private key associated with the provided Stacks address.
+[signer]
+# The private key associated with the signer. This is used to generate the
+# signers associated public key and sign messages to other signers.
 #
 # Required: true
 private_key = "8183dc385a7a1fc8353b9e781ee0859a71e57abea478a5bca679334094f7adb5"
-
+# Specifies which network to use when constructing and sending transactions
+# on stacks and bitcoin. This cooresponds to the `chain` flag in the
+# bitcoin.conf file of the connected bitcoin-core node, and the
+# `burnchain.mode` flag int he config.toml of the connected stacks-core
+# node.
+#
+# Required: true
+network = "regtest"
 # !! ==============================================================================
 # !! Signer P2P Networking Configuration
 # !! ==============================================================================

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -64,7 +64,7 @@ pub enum Error {
 
     /// This happens when we expect one clarity variant but got another.
     #[error("Got an unexpected clarity value: {0:?}")]
-    ClarityUnexpectedValue(clarity::vm::Value),
+    ClarityUnexpectedValue(clarity::vm::Value, blockstack_lib::burnchains::Txid),
 
     /// This should never happen, but happens when one of the given topics
     /// is not on the list of expected topics.

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -72,8 +72,8 @@ pub enum Error {
     ClarityUnexpectedEventTopic(String),
 
     /// This a programmer error bug that should never be thrown.
-    #[error("The field {0} was missing from the print event for topic")]
-    TupleEventField(&'static str),
+    #[error("The field {0} was missing from the print event for topic. Txid: {1}")]
+    TupleEventField(&'static str, blockstack_lib::burnchains::Txid),
 
     /// This can only be thrown when the number of bytes for a txid field
     /// is not exactly equal to 32. This should never occur.

--- a/signer/src/main.rs
+++ b/signer/src/main.rs
@@ -114,7 +114,7 @@ async fn run_stacks_event_observer(ctx: &impl Context) -> Result<(), Error> {
     // Build the signer API application
     let app = Router::new()
         .route("/", get(api::status_handler))
-        .route("/new_block", post(api::new_block_handler::<PgStore>))
+        .route("/new_block", post(api::new_block_handler))
         .with_state(pool_store);
 
     // run our app with hyper

--- a/signer/src/main.rs
+++ b/signer/src/main.rs
@@ -6,6 +6,7 @@ use axum::Router;
 use cfg_if::cfg_if;
 use clap::Parser;
 use signer::api;
+use signer::api::ApiState;
 use signer::context::Context;
 use signer::context::SignerContext;
 use signer::context::SignerSignal;
@@ -110,12 +111,15 @@ async fn run_libp2p_swarm(ctx: &impl Context) -> Result<(), Error> {
 /// Runs the Stacks event observer server.
 async fn run_stacks_event_observer(ctx: &impl Context) -> Result<(), Error> {
     let pool = get_connection_pool();
-    let pool_store = PgStore::from(pool);
+    let state = ApiState {
+        db: PgStore::from(pool),
+        settings: ctx.config().clone(),
+    };
     // Build the signer API application
     let app = Router::new()
         .route("/", get(api::status_handler))
         .route("/new_block", post(api::new_block_handler))
-        .with_state(pool_store);
+        .with_state(state);
 
     // run our app with hyper
     // TODO: This should be read from configuration

--- a/signer/src/stacks/events.rs
+++ b/signer/src/stacks/events.rs
@@ -272,7 +272,7 @@ impl RawTupleData {
     /// ```
     ///
     /// Also see <https://docs.stacks.co/clarity/functions#get-burn-block-info>
-    /// 
+    ///
     /// Below is a detailed breakdown of bitcoin address types and how they
     /// map to the clarity value. In what follows below, the network used
     /// for the human-readable parts is inherited from the network of the

--- a/signer/src/stacks/events.rs
+++ b/signer/src/stacks/events.rs
@@ -67,7 +67,7 @@ pub enum RegistryEvent {
 
 /// This is the event that is emitted from the `create-withdrawal-request`
 /// public function in sbtc-registry smart contract.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CompletedDepositEvent {
     /// This is the amount of sBTC to mint to the intended recipient.
     pub amount: u64,
@@ -77,7 +77,7 @@ pub struct CompletedDepositEvent {
 
 /// This is the event that is emitted from the `create-withdrawal-request`
 /// public function in sbtc-registry smart contract.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct WithdrawalCreateEvent {
     /// This is the unique identifier of the withdrawal request.
     pub request_id: u64,
@@ -99,7 +99,7 @@ pub struct WithdrawalCreateEvent {
 
 /// This is the event that is emitted from the `complete-withdrawal-accept`
 /// public function in sbtc-registry smart contract.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct WithdrawalAcceptEvent {
     /// This is the unique identifier of the withdrawal request.
     pub request_id: u64,
@@ -117,7 +117,7 @@ pub struct WithdrawalAcceptEvent {
 
 /// This is the event that is emitted from the `complete-withdrawal-reject`
 /// public function in sbtc-registry smart contract.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct WithdrawalRejectEvent {
     /// This is the unique identifier of user created the withdrawal
     /// request.

--- a/signer/src/stacks/events.rs
+++ b/signer/src/stacks/events.rs
@@ -161,21 +161,21 @@ impl RawTupleData {
     fn remove_u128(&mut self, field: &'static str) -> Result<u128, Error> {
         match self.data_map.remove(field) {
             Some(ClarityValue::UInt(val)) => Ok(val),
-            _ => Err(Error::TupleEventField(field)),
+            _ => Err(Error::TupleEventField(field, self.txid)),
         }
     }
     /// Extract the buff value from the given field
     fn remove_buff(&mut self, field: &'static str) -> Result<Vec<u8>, Error> {
         match self.data_map.remove(field) {
             Some(ClarityValue::Sequence(SequenceData::Buffer(buf))) => Ok(buf.data),
-            _ => Err(Error::TupleEventField(field)),
+            _ => Err(Error::TupleEventField(field, self.txid)),
         }
     }
     /// Extract the principal value from the given field
     fn remove_principal(&mut self, field: &'static str) -> Result<PrincipalData, Error> {
         match self.data_map.remove(field) {
             Some(ClarityValue::Principal(principal)) => Ok(principal),
-            _ => Err(Error::TupleEventField(field)),
+            _ => Err(Error::TupleEventField(field, self.txid)),
         }
     }
     /// Extract the string value from the given field
@@ -184,7 +184,7 @@ impl RawTupleData {
             Some(ClarityValue::Sequence(SequenceData::String(CharType::ASCII(ascii)))) => {
                 String::from_utf8(ascii.data).map_err(Error::ClarityStringConversion)
             }
-            _ => Err(Error::TupleEventField(field)),
+            _ => Err(Error::TupleEventField(field, self.txid)),
         }
     }
     /// Extract the tuple value from the given field
@@ -193,7 +193,7 @@ impl RawTupleData {
             Some(ClarityValue::Tuple(TupleData { data_map, .. })) => {
                 Ok(Self::new(data_map, self.txid))
             }
-            _ => Err(Error::TupleEventField(field)),
+            _ => Err(Error::TupleEventField(field, self.txid)),
         }
     }
 

--- a/signer/src/storage/in_memory.rs
+++ b/signer/src/storage/in_memory.rs
@@ -6,9 +6,14 @@ use futures::TryStreamExt;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::Mutex;
+use bitcoin::OutPoint;
 
 use crate::keys::PublicKey;
 use crate::storage::model;
+use crate::stacks::events::CompletedDepositEvent;
+use crate::stacks::events::WithdrawalAcceptEvent;
+use crate::stacks::events::WithdrawalCreateEvent;
+use crate::stacks::events::WithdrawalRejectEvent;
 
 /// A store wrapped in an Arc<Mutex<...>> for interior mutability
 pub type SharedStore = Arc<Mutex<Store>>;
@@ -63,6 +68,26 @@ pub struct Store {
 
     /// Rotate keys transactions
     pub rotate_keys_transactions: HashMap<model::StacksTxId, model::RotateKeysTransaction>,
+
+    /// A mapping between request_ids and withdrawal-create events. Note
+    /// that in prod we can have a single request_id be associated with
+    /// more than one withdrawal-create event because of reorgs.
+    pub withdrawal_create_events: HashMap<u64, WithdrawalCreateEvent>,
+
+    /// A mapping between request_ids and withdrawal-accept events. Note
+    /// that in prod we can have a single request_id be associated with
+    /// more than one withdrawal-accept event because of reorgs.
+    pub withdrawal_accept_events: HashMap<u64, WithdrawalAcceptEvent>,
+
+    /// A mapping between request_ids and withdrawal-reject events. Note
+    /// that in prod we can have a single request_id be associated with
+    /// more than one withdrawal-reject event because of reorgs.
+    pub withdrawal_reject_events: HashMap<u64, WithdrawalRejectEvent>,
+
+    /// A mapping between request_ids and completed-deposit events. Note
+    /// that in prod we can have a single outpoint be associated with
+    /// more than one completed-deposit event because of reorgs.
+    pub completed_deposit_events: HashMap<OutPoint, CompletedDepositEvent>,
 }
 
 impl Store {
@@ -610,6 +635,54 @@ impl super::DbWrite for SharedStore {
             .await
             .rotate_keys_transactions
             .insert(key_rotation.txid.clone(), key_rotation.clone());
+
+        Ok(())
+    }
+
+    async fn write_withdrawal_create_event(
+        &self,
+        event: &WithdrawalCreateEvent,
+    ) -> Result<(), Self::Error> {
+        self.lock()
+            .await
+            .withdrawal_create_events
+            .insert(event.request_id, event.clone());
+
+        Ok(())
+    }
+
+    async fn write_withdrawal_accept_event(
+        &self,
+        event: &WithdrawalAcceptEvent,
+    ) -> Result<(), Self::Error> {
+        self.lock()
+            .await
+            .withdrawal_accept_events
+            .insert(event.request_id, event.clone());
+
+        Ok(())
+    }
+
+    async fn write_withdrawal_reject_event(
+        &self,
+        event: &WithdrawalRejectEvent,
+    ) -> Result<(), Self::Error> {
+        self.lock()
+            .await
+            .withdrawal_reject_events
+            .insert(event.request_id, event.clone());
+
+        Ok(())
+    }
+
+    async fn write_completed_deposit_event(
+        &self,
+        event: &CompletedDepositEvent,
+    ) -> Result<(), Self::Error> {
+        self.lock()
+            .await
+            .completed_deposit_events
+            .insert(event.outpoint, event.clone());
 
         Ok(())
     }

--- a/signer/src/storage/in_memory.rs
+++ b/signer/src/storage/in_memory.rs
@@ -1,19 +1,19 @@
 //! In-memory store implementation - useful for tests
 
+use bitcoin::OutPoint;
 use blockstack_lib::types::chainstate::StacksBlockId;
 use futures::StreamExt;
 use futures::TryStreamExt;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::Mutex;
-use bitcoin::OutPoint;
 
 use crate::keys::PublicKey;
-use crate::storage::model;
 use crate::stacks::events::CompletedDepositEvent;
 use crate::stacks::events::WithdrawalAcceptEvent;
 use crate::stacks::events::WithdrawalCreateEvent;
 use crate::stacks::events::WithdrawalRejectEvent;
+use crate::storage::model;
 
 /// A store wrapped in an Arc<Mutex<...>> for interior mutability
 pub type SharedStore = Arc<Mutex<Store>>;

--- a/signer/src/storage/mod.rs
+++ b/signer/src/storage/mod.rs
@@ -15,6 +15,10 @@ use std::future::Future;
 use blockstack_lib::types::chainstate::StacksBlockId;
 
 use crate::keys::PublicKey;
+use crate::stacks::events::CompletedDepositEvent;
+use crate::stacks::events::WithdrawalAcceptEvent;
+use crate::stacks::events::WithdrawalCreateEvent;
+use crate::stacks::events::WithdrawalRejectEvent;
 
 /// Represents the ability to read data from the signer storage.
 pub trait DbRead {
@@ -219,5 +223,29 @@ pub trait DbWrite {
     fn write_rotate_keys_transaction(
         &self,
         key_rotation: &model::RotateKeysTransaction,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+
+    /// Write the withdrawal-reject event to the database.
+    fn write_withdrawal_reject_event(
+        &self,
+        event: &WithdrawalRejectEvent,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+
+    /// Write the withdrawal-accept event to the database.
+    fn write_withdrawal_accept_event(
+        &self,
+        event: &WithdrawalAcceptEvent,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+
+    /// Write the withdrawal-create event to the database.
+    fn write_withdrawal_create_event(
+        &self,
+        event: &WithdrawalCreateEvent,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+
+    /// Write the completed deposit event to the database.
+    fn write_completed_deposit_event(
+        &self,
+        event: &CompletedDepositEvent,
     ) -> impl Future<Output = Result<(), Self::Error>> + Send;
 }

--- a/signer/src/storage/model.rs
+++ b/signer/src/storage/model.rs
@@ -1,11 +1,8 @@
 //! Database models for the signer.
 
-use std::ops::Range;
-
 use bitcoin::hashes::Hash as _;
 use bitcoin::Address;
 use bitcoin::Network;
-use rand::seq::IteratorRandom as _;
 use sbtc::deposits::Deposit;
 
 use crate::keys::PublicKey;
@@ -71,27 +68,11 @@ pub struct DepositRequest {
     #[cfg_attr(feature = "testing", dummy(faker = "100..i64::MAX as u64"))]
     pub max_fee: u64,
     /// The addresses of the input UTXOs funding the deposit request.
-    #[cfg_attr(feature = "testing", dummy(faker = "BitcoinAddresses(1..5)"))]
+    #[cfg_attr(
+        feature = "testing",
+        dummy(faker = "crate::testing::dummy::BitcoinAddresses(1..5)")
+    )]
     pub sender_addresses: Vec<BitcoinAddress>,
-}
-
-/// Used to for fine-grained control of generating fake testing addresses.
-#[cfg(feature = "testing")]
-#[derive(Debug)]
-pub struct BitcoinAddresses(Range<usize>);
-
-#[cfg(feature = "testing")]
-impl fake::Dummy<BitcoinAddresses> for Vec<String> {
-    fn dummy_with_rng<R: rand::Rng + ?Sized>(config: &BitcoinAddresses, rng: &mut R) -> Self {
-        let num_addresses = config.0.clone().choose(rng).unwrap_or(1);
-        std::iter::repeat_with(|| secp256k1::Keypair::new_global(rng))
-            .take(num_addresses)
-            .map(|kp| {
-                let pk = bitcoin::CompressedPublicKey(kp.public_key());
-                Address::p2wpkh(&pk, Network::Regtest).to_string()
-            })
-            .collect()
-    }
 }
 
 impl DepositRequest {

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -1232,8 +1232,7 @@ impl super::DbWrite for PgStore {
           , txid
           , output_index
         )
-        VALUES ($1, $2, $3)
-        ON CONFLICT DO NOTHING",
+        VALUES ($1, $2, $3)",
         )
         .bind(i64::try_from(event.amount).map_err(Error::ConversionDatabaseInt)?)
         .bind(event.outpoint.txid.to_byte_array())
@@ -1259,8 +1258,7 @@ impl super::DbWrite for PgStore {
           , max_fee
           , block_height
         )
-        VALUES ($1, $2, $3, $4, $5, $6)
-        ON CONFLICT DO NOTHING",
+        VALUES ($1, $2, $3, $4, $5, $6)",
         )
         .bind(i64::try_from(event.request_id).map_err(Error::ConversionDatabaseInt)?)
         .bind(i64::try_from(event.amount).map_err(Error::ConversionDatabaseInt)?)
@@ -1288,8 +1286,7 @@ impl super::DbWrite for PgStore {
           , output_index
           , fee
         )
-        VALUES ($1, $2, $3, $4, $5)
-        ON CONFLICT DO NOTHING",
+        VALUES ($1, $2, $3, $4, $5)",
         )
         .bind(i64::try_from(event.request_id).map_err(Error::ConversionDatabaseInt)?)
         .bind(event.signer_bitmap.into_inner())
@@ -1313,8 +1310,7 @@ impl super::DbWrite for PgStore {
             request_id
           , signer_bitmap
         )
-        VALUES ($1, $2)
-        ON CONFLICT DO NOTHING",
+        VALUES ($1, $2)",
         )
         .bind(i64::try_from(event.request_id).map_err(Error::ConversionDatabaseInt)?)
         .bind(event.signer_bitmap.into_inner())

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -1228,12 +1228,14 @@ impl super::DbWrite for PgStore {
         sqlx::query(
             "
         INSERT INTO sbtc_signer.completed_deposit_events (
-            amount
-          , txid
+            txid
+          , amount
+          , bitcoin_txid
           , output_index
         )
-        VALUES ($1, $2, $3)",
+        VALUES ($1, $2, $3, $4)",
         )
+        .bind(event.txid.0)
         .bind(i64::try_from(event.amount).map_err(Error::ConversionDatabaseInt)?)
         .bind(event.outpoint.txid.to_byte_array())
         .bind(event.outpoint.vout as i64)
@@ -1251,15 +1253,17 @@ impl super::DbWrite for PgStore {
         sqlx::query(
             "
         INSERT INTO sbtc_signer.withdrawal_create_events (
-            request_id
+            txid
+          , request_id
           , amount
           , sender
           , recipient
           , max_fee
           , block_height
         )
-        VALUES ($1, $2, $3, $4, $5, $6)",
+        VALUES ($1, $2, $3, $4, $5, $6, $7)",
         )
+        .bind(event.txid.0)
         .bind(i64::try_from(event.request_id).map_err(Error::ConversionDatabaseInt)?)
         .bind(i64::try_from(event.amount).map_err(Error::ConversionDatabaseInt)?)
         .bind(event.sender.to_string())
@@ -1280,14 +1284,16 @@ impl super::DbWrite for PgStore {
         sqlx::query(
             "
         INSERT INTO sbtc_signer.withdrawal_accept_events (
-            request_id
+            txid
+          , request_id
           , signer_bitmap
-          , txid
+          , bitcoin_txid
           , output_index
           , fee
         )
-        VALUES ($1, $2, $3, $4, $5)",
+        VALUES ($1, $2, $3, $4, $5, $6)",
         )
+        .bind(event.txid.0)
         .bind(i64::try_from(event.request_id).map_err(Error::ConversionDatabaseInt)?)
         .bind(event.signer_bitmap.into_inner())
         .bind(event.outpoint.txid.to_byte_array())
@@ -1307,11 +1313,13 @@ impl super::DbWrite for PgStore {
         sqlx::query(
             "
         INSERT INTO sbtc_signer.withdrawal_reject_events (
-            request_id
+            txid
+          , request_id
           , signer_bitmap
         )
-        VALUES ($1, $2)",
+        VALUES ($1, $2, $3)",
         )
+        .bind(event.txid.0)
         .bind(i64::try_from(event.request_id).map_err(Error::ConversionDatabaseInt)?)
         .bind(event.signer_bitmap.into_inner())
         .execute(&self.0)

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -183,114 +183,6 @@ impl PgStore {
 
         Ok(model::TransactionIds { tx_ids, block_hashes })
     }
-
-    /// Write the completed deposit event to the database.
-    pub async fn write_completed_deposit_event(
-        &self,
-        event: &CompletedDepositEvent,
-    ) -> Result<(), Error> {
-        sqlx::query(
-            "
-        INSERT INTO sbtc_signer.completed_deposit_events (
-            amount
-          , txid
-          , output_index
-        )
-        VALUES ($1, $2, $3)
-        ON CONFLICT DO NOTHING",
-        )
-        .bind(i64::try_from(event.amount).map_err(Error::ConversionDatabaseInt)?)
-        .bind(event.outpoint.txid.to_byte_array())
-        .bind(event.outpoint.vout as i64)
-        .execute(&self.0)
-        .await
-        .map_err(Error::SqlxQuery)?;
-
-        Ok(())
-    }
-
-    /// Write the completed deposit event to the database.
-    pub async fn write_withdrawal_create_event(
-        &self,
-        event: &WithdrawalCreateEvent,
-    ) -> Result<(), Error> {
-        sqlx::query(
-            "
-        INSERT INTO sbtc_signer.withdrawal_create_events (
-            request_id
-          , amount
-          , sender
-          , recipient
-          , max_fee
-          , block_height
-        )
-        VALUES ($1, $2, $3, $4, $5, $6)
-        ON CONFLICT DO NOTHING",
-        )
-        .bind(i64::try_from(event.request_id).map_err(Error::ConversionDatabaseInt)?)
-        .bind(i64::try_from(event.amount).map_err(Error::ConversionDatabaseInt)?)
-        .bind(event.sender.to_string())
-        .bind(event.recipient.to_string())
-        .bind(i64::try_from(event.max_fee).map_err(Error::ConversionDatabaseInt)?)
-        .bind(i64::try_from(event.block_height).map_err(Error::ConversionDatabaseInt)?)
-        .execute(&self.0)
-        .await
-        .map_err(Error::SqlxQuery)?;
-
-        Ok(())
-    }
-
-    /// Write the completed deposit event to the database.
-    pub async fn write_withdrawal_accept_event(
-        &self,
-        event: &WithdrawalAcceptEvent,
-    ) -> Result<(), Error> {
-        sqlx::query(
-            "
-        INSERT INTO sbtc_signer.withdrawal_accept_events (
-            request_id
-          , signer_bitmap
-          , txid
-          , output_index
-          , fee
-        )
-        VALUES ($1, $2, $3, $4, $5)
-        ON CONFLICT DO NOTHING",
-        )
-        .bind(i64::try_from(event.request_id).map_err(Error::ConversionDatabaseInt)?)
-        .bind(event.signer_bitmap.into_inner())
-        .bind(event.outpoint.txid.to_byte_array())
-        .bind(event.outpoint.vout as i64)
-        .bind(i64::try_from(event.fee).map_err(Error::ConversionDatabaseInt)?)
-        .execute(&self.0)
-        .await
-        .map_err(Error::SqlxQuery)?;
-
-        Ok(())
-    }
-
-    /// Write the completed deposit event to the database.
-    pub async fn write_withdrawal_reject_event(
-        &self,
-        event: &WithdrawalRejectEvent,
-    ) -> Result<(), Error> {
-        sqlx::query(
-            "
-        INSERT INTO sbtc_signer.withdrawal_reject_events (
-            request_id
-          , signer_bitmap
-        )
-        VALUES ($1, $2)
-        ON CONFLICT DO NOTHING",
-        )
-        .bind(i64::try_from(event.request_id).map_err(Error::ConversionDatabaseInt)?)
-        .bind(event.signer_bitmap.into_inner())
-        .execute(&self.0)
-        .await
-        .map_err(Error::SqlxQuery)?;
-
-        Ok(())
-    }
 }
 
 impl From<sqlx::PgPool> for PgStore {
@@ -1322,6 +1214,110 @@ impl super::DbWrite for PgStore {
         .bind(key_rotation.aggregate_key)
         .bind(&key_rotation.signer_set)
         .bind(key_rotation.signatures_required as i32)
+        .execute(&self.0)
+        .await
+        .map_err(Error::SqlxQuery)?;
+
+        Ok(())
+    }
+
+    async fn write_completed_deposit_event(
+        &self,
+        event: &CompletedDepositEvent,
+    ) -> Result<(), Error> {
+        sqlx::query(
+            "
+        INSERT INTO sbtc_signer.completed_deposit_events (
+            amount
+          , txid
+          , output_index
+        )
+        VALUES ($1, $2, $3)
+        ON CONFLICT DO NOTHING",
+        )
+        .bind(i64::try_from(event.amount).map_err(Error::ConversionDatabaseInt)?)
+        .bind(event.outpoint.txid.to_byte_array())
+        .bind(event.outpoint.vout as i64)
+        .execute(&self.0)
+        .await
+        .map_err(Error::SqlxQuery)?;
+
+        Ok(())
+    }
+
+    async fn write_withdrawal_create_event(
+        &self,
+        event: &WithdrawalCreateEvent,
+    ) -> Result<(), Error> {
+        sqlx::query(
+            "
+        INSERT INTO sbtc_signer.withdrawal_create_events (
+            request_id
+          , amount
+          , sender
+          , recipient
+          , max_fee
+          , block_height
+        )
+        VALUES ($1, $2, $3, $4, $5, $6)
+        ON CONFLICT DO NOTHING",
+        )
+        .bind(i64::try_from(event.request_id).map_err(Error::ConversionDatabaseInt)?)
+        .bind(i64::try_from(event.amount).map_err(Error::ConversionDatabaseInt)?)
+        .bind(event.sender.to_string())
+        .bind(event.recipient.to_string())
+        .bind(i64::try_from(event.max_fee).map_err(Error::ConversionDatabaseInt)?)
+        .bind(i64::try_from(event.block_height).map_err(Error::ConversionDatabaseInt)?)
+        .execute(&self.0)
+        .await
+        .map_err(Error::SqlxQuery)?;
+
+        Ok(())
+    }
+
+    async fn write_withdrawal_accept_event(
+        &self,
+        event: &WithdrawalAcceptEvent,
+    ) -> Result<(), Error> {
+        sqlx::query(
+            "
+        INSERT INTO sbtc_signer.withdrawal_accept_events (
+            request_id
+          , signer_bitmap
+          , txid
+          , output_index
+          , fee
+        )
+        VALUES ($1, $2, $3, $4, $5)
+        ON CONFLICT DO NOTHING",
+        )
+        .bind(i64::try_from(event.request_id).map_err(Error::ConversionDatabaseInt)?)
+        .bind(event.signer_bitmap.into_inner())
+        .bind(event.outpoint.txid.to_byte_array())
+        .bind(event.outpoint.vout as i64)
+        .bind(i64::try_from(event.fee).map_err(Error::ConversionDatabaseInt)?)
+        .execute(&self.0)
+        .await
+        .map_err(Error::SqlxQuery)?;
+
+        Ok(())
+    }
+
+    async fn write_withdrawal_reject_event(
+        &self,
+        event: &WithdrawalRejectEvent,
+    ) -> Result<(), Error> {
+        sqlx::query(
+            "
+        INSERT INTO sbtc_signer.withdrawal_reject_events (
+            request_id
+          , signer_bitmap
+        )
+        VALUES ($1, $2)
+        ON CONFLICT DO NOTHING",
+        )
+        .bind(i64::try_from(event.request_id).map_err(Error::ConversionDatabaseInt)?)
+        .bind(event.signer_bitmap.into_inner())
         .execute(&self.0)
         .await
         .map_err(Error::SqlxQuery)?;

--- a/signer/src/testing/dummy.rs
+++ b/signer/src/testing/dummy.rs
@@ -8,6 +8,7 @@ use bitcoin::Address;
 use bitcoin::Network;
 use bitcoin::OutPoint;
 use bitvec::array::BitArray;
+use blockstack_lib::burnchains::Txid as StacksTxid;
 use blockstack_lib::chainstate::{nakamoto, stacks};
 use fake::Fake;
 use rand::seq::IteratorRandom as _;
@@ -260,6 +261,7 @@ impl<T> fake::Dummy<T> for WithdrawalAcceptEvent {
     fn dummy_with_rng<R: Rng + ?Sized>(_: &T, rng: &mut R) -> Self {
         let bitmap = rng.next_u64() as u128;
         WithdrawalAcceptEvent {
+            txid: StacksTxid(fake::Faker.fake_with_rng(rng)),
             request_id: rng.next_u32() as u64,
             signer_bitmap: BitArray::new(bitmap.to_le_bytes()),
             outpoint: OutPoint {
@@ -275,6 +277,7 @@ impl<T> fake::Dummy<T> for WithdrawalRejectEvent {
     fn dummy_with_rng<R: Rng + ?Sized>(_: &T, rng: &mut R) -> Self {
         let bitmap = rng.next_u64() as u128;
         WithdrawalRejectEvent {
+            txid: StacksTxid(fake::Faker.fake_with_rng(rng)),
             request_id: rng.next_u32() as u64,
             signer_bitmap: BitArray::new(bitmap.to_le_bytes()),
         }
@@ -289,6 +292,7 @@ impl<T> fake::Dummy<T> for WithdrawalCreateEvent {
         let pk = bitcoin::CompressedPublicKey(kp.public_key());
 
         WithdrawalCreateEvent {
+            txid: StacksTxid(fake::Faker.fake_with_rng(rng)),
             request_id: rng.next_u32() as u64,
             amount: rng.next_u32() as u64,
             sender: StacksAddress::new(version, Hash160(address_hash)).into(),
@@ -302,6 +306,7 @@ impl<T> fake::Dummy<T> for WithdrawalCreateEvent {
 impl<T> fake::Dummy<T> for CompletedDepositEvent {
     fn dummy_with_rng<R: Rng + ?Sized>(_: &T, rng: &mut R) -> Self {
         CompletedDepositEvent {
+            txid: StacksTxid(fake::Faker.fake_with_rng(rng)),
             outpoint: OutPoint {
                 txid: txid(&fake::Faker, rng),
                 vout: rng.next_u32(),

--- a/signer/src/testing/dummy.rs
+++ b/signer/src/testing/dummy.rs
@@ -257,15 +257,15 @@ impl fake::Dummy<BitcoinAddresses> for Vec<String> {
     }
 }
 
-impl<T> fake::Dummy<T> for WithdrawalAcceptEvent {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &T, rng: &mut R) -> Self {
+impl fake::Dummy<fake::Faker> for WithdrawalAcceptEvent {
+    fn dummy_with_rng<R: Rng + ?Sized>(config: &fake::Faker, rng: &mut R) -> Self {
         let bitmap = rng.next_u64() as u128;
         WithdrawalAcceptEvent {
-            txid: StacksTxid(fake::Faker.fake_with_rng(rng)),
+            txid: StacksTxid(config.fake_with_rng(rng)),
             request_id: rng.next_u32() as u64,
             signer_bitmap: BitArray::new(bitmap.to_le_bytes()),
             outpoint: OutPoint {
-                txid: txid(&fake::Faker, rng),
+                txid: txid(config, rng),
                 vout: rng.next_u32(),
             },
             fee: rng.next_u32() as u64,
@@ -273,26 +273,26 @@ impl<T> fake::Dummy<T> for WithdrawalAcceptEvent {
     }
 }
 
-impl<T> fake::Dummy<T> for WithdrawalRejectEvent {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &T, rng: &mut R) -> Self {
+impl fake::Dummy<fake::Faker> for WithdrawalRejectEvent {
+    fn dummy_with_rng<R: Rng + ?Sized>(config: &fake::Faker, rng: &mut R) -> Self {
         let bitmap = rng.next_u64() as u128;
         WithdrawalRejectEvent {
-            txid: StacksTxid(fake::Faker.fake_with_rng(rng)),
+            txid: StacksTxid(config.fake_with_rng(rng)),
             request_id: rng.next_u32() as u64,
             signer_bitmap: BitArray::new(bitmap.to_le_bytes()),
         }
     }
 }
 
-impl<T> fake::Dummy<T> for WithdrawalCreateEvent {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &T, rng: &mut R) -> Self {
-        let address_hash: [u8; 20] = fake::Faker.fake_with_rng(rng);
+impl fake::Dummy<fake::Faker> for WithdrawalCreateEvent {
+    fn dummy_with_rng<R: Rng + ?Sized>(config: &fake::Faker, rng: &mut R) -> Self {
+        let address_hash: [u8; 20] = config.fake_with_rng(rng);
         let version = C32_ADDRESS_VERSION_TESTNET_SINGLESIG;
         let kp = secp256k1::Keypair::new_global(rng);
         let pk = bitcoin::CompressedPublicKey(kp.public_key());
 
         WithdrawalCreateEvent {
-            txid: StacksTxid(fake::Faker.fake_with_rng(rng)),
+            txid: StacksTxid(config.fake_with_rng(rng)),
             request_id: rng.next_u32() as u64,
             amount: rng.next_u32() as u64,
             sender: StacksAddress::new(version, Hash160(address_hash)).into(),
@@ -303,12 +303,12 @@ impl<T> fake::Dummy<T> for WithdrawalCreateEvent {
     }
 }
 
-impl<T> fake::Dummy<T> for CompletedDepositEvent {
-    fn dummy_with_rng<R: Rng + ?Sized>(_: &T, rng: &mut R) -> Self {
+impl fake::Dummy<fake::Faker> for CompletedDepositEvent {
+    fn dummy_with_rng<R: Rng + ?Sized>(config: &fake::Faker, rng: &mut R) -> Self {
         CompletedDepositEvent {
-            txid: StacksTxid(fake::Faker.fake_with_rng(rng)),
+            txid: StacksTxid(config.fake_with_rng(rng)),
             outpoint: OutPoint {
-                txid: txid(&fake::Faker, rng),
+                txid: txid(config, rng),
                 vout: rng.next_u32(),
             },
             amount: rng.next_u32() as u64,

--- a/signer/src/testing/mod.rs
+++ b/signer/src/testing/mod.rs
@@ -17,6 +17,9 @@ use bitcoin::Witness;
 use bitcoin::XOnlyPublicKey;
 use secp256k1::SECP256K1;
 
+/// The path for the configuration file that we should use during testing.
+pub const DEFAULT_CONFIG_PATH: Option<&str> = Some("./src/config/default");
+
 /// A helper function for correctly setting witness data
 pub fn set_witness_data(unsigned: &mut UnsignedTransaction, keypair: secp256k1::Keypair) {
     let sighash_type = TapSighashType::Default;

--- a/signer/tests/fixtures/complete-deposit-event.json
+++ b/signer/tests/fixtures/complete-deposit-event.json
@@ -1,0 +1,194 @@
+{
+    "anchored_cost": {
+        "read_count": 28,
+        "read_length": 42790,
+        "runtime": 80123,
+        "write_count": 3,
+        "write_length": 139
+    },
+    "block_hash": "0x6bf165f5a1930cca370cf28158d6d86c9ed8103a6066de6138f5fff0c7835590",
+    "block_height": 227,
+    "burn_block_hash": "0x15e7d138f2b0b155418f588b7c193eae38f7943a83b4aa1af17aebec6f0e364f",
+    "burn_block_height": 136,
+    "burn_block_time": 1725050720,
+    "confirmed_microblocks_cost": {
+        "read_count": 0,
+        "read_length": 0,
+        "runtime": 0,
+        "write_count": 0,
+        "write_length": 0
+    },
+    "cycle_number": null,
+    "events": [
+        {
+            "committed": true,
+            "contract_event": {
+                "contract_identifier": "SN2V7WTJ7BHR03MPHZ1C9A9ZR6NZGR4WM8HT4V67Y.sbtc-registry",
+                "raw_value": "0x0c0000000406616d6f756e7401000000000000000000000000075ed2850c626974636f696e2d74786964020000002000000000000000000000000000000000000000000000000000000000000000000c6f75747075742d696e64657801000000000000000000000000ffffffff05746f7069630d00000011636f6d706c657465642d6465706f736974",
+                "topic": "print",
+                "value": {
+                    "Tuple": {
+                        "data_map": {
+                            "amount": {
+                                "UInt": 123654789
+                            },
+                            "bitcoin-txid": {
+                                "Sequence": {
+                                    "Buffer": {
+                                        "data": [
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0
+                                        ]
+                                    }
+                                }
+                            },
+                            "output-index": {
+                                "UInt": 4294967295
+                            },
+                            "topic": {
+                                "Sequence": {
+                                    "String": {
+                                        "ASCII": {
+                                            "data": [
+                                                99,
+                                                111,
+                                                109,
+                                                112,
+                                                108,
+                                                101,
+                                                116,
+                                                101,
+                                                100,
+                                                45,
+                                                100,
+                                                101,
+                                                112,
+                                                111,
+                                                115,
+                                                105,
+                                                116
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "type_signature": {
+                            "type_map": {
+                                "amount": "UIntType",
+                                "bitcoin-txid": {
+                                    "SequenceType": {
+                                        "BufferType": 32
+                                    }
+                                },
+                                "output-index": "UIntType",
+                                "topic": {
+                                    "SequenceType": {
+                                        "StringType": {
+                                            "ASCII": 17
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "event_index": 1,
+            "txid": "0x58a9074c3299c2f627829b7e5ecf8b7136e380cbce3900461c679939925f77bc",
+            "type": "contract_event"
+        }
+    ],
+    "index_block_hash": "0xacf821a2df6700046a2e2cd8042b394bcae4d62aadd3e940597658ece9852c30",
+    "matured_miner_rewards": [],
+    "miner_signature": "0x01b2d4622b2e17c65e93c232f8009af1b143ceac0d7746a76db252db7fe8618c1d59fc3d24285aaf3360e207b498749e70d86a2df6146a3dd96a204ca7fa388a78",
+    "miner_txid": "0x5349bb3131e563b1daae3f5abadcb250d5f1a985177ebf11068d5e1dc8266629",
+    "parent_block_hash": "0x9d1dc0ff0fae7648ddaa0fdd30fcf5e4f5c587f172959a2e602d678e6f08cae0",
+    "parent_burn_block_hash": "0x15e7d138f2b0b155418f588b7c193eae38f7943a83b4aa1af17aebec6f0e364f",
+    "parent_burn_block_height": 136,
+    "parent_burn_block_timestamp": 1725050720,
+    "parent_index_block_hash": "0x1d8063dcc9061138bbcd89f5eab10dedf970526af50bedef542bba592228db74",
+    "parent_microblock": "0x0000000000000000000000000000000000000000000000000000000000000000",
+    "parent_microblock_sequence": 0,
+    "pox_v1_unlock_height": 104,
+    "pox_v2_unlock_height": 106,
+    "pox_v3_unlock_height": 109,
+    "reward_set": null,
+    "signer_bitvec": "000800000001ff",
+    "signer_signature": [
+        "0075708c545456ad085204a87ae0b22229c53aaf325e84e1e52e99bed4c74b727a540dbafecbec69179af3201a881d250bd45b67bc8ada7b008f50e811d49159d4",
+        "01d620ebcfc4a18b781369ad9f996e87ecaa617852a3b92c420c633627c88da9e97058e896290df6ddd0070f8838970c39e46d756690017fe24545252cf7078b28",
+        "002cee5b1219127b8784d2c973ffa6de044bd5636c1b3a3db08b701c17ab6875ad394e3ea55e37d46db5292fb61e52744d1420c38ac910b6b92691c0091c2adbf2"
+    ],
+    "signer_signature_hash": "0x6bf165f5a1930cca370cf28158d6d86c9ed8103a6066de6138f5fff0c7835590",
+    "transactions": [
+        {
+            "burnchain_op": null,
+            "contract_abi": null,
+            "execution_cost": {
+                "read_count": 28,
+                "read_length": 42790,
+                "runtime": 80123,
+                "write_count": 3,
+                "write_length": 139
+            },
+            "microblock_hash": null,
+            "microblock_parent_hash": null,
+            "microblock_sequence": null,
+            "raw_result": "0x070703",
+            "raw_tx": "0x80800000000405b67e6a475c7001d2d1f8589527f8357f0c1394440000000000000005000000000001e07800000003020005426366ae35702fbe63153afa0548b74b67ec94b8c356ed603bccc5e83a05445bd1bbb13703fad948f16443ca2a5c632ac642713f4d15d3964a230118701b38020144f48d62736cbe730394468f8f9ad1e482d5e4f091b98b581a88d1163b3ed8c02f2ae726627c5c8f090e3ac7eaa86d38df46d5891eef92449ddff22dfb2bb97b0200652613e261d9be17a6c690c53cf90a81d005eff00c46f43c07bd6806723d45ed4a258f4eab6393f5136c789d96864875f28e8dbeadf6db2446587648f1b7b0f400020301000000000215b67e6a475c7001d2d1f8589527f8357f0c1394440c736274632d6465706f73697418636f6d706c6574652d6465706f7369742d77726170706572000000040200000020000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000ffffffff01000000000000000000000000075ed2850515b67e6a475c7001d2d1f8589527f8357f0c139444",
+            "status": "success",
+            "tx_index": 0,
+            "txid": "0x58a9074c3299c2f627829b7e5ecf8b7136e380cbce3900461c679939925f77bc"
+        },
+        {
+            "burnchain_op": null,
+            "contract_abi": null,
+            "execution_cost": {
+                "read_count": 0,
+                "read_length": 0,
+                "runtime": 0,
+                "write_count": 0,
+                "write_length": 0
+            },
+            "microblock_hash": null,
+            "microblock_parent_hash": null,
+            "microblock_sequence": null,
+            "raw_result": "0x0703",
+            "raw_tx": "0x8080000000040062b0e91cc557e583c3d1f9dfe468ace76d2f03740000000000000041000000000000012c0001f85034c2bf767a4211b295c864527c380b1260741d5368baf8abbf4b4ad8c0c15433af07aa4b24adfca8525fb2ffacfa596eb380e5db4f30d36a417a984da96703020000000000051a93b082ee51d78faf5cc3d84a1c1591246c4965b000000000000003e800000000000000000000000000000000000000000000000000000000000000000000",
+            "status": "success",
+            "tx_index": 1,
+            "txid": "0xf7dea34b0473d7cbb3aebae49a93507dda58e18435e8c496e90253bf07fda3a8"
+        }
+    ]
+}

--- a/signer/tests/fixtures/withdrawal-accept-event.json
+++ b/signer/tests/fixtures/withdrawal-accept-event.json
@@ -1,0 +1,259 @@
+{
+    "anchored_cost": {
+        "read_count": 116,
+        "read_length": 297369,
+        "runtime": 2373429,
+        "write_count": 23,
+        "write_length": 2596
+    },
+    "block_hash": "0x8618f550170be131d4ca877556590ca98e42652c6970f33bcb521ea5786f5efe",
+    "block_height": 301,
+    "burn_block_hash": "0x43031d81b936d345d622ebc6e8c0cb8c9524ef153723fdc3461d1df09b064a5f",
+    "burn_block_height": 140,
+    "burn_block_time": 1725050960,
+    "confirmed_microblocks_cost": {
+        "read_count": 0,
+        "read_length": 0,
+        "runtime": 0,
+        "write_count": 0,
+        "write_length": 0
+    },
+    "cycle_number": null,
+    "events": [
+        {
+            "committed": true,
+            "contract_event": {
+                "contract_identifier": "SN2V7WTJ7BHR03MPHZ1C9A9ZR6NZGR4WM8HT4V67Y.sbtc-registry",
+                "raw_value": "0x0c000000060c626974636f696e2d74786964020000002000000000000000000000000000000000000000000000000000000000000000000366656501000000000000000000000000000009c40c6f75747075742d696e64657801000000000000000000000000ffffffff0a726571756573742d696401000000000000000000000000000000010d7369676e65722d6269746d6170010000000000000000000000000000000005746f7069630d000000117769746864726177616c2d616363657074",
+                "topic": "print",
+                "value": {
+                    "Tuple": {
+                        "data_map": {
+                            "bitcoin-txid": {
+                                "Sequence": {
+                                    "Buffer": {
+                                        "data": [
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0
+                                        ]
+                                    }
+                                }
+                            },
+                            "fee": {
+                                "UInt": 2500
+                            },
+                            "output-index": {
+                                "UInt": 4294967295
+                            },
+                            "request-id": {
+                                "UInt": 1
+                            },
+                            "signer-bitmap": {
+                                "UInt": 0
+                            },
+                            "topic": {
+                                "Sequence": {
+                                    "String": {
+                                        "ASCII": {
+                                            "data": [
+                                                119,
+                                                105,
+                                                116,
+                                                104,
+                                                100,
+                                                114,
+                                                97,
+                                                119,
+                                                97,
+                                                108,
+                                                45,
+                                                97,
+                                                99,
+                                                99,
+                                                101,
+                                                112,
+                                                116
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "type_signature": {
+                            "type_map": {
+                                "bitcoin-txid": {
+                                    "SequenceType": {
+                                        "BufferType": 32
+                                    }
+                                },
+                                "fee": "UIntType",
+                                "output-index": "UIntType",
+                                "request-id": "UIntType",
+                                "signer-bitmap": "UIntType",
+                                "topic": {
+                                    "SequenceType": {
+                                        "StringType": {
+                                            "ASCII": 17
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "event_index": 2,
+            "txid": "0x95a8cf1ed4aa559a0cd8b380174272c3629942a57eb1a2b9aa8281020c36359f",
+            "type": "contract_event"
+        }
+    ],
+    "index_block_hash": "0x0ce5807894c9da8cddcd7b00d15b916f067b1d53487ecc4cae98bc4b7e8fc253",
+    "matured_miner_rewards": [],
+    "miner_signature": "0x0093afff926e01f9474f0b4ead0584a7361ffbc13c41003759ebc599b50c9bf7cb04dfe085898fd84e09b41a6739b596c0187d91769ee3bb2d01676fc9525b9740",
+    "miner_txid": "0x1fbdea52de289061d9c8a0f67c11cc1f53d425cbbc36431a0e3e3659c8f4e599",
+    "parent_block_hash": "0xaa08e0912b07c67b60189b7ceec84dd87658f636309708af857dfdb27e005eb4",
+    "parent_burn_block_hash": "0x43031d81b936d345d622ebc6e8c0cb8c9524ef153723fdc3461d1df09b064a5f",
+    "parent_burn_block_height": 140,
+    "parent_burn_block_timestamp": 1725050960,
+    "parent_index_block_hash": "0x65ffcd8561039711f13f614863f8c4bb4dff17e4e05b0956a0700ae1ee9de69b",
+    "parent_microblock": "0x0000000000000000000000000000000000000000000000000000000000000000",
+    "parent_microblock_sequence": 0,
+    "pox_v1_unlock_height": 104,
+    "pox_v2_unlock_height": 106,
+    "pox_v3_unlock_height": 109,
+    "reward_set": null,
+    "signer_bitvec": "000800000001ff",
+    "signer_signature": [
+        "01b4e92ac4e34799b0c3fbc774dae424bb01595d2cbd148b6b7ae39a4404e406d61400fc1c43ffdfd627fd0a5dd950e4efe649dd4ef4277feebd7733ba9df59e1e",
+        "017b82d1f03d7ffdf99676c484e4029e407a0248f22fd87763e392df968eee74364ac3a3f396bc017d676fb88b8e9c528892d79500bc3b758a31084f4a2b902cc7",
+        "01f0ca5eaca73802ede91e4db6417eda37f7e37073f4c5255e4d3051b1f51190984d6cda9db1d1159071d0843aae19449c4d8f94ab93ac5c45f333c981b1ac2000"
+    ],
+    "signer_signature_hash": "0x8618f550170be131d4ca877556590ca98e42652c6970f33bcb521ea5786f5efe",
+    "transactions": [
+        {
+            "burnchain_op": null,
+            "contract_abi": null,
+            "execution_cost": {
+                "read_count": 38,
+                "read_length": 64075,
+                "runtime": 117077,
+                "write_count": 5,
+                "write_length": 22
+            },
+            "microblock_hash": null,
+            "microblock_parent_hash": null,
+            "microblock_sequence": null,
+            "raw_result": "0x0703",
+            "raw_tx": "0x80800000000405b67e6a475c7001d2d1f8589527f8357f0c1394440000000000000007000000000001e0780000000302019c215bfb9b37d6288b871f262204537105feca2c86cfeb62ebf9d752518379282efb37e8d7cc2e8877db08b0fffc80c9dfe162a0ff88a88a06c499486339cf5f0200ef9aceef6b34dbc1e04373be7e100f021ee613cb043f4b7fd1f38983b8c9cd134591fd90ec156386ccbd16fdf6457dc6f9c5008901b1ec8f2f2b54fa280e4fdd02011f712b16bde7ff16975b81ebb7efddb15e915cc03e3b9fb3cd17cc45de3ec92503881e35ecad84f39a266635445df8f07ed7561e80361b58976ad6a69e7f038b00020301000000000215b67e6a475c7001d2d1f8589527f8357f0c1394440f736274632d7769746864726177616c196163636570742d7769746864726177616c2d7265717565737400000005010000000000000000000000000000000102000000200000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000001000000000000000000000000ffffffff01000000000000000000000000000009c4",
+            "status": "success",
+            "tx_index": 0,
+            "txid": "0x95a8cf1ed4aa559a0cd8b380174272c3629942a57eb1a2b9aa8281020c36359f"
+        },
+        {
+            "burnchain_op": null,
+            "contract_abi": null,
+            "execution_cost": {
+                "read_count": 0,
+                "read_length": 0,
+                "runtime": 0,
+                "write_count": 0,
+                "write_length": 0
+            },
+            "microblock_hash": null,
+            "microblock_parent_hash": null,
+            "microblock_sequence": null,
+            "raw_result": "0x0703",
+            "raw_tx": "0x8080000000040062b0e91cc557e583c3d1f9dfe468ace76d2f03740000000000000059000000000000012c0001418e50f35a9f7c23703e4e87be252600c194bd5c71f019cf9dafc17983940d1315a935a571eee746342e85ee35d31e487c2caa3d05a675490f89ab871a677cf403020000000000051a93b082ee51d78faf5cc3d84a1c1591246c4965b000000000000003e800000000000000000000000000000000000000000000000000000000000000000000",
+            "status": "success",
+            "tx_index": 1,
+            "txid": "0x533338a40b0415af6178d5e1046758ee16184c95b9feddbd99a9d2f0af73af54"
+        },
+        {
+            "burnchain_op": null,
+            "contract_abi": null,
+            "execution_cost": {
+                "read_count": 26,
+                "read_length": 77724,
+                "runtime": 749762,
+                "write_count": 6,
+                "write_length": 858
+            },
+            "microblock_hash": null,
+            "microblock_parent_hash": null,
+            "microblock_sequence": null,
+            "raw_result": "0x070c0000000207737461636b6572051ad540a8a654c4c0f54f910212ff3b119cb2257bb812756e6c6f636b2d6275726e2d68656967687401000000000000000000000000000000b4",
+            "raw_tx": "0x80800000000400d540a8a654c4c0f54f910212ff3b119cb2257bb8000000000000000200000000000003f00001230c0fc3c762ea4b821773fe5fffc8770032a0ada3bd301a7282d1ca54f844b66676584776caf0ae5dde5c55a5890fee8aaa064911350c5d10623e95c1051cef030200000000021a000000000000000000000000000000000000000005706f782d340c737461636b2d657874656e640000000601000000000000000000000000000000010c00000002096861736862797465730200000014d540a8a654c4c0f54f910212ff3b119cb2257bb80776657273696f6e0200000001000a02000000415e2653caa4107d0bccf058aac617ac53895cbb0991ffdcf0d3e30dd772f454da4fc6cfc1d657b68ebbf3f77197fcd6a72f5263ac9e74cd98ebc9c095f3691f3f000200000021028efa20fa5706567008ebaf48f7ae891342eeb944d96392f719c505c89f84ed8d01ffffffffffffffffffffffffffffffff0100000000000000000000bd311381dcf2",
+            "status": "success",
+            "tx_index": 2,
+            "txid": "0xa7d4a0ac8327652bbb202eb2cac50dd893559b5b29ccf88f412022baa9005252"
+        },
+        {
+            "burnchain_op": null,
+            "contract_abi": null,
+            "execution_cost": {
+                "read_count": 26,
+                "read_length": 77785,
+                "runtime": 753295,
+                "write_count": 6,
+                "write_length": 858
+            },
+            "microblock_hash": null,
+            "microblock_parent_hash": null,
+            "microblock_sequence": null,
+            "raw_result": "0x070c0000000207737461636b6572051aecf08f87f8318a104a46ff8dbee72e761988d8eb12756e6c6f636b2d6275726e2d68656967687401000000000000000000000000000000b4",
+            "raw_tx": "0x80800000000400ecf08f87f8318a104a46ff8dbee72e761988d8eb000000000000000200000000000003ef0001072ed11244fa46abc35d767785a3dbc11d646fe0414b91774db1ac663541c0c62d8411dcee0850deaf788d2108cacf9697eaa430670f1ab49904d7fd09bab87f030200000000021a000000000000000000000000000000000000000005706f782d340c737461636b2d657874656e640000000601000000000000000000000000000000010c00000002096861736862797465730200000014ecf08f87f8318a104a46ff8dbee72e761988d8eb0776657273696f6e0200000001000a020000004137d28ab38c1507e63bdf6c98e6c6c5fee240efca183bc6040a9be7cd69340012638c0d205b87fa7ee5d6f1b494ea75927a8759a5fdb3d21c834b65a5fa89c0ad010200000021023f19d77c842b675bd8c858e9ac8b0ca2efa566f17accf8ef9ceb5a992dc6783601ffffffffffffffffffffffffffffffff0100000000000000000000c831e13cb1fc",
+            "status": "success",
+            "tx_index": 3,
+            "txid": "0x6e5f0ee83e5d5271629effdd3bdba9e49040a0b002489a841b7b7f71c1d5d5dd"
+        },
+        {
+            "burnchain_op": null,
+            "contract_abi": null,
+            "execution_cost": {
+                "read_count": 26,
+                "read_length": 77785,
+                "runtime": 753295,
+                "write_count": 6,
+                "write_length": 858
+            },
+            "microblock_hash": null,
+            "microblock_parent_hash": null,
+            "microblock_sequence": null,
+            "raw_result": "0x070c0000000207737461636b6572051aeabc65f3e890fb8bf20d153e95119c72d85765a912756e6c6f636b2d6275726e2d68656967687401000000000000000000000000000000b4",
+            "raw_tx": "0x80800000000400eabc65f3e890fb8bf20d153e95119c72d85765a9000000000000000200000000000003ee00003bb0e8a88e8af714a1e79f10cfcd7adf51cb72475884a5fc2414cdaffa1ca99d063a69b8220f359d0170e7380ff26b9655308e74357eab5e039624a94d0b20bb030200000000021a000000000000000000000000000000000000000005706f782d340c737461636b2d657874656e640000000601000000000000000000000000000000010c00000002096861736862797465730200000014eabc65f3e890fb8bf20d153e95119c72d85765a90776657273696f6e0200000001000a02000000410e73318bbb53a7426b5f8576e1afc63f9e925665d8cc9af35587f7215abb4bcc78c1b18216578003b0d63497f6013b0296b332168532b199d2dac8b7582549d4010200000021029fb154a570a1645af3dd43c3c668a979b59d21a46dd717fd799b13be3b2a0dc701ffffffffffffffffffffffffffffffff01000000000000000000009d24a3105474",
+            "status": "success",
+            "tx_index": 4,
+            "txid": "0x6ddd7e46a1a03ef6b4d78306a1d4c0748892948f5d602770b596794af24e4fb3"
+        }
+    ]
+}

--- a/signer/tests/fixtures/withdrawal-create-event.json
+++ b/signer/tests/fixtures/withdrawal-create-event.json
@@ -1,0 +1,260 @@
+{
+    "anchored_cost": {
+        "read_count": 22,
+        "read_length": 33549,
+        "runtime": 73067,
+        "write_count": 6,
+        "write_length": 216
+    },
+    "block_hash": "0x53fd8cfcd5203274dc960e7f48f9971e5791bda9b51484e3c9635b209901c6cc",
+    "block_height": 253,
+    "burn_block_hash": "0x013b81f12774594243704a9ca20a546813141ee5587c845955e42f588f753316",
+    "burn_block_height": 137,
+    "burn_block_time": 1725050780,
+    "confirmed_microblocks_cost": {
+        "read_count": 0,
+        "read_length": 0,
+        "runtime": 0,
+        "write_count": 0,
+        "write_length": 0
+    },
+    "cycle_number": null,
+    "events": [
+        {
+            "committed": true,
+            "contract_event": {
+                "contract_identifier": "SN2V7WTJ7BHR03MPHZ1C9A9ZR6NZGR4WM8HT4V67Y.sbtc-registry",
+                "raw_value": "0x0c0000000706616d6f756e7401000000000000000000000000000057e40c626c6f636b2d6865696768740100000000000000000000000000000089076d61782d6665650100000000000000000000000000000bb809726563697069656e740c0000000209686173686279746573020000001400000000000000000000000000000000000000000776657273696f6e0200000001000a726571756573742d696401000000000000000000000000000000010673656e6465720515b67e6a475c7001d2d1f8589527f8357f0c13944405746f7069630d000000117769746864726177616c2d637265617465",
+                "topic": "print",
+                "value": {
+                    "Tuple": {
+                        "data_map": {
+                            "amount": {
+                                "UInt": 22500
+                            },
+                            "block-height": {
+                                "UInt": 137
+                            },
+                            "max-fee": {
+                                "UInt": 3000
+                            },
+                            "recipient": {
+                                "Tuple": {
+                                    "data_map": {
+                                        "hashbytes": {
+                                            "Sequence": {
+                                                "Buffer": {
+                                                    "data": [
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        0
+                                                    ]
+                                                }
+                                            }
+                                        },
+                                        "version": {
+                                            "Sequence": {
+                                                "Buffer": {
+                                                    "data": [
+                                                        0
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "type_signature": {
+                                        "type_map": {
+                                            "hashbytes": {
+                                                "SequenceType": {
+                                                    "BufferType": 32
+                                                }
+                                            },
+                                            "version": {
+                                                "SequenceType": {
+                                                    "BufferType": 1
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "request-id": {
+                                "UInt": 1
+                            },
+                            "sender": {
+                                "Principal": {
+                                    "Standard": [
+                                        21,
+                                        [
+                                            182,
+                                            126,
+                                            106,
+                                            71,
+                                            92,
+                                            112,
+                                            1,
+                                            210,
+                                            209,
+                                            248,
+                                            88,
+                                            149,
+                                            39,
+                                            248,
+                                            53,
+                                            127,
+                                            12,
+                                            19,
+                                            148,
+                                            68
+                                        ]
+                                    ]
+                                }
+                            },
+                            "topic": {
+                                "Sequence": {
+                                    "String": {
+                                        "ASCII": {
+                                            "data": [
+                                                119,
+                                                105,
+                                                116,
+                                                104,
+                                                100,
+                                                114,
+                                                97,
+                                                119,
+                                                97,
+                                                108,
+                                                45,
+                                                99,
+                                                114,
+                                                101,
+                                                97,
+                                                116,
+                                                101
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "type_signature": {
+                            "type_map": {
+                                "amount": "UIntType",
+                                "block-height": "UIntType",
+                                "max-fee": "UIntType",
+                                "recipient": {
+                                    "TupleType": {
+                                        "type_map": {
+                                            "hashbytes": {
+                                                "SequenceType": {
+                                                    "BufferType": 32
+                                                }
+                                            },
+                                            "version": {
+                                                "SequenceType": {
+                                                    "BufferType": 1
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "request-id": "UIntType",
+                                "sender": "PrincipalType",
+                                "topic": {
+                                    "SequenceType": {
+                                        "StringType": {
+                                            "ASCII": 17
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "event_index": 2,
+            "txid": "0x25982fe028733fe0158fa3972b68fe93ade7f242fb51283c3bc18145d0248d9a",
+            "type": "contract_event"
+        }
+    ],
+    "index_block_hash": "0x75b02b9884ec41c05f2cfa6e20823328321518dd0b027e7b609b63d4d1ea7c78",
+    "matured_miner_rewards": [],
+    "miner_signature": "0x00bedd886bbc3b72e4bb3427cfd6acc8466036f20942511d0f0468ed1c8c32614436d0ccca5ac783e344f6c02356e63696c48e55a84e21d9af3539c3568207e734",
+    "miner_txid": "0xbfe53413948e7683414635d3976c851686a5d9d851658ddf85f706c185d82811",
+    "parent_block_hash": "0x992d155d9dcb80e00eec8f2acea43b5d9a054b6295f0da7c9965f438c0eb9e73",
+    "parent_burn_block_hash": "0x013b81f12774594243704a9ca20a546813141ee5587c845955e42f588f753316",
+    "parent_burn_block_height": 137,
+    "parent_burn_block_timestamp": 1725050780,
+    "parent_index_block_hash": "0xbed2058c54b8b9763f9f79e576e5fece4a02d71452b33879c9e5628bc3aa5993",
+    "parent_microblock": "0x0000000000000000000000000000000000000000000000000000000000000000",
+    "parent_microblock_sequence": 0,
+    "pox_v1_unlock_height": 104,
+    "pox_v2_unlock_height": 106,
+    "pox_v3_unlock_height": 109,
+    "reward_set": null,
+    "signer_bitvec": "000800000001ff",
+    "signer_signature": [
+        "0092c2fa7aaefaa5206120e04c5d61795af734a824dc8b6d8affabe758928735a97407046f66c6ae9dab300f4701c28f85d68667688ccd47d86431f7fa55e25603",
+        "00a3b00b00ec5d2d5834a4b1465e403a130d4f133fd11ad73909648bc92f012c1a63c222121b76c34b96f126b74be3d3ade874560705ff6d0428f65f50f8d0a25d",
+        "00c986c82e76a6edf5df6214fa759d656a3ff2d4e823f9152e09dd7a731696e1fd0019c26b92dc1c015f60ad22f47114fc81ab2b95d3dd3aa93cb7aa2918c84cb5"
+    ],
+    "signer_signature_hash": "0x53fd8cfcd5203274dc960e7f48f9971e5791bda9b51484e3c9635b209901c6cc",
+    "transactions": [
+        {
+            "burnchain_op": null,
+            "contract_abi": null,
+            "execution_cost": {
+                "read_count": 22,
+                "read_length": 33549,
+                "runtime": 73067,
+                "write_count": 6,
+                "write_length": 216
+            },
+            "microblock_hash": null,
+            "microblock_parent_hash": null,
+            "microblock_sequence": null,
+            "raw_result": "0x070100000000000000000000000000000001",
+            "raw_tx": "0x80800000000405b67e6a475c7001d2d1f8589527f8357f0c1394440000000000000006000000000001e0780000000302016f58f74296efb304398634e681a4300aa93f39155a371ca4406d4aa5dfb76c752a234176a9f1fb636cbd50593b3626a5f5894b06f288e740e9d3aa02d5aec3d1020010afd9f14faa159d31153a821079fdcfd80bfe3662e840eda2383665a113402b66ec622af0ec2c052d8ff5cb508d296fe164dbcc8653ad552625f33947d61944020044e318502c37f69f6e4d0c75825cc47a5f4707d08308288400f4a4f1c434151c24e2a5d10e532bb67e3819babcc4e8d0e5ca4f96dac116349fae44b38d9ba78c00020301000000000215b67e6a475c7001d2d1f8589527f8357f0c1394440f736274632d7769746864726177616c1b696e6974696174652d7769746864726177616c2d726571756573740000000301000000000000000000000000000057e40c0000000209686173686279746573020000001400000000000000000000000000000000000000000776657273696f6e0200000001000100000000000000000000000000000bb8",
+            "status": "success",
+            "tx_index": 0,
+            "txid": "0x25982fe028733fe0158fa3972b68fe93ade7f242fb51283c3bc18145d0248d9a"
+        },
+        {
+            "burnchain_op": null,
+            "contract_abi": null,
+            "execution_cost": {
+                "read_count": 0,
+                "read_length": 0,
+                "runtime": 0,
+                "write_count": 0,
+                "write_length": 0
+            },
+            "microblock_hash": null,
+            "microblock_parent_hash": null,
+            "microblock_sequence": null,
+            "raw_result": "0x0703",
+            "raw_tx": "0x80800000000400ad08341feab8ea788ef8045c343d21dcedc4483e000000000000004a000000000000012c0001b348a285f5dff4de0fafbee44934100167310a0ec0c930a75ba3993c0a2a3e6b1bce06c337d8445cdf65bf41423b187fa42aa4a4e0cd1cbe1095aeafbda8fe8c03020000000000051a62b0e91cc557e583c3d1f9dfe468ace76d2f037400000000000003e800000000000000000000000000000000000000000000000000000000000000000000",
+            "status": "success",
+            "tx_index": 1,
+            "txid": "0x538cb5f2bc1f77892b5b9ef7281c8bdd4c4d6792a80b06fa61fd48c7819b7dfe"
+        }
+    ]
+}

--- a/signer/tests/fixtures/withdrawal-reject-event.json
+++ b/signer/tests/fixtures/withdrawal-reject-event.json
@@ -1,0 +1,149 @@
+{
+    "anchored_cost": {
+        "read_count": 31,
+        "read_length": 51115,
+        "runtime": 92633,
+        "write_count": 5,
+        "write_length": 22
+    },
+    "block_hash": "0x4a4e03eef3326030f42faba09c8bb0177b52f39d9d90c9502de0075c90da2fa6",
+    "block_height": 350,
+    "burn_block_hash": "0x45edc2fdd174ef2949f1370ec67302ccd29c20a6ac58da0895ac77b0783caa04",
+    "burn_block_height": 142,
+    "burn_block_time": 1725051080,
+    "confirmed_microblocks_cost": {
+        "read_count": 0,
+        "read_length": 0,
+        "runtime": 0,
+        "write_count": 0,
+        "write_length": 0
+    },
+    "cycle_number": null,
+    "events": [
+        {
+            "committed": true,
+            "contract_event": {
+                "contract_identifier": "SN2V7WTJ7BHR03MPHZ1C9A9ZR6NZGR4WM8HT4V67Y.sbtc-registry",
+                "raw_value": "0x0c000000030a726571756573742d696401000000000000000000000000000000020d7369676e65722d6269746d6170010000000000000000000000000000000005746f7069630d000000117769746864726177616c2d72656a656374",
+                "topic": "print",
+                "value": {
+                    "Tuple": {
+                        "data_map": {
+                            "request-id": {
+                                "UInt": 2
+                            },
+                            "signer-bitmap": {
+                                "UInt": 0
+                            },
+                            "topic": {
+                                "Sequence": {
+                                    "String": {
+                                        "ASCII": {
+                                            "data": [
+                                                119,
+                                                105,
+                                                116,
+                                                104,
+                                                100,
+                                                114,
+                                                97,
+                                                119,
+                                                97,
+                                                108,
+                                                45,
+                                                114,
+                                                101,
+                                                106,
+                                                101,
+                                                99,
+                                                116
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "type_signature": {
+                            "type_map": {
+                                "request-id": "UIntType",
+                                "signer-bitmap": "UIntType",
+                                "topic": {
+                                    "SequenceType": {
+                                        "StringType": {
+                                            "ASCII": 17
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "event_index": 2,
+            "txid": "0x95e3d38a1a0c001886b3d1d3a4ed376bf9e44cfc2820164457fe4e9a5fa2e450",
+            "type": "contract_event"
+        }
+    ],
+    "index_block_hash": "0xfc1b44b2db9997d9f37ea1c8704318ed8c1bce2f077b6e73fb583deac167ce98",
+    "matured_miner_rewards": [],
+    "miner_signature": "0x008572bf213cbab23671fa186206d7f1292b1d7c83d4b0be59bac4de7bb2dc537c2a273bf61496991515c11ef8f25a951b054e98a9286fe3913972ce1169828f5f",
+    "miner_txid": "0x5be6482d26dcabc102ad7be7010721fd78115df08f3b58cd91e734ab1d3d4871",
+    "parent_block_hash": "0x81d59937124973abb27d07466d47e2e3155f72149f66f2d2830f64426fd05960",
+    "parent_burn_block_hash": "0x45edc2fdd174ef2949f1370ec67302ccd29c20a6ac58da0895ac77b0783caa04",
+    "parent_burn_block_height": 142,
+    "parent_burn_block_timestamp": 1725051080,
+    "parent_index_block_hash": "0x96b3f5a3f19af33ccc66bed0adde0fcf93322fcc9b6ddacd93c3968cbfb248de",
+    "parent_microblock": "0x0000000000000000000000000000000000000000000000000000000000000000",
+    "parent_microblock_sequence": 0,
+    "pox_v1_unlock_height": 104,
+    "pox_v2_unlock_height": 106,
+    "pox_v3_unlock_height": 109,
+    "reward_set": null,
+    "signer_bitvec": "000800000001ff",
+    "signer_signature": [
+        "01a05e94db0e82a0a1e6c35851be3cae5bf1dbb30a64bffe014ab6ced36204c14d27ac483b6cfbe73d88ffcd1a596796627b462c156789bae78263f53419e7c5e2",
+        "013731592cf7585654652375443057ef78bd2267a504343a528e41fba2630baa726fc34ccfe8f9ff42a4f81508ff99a904b08d7260c059b9d986b4a9d26af5dbdd",
+        "00b229992c67772f5480f3d5ac1ed17833a824850bc8c36d11369902cdee27cb5d58872086086613200c085e58657b7e6c604d1a87abe62645ba4f9f8f5a6060f6"
+    ],
+    "signer_signature_hash": "0x4a4e03eef3326030f42faba09c8bb0177b52f39d9d90c9502de0075c90da2fa6",
+    "transactions": [
+        {
+            "burnchain_op": null,
+            "contract_abi": null,
+            "execution_cost": {
+                "read_count": 31,
+                "read_length": 51115,
+                "runtime": 92633,
+                "write_count": 5,
+                "write_length": 22
+            },
+            "microblock_hash": null,
+            "microblock_parent_hash": null,
+            "microblock_sequence": null,
+            "raw_result": "0x0703",
+            "raw_tx": "0x80800000000405b67e6a475c7001d2d1f8589527f8357f0c1394440000000000000009000000000001e078000000030201a6f5f94c13e46ca387c8466f3a0523aa613b05e61a311c51cef6464e57de95d640c8545a9c1d26d162604e66b572e107fd8f5bd03edd55676feded60597047f20201e62b36a7c870c182f9484177cd69436d6a06714ded3ab6016ed6551217aafc7c5c67f62a6ce8dec212435dbf4aa5a4d2dc7385210565377b790fbc71ddac82b4020104a0503fe0a76914b9fabc1b467bdfd278be772695d8ab2256bedde47d78db4b0c288644be085cb4f6efd1db68eae4977592c3408bb87da2299677046d943dd000020301000000000215b67e6a475c7001d2d1f8589527f8357f0c1394440f736274632d7769746864726177616c1972656a6563742d7769746864726177616c2d726571756573740000000201000000000000000000000000000000020100000000000000000000000000000000",
+            "status": "success",
+            "tx_index": 0,
+            "txid": "0x95e3d38a1a0c001886b3d1d3a4ed376bf9e44cfc2820164457fe4e9a5fa2e450"
+        },
+        {
+            "burnchain_op": null,
+            "contract_abi": null,
+            "execution_cost": {
+                "read_count": 0,
+                "read_length": 0,
+                "runtime": 0,
+                "write_count": 0,
+                "write_length": 0
+            },
+            "microblock_hash": null,
+            "microblock_parent_hash": null,
+            "microblock_sequence": null,
+            "raw_result": "0x0703",
+            "raw_tx": "0x80800000000400ad08341feab8ea788ef8045c343d21dcedc4483e0000000000000069000000000000012c0001a4721b7dd6b315354d3c8fc35d0c5cb7862cc640ac4116569c5ed8709e1fe6e80b76dadaedcb8be1c1d9299e97296263e6ff0364b1979a705bed3dfa0e123da603020000000000051a62b0e91cc557e583c3d1f9dfe468ace76d2f037400000000000003e800000000000000000000000000000000000000000000000000000000000000000000",
+            "status": "success",
+            "tx_index": 1,
+            "txid": "0xff33ff3a54b1379f9297ff2840afb4ab17e799ec3bf80f430d0e1aa15bd9d5b7"
+        }
+    ]
+}

--- a/signer/tests/integration/contracts.rs
+++ b/signer/tests/integration/contracts.rs
@@ -100,7 +100,7 @@ impl SignerStxState {
     {
         // If we get an Ok response then we know the contract has been
         // deployed already, and deploying it would probably be harmful (it
-        // appears to stalls subsequent transactions for some reason).
+        // appears to stall subsequent transactions for some reason).
         if self.get_contract_source::<T>().await.is_ok() {
             return;
         }

--- a/signer/tests/integration/contracts.rs
+++ b/signer/tests/integration/contracts.rs
@@ -122,9 +122,9 @@ impl SignerStxState {
     }
 
     /// Get the source of the a deployed smart contract.
-    /// 
+    ///
     /// # Notes
-    /// 
+    ///
     /// This is useful just to know whether a contract has been deployed
     /// already or not. If the smart contract has not been deployed yet,
     /// the stacks node returns a 404 Not Found.

--- a/signer/tests/integration/contracts.rs
+++ b/signer/tests/integration/contracts.rs
@@ -34,7 +34,7 @@ use signer::testing::wallet::InitiateWithdrawalRequest;
 
 use test_case::test_case;
 
-const TX_FEE: u64 = 1500000;
+const TX_FEE: u64 = 123000;
 
 pub struct SbtcTokenContract;
 
@@ -176,9 +176,9 @@ pub async fn deploy_smart_contracts() -> &'static SignerStxState {
     deployer: testing::wallet::WALLET.0.address(),
 }); "complete-deposit contract recipient")]
 #[test_case(ContractCallWrapper(AcceptWithdrawalV1 {
-    request_id: 0,
+    request_id: 1,
     outpoint: bitcoin::OutPoint::null(),
-    tx_fee: 3500,
+    tx_fee: 2500,
     signer_bitmap: BitArray::ZERO,
     deployer: testing::wallet::WALLET.0.address(),
 }); "accept-withdrawal")]
@@ -189,7 +189,7 @@ pub async fn deploy_smart_contracts() -> &'static SignerStxState {
     deployer: testing::wallet::WALLET.0.address(),
 }); "create-withdrawal")]
 #[test_case(ContractCallWrapper(RejectWithdrawalV1 {
-    request_id: 0,
+    request_id: 2,
     signer_bitmap: BitArray::ZERO,
     deployer: testing::wallet::WALLET.0.address(),
 }); "reject-withdrawal")]

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -18,6 +18,10 @@ use signer::stacks::contracts::AsTxPayload as _;
 use signer::stacks::contracts::CompleteDepositV1;
 use signer::stacks::contracts::RejectWithdrawalV1;
 use signer::stacks::contracts::RotateKeysV1;
+use signer::stacks::events::CompletedDepositEvent;
+use signer::stacks::events::WithdrawalAcceptEvent;
+use signer::stacks::events::WithdrawalCreateEvent;
+use signer::stacks::events::WithdrawalRejectEvent;
 use signer::storage;
 use signer::storage::model;
 use signer::storage::DbRead;
@@ -700,5 +704,149 @@ async fn writing_transactions_postgres() {
 
     // let's see, who knows what will happen!
     assert_eq!(num_rows, count as usize);
+    signer::testing::storage::drop_db(store).await;
+}
+
+/// Here we test that we can store completed deposit events.
+#[cfg_attr(not(feature = "integration-tests"), ignore)]
+#[tokio::test]
+async fn writing_completed_deposit_requests_postgres() {
+    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
+    let store = signer::testing::storage::new_test_database(db_num).await;
+
+    let mut rng = rand::rngs::StdRng::seed_from_u64(51);
+    let event: CompletedDepositEvent = fake::Faker.fake_with_rng(&mut rng);
+
+    // Let's see if we can write these rows to the database.
+    store.write_completed_deposit_event(&event).await.unwrap();
+    let mut db_event = sqlx::query_as::<_, (i64, [u8; 32], i64)>(
+        r#"
+            SELECT amount
+                 , txid
+                 , output_index
+            FROM sbtc_signer.completed_deposit_events"#,
+    )
+    .fetch_all(store.pool())
+    .await
+    .unwrap();
+    // Did we only write one row
+    assert_eq!(db_event.len(), 1);
+
+    let (amount, txid, vout) = db_event.pop().unwrap();
+
+    assert_eq!(amount as u64, event.amount);
+    assert_eq!(txid, event.outpoint.txid.to_byte_array());
+    assert_eq!(vout as u32, event.outpoint.vout);
+
+    signer::testing::storage::drop_db(store).await;
+}
+
+/// Here we test that we can store withdrawal-create events.
+#[cfg_attr(not(feature = "integration-tests"), ignore)]
+#[tokio::test]
+async fn writing_withdrawal_create_requests_postgres() {
+    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
+    let store = signer::testing::storage::new_test_database(db_num).await;
+
+    let mut rng = rand::rngs::StdRng::seed_from_u64(51);
+    let event: WithdrawalCreateEvent = fake::Faker.fake_with_rng(&mut rng);
+
+    // Let's see if we can write these rows to the database.
+    store.write_withdrawal_create_event(&event).await.unwrap();
+    let mut db_event = sqlx::query_as::<_, (i64, i64, String, String, i64, i64)>(
+        r#"
+            SELECT request_id
+                 , amount
+                 , sender
+                 , recipient
+                 , max_fee
+                 , block_height
+            FROM sbtc_signer.withdrawal_create_events"#,
+    )
+    .fetch_all(store.pool())
+    .await
+    .unwrap();
+    // Did we only write one row
+    assert_eq!(db_event.len(), 1);
+
+    let (request_id, amount, sender, recipient, max_fee, block_height) = db_event.pop().unwrap();
+
+    assert_eq!(request_id as u64, event.request_id);
+    assert_eq!(amount as u64, event.amount);
+    assert_eq!(sender, event.sender.to_string());
+    assert_eq!(recipient, event.recipient.to_string());
+    assert_eq!(max_fee as u64, event.max_fee);
+    assert_eq!(block_height as u64, event.block_height);
+
+    signer::testing::storage::drop_db(store).await;
+}
+
+/// Here we test that we can store withdrawal-accept events.
+#[cfg_attr(not(feature = "integration-tests"), ignore)]
+#[tokio::test]
+async fn writing_withdrawal_accept_requests_postgres() {
+    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
+    let store = signer::testing::storage::new_test_database(db_num).await;
+
+    let mut rng = rand::rngs::StdRng::seed_from_u64(51);
+    let event: WithdrawalAcceptEvent = fake::Faker.fake_with_rng(&mut rng);
+
+    // Let's see if we can write these rows to the database.
+    store.write_withdrawal_accept_event(&event).await.unwrap();
+    let mut db_event = sqlx::query_as::<_, (i64, [u8; 16], [u8; 32], i64, i64)>(
+        r#"
+            SELECT request_id
+                 , signer_bitmap
+                 , txid
+                 , output_index
+                 , fee
+            FROM sbtc_signer.withdrawal_accept_events"#,
+    )
+    .fetch_all(store.pool())
+    .await
+    .unwrap();
+    // Did we only write one row
+    assert_eq!(db_event.len(), 1);
+
+    let (request_id, bitmap, txid, vout, fee) = db_event.pop().unwrap();
+
+    assert_eq!(request_id as u64, event.request_id);
+    assert_eq!(bitmap, event.signer_bitmap.into_inner());
+    assert_eq!(txid, event.outpoint.txid.to_byte_array());
+    assert_eq!(vout as u32, event.outpoint.vout);
+    assert_eq!(fee as u64, event.fee);
+
+    signer::testing::storage::drop_db(store).await;
+}
+
+/// Here we test that we can store withdrawal-reject events.
+#[cfg_attr(not(feature = "integration-tests"), ignore)]
+#[tokio::test]
+async fn writing_withdrawal_reject_requests_postgres() {
+    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
+    let store = signer::testing::storage::new_test_database(db_num).await;
+
+    let mut rng = rand::rngs::StdRng::seed_from_u64(51);
+    let event: WithdrawalRejectEvent = fake::Faker.fake_with_rng(&mut rng);
+
+    // Let's see if we can write these rows to the database.
+    store.write_withdrawal_reject_event(&event).await.unwrap();
+    let mut db_event = sqlx::query_as::<_, (i64, [u8; 16])>(
+        r#"
+            SELECT request_id
+                 , signer_bitmap
+            FROM sbtc_signer.withdrawal_reject_events"#,
+    )
+    .fetch_all(store.pool())
+    .await
+    .unwrap();
+    // Did we only write one row
+    assert_eq!(db_event.len(), 1);
+
+    let (request_id, bitmap) = db_event.pop().unwrap();
+
+    assert_eq!(request_id as u64, event.request_id);
+    assert_eq!(bitmap, event.signer_bitmap.into_inner());
+
     signer::testing::storage::drop_db(store).await;
 }


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/426. This wraps up the handler for stacks print events.

## Changes

* Add the network to the list of options in the signer's config file.
* Have the private key in the config file to be the generic signer private key.
* Add new tables for our print events from the `sbtc-registry` smart contract.
* Add functions for writing the above print events to the database.
* Add test fixtures for the various print events and unit tests that use them.

## Testing Information

This includes a unit test that checks the deserialization of the webhooks emitted from stacks core. This payload was sent from a stacks core node under Nakamoto on commit https://github.com/stacks-network/stacks-core/commit/cbf0c52fb7a0b8ac55badadcf3773ca0848a25cf which was made on 2024-08-20. The raw body of the webhook was stored as the test fixtures added in this PR. These events were triggered by running test cases in the `complete_deposit_wrapper_tx_accepted` integration test. The stacks node was configured to emit events like so:

```toml
[[events_observer]]
endpoint = "host.docker.internal:8801"
retry_count = 3
include_data_events = false
events_keys = [
    "SN2V7WTJ7BHR03MPHZ1C9A9ZR6NZGR4WM8HT4V67Y.sbtc-registry::print",
]
```

This testing setup followed the same testing setup as in https://github.com/stacks-network/sbtc/pull/303 and https://github.com/stacks-network/sbtc/pull/442. 

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
