### PR TITLE
feat: add support for bitcoin core rpc endpoint configuration

### DIFF
--- a/signer/src/config.rs
+++ b/signer/src/config.rs
@@ -69,7 +69,7 @@ pub struct Settings {
 #[derive(Deserialize, Clone, Debug)]
 pub struct BitcoinConfig {
     /// Bitcoin RPC endpoints.
-    #[serde(deserialize_with = "url_deserializer")]
+    #[serde(deserialize_with = "url_deserializer_vec")]
     pub endpoints: Vec<url::Url>,
 }
 

--- a/signer/src/config.rs
+++ b/signer/src/config.rs
@@ -61,6 +61,16 @@ pub struct Settings {
     pub block_notifier: BlockNotifierConfig,
     /// Signer-specific configuration
     pub signer: SignerConfig,
+    /// Bitcoin core configuration
+    pub bitcoin: BitcoinConfig,
+}
+
+/// Configuration used for the [`BitcoinCoreClient`](sbtc::rpc::BitcoinCoreClient).
+#[derive(Deserialize, Clone, Debug)]
+pub struct BitcoinConfig {
+    /// Bitcoin RPC endpoints.
+    #[serde(deserialize_with = "url_deserializer")]
+    pub endpoints: Vec<url::Url>,
 }
 
 /// Signer network configuration
@@ -240,12 +250,16 @@ impl Settings {
             .with_list_parse_key("signer.p2p.seeds")
             .with_list_parse_key("signer.p2p.listen_on")
             .with_list_parse_key("signer.p2p.public_endpoints")
+            .with_list_parse_key("bitcoin.endpoints")
             .prefix_separator("_");
+
         let mut cfg_builder = Config::builder();
         if let Some(path) = config_path {
             cfg_builder = cfg_builder.add_source(File::from(path.as_ref()));
         }
-        let cfg = cfg_builder.add_source(env).build()?;
+        cfg_builder = cfg_builder.add_source(env);
+
+        let cfg = cfg_builder.build()?;
 
         let settings: Settings = cfg.try_deserialize()?;
 
@@ -346,8 +360,6 @@ where
 mod tests {
     use super::*;
 
-    use crate::testing::DEFAULT_CONFIG_PATH;
-
     /// Helper function to quickly create a URL from a string in tests.
     fn url(s: &str) -> url::Url {
         s.parse().unwrap()
@@ -361,14 +373,16 @@ mod tests {
     // !! default.toml file are changed.
     #[test]
     fn default_config_toml_loads() {
-        let settings = Settings::new(DEFAULT_CONFIG_PATH).unwrap();
+        let settings = Settings::new_from_default_config().unwrap();
         assert_eq!(settings.blocklist_client.host, "127.0.0.1");
         assert_eq!(settings.blocklist_client.port, 8080);
+
         assert_eq!(settings.block_notifier.server, "tcp://localhost:60401");
         assert_eq!(settings.block_notifier.retry_interval, 10);
         assert_eq!(settings.block_notifier.max_retry_attempts, 5);
         assert_eq!(settings.block_notifier.ping_interval, 60);
         assert_eq!(settings.block_notifier.subscribe_interval, 10);
+
         assert_eq!(
             settings.signer.private_key,
             PrivateKey::from_str(
@@ -376,12 +390,20 @@ mod tests {
             )
             .unwrap()
         );
+        assert_eq!(settings.signer.network, NetworkKind::Regtest);
+
         assert_eq!(settings.signer.p2p.seeds, vec![]);
         assert_eq!(
             settings.signer.p2p.listen_on,
             vec![url("tcp://0.0.0.0:4122"), url("quic-v1://0.0.0.0:4122")]
         );
-        assert_eq!(settings.signer.network, NetworkKind::Regtest);
+
+        assert_eq!(
+            settings.bitcoin.endpoints,
+            vec![url("http://user:pass@localhost:18443")]
+        );
+        assert_eq!(settings.bitcoin.endpoints[0].username(), "user");
+        assert_eq!(settings.bitcoin.endpoints[0].password(), Some("pass"));
     }
 
     #[test]
@@ -392,7 +414,7 @@ mod tests {
         );
         std::env::set_var("SIGNER_SIGNER__P2P__LISTEN_ON", "tcp://1.2.3.4:1234");
 
-        let settings = Settings::new(DEFAULT_CONFIG_PATH).unwrap();
+        let settings = Settings::new_from_default_config().unwrap();
 
         assert_eq!(
             settings.signer.p2p.seeds,
@@ -405,11 +427,32 @@ mod tests {
     }
 
     #[test]
+    fn default_config_toml_loads_bitcoin_config_with_environment() {
+        std::env::set_var(
+            "SIGNER_BITCOIN__ENDPOINTS",
+            "http://user:pass@localhost:1234,http://foo:bar@localhost:5678",
+        );
+
+        let settings = Settings::new_from_default_config().unwrap();
+
+        dbg!(settings.bitcoin.endpoints.clone());
+        assert!(settings.bitcoin.endpoints.len() == 2);
+        assert!(settings
+            .bitcoin
+            .endpoints
+            .contains(&url("http://user:pass@localhost:1234")));
+        assert!(settings
+            .bitcoin
+            .endpoints
+            .contains(&url("http://foo:bar@localhost:5678")));
+    }
+
+    #[test]
     fn default_config_toml_loads_signer_private_key_config_with_environment() {
         let new = "a1a6fcf2de80dcde3e0e4251eae8c69adf57b88613b2dcb79332cc325fa439bd";
         std::env::set_var("SIGNER_SIGNER__PRIVATE_KEY", new);
 
-        let settings = Settings::new(DEFAULT_CONFIG_PATH).unwrap();
+        let settings = Settings::new_from_default_config().unwrap();
 
         assert_eq!(
             settings.signer.private_key,
@@ -422,13 +465,13 @@ mod tests {
         let new = "testnet";
         std::env::set_var("SIGNER_SIGNER__NETWORK", new);
 
-        let settings = Settings::new(DEFAULT_CONFIG_PATH).unwrap();
+        let settings = Settings::new_from_default_config().unwrap();
         assert_eq!(settings.signer.network, NetworkKind::Testnet);
 
         let new = "regtest";
         std::env::set_var("SIGNER_SIGNER__NETWORK", new);
 
-        let settings = Settings::new(DEFAULT_CONFIG_PATH).unwrap();
+        let settings = Settings::new_from_default_config().unwrap();
         assert_eq!(settings.signer.network, NetworkKind::Regtest);
     }
 
@@ -473,7 +516,7 @@ mod tests {
     fn invalid_private_key_length_returns_correct_error() {
         std::env::set_var("SIGNER_SIGNER__PRIVATE_KEY", "1234");
 
-        let settings = Settings::new(DEFAULT_CONFIG_PATH);
+        let settings = Settings::new_from_default_config();
         assert!(settings.is_err());
         assert!(matches!(
             settings.unwrap_err(),
@@ -486,7 +529,7 @@ mod tests {
         std::env::set_var("SIGNER_SIGNER__PRIVATE_KEY", "zz");
         let hex_err = hex::decode("zz").unwrap_err();
 
-        let settings = Settings::new(DEFAULT_CONFIG_PATH);
+        let settings = Settings::new_from_default_config();
         assert!(settings.is_err());
         assert!(matches!(
             settings.unwrap_err(),

--- a/signer/src/config/default.toml
+++ b/signer/src/config/default.toml
@@ -8,6 +8,24 @@ host = "127.0.0.1"
 port = 8080
 
 # !! ==============================================================================
+# !! Bitcoin Core Configuration
+# !! ==============================================================================
+[bitcoin]
+# The URI(s) of the Bitcoin Core RPC server(s) to connect to.
+#
+# You may specify multiple Bitcoin Core RPC servers if you have them. They will
+# be randomly tried until one succeeds.
+#
+# Format: ["http://<user>:<pass>@<host>:<port>", ..]
+# Default: <none>
+# Required: true
+# Environment: SIGNER_BITCOIN__ENDPOINTS
+# Environment Example: http://user:pass@seed-1:4122,http://foo:bar@seed-2:4122
+endpoints = [
+    "http://user:pass@localhost:18443",
+]
+
+# !! ==============================================================================
 # !! Block Notifier Configuration
 # !! ==============================================================================
 # Electrum server connection confirmation.
@@ -17,7 +35,7 @@ port = 8080
 # Format: "<protocol>://<host>:<port>"
 # Default: <none>
 # Required: true
-# Environment: SIGNER__BLOCK_NOTIFIER__SERVER
+# Environment: SIGNER_BLOCK_NOTIFIER__SERVER
 server = "tcp://localhost:60401"
 retry_interval = 10
 max_retry_attempts = 5
@@ -68,9 +86,12 @@ network = "regtest"
 # If not specified or if none of the specified seeds could be reached, the node
 # will attempt to discover other nodes using StackerDB.
 #
+# See the `listen_on` parameter for available protocols.
+#
 # Format: ["<protocol>:<ip>:<port>", "<protocol>:<ip>:<port>", ...]
 # Required: false
 # Environment: SIGNER_SIGNER__P2P__SEEDS
+# Environment Example: tcp://seed-1:4122,tcp://seed-2:4122
 # TODO(429): Add well-known seed nodes
 seeds = []
 

--- a/signer/src/testing/mod.rs
+++ b/signer/src/testing/mod.rs
@@ -10,6 +10,7 @@ pub mod wallet;
 pub mod wsts;
 
 use crate::bitcoin::utxo::UnsignedTransaction;
+use crate::config::Settings;
 use bitcoin::key::TapTweak;
 use bitcoin::opcodes;
 use bitcoin::ScriptBuf;
@@ -20,6 +21,14 @@ use secp256k1::SECP256K1;
 
 /// The path for the configuration file that we should use during testing.
 pub const DEFAULT_CONFIG_PATH: Option<&str> = Some("./src/config/default");
+
+impl Settings {
+    /// Create a new `Settings` instance from the default configuration file.
+    /// This is useful for testing.
+    pub fn new_from_default_config() -> Result<Self, config::ConfigError> {
+        Self::new(DEFAULT_CONFIG_PATH)
+    }
+}
 
 /// A helper function for correctly setting witness data
 pub fn set_witness_data(unsigned: &mut UnsignedTransaction, keypair: secp256k1::Keypair) {


### PR DESCRIPTION
## Description

Adds support for configuring bitcoin RPC endpoints, both via config file and environment.

## Changes

- Add support for bitcoin RPC endpoint configuration. This accepts a list, so we should do the same with the `BitcoinCoreClient` as was done with the `StacksClient` and support rotating endpoints on failure. This could be important if the signer wants to avoid any potential downtime during i.e. bitcoin core binary updates, etc.
- Added tests, and added a new convenience method on `Settings` for testing.

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
