### PR TITLE
feat: change withdrawal lock amounts

### DIFF
--- a/contracts/contracts/sbtc-withdrawal.clar
+++ b/contracts/contracts/sbtc-withdrawal.clar
@@ -29,7 +29,20 @@
 ;; The minimum amount of sBTC you can withdraw
 (define-constant DUST_LIMIT u546)
 
-;; Initiate a new withdrawal request
+;; Initiate a new withdrawal request.
+;;
+;; # Notes
+;;
+;; ## Amounts
+;;
+;; This function locks up `amount + max-fee` from the tx-sender's account,
+;; and when the withdrawal request is accepted, the signers will send
+;; `amount` of sats to the recipient and spend an a fee amount to bitcoin
+;; miners where fee less than or equal to max-fee. If fee is less than
+;; max-fee, then the difference will be minted back to the user when
+;; `accept-withdrawal-request` is invoked.
+;;
+;; ## The recipient
 ;;
 ;; This constraints and meaning of the recipient field is summarized as:
 ;; ```text
@@ -42,7 +55,7 @@
 ;; version == 0x06 and (len hashbytes) == 32 => P2TR
 ;; ```
 ;; Also see <https://docs.stacks.co/clarity/functions#get-burn-block-info>
-;; 
+;;
 ;; Below is a detailed breakdown of bitcoin address types and how they map
 ;; to the clarity value. In what follows below, the network used for the
 ;; human-readable parts is inherited from the network of the underlying
@@ -50,7 +63,7 @@
 ;; bitcoin addresses and similarly on stacks testnet we send to bitcoin
 ;; testnet addresses).
 ;;
