### PR TITLE
feat: add config for event observer

### DIFF
--- a/signer/src/config.rs
+++ b/signer/src/config.rs
@@ -210,10 +210,8 @@ impl Validatable for SignerConfig {
 /// Configuration for the Stacks event observer server (hosted within the signer).
 #[derive(Debug, Clone, Deserialize)]
 pub struct EventObserverConfig {
-    /// The address to bind the server to.
-    pub bind: std::net::IpAddr,
-    /// The port to bind the server to.
-    pub port: u16,
+    /// The address and port to bind the server to.
+    pub bind: std::net::SocketAddr,
 }
 
 impl Settings {
@@ -355,7 +353,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::net::IpAddr;
+    use std::net::SocketAddr;
 
     use super::*;
 
@@ -397,9 +395,8 @@ mod tests {
         assert_eq!(settings.signer.network, NetworkKind::Regtest);
         assert_eq!(
             settings.signer.event_observer.bind,
-            "0.0.0.0".parse::<IpAddr>().unwrap()
+            "0.0.0.0:8801".parse::<SocketAddr>().unwrap()
         );
-        assert_eq!(settings.signer.event_observer.port, 8801);
     }
 
     #[test]

--- a/signer/src/config.rs
+++ b/signer/src/config.rs
@@ -68,17 +68,17 @@ pub struct Settings {
 pub struct P2PNetworkConfig {
     /// List of seeds for the P2P network. If empty then the signer will
     /// only use peers discovered via StackerDB.
-    #[serde(deserialize_with = "url_deserializer")]
+    #[serde(deserialize_with = "url_deserializer_vec")]
     pub seeds: Vec<url::Url>,
     /// The local network interface(s) to listen on. If empty, then
     /// the signer will use [`DEFAULT_NETWORK_HOST`]:[`DEFAULT_NETWORK_PORT] as
     /// the default and listen on both TCP and QUIC protocols.
-    #[serde(deserialize_with = "url_deserializer")]
+    #[serde(deserialize_with = "url_deserializer_vec")]
     pub listen_on: Vec<url::Url>,
     /// Optionally specifies the public endpoints of the signer. If empty, the
     /// signer will attempt to use peers in the network to discover its own
     /// public endpoint(s).
-    #[serde(deserialize_with = "url_deserializer")]
+    #[serde(deserialize_with = "url_deserializer_vec")]
     pub public_endpoints: Vec<url::Url>,
 }
 
@@ -196,6 +196,8 @@ pub struct SignerConfig {
     pub p2p: P2PNetworkConfig,
     /// P2P network configuration
     pub network: NetworkKind,
+    /// Event observer server configuration
+    pub event_observer: EventObserverConfig,
 }
 
 impl Validatable for SignerConfig {
@@ -203,6 +205,15 @@ impl Validatable for SignerConfig {
         self.p2p.validate()?;
         Ok(())
     }
+}
+
+/// Configuration for the Stacks event observer server (hosted within the signer).
+#[derive(Debug, Clone, Deserialize)]
+pub struct EventObserverConfig {
+    /// The address to bind the server to.
+    pub bind: std::net::IpAddr,
+    /// The port to bind the server to.
+    pub port: u16,
 }
 
 impl Settings {
@@ -279,7 +290,7 @@ pub struct StacksNodeSettings {
     /// endpoints.
     ///
     /// The endpoint to use when making requests to a stacks node.
-    #[serde(deserialize_with = "url_deserializer")]
+    #[serde(deserialize_with = "url_deserializer_vec")]
     pub endpoints: Vec<url::Url>,
     /// This is the start height of the first EPOCH 3.0 block on the stacks
     /// blockchain.
@@ -322,7 +333,7 @@ impl StacksSettings {
 
 /// A deserializer for the url::Url type. This will return an empty [`Vec`] if
 /// there are no URLs to deserialize.
-fn url_deserializer<'de, D>(deserializer: D) -> Result<Vec<url::Url>, D::Error>
+fn url_deserializer_vec<'de, D>(deserializer: D) -> Result<Vec<url::Url>, D::Error>
 where
     D: Deserializer<'de>,
 {
@@ -344,6 +355,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::net::IpAddr;
+
     use super::*;
 
     use crate::testing::DEFAULT_CONFIG_PATH;
@@ -382,6 +395,11 @@ mod tests {
             vec![url("tcp://0.0.0.0:4122"), url("quic-v1://0.0.0.0:4122")]
         );
         assert_eq!(settings.signer.network, NetworkKind::Regtest);
+        assert_eq!(
+            settings.signer.event_observer.bind,
+            "0.0.0.0".parse::<IpAddr>().unwrap()
+        );
+        assert_eq!(settings.signer.event_observer.port, 8801);
     }
 
     #[test]

--- a/signer/src/config/default.toml
+++ b/signer/src/config/default.toml
@@ -58,6 +58,31 @@ private_key = "8183dc385a7a1fc8353b9e781ee0859a71e57abea478a5bca679334094f7adb5"
 # Possible values: mainnet, testnet, regtest
 # Environment: SIGNER_SIGNER__NETWORK
 network = "regtest"
+
+# !! ==============================================================================
+# !! Stacks Event Observer Configuration
+# !! ==============================================================================
+
+# The event observer listens for events on the Stacks blockchain. The listen 
+# address must be reachable by your Stacks node, and must be configured in the 
+# node's `event_observer` configuration section.
+#
+# This endpoint _does not_ support TLS and are served over HTTP.
+[signer.event_observer]
+# The network interface (ip address) to bind the event observer server to.
+# 
+# Format: "<ip>"
+# Required: true
+# Environment: SIGNER_SIGNER__EVENT_OBSERVER__BIND
+bind = "0.0.0.0"
+
+# The port to bind the event observer server to (on the above bind interface).
+#
+# Format: <port>
+# Required: true
+# Environment: SIGNER_SIGNER__EVENT_OBSERVER__PORT
+port = 8801
+
 # !! ==============================================================================
 # !! Signer P2P Networking Configuration
 # !! ==============================================================================

--- a/signer/src/config/default.toml
+++ b/signer/src/config/default.toml
@@ -61,27 +61,21 @@ network = "regtest"
 
 # !! ==============================================================================
 # !! Stacks Event Observer Configuration
+# !!
+# !! The event observer listens for events on the Stacks blockchain. The listen 
+# !! address must be reachable by your Stacks node, and must be configured in the 
+# !! node's `event_observer` configuration section.
+# !!
+# !! Note that the event observer endpoint _does not_ support TLS and is served 
+# !! over HTTP.
 # !! ==============================================================================
-
-# The event observer listens for events on the Stacks blockchain. The listen 
-# address must be reachable by your Stacks node, and must be configured in the 
-# node's `event_observer` configuration section.
-#
-# This endpoint _does not_ support TLS and are served over HTTP.
 [signer.event_observer]
-# The network interface (ip address) to bind the event observer server to.
+# The network interface (ip address) and port to bind the event observer server to.
 # 
-# Format: "<ip>"
+# Format: "<ip>:<port>"
 # Required: true
 # Environment: SIGNER_SIGNER__EVENT_OBSERVER__BIND
-bind = "0.0.0.0"
-
-# The port to bind the event observer server to (on the above bind interface).
-#
-# Format: <port>
-# Required: true
-# Environment: SIGNER_SIGNER__EVENT_OBSERVER__PORT
-port = 8801
+bind = "0.0.0.0:8801"
 
 # !! ==============================================================================
 # !! Signer P2P Networking Configuration

--- a/signer/src/main.rs
+++ b/signer/src/main.rs
@@ -1,3 +1,4 @@
+use std::net::SocketAddr;
 use std::path::PathBuf;
 
 use axum::routing::get;
@@ -121,9 +122,12 @@ async fn run_stacks_event_observer(ctx: &impl Context) -> Result<(), Error> {
         .route("/new_block", post(api::new_block_handler))
         .with_state(state);
 
+    let config = ctx.config().signer.event_observer.clone();
+
     // run our app with hyper
     // TODO: This should be read from configuration
-    let listener = tokio::net::TcpListener::bind("0.0.0.0:8801").await.unwrap();
+    let bind = SocketAddr::new(config.bind, config.port);
+    let listener = tokio::net::TcpListener::bind(bind).await.unwrap();
 
     // Subscribe to the signal channel so that we can catch shutdown events.
     let mut signal = ctx.get_signal_receiver();

--- a/signer/src/main.rs
+++ b/signer/src/main.rs
@@ -124,14 +124,14 @@ async fn run_stacks_event_observer(ctx: &impl Context) -> Result<(), Error> {
 
     let config = ctx.config().signer.event_observer.clone();
 
-    // run our app with hyper
-    // TODO: This should be read from configuration
+    // Bind to the configured address and port
     let bind = SocketAddr::new(config.bind, config.port);
     let listener = tokio::net::TcpListener::bind(bind).await.unwrap();
 
     // Subscribe to the signal channel so that we can catch shutdown events.
     let mut signal = ctx.get_signal_receiver();
 
+    // Run our app with hyper
     axum::serve(listener, app)
         .with_graceful_shutdown(async move {
             // Listen for an application shutdown signal. We need to loop here

--- a/signer/src/main.rs
+++ b/signer/src/main.rs
@@ -1,4 +1,3 @@
-use std::net::SocketAddr;
 use std::path::PathBuf;
 
 use axum::routing::get;
@@ -125,8 +124,7 @@ async fn run_stacks_event_observer(ctx: &impl Context) -> Result<(), Error> {
     let config = ctx.config().signer.event_observer.clone();
 
     // Bind to the configured address and port
-    let bind = SocketAddr::new(config.bind, config.port);
-    let listener = tokio::net::TcpListener::bind(bind).await.unwrap();
+    let listener = tokio::net::TcpListener::bind(config.bind).await.unwrap();
 
     // Subscribe to the signal channel so that we can catch shutdown events.
     let mut signal = ctx.get_signal_receiver();


### PR DESCRIPTION
## Description

Adds config support for the event observer. 

## Changes

Adds a new configuration section under `signer`: `event_observer`, with two properties: `bind` and `port`.

```toml
# !! ==============================================================================
# !! Stacks Event Observer Configuration
# !! ==============================================================================

# The event observer listens for events on the Stacks blockchain. The listen 
# address must be reachable by your Stacks node, and must be configured in the 
# node's `event_observer` configuration section.
#
# This endpoint _does not_ support TLS and are served over HTTP.
[signer.event_observer]
# The network interface (ip address) to bind the event observer server to.
# 
# Format: "<ip>"
# Required: true
# Environment: SIGNER_SIGNER__EVENT_OBSERVER__BIND
bind = "0.0.0.0"

# The port to bind the event observer server to (on the above bind interface).
#
# Format: <port>
# Required: true
# Environment: SIGNER_SIGNER__EVENT_OBSERVER__PORT
port = 8801
```



## Testing Information

Added relevant asserts to the `load_default_config` test.

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