-;; ## P2PKH
+;; ### P2PKH
 ;;
 ;; Generally speaking, Pay-to-Public-Key-Hash addresses are formed by
 ;; taking the Hash160 of the public key, prefixing it with one byte (0x00
@@ -60,7 +73,7 @@
 ;; the `hashbytes` is the Hash160 of the public key.
 ;;
 ;;
-;; ## P2SH, P2SH-P2WPKH, and P2SH-P2WSH
+;; ### P2SH, P2SH-P2WPKH, and P2SH-P2WSH
 ;;
 ;; Pay-to-script-hash-* addresses are formed by taking the Hash160 of the
 ;; locking script, prefixing it with one byte (0x05 on mainnet and 0xC4 on
@@ -84,7 +97,7 @@
 ;; the `hashbytes` is the Hash160 of the locking script.
 ;;
 ;;
-;; ## P2WPKH
+;; ### P2WPKH
 ;;
 ;; Pay-to-witness-public-key-hash addresses are formed by creating a
 ;; witness program made entirely of the Hash160 of the compressed public
@@ -94,7 +107,7 @@
 ;; the `hashbytes` is the Hash160 of the compressed public key.
 ;;
 ;;
-;; ## P2WSH
+;; ### P2WSH
 ;;
 ;; Pay-to-witness-script-hash addresses are formed by taking a witness
 ;; program that is compressed entirely of the SHA256 of the redeem script.
@@ -103,7 +116,7 @@
 ;; the `hashbytes` is the SHA256 of the redeem script.
 ;;
 ;;
-;; ## P2TR
+;; ### P2TR
 ;;
 ;; Pay-to-taproot addresses are formed by "tweaking" the x-coordinate of a
 ;; public key with a merkle tree. The result of the tweak is used as the
@@ -116,7 +129,7 @@
                                             (max-fee uint)
   )
   (begin
-    (try! (contract-call? .sbtc-token protocol-lock amount tx-sender))
+    (try! (contract-call? .sbtc-token protocol-lock (+ amount max-fee) tx-sender))
     (asserts! (> amount DUST_LIMIT) ERR_DUST_LIMIT)
   
     ;; Validate the recipient address
@@ -137,6 +150,7 @@
       (current-signer-data (contract-call? .sbtc-registry get-current-signer-data))   
       (request  (unwrap! (contract-call? .sbtc-registry get-withdrawal-request request-id) ERR_INVALID_REQUEST))
       (requested-max-fee (get max-fee request))
+      (requested-amount (get amount request))
       (requester (get sender request))
     )
       ;; Check that the caller is the current signer principal
@@ -149,7 +163,7 @@
       (asserts! (<= fee requested-max-fee) ERR_FEE_TOO_HIGH)
 
       ;; Burn the locked-sbtc
-      (try! (contract-call? .sbtc-token protocol-burn-locked (get amount request) requester))
+      (try! (contract-call? .sbtc-token protocol-burn-locked (+ requested-amount requested-max-fee) requester))
 
       ;; Mint the difference b/w max-fee of the request & fee actually paid back to the user in sBTC
       (if (is-eq (- requested-max-fee fee) u0)

--- a/contracts/contracts/sbtc-withdrawal.clar
+++ b/contracts/contracts/sbtc-withdrawal.clar
@@ -184,6 +184,9 @@
      (
       (current-signer-data (contract-call? .sbtc-registry get-current-signer-data))   
       (withdrawal (unwrap! (contract-call? .sbtc-registry get-withdrawal-request request-id) ERR_INVALID_REQUEST))
+      (requested-max-fee (get max-fee withdrawal))
+      (requested-amount (get amount withdrawal))
+      (requester (get sender withdrawal))
      )
 
     ;; Check that the caller is the current signer principal
@@ -193,7 +196,7 @@
     (asserts! (is-none (get status withdrawal)) ERR_ALREADY_PROCESSED)
 
     ;; Burn sbtc-locked & re-mint sbtc to original requester
-    (try! (contract-call? .sbtc-token protocol-unlock (get amount withdrawal) (get sender withdrawal)))
+    (try! (contract-call? .sbtc-token protocol-unlock (+ requested-amount requested-max-fee) requester))
 
     ;; Call into registry to confirm accepted withdrawal
     (try! (contract-call? .sbtc-registry complete-withdrawal-reject request-id signer-bitmap))

--- a/contracts/tests/sbtc-withdrawal.test.ts
+++ b/contracts/tests/sbtc-withdrawal.test.ts
@@ -247,13 +247,13 @@ test("max-fee must be accounted for", () => {
   );
   // We're going to try to initate a withdrawal request where amount +
   // maxFee is greater than the available balance in the account (which in
-  // this case os just amount). This should error.
+  // this case is just amount). This should error.
   expect(rovOk(token.getBalanceAvailable(alice))).toEqual(4000n);
   const receipt = txErr(
     withdrawal.initiateWithdrawalRequest({
       amount: 4000n,
       recipient: alicePoxAddr,
-      maxFee: 1000000n,
+      maxFee: 1n,
     }),
     alice
   );

--- a/contracts/tests/sbtc-withdrawal.test.ts
+++ b/contracts/tests/sbtc-withdrawal.test.ts
@@ -424,6 +424,7 @@ describe("Accepting a withdrawal request", () => {
       deployer
     );
     expect(rovOk(token.getBalance(alice))).toEqual(0n);
+    expect(rovOk(token.getBalanceAvailable(alice))).toEqual(0n);
 
     // An event is emitted properly
     const prints = filterEvents(
@@ -480,6 +481,7 @@ describe("Accepting a withdrawal request", () => {
       deployer
     );
     expect(rovOk(token.getBalance(alice))).toEqual(0n);
+    expect(rovOk(token.getBalanceAvailable(alice))).toEqual(0n);
 
     // Check that the request was stored correctly with the correct status
     const request = rov(registry.getWithdrawalRequest(1n));
@@ -496,6 +498,10 @@ describe("Accepting a withdrawal request", () => {
     });
   });
   test("reject withdrawal sets withdrawal-status to false", () => {
+    // We start off with a balance of zero
+    expect(rovOk(token.getBalance(alice))).toEqual(0n);
+    expect(rovOk(token.getBalanceAvailable(alice))).toEqual(0n);
+    expect(rovOk(token.getBalanceLocked(alice))).toEqual(0n);
     // Alice initiates withdrawalrequest
     txOk(
       deposit.completeDepositWrapper({
@@ -506,6 +512,9 @@ describe("Accepting a withdrawal request", () => {
       }),
       deployer
     );
+    expect(rovOk(token.getBalance(alice))).toEqual(1010n);
+    expect(rovOk(token.getBalanceAvailable(alice))).toEqual(1010n);
+    expect(rovOk(token.getBalanceLocked(alice))).toEqual(0n);
     txOk(
       withdrawal.initiateWithdrawalRequest({
         amount: 1000n,
@@ -514,6 +523,11 @@ describe("Accepting a withdrawal request", () => {
       }),
       alice
     );
+    // Initiating a withdrawal request doesn't change the "balance", but
+    // does change how much is available.
+    expect(rovOk(token.getBalance(alice))).toEqual(1010n);
+    expect(rovOk(token.getBalanceAvailable(alice))).toEqual(0n);
+    expect(rovOk(token.getBalanceLocked(alice))).toEqual(1010n);
     const receipt = txOk(
       withdrawal.rejectWithdrawalRequest({
         requestId: 1n,
@@ -523,6 +537,8 @@ describe("Accepting a withdrawal request", () => {
     );
     // This is the original balance, rejecting the request restores it.
     expect(rovOk(token.getBalance(alice))).toEqual(1010n);
+    expect(rovOk(token.getBalanceAvailable(alice))).toEqual(1010n);
+    expect(rovOk(token.getBalanceLocked(alice))).toEqual(0n);
 
     // Check that the request was stored correctly with the correct status
     const request = rov(registry.getWithdrawalRequest(1n));

--- a/contracts/tests/sbtc-withdrawal.test.ts
+++ b/contracts/tests/sbtc-withdrawal.test.ts
@@ -77,7 +77,7 @@ describe("initiating a withdrawal request", () => {
       deposit.completeDepositWrapper({
         txid: new Uint8Array(32).fill(0),
         voutIndex: 0,
-        amount: 1001n,
+        amount: 1011n,
         recipient: alice,
       }),
       deployer
@@ -140,12 +140,12 @@ describe("initiating a withdrawal request", () => {
       deposit.completeDepositWrapper({
         txid: new Uint8Array(32).fill(0),
         voutIndex: 0,
-        amount: 1000n,
+        amount: 1000n + 10n,
         recipient: alice,
       }),
       deployer
     );
-    expect(rovOk(token.getBalance(alice))).toEqual(1000n);
+    expect(rovOk(token.getBalance(alice))).toEqual(1010n);
     const receipt = txOk(
       withdrawal.initiateWithdrawalRequest({
         amount: 1000n,
@@ -155,7 +155,7 @@ describe("initiating a withdrawal request", () => {
       alice
     );
     const lockedBalance = rovOk(token.getBalanceLocked(alice));
-    expect(lockedBalance).toEqual(1000n);
+    expect(lockedBalance).toEqual(1010n);
     const [mintEvent] = filterEvents(
       receipt.events,
       CoreNodeEventType.FtMintEvent
@@ -163,7 +163,7 @@ describe("initiating a withdrawal request", () => {
     expect(mintEvent.data.asset_identifier).toEqual(
       `${token.identifier}::${token.fungible_tokens[1].name}`
     );
-    expect(mintEvent.data.amount).toEqual(1000n.toString());
+    expect(mintEvent.data.amount).toEqual(1010n.toString());
     expect(rovOk(token.getBalanceAvailable(alice))).toEqual(0n);
   });
 
@@ -233,6 +233,32 @@ describe("initiating a withdrawal request", () => {
   });
 });
 
+test("max-fee must be accounted for", () => {
+  txOk(
+    deposit.completeDepositWrapper({
+      txid: new Uint8Array(32).fill(0),
+      voutIndex: 0,
+      amount: 4000n,
+      recipient: alice,
+    }),
+    deployer
+  );
+  const receipt = txErr(
+    withdrawal.initiateWithdrawalRequest({
+      amount: 4000n,
+      recipient: alicePoxAddr,
+      maxFee: 1000000n,
+    }),
+    alice
+  );
+  // Under the hood `initiate-withdrawal-request` attempts `ft-burn?`
+  // amount + max-fee for the `tx-sender`, so if the transaction sender
+  // does not have enough in their account then `(err u1)` is returned in
+  // the response.
+  expect(receipt.value).toEqual(1n);
+});
+
+
 describe("Accepting a withdrawal request", () => {
   test("Fails with non-existant request-id", () => {
     // Alice initiates withdrawalrequest
@@ -240,7 +266,7 @@ describe("Accepting a withdrawal request", () => {
       deposit.completeDepositWrapper({
         txid: new Uint8Array(32).fill(0),
         voutIndex: 0,
-        amount: 1000n,
+        amount: 1000n + 10n,
         recipient: alice,
       }),
       deployer
@@ -271,7 +297,7 @@ describe("Accepting a withdrawal request", () => {
       deposit.completeDepositWrapper({
         txid: new Uint8Array(32).fill(0),
         voutIndex: 0,
-        amount: 1000n,
+        amount: 1000n + 10n,
         recipient: alice,
       }),
       deployer
@@ -302,7 +328,7 @@ describe("Accepting a withdrawal request", () => {
       deposit.completeDepositWrapper({
         txid: new Uint8Array(32).fill(0),
         voutIndex: 0,
-        amount: 1000n,
+        amount: 1000n + 10n,
         recipient: alice,
       }),
       deployer
@@ -343,7 +369,7 @@ describe("Accepting a withdrawal request", () => {
       deposit.completeDepositWrapper({
         txid: new Uint8Array(32).fill(0),
         voutIndex: 0,
-        amount: 1000n,
+        amount: 1000n + 10n,
         recipient: alice,
       }),
       deployer
@@ -374,7 +400,7 @@ describe("Accepting a withdrawal request", () => {
       deposit.completeDepositWrapper({
         txid: new Uint8Array(32).fill(0),
         voutIndex: 0,
-        amount: 1000n,
+        amount: 1000n + 20n,
         recipient: alice,
       }),
       deployer
@@ -430,7 +456,7 @@ describe("Accepting a withdrawal request", () => {
       deposit.completeDepositWrapper({
         txid: new Uint8Array(32).fill(0),
         voutIndex: 0,
-        amount: 1000n,
+        amount: 1000n + 10n,
         recipient: alice,
       }),
       deployer
@@ -475,7 +501,7 @@ describe("Accepting a withdrawal request", () => {
       deposit.completeDepositWrapper({
         txid: new Uint8Array(32).fill(0),
         voutIndex: 0,
-        amount: 1000n,
+        amount: 1000n + 10n,
         recipient: alice,
       }),
       deployer
@@ -496,7 +522,7 @@ describe("Accepting a withdrawal request", () => {
       deployer
     );
     // This is the original balance, rejecting the request restores it.
-    expect(rovOk(token.getBalance(alice))).toEqual(1000n);
+    expect(rovOk(token.getBalance(alice))).toEqual(1010n);
 
     // Check that the request was stored correctly with the correct status
     const request = rov(registry.getWithdrawalRequest(1n));
@@ -540,7 +566,7 @@ describe("Accepting a withdrawal request", () => {
       deposit.completeDepositWrapper({
         txid: new Uint8Array(32).fill(0),
         voutIndex: 0,
-        amount: 1000n,
+        amount: 1000n + 10n,
         recipient: alice,
       }),
       deployer
@@ -574,7 +600,7 @@ describe("Reject a withdrawal request", () => {
       deposit.completeDepositWrapper({
         txid: new Uint8Array(32).fill(0),
         voutIndex: 0,
-        amount: 1000n,
+        amount: 1000n + 10n,
         recipient: alice,
       }),
       deployer
@@ -602,7 +628,7 @@ describe("Reject a withdrawal request", () => {
       deposit.completeDepositWrapper({
         txid: new Uint8Array(32).fill(0),
         voutIndex: 0,
-        amount: 1000n,
+        amount: 1000n + 10n,
         recipient: alice,
       }),
       deployer
@@ -630,7 +656,7 @@ describe("Reject a withdrawal request", () => {
       deposit.completeDepositWrapper({
         txid: new Uint8Array(32).fill(0),
         voutIndex: 0,
-        amount: 1000n,
+        amount: 1000n + 10n,
         recipient: alice,
       }),
       deployer
@@ -668,7 +694,7 @@ describe("Reject a withdrawal request", () => {
       deposit.completeDepositWrapper({
         txid: new Uint8Array(32).fill(0),
         voutIndex: 0,
-        amount: 1000n,
+        amount: 1000n + 10n,
         recipient: alice,
       }),
       deployer
@@ -702,7 +728,7 @@ describe("Complete multiple withdrawals", () => {
       deposit.completeDepositWrapper({
         txid: new Uint8Array(32).fill(0),
         voutIndex: 0,
-        amount: 1000n,
+        amount: 1000n + 10n,
         recipient: alice,
       }),
       deployer
@@ -720,7 +746,7 @@ describe("Complete multiple withdrawals", () => {
       deposit.completeDepositWrapper({
         txid: new Uint8Array(32).fill(1),
         voutIndex: 1,
-        amount: 1000n,
+        amount: 1000n + 10n,
         recipient: bob,
       }),
       deployer
@@ -766,6 +792,7 @@ describe("optimization tests for completing withdrawals", () => {
     const totalAmount = 1000000n;
     const runs = 500;
     const perAmount = totalAmount / BigInt(runs);
+    const maxFee = 10n;
     const txids = randomPublicKeys(runs).map((pk) => pk.slice(0, 32));
     for (let index = 0; index < runs; index++) {
       const txid = txids[index];
@@ -773,7 +800,7 @@ describe("optimization tests for completing withdrawals", () => {
         deposit.completeDepositWrapper({
           txid,
           voutIndex: 0,
-          amount: perAmount,
+          amount: perAmount + maxFee,
           recipient: alice,
         }),
         deployer
@@ -782,7 +809,7 @@ describe("optimization tests for completing withdrawals", () => {
         withdrawal.initiateWithdrawalRequest({
           amount: perAmount,
           recipient: alicePoxAddr,
-          maxFee: 10n,
+          maxFee: maxFee,
         }),
         alice
       );
@@ -796,7 +823,7 @@ describe("optimization tests for completing withdrawals", () => {
             signerBitmap: 1n,
             bitcoinTxid: txid,
             outputIndex: 0n,
-            fee: 10n,
+            fee: maxFee,
           };
         })
       ),

--- a/signer/src/bitcoin/utxo.rs
+++ b/signer/src/bitcoin/utxo.rs
@@ -454,8 +454,8 @@ impl<'a> Weighted for RequestRef<'a> {
     }
 }
 
-/// A struct for the transaction inputs and outputs associated with the
-/// deposit and withdrawal requests.
+/// A struct for constructing transaction inputs and outputs from deposit
+/// and withdrawal requests.
 #[derive(Debug)]
 pub struct Requests<'a> {
     request_refs: Vec<RequestRef<'a>>,

--- a/signer/src/bitcoin/utxo.rs
+++ b/signer/src/bitcoin/utxo.rs
@@ -1,5 +1,7 @@
 //! Utxo management and transaction construction
 
+use std::collections::BTreeMap;
+
 use bitcoin::absolute::LockTime;
 use bitcoin::address::NetworkUnchecked;
 use bitcoin::secp256k1::SECP256K1;
@@ -145,7 +147,8 @@ impl SbtcRequests {
         let items = deposits.chain(withdrawals);
 
         compute_optimal_packages(items, self.reject_capacity())
-            .scan(self.signer_state, |state, requests| {
+            .scan(self.signer_state, |state, request_refs| {
+                let requests = Requests::new(request_refs);
                 let tx = UnsignedTransaction::new(requests, state);
                 if let Ok(tx_ref) = tx.as_ref() {
                     state.utxo = tx_ref.new_signer_utxo();
@@ -223,7 +226,7 @@ fn compute_transaction_fee(tx_vsize: f64, fee_rate: f64, last_fees: Option<Fees>
 /// Deposit requests are assumed to happen via taproot BTC spend where the
 /// key-spend path is assumed to be unspendable since the public key has no
 /// known private key.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct DepositRequest {
     /// The UTXO to be spent by the signers.
     pub outpoint: OutPoint,
@@ -357,7 +360,7 @@ impl DepositRequest {
 }
 
 /// An accepted or pending withdraw request.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct WithdrawalRequest {
     /// The amount of BTC, in sats, to withdraw.
     pub amount: u64,
@@ -408,7 +411,7 @@ impl WithdrawalRequest {
 }
 
 /// A reference to either a deposit or withdraw request
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum RequestRef<'a> {
     /// A reference to a deposit request
     Deposit(&'a DepositRequest),
@@ -448,6 +451,58 @@ impl<'a> Weighted for RequestRef<'a> {
             Self::Deposit(req) => req.votes_against(),
             Self::Withdrawal(req) => req.votes_against(),
         }
+    }
+}
+
+/// A struct for the transaction inputs and outputs associated with the
+/// deposit and withdrawal requests.
+#[derive(Debug)]
+pub struct Requests<'a> {
+    request_refs: Vec<RequestRef<'a>>,
+    /// This is a dummy signature here only to simplify the creation of
+    /// TxIns that have the correct weight with a proper signature.
+    signature: Signature,
+}
+
+impl<'a> std::ops::Deref for Requests<'a> {
+    type Target = Vec<RequestRef<'a>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.request_refs
+    }
+}
+
+impl<'a> Requests<'a> {
+    /// Create a new one
+    pub fn new(request_refs: Vec<RequestRef<'a>>) -> Self {
+        let signature = UnsignedTransaction::generate_dummy_signature();
+        Self { request_refs, signature }
+    }
+    /// Return an iterator for the transaction inputs for the deposit
+    /// requests. These transaction inputs include a dummy signature so
+    /// that the transaction inputs have the correct weight.
+    pub fn tx_ins(&'a self) -> impl Iterator<Item = TxIn> + 'a {
+        self.request_refs
+            .iter()
+            .filter_map(|req| Some(req.as_deposit()?.as_tx_input(self.signature)))
+    }
+    /// Return an iterator for the transaction outputs for the withdrawal
+    /// requests.
+    pub fn tx_outs(&'a self) -> impl Iterator<Item = TxOut> + 'a {
+        self.request_refs
+            .iter()
+            .filter_map(|req| Some(req.as_withdrawal()?.as_tx_output()))
+    }
+    /// Construct a mapping between the requests and the weight associated
+    /// with the transaction on the bitcoin blockchain.
+    pub fn tx_weights(&self) -> BTreeMap<RequestRef<'a>, Weight> {
+        self.request_refs
+            .iter()
+            .map(|req| match req {
+                RequestRef::Deposit(dep) => (*req, dep.as_tx_input(self.signature).segwit_weight()),
+                RequestRef::Withdrawal(wit) => (*req, wit.as_tx_output().weight()),
+            })
+            .collect()
     }
 }
 
@@ -507,15 +562,15 @@ impl SignerUtxo {
 #[derive(Debug)]
 pub struct UnsignedTransaction<'a> {
     /// The requests used to construct the transaction.
-    pub requests: Vec<RequestRef<'a>>,
+    pub requests: Requests<'a>,
     /// The BTC transaction that needs to be signed.
     pub tx: Transaction,
     /// The public key used for the public key of the signers' UTXO output.
     pub signer_public_key: XOnlyPublicKey,
     /// The signers' UTXO used as inputs to this transaction.
     pub signer_utxo: SignerBtcState,
-    /// The total amount of fees associated with the deposit requests.
-    pub deposit_fees: u64,
+    /// The total amount of fees associated with the transaction.
+    pub tx_fee: u64,
 }
 
 /// A struct containing Taproot-tagged hashes used for computing taproot
@@ -543,7 +598,7 @@ impl<'a> UnsignedTransaction<'a> {
     ///      is the OP_RETURN data output.
     ///   4. Each input needs a signature in the witness data.
     ///   5. There is no witness data for deposit UTXOs.
-    pub fn new(requests: Vec<RequestRef<'a>>, state: &SignerBtcState) -> Result<Self, Error> {
+    pub fn new(requests: Requests<'a>, state: &SignerBtcState) -> Result<Self, Error> {
         // Construct a transaction base. This transaction's inputs have
         // witness data with dummy signatures so that our virtual size
         // estimates are accurate. Later we will update the fees and
@@ -552,11 +607,12 @@ impl<'a> UnsignedTransaction<'a> {
         // We now compute the total fees for the transaction.
         let tx_vsize = tx.vsize() as f64;
         let tx_fee = compute_transaction_fee(tx_vsize, state.fee_rate, state.last_fees);
-        // Now adjust the deposits and withdrawals by an amount proportional
-        // to their weight.
-        let deposit_fees = Self::adjust_amounts(&mut tx, tx_fee);
+        // Now adjust the amount for the signers UTXO for the transaction
+        // fee.
+        Self::adjust_amounts(&mut tx, tx_fee);
 
-        // Now we can reset the witness data.
+        // Now we can reset the witness data, since this is an unsigned
+        // transaction.
         Self::reset_witness_data(&mut tx);
 
         Ok(Self {
@@ -564,89 +620,7 @@ impl<'a> UnsignedTransaction<'a> {
             requests,
             signer_public_key: state.public_key,
             signer_utxo: *state,
-            deposit_fees,
-        })
-    }
-
-    /// Construct a "stub" BTC transaction from the given requests.
-    ///
-    /// The returned BTC transaction is signed with dummy signatures, so it
-    /// has the same virtual size as a proper transaction. Note that the
-    /// output amounts haven't been adjusted for fees.
-    ///
-    /// An Err is returned if the amounts withdrawn is greater than the sum
-    /// of all the input amounts.
-    fn new_transaction(reqs: &[RequestRef], state: &SignerBtcState) -> Result<Transaction, Error> {
-        let signature = Self::generate_dummy_signature();
-
-        let deposits = reqs
-            .iter()
-            .filter_map(|req| Some(req.as_deposit()?.as_tx_input(signature)));
-        let withdrawals = reqs
-            .iter()
-            .filter_map(|req| Some(req.as_withdrawal()?.as_tx_output()));
-
-        let signer_input = state.utxo.as_tx_input(&signature);
-        let signer_output_sats = Self::compute_signer_amount(reqs, state)?;
-        let signer_output = SignerUtxo::new_tx_output(state.public_key, signer_output_sats);
-
-        Ok(Transaction {
-            version: Version::TWO,
-            lock_time: LockTime::ZERO,
-            input: std::iter::once(signer_input).chain(deposits).collect(),
-            output: std::iter::once(signer_output)
-                .chain(Self::new_op_return_output(reqs, state))
-                .chain(withdrawals)
-                .collect(),
-        })
-    }
-
-    /// Create the new SignerUtxo for this transaction.
-    fn new_signer_utxo(&self) -> SignerUtxo {
-        SignerUtxo {
-            outpoint: OutPoint {
-                txid: self.tx.compute_txid(),
-                vout: 0,
-            },
-            amount: self.tx.output[0].value.to_sat(),
-            public_key: self.signer_public_key,
-        }
-    }
-
-    /// An OP_RETURN output with the bitmap for how the signers voted for
-    /// the package.
-    ///
-    /// None is only returned if there are no requests in the input slice.
-    ///
-    /// The data layout for the OP_RETURN is:
-    ///
-    ///  0      2  3    5                           21
-    ///  |------|--|----|---------------------------|
-    ///   magic  op  N_d       signer bitmap
-    ///
-    /// In the above layout, magic is the UTF-8 encoded string "ST", op is
-    /// the UTF-8 encoded string "B", and N_d is the of deposits in this
-    /// transaction encoded as a big-endian two byte integer.
-    fn new_op_return_output(reqs: &[RequestRef], state: &SignerBtcState) -> Option<TxOut> {
-        let bitmap: BitArray<[u8; 16]> = reqs
-            .iter()
-            .map(RequestRef::signer_bitmap)
-            .reduce(|bm1, bm2| bm1 | bm2)?;
-        let num_deposits = reqs.iter().filter_map(RequestRef::as_deposit).count() as u16;
-
-        let mut data: [u8; 21] = [0; 21];
-        // The magic_bytes is exactly 2 bytes
-        data[0..2].copy_from_slice(&state.magic_bytes);
-        // Yeah, this is one byte.
-        data[2..3].copy_from_slice(&[OP_RETURN_OP]);
-        // The num_deposits variable is an u16, so 2 bytes.
-        data[3..5].copy_from_slice(&num_deposits.to_be_bytes());
-        // The bitmap is 16 bytes so this fits exactly.
-        data[5..].copy_from_slice(&bitmap.into_inner());
-
-        Some(TxOut {
-            value: Amount::ZERO,
-            script_pubkey: ScriptBuf::new_op_return(data),
+            tx_fee,
         })
     }
 
@@ -721,11 +695,86 @@ impl<'a> UnsignedTransaction<'a> {
         self.tx.output.iter().map(|out| out.value.to_sat()).sum()
     }
 
+    /// Construct a "stub" BTC transaction from the given requests.
+    ///
+    /// The returned BTC transaction is signed with dummy signatures, so it
+    /// has the same virtual size as a proper transaction. Note that the
+    /// output amounts haven't been adjusted for fees.
+    ///
+    /// An Err is returned if the amounts withdrawn is greater than the sum
+    /// of all the input amounts.
+    fn new_transaction(reqs: &Requests, state: &SignerBtcState) -> Result<Transaction, Error> {
+        let signature = Self::generate_dummy_signature();
+
+        let signer_input = state.utxo.as_tx_input(&signature);
+        let signer_output_sats = Self::compute_signer_amount(reqs, state)?;
+        let signer_output = SignerUtxo::new_tx_output(state.public_key, signer_output_sats);
+
+        Ok(Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: std::iter::once(signer_input).chain(reqs.tx_ins()).collect(),
+            output: std::iter::once(signer_output)
+                .chain(Self::new_op_return_output(&reqs.request_refs, state))
+                .chain(reqs.tx_outs())
+                .collect(),
+        })
+    }
+
+    /// Create the new SignerUtxo for this transaction.
+    fn new_signer_utxo(&self) -> SignerUtxo {
+        SignerUtxo {
+            outpoint: OutPoint {
+                txid: self.tx.compute_txid(),
+                vout: 0,
+            },
+            amount: self.tx.output[0].value.to_sat(),
+            public_key: self.signer_public_key,
+        }
+    }
+
+    /// An OP_RETURN output with the bitmap for how the signers voted for
+    /// the package.
+    ///
+    /// None is only returned if there are no requests in the input slice.
+    ///
+    /// The data layout for the OP_RETURN is:
+    ///
+    ///  0      2  3    5                           21
+    ///  |------|--|----|---------------------------|
+    ///   magic  op  N_d       signer bitmap
+    ///
+    /// In the above layout, magic is the UTF-8 encoded string "ST", op is
+    /// the UTF-8 encoded string "B", and N_d is the of deposits in this
+    /// transaction encoded as a big-endian two byte integer.
+    fn new_op_return_output(reqs: &[RequestRef], state: &SignerBtcState) -> Option<TxOut> {
+        let bitmap: BitArray<[u8; 16]> = reqs
+            .iter()
+            .map(RequestRef::signer_bitmap)
+            .reduce(|bm1, bm2| bm1 | bm2)?;
+        let num_deposits = reqs.iter().filter_map(RequestRef::as_deposit).count() as u16;
+
+        let mut data: [u8; 21] = [0; 21];
+        // The magic_bytes is exactly 2 bytes
+        data[0..2].copy_from_slice(&state.magic_bytes);
+        // Yeah, this is one byte.
+        data[2..3].copy_from_slice(&[OP_RETURN_OP]);
+        // The num_deposits variable is an u16, so 2 bytes.
+        data[3..5].copy_from_slice(&num_deposits.to_be_bytes());
+        // The bitmap is 16 bytes so this fits exactly.
+        data[5..].copy_from_slice(&bitmap.into_inner());
+
+        Some(TxOut {
+            value: Amount::ZERO,
+            script_pubkey: ScriptBuf::new_op_return(data),
+        })
+    }
+
     /// Compute the final amount for the signers' UTXO given the current
     /// UTXO amount and the incoming requests.
     ///
     /// This amount does not take into account fees.
-    fn compute_signer_amount(reqs: &[RequestRef], state: &SignerBtcState) -> Result<u64, Error> {
+    fn compute_signer_amount(reqs: &Requests, state: &SignerBtcState) -> Result<u64, Error> {
         let amount = reqs
             .iter()
             .fold(state.utxo.amount as i64, |amount, req| match req {
@@ -744,57 +793,25 @@ impl<'a> UnsignedTransaction<'a> {
 
     /// Adjust the amounts for each output given the transaction fee.
     ///
-    /// This function adjusts each output by an amount that is proportional
-    /// to their weight (but considering only the weight of the requests).
-    /// The signers' UTXOs amount absorbs the fee on-chain that the
-    /// depositors are supposed to pay. This amount must be accounted for
-    /// when minting sBTC.
-    fn adjust_amounts(tx: &mut Transaction, tx_fee: u64) -> u64 {
-        // Since the first input and first output correspond to the signers'
-        // UTXOs, we subtract them when computing the number of requests.
-        let num_requests = (tx.input.len() + tx.output.len()).saturating_sub(2) as u64;
-        // This is a bizarre case that should never happen.
-        if num_requests == 0 {
-            tracing::warn!("No deposit or withdrawal related inputs in the transaction");
-            return 0;
-        }
-        // Fees are assigned proportionally to their weight amongst all
-        // requests in the transaction. So let's get the total request weight.
-        let requests_vsize = Self::request_weight(tx).to_vbytes_ceil();
-        // The sum of all fees paid for each withdrawal UTXO.
-        let mut withdrawal_fees: u64 = 0;
-        // We now update the remaining withdrawal amounts to account for fees.
-        tx.output.iter_mut().skip(2).for_each(|tx_out| {
-            let fee = (tx_out.weight().to_vbytes_ceil() * tx_fee).div_ceil(requests_vsize);
-            withdrawal_fees += fee;
-            tx_out.value = Amount::from_sat(tx_out.value.to_sat().saturating_sub(fee));
-        });
-
-        // The first output is the signer's UTXO. The correct fee amount
-        // for this UTXO is the total transaction fee minus the fees paid
-        // by the other UTXOs in this transaction. This fee is later deducted
-        // in the amount that is minted in sBTC to each depositor.
-        let deposit_fees = tx_fee.saturating_sub(withdrawal_fees);
+    /// The bitcoin mining fees are ultimately paid for by the users during
+    /// deposit and withdrawal sweep transactions. This fees are captured
+    /// on the sBTC side of things:
+    /// * for deposits the minted amount is the deposited amount less any
+    ///   fees.
+    /// * for withdrawals the user locks the amount spent to the desired
+    ///   recipient on plus their max fee.
+    ///
+    /// Since mining fees come out of the new UTXOs, that means the signers
+    /// UTXO appears to pay the fee on chain. Thus, to adjust the output
+    /// amounts, for fees we only need to change the amount associated with
+    /// the signers' UTXO.
+    fn adjust_amounts(tx: &mut Transaction, tx_fee: u64) {
+        // The first output is the signer's UTXO and this UTXO pays for all
+        // on-chain fees.
         if let Some(utxo_out) = tx.output.first_mut() {
-            let signers_amount = utxo_out.value.to_sat().saturating_sub(deposit_fees);
+            let signers_amount = utxo_out.value.to_sat().saturating_sub(tx_fee);
             utxo_out.value = Amount::from_sat(signers_amount);
         }
-
-        deposit_fees
-    }
-
-    /// Computes the total weight of the inputs and the outputs, excluding
-    /// the ones related to the signers' UTXO.
-    fn request_weight(tx: &Transaction) -> Weight {
-        // We skip the first input and output because those are always the
-        // signers' UTXO input and output. We skip the second output
-        // because that is always the OP_RETURN data output.
-        tx.input
-            .iter()
-            .skip(1)
-            .map(|x| x.segwit_weight())
-            .chain(tx.output.iter().skip(2).map(|x| x.weight()))
-            .sum()
     }
 
     /// Helper function for generating dummy Schnorr signatures.
@@ -819,7 +836,6 @@ impl<'a> UnsignedTransaction<'a> {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
     use std::collections::BTreeSet;
     use std::str::FromStr;
 
@@ -1083,7 +1099,8 @@ mod tests {
 
         // No requests so the first output should be the signers UTXO and
         // that's it. No OP_RETURN output.
-        let unsigned = UnsignedTransaction::new(Vec::new(), &signer_state).unwrap();
+        let requests = Requests::new(Vec::new());
+        let unsigned = UnsignedTransaction::new(requests, &signer_state).unwrap();
         assert_eq!(unsigned.tx.output.len(), 1);
 
         // There is only one output and it's a P2TR output
@@ -1449,15 +1466,6 @@ mod tests {
             accept_threshold: 8,
         };
 
-        // It's tough to match the outputs to the original request. We do
-        // that here by matching the expected scripts, which are unique for
-        // each public key. Since each public key is unique, this works.
-        let mut withdrawal_amounts: BTreeMap<String, u64> = requests
-            .withdrawals
-            .iter()
-            .map(|req| (req.address.script_pubkey().to_hex_string(), req.amount))
-            .collect();
-
         let mut transactions = requests.construct_transactions().unwrap();
         more_asserts::assert_gt!(transactions.len(), 1);
 
@@ -1473,21 +1481,13 @@ mod tests {
 
             let output_amounts: u64 = utx.output_amounts();
             let input_amounts: u64 = utx.input_amounts();
-            let total_fees = input_amounts - output_amounts;
-
-            let request_vsize = UnsignedTransaction::request_weight(&utx.tx).to_vbytes_ceil();
 
             let reqs = utx.requests.iter().filter_map(RequestRef::as_withdrawal);
             for (output, req) in utx.tx.output.iter().skip(2).zip(reqs) {
-                let expected_fee =
-                    (output.weight().to_vbytes_ceil() * total_fees).div_ceil(request_vsize);
-                let fee = req.amount - output.value.to_sat();
-
-                assert_eq!(fee, expected_fee);
-                let original_amount = withdrawal_amounts
-                    .remove(&output.script_pubkey.to_hex_string())
-                    .unwrap();
-                assert_eq!(original_amount, output.value.to_sat() + fee);
+                // One of the invariants is that the amount spent to the
+                // withdrawal recipient is the amount in the withdrawal
+                // request. The fees are already paid for separately.
+                assert_eq!(req.amount, output.value.to_sat());
             }
 
             more_asserts::assert_gt!(input_amounts, output_amounts);
@@ -1559,20 +1559,7 @@ mod tests {
         // Since there are often both deposits and withdrawal, the
         // following assertion checks that we capture the fees that
         // depositors must pay.
-        let deposit_requests = utx.requests.iter().filter_map(RequestRef::as_withdrawal);
-        let withdrawal_fees: u64 = utx
-            .tx
-            .output
-            .iter()
-            .skip(2)
-            .zip(deposit_requests)
-            .map(|(tx_out, req)| req.amount - tx_out.value.to_sat())
-            .sum();
-
-        assert_eq!(
-            input_amounts,
-            output_amounts + withdrawal_fees + utx.deposit_fees
-        );
+        assert_eq!(input_amounts, output_amounts + utx.tx_fee);
 
         let state = &requests.signer_state;
         let signed_vsize = UnsignedTransaction::new_transaction(&utx.requests, state)

--- a/signer/tests/integration/rbf.rs
+++ b/signer/tests/integration/rbf.rs
@@ -307,15 +307,12 @@ pub fn transaction_with_rbf(
 
     let deposit_amounts: u64 = requests.deposits.iter().map(|req| req.amount).sum();
     let withdrawal_amounts: u64 = requests.withdrawals.iter().map(|req| req.amount).sum();
-    let deposit_fees: u64 = transactions
-        .iter()
-        .map(|unsigned| unsigned.deposit_fees)
-        .sum();
+    let fees: u64 = transactions.iter().map(|unsigned| unsigned.tx_fee).sum();
 
     // The signer's balance should now reflect the deposits and withdrawals
     // less the fees that depositors are supposed to pay.
     let signers_balance = signer.get_balance(rpc);
-    let expected_balance = 100_000_000 + deposit_amounts - withdrawal_amounts - deposit_fees;
+    let expected_balance = 100_000_000 + deposit_amounts - withdrawal_amounts - fees;
     assert_eq!(signers_balance.to_sat(), expected_balance);
 
     // Any unused deposits still have their balances adjusted since their

--- a/signer/tests/integration/utxo_construction.rs
+++ b/signer/tests/integration/utxo_construction.rs
@@ -282,14 +282,14 @@ fn withdrawals_reduce_to_signers_amounts() {
     // Note that the signer started with 1 BTC.
     let signers_balance = signer.get_balance(rpc).to_sat();
 
-    assert_eq!(signers_balance, 100_000_000 - withdrawal_request.amount);
+    assert_eq!(
+        signers_balance,
+        100_000_000 - withdrawal_request.amount - unsigned.tx_fee
+    );
 
     let withdrawal_fee = unsigned.input_amounts() - unsigned.output_amounts();
     let recipient_balance = recipient.get_balance(rpc).to_sat();
-    assert_eq!(
-        recipient_balance,
-        withdrawal_request.amount - withdrawal_fee
-    );
+    assert_eq!(recipient_balance, withdrawal_request.amount);
 
     // Let's check that we have the right fee rate too.
     let fee_rate = withdrawal_fee as f64 / unsigned.tx.vsize() as f64;
@@ -335,7 +335,7 @@ fn withdrawals_reduce_to_signers_amounts() {
     let recipient_balance = recipient.get_balance(rpc).to_sat();
     assert_eq!(
         recipient_balance,
-        withdrawal_request.amount - withdrawal_fee - 50_000 - fallback_fee
+        withdrawal_request.amount - 50_000 - fallback_fee
     );
 
     // And what about the person that they just sent coins to?


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/496 and closes https://github.com/stacks-network/sbtc/issues/503.

## Changes

* Update the `initiate-withdrawal-request` public function to lock up the max-fee
* Update the `utxo` module to only adjust the signer's UTXO for fees. This means that we always send the amount in the withdrawal request to the intended recipient.
* There was a minor refactor of `UnsignedTransaction` where now unused functions were removed, and I moved the public function impls together.

## Testing Information

On the clarity side, this adds a new test for the new behavior, just to be extra safe. On the signer side, the tests were updated after making the changes.

## Checklist:

- [x] I have performed a self-review of my code