### PR TITLE
suggestion: support multiple db's at runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,9 +220,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.80"
+version = "0.1.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
+checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4576,6 +4576,7 @@ name = "signer"
 version = "0.1.0"
 dependencies = [
  "aquamarine",
+ "async-trait",
  "axum 0.7.5",
  "backoff",
  "bincode",

--- a/signer/Cargo.toml
+++ b/signer/Cargo.toml
@@ -56,6 +56,7 @@ wsts.workspace = true
 zeromq.workspace = true
 hex.workspace = true
 cfg-if = "1.0"
+async-trait = "0.1.82"
 
 # Only for testing
 fake = { version = "2.9.2", features = ["derive", "time"], optional = true }

--- a/signer/src/api/mod.rs
+++ b/signer/src/api/mod.rs
@@ -4,16 +4,18 @@
 pub mod new_block;
 pub mod status;
 
+use std::sync::Arc;
+
 pub use new_block::new_block_handler;
 pub use status::status_handler;
 
-use crate::config::Settings;
+use crate::{config::Settings, storage::DbReadWrite};
 
 /// A struct with state data necessary for runtime operation.
-#[derive(Debug, Clone)]
-pub struct ApiState<S> {
+#[derive(Clone)]
+pub struct ApiState {
     /// For writing to the database.
-    pub db: S,
+    pub db: Arc<dyn DbReadWrite>,
     /// The runtime settings of the system.
     pub settings: Settings,
 }

--- a/signer/src/api/new_block.rs
+++ b/signer/src/api/new_block.rs
@@ -2,8 +2,6 @@
 //! which is for processing new block webhooks from a stacks node.
 //!
 
-use std::sync::LazyLock;
-
 use axum::extract::State;
 use axum::http::StatusCode;
 
@@ -94,12 +92,10 @@ mod tests {
 
     use bitcoin::OutPoint;
     use test_case::test_case;
-    use tokio::runtime::Handle;
 
     use crate::config::Settings;
     use crate::error::Error;
     use crate::storage::in_memory::Store;
-    use crate::storage::model::CompletedDepositEvent;
     use crate::storage::DbReadWrite;
 
     /// These were generated from a stacks node after running the

--- a/signer/src/api/new_block.rs
+++ b/signer/src/api/new_block.rs
@@ -122,15 +122,19 @@ mod tests {
     }; "completed-deposit")]
     #[test_case(WITHDRAWAL_CREATE_WEBHOOK, |db: Arc<dyn DbReadWrite>| {
         Box::pin(async move {
-            db.get_withdrawal_created_event(1).await //.is_none()
+            db.get_withdrawal_created_event(1).await
         })
     }; "withdrawal-create")]
     #[test_case(WITHDRAWAL_ACCEPT_WEBHOOK, |db: Arc<dyn DbReadWrite>| {
         Box::pin(async move {
-            db.get_withdrawal_accepted_event(1).await //.is_none()
+            db.get_withdrawal_accepted_event(1).await
         })
     }; "withdrawal-accept")]
-    //#[test_case(WITHDRAWAL_REJECT_WEBHOOK, |db: Arc<dyn DbReadWrite>| db.withdrawal_reject_events.get(&2).is_none(); "withdrawal-reject")]
+    #[test_case(WITHDRAWAL_REJECT_WEBHOOK, |db: Arc<dyn DbReadWrite>| {
+        Box::pin(async move {
+            db.get_withdrawal_rejected_event(2).await
+        })
+    }; "withdrawal-reject")]
     #[tokio::test]
     async fn test_events<F, T>(body_str: &str, table_is_empty: F)
     where

--- a/signer/src/api/new_block.rs
+++ b/signer/src/api/new_block.rs
@@ -124,16 +124,16 @@ mod tests {
             db.get_completed_deposit_event(&OutPoint::null()).await
         })
     }; "completed-deposit")]
-    // #[test_case(WITHDRAWAL_CREATE_WEBHOOK, |db: Arc<dyn DbReadWrite>| {
-    //     Box::pin(async move {
-    //         db.get_withdrawal_created_event(&1).await //.is_none()
-    //     })
-    // }; "withdrawal-create")]
-    // #[test_case(WITHDRAWAL_ACCEPT_WEBHOOK, |db: Arc<dyn DbReadWrite>| {
-    //     Box::pin(async move {
-    //         db.get_withdrawal_accepted_event.get(&1).await //.is_none()
-    //     })
-    // }; "withdrawal-accept")]
+    #[test_case(WITHDRAWAL_CREATE_WEBHOOK, |db: Arc<dyn DbReadWrite>| {
+        Box::pin(async move {
+            db.get_withdrawal_created_event(1).await //.is_none()
+        })
+    }; "withdrawal-create")]
+    #[test_case(WITHDRAWAL_ACCEPT_WEBHOOK, |db: Arc<dyn DbReadWrite>| {
+        Box::pin(async move {
+            db.get_withdrawal_accepted_event(1).await //.is_none()
+        })
+    }; "withdrawal-accept")]
     //#[test_case(WITHDRAWAL_REJECT_WEBHOOK, |db: Arc<dyn DbReadWrite>| db.withdrawal_reject_events.get(&2).is_none(); "withdrawal-reject")]
     #[tokio::test]
     async fn test_events<F, T>(body_str: &str, table_is_empty: F)

--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -71,8 +71,6 @@ where
     EC: EmilyInteract,
     S: DbWrite + DbRead + Send + Sync,
     BHS: futures::stream::Stream<Item = bitcoin::BlockHash> + Unpin,
-    error::Error: From<<S as DbRead>::Error>,
-    error::Error: From<<S as DbWrite>::Error>,
     error::Error: From<<BC as BitcoinInteract>::Error>,
 {
     /// Run the block observer

--- a/signer/src/blocklist_client.rs
+++ b/signer/src/blocklist_client.rs
@@ -39,9 +39,9 @@ impl BlocklistChecker for BlocklistClient {
     }
 }
 
-impl<'a> BlocklistClient {
+impl BlocklistClient {
     /// Construct a new [`BlocklistClient`]
-    pub fn new(ctx: &'a impl Context<'a>) -> Self {
+    pub fn new(ctx: &impl Context) -> Self {
         let base_url = format!(
             "http://{}:{}",
             ctx.config().blocklist_client.host,

--- a/signer/src/blocklist_client.rs
+++ b/signer/src/blocklist_client.rs
@@ -39,9 +39,9 @@ impl BlocklistChecker for BlocklistClient {
     }
 }
 
-impl BlocklistClient {
+impl<'a> BlocklistClient {
     /// Construct a new [`BlocklistClient`]
-    pub fn new(ctx: &impl Context) -> Self {
+    pub fn new(ctx: &'a impl Context<'a>) -> Self {
         let base_url = format!(
             "http://{}:{}",
             ctx.config().blocklist_client.host,

--- a/signer/src/config.rs
+++ b/signer/src/config.rs
@@ -232,7 +232,7 @@ impl Validatable for SignerConfig {
         self.p2p.validate()?;
 
         match (self.network, self.db_endpoint.scheme()) {
-            (NetworkKind::Mainnet, IN_MEMORY_DB_SCHEME) 
+            (NetworkKind::Mainnet, IN_MEMORY_DB_SCHEME)
             | (NetworkKind::Testnet, IN_MEMORY_DB_SCHEME) => {
                 return Err(ConfigError::Message(
                     "In-memory database may only be used in REGTEST.".to_string(),
@@ -531,10 +531,10 @@ mod tests {
 
     #[test]
     fn default_config_toml_loads_signer_network_with_environment() {
-        // In-memory db (default) can't be used together with testnet/mainnet, 
+        // In-memory db (default) can't be used together with testnet/mainnet,
         // so we simulate that we're using postgres.
         std::env::set_var("SIGNER_SIGNER__DB_ENDPOINT", "postgres://");
-        
+
         let new = "testnet";
         std::env::set_var("SIGNER_SIGNER__NETWORK", new);
 

--- a/signer/src/config/default.toml
+++ b/signer/src/config/default.toml
@@ -61,10 +61,25 @@ nakamoto_start_height = 31
 # !! Signer Configuration
 # !! ==============================================================================
 [signer]
+# The connection string/URI to the signer's database.
+#
+# Supported databases:
+# - PostgreSQL [db_type: 'pgsql']
+# - In-Memory [db_type: 'memory'] ** For testing purposes only **
+#
+# Format: "<db_type>://<connection_string>"
+# Required: true
+# Environment: SIGNER_SIGNER__DB_ENDPOINT
+#
+# Examples:
+# - PostgreSQL: "postgres://user:password@localhost:5432/signer"
+# - In-Memory: "memory"
+db_endpoint = "memory"
 # The private key associated with the signer. This is used to generate the
 # signers associated public key and sign messages to other signers.
 #
 # Required: true
+# Environment: SIGNER_SIGNER__PRIVATE_KEY
 private_key = "8183dc385a7a1fc8353b9e781ee0859a71e57abea478a5bca679334094f7adb5"
 # Specifies which network to use when constructing and sending transactions
 # on stacks and bitcoin. This cooresponds to the `chain` flag in the

--- a/signer/src/context.rs
+++ b/signer/src/context.rs
@@ -63,6 +63,7 @@ impl SignerContext {
     pub async fn init(config: Settings) -> Result<Self, Error> {
         // Create a channel for signalling within the application.
         let (signal_tx, _) = tokio::sync::broadcast::channel(128);
+        // Create a channel for termination signalling.
         let (term_tx, _) = tokio::sync::watch::channel(false);
 
         // Create a database connection.

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -205,6 +205,14 @@ pub enum Error {
     #[error("received an error when attempting to query the database: {0}")]
     SqlxQuery(#[source] sqlx::Error),
 
+    /// An error occurred while attempting to connect to the database.
+    #[error("received an error when attempting to connect to the database: {0}")]
+    SqlxConnect(#[from] sqlx::Error),
+
+    /// An unsupported database kind was given when trying to connect.
+    #[error("unsupported database: {0}")]
+    SqlxUnsupportedDatabase(String),
+
     /// An error when attempting to generically decode bytes using the
     /// trait implementation.
     #[error("got an error wen attempting to call StacksMessageCodec::consensus_deserialize {0}")]

--- a/signer/src/main.rs
+++ b/signer/src/main.rs
@@ -12,18 +12,7 @@ use signer::context::Context;
 use signer::context::SignerContext;
 use signer::context::SignerSignal;
 use signer::error::Error;
-use signer::storage::postgres::PgStore;
 use tokio::signal;
-
-// TODO: This should be read from configuration
-const DATABASE_URL: &str = "postgres://user:password@localhost:5432/signer";
-
-// TODO: Should this be part of the SignerContext?
-fn get_connection_pool() -> sqlx::PgPool {
-    sqlx::postgres::PgPoolOptions::new()
-        .connect_lazy(DATABASE_URL)
-        .unwrap()
-}
 
 /// Command line arguments for the signer.
 #[derive(Debug, Parser)]
@@ -115,11 +104,11 @@ async fn run_libp2p_swarm(ctx: &impl Context) -> Result<(), Error> {
 
 /// Runs the Stacks event observer server.
 async fn run_stacks_event_observer(ctx: &impl Context) -> Result<(), Error> {
-    let pool = get_connection_pool();
     let state = ApiState {
-        db: PgStore::from(pool),
+        db: ctx.get_storage_mut(),
         settings: ctx.config().clone(),
     };
+
     // Build the signer API application
     let app = Router::new()
         .route("/", get(api::status_handler))

--- a/signer/src/main.rs
+++ b/signer/src/main.rs
@@ -64,7 +64,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 /// Runs the shutdown-signal watcher. On Unix systems, this listens for SIGHUP,
 /// SIGTERM, and SIGINT. On other systems, it listens for Ctrl-C.
-async fn run_shutdown_signal_watcher(ctx: &impl Context<'_>) -> Result<(), Error> {
+async fn run_shutdown_signal_watcher(ctx: &impl Context) -> Result<(), Error> {
     cfg_if! {
         // If we are on a Unix system, we can listen for more signals.
         if #[cfg(unix)] {
@@ -99,7 +99,7 @@ async fn run_shutdown_signal_watcher(ctx: &impl Context<'_>) -> Result<(), Error
 }
 
 /// Runs the libp2p swarm.
-async fn run_libp2p_swarm(ctx: &impl Context<'_>) -> Result<(), Error> {
+async fn run_libp2p_swarm(ctx: &impl Context) -> Result<(), Error> {
     // Subscribe to the signal channel so that we can catch shutdown events.
     let mut signal = ctx.get_signal_receiver();
 
@@ -114,7 +114,7 @@ async fn run_libp2p_swarm(ctx: &impl Context<'_>) -> Result<(), Error> {
 }
 
 /// Runs the Stacks event observer server.
-async fn run_stacks_event_observer(ctx: &impl Context<'_>) -> Result<(), Error> {
+async fn run_stacks_event_observer(ctx: &impl Context) -> Result<(), Error> {
     let pool = get_connection_pool();
     let state = ApiState {
         db: PgStore::from(pool),

--- a/signer/src/stacks/api.rs
+++ b/signer/src/stacks/api.rs
@@ -764,7 +764,6 @@ pub async fn fetch_unknown_ancestors<S, D>(
 where
     S: StacksInteract,
     D: DbRead + Send + Sync,
-    Error: From<<D as DbRead>::Error>,
 {
     let mut blocks = vec![stacks.get_block(block_id).await?];
 

--- a/signer/src/stacks/contracts.rs
+++ b/signer/src/stacks/contracts.rs
@@ -130,8 +130,7 @@ pub trait AsContractCall {
     /// stacks and bitcoin blockchains.
     fn validate<S>(&self, _: &S) -> impl Future<Output = Result<bool, Error>> + Send
     where
-        S: DbRead + Send + Sync,
-        Error: From<<S as DbRead>::Error>;
+        S: DbRead + Send + Sync;
 }
 
 /// An enum representing all contract calls that the signers can make.
@@ -222,7 +221,6 @@ impl AsContractCall for CompleteDepositV1 {
     async fn validate<S>(&self, _storage: &S) -> Result<bool, Error>
     where
         S: DbRead + Send + Sync,
-        Error: From<<S as DbRead>::Error>,
     {
         // TODO(255): Add validation implementation
         Ok(false)
@@ -284,7 +282,6 @@ impl AsContractCall for AcceptWithdrawalV1 {
     async fn validate<S>(&self, _storage: &S) -> Result<bool, Error>
     where
         S: DbRead + Send + Sync,
-        Error: From<<S as DbRead>::Error>,
     {
         // TODO(255): Add validation implementation
         Ok(false)
@@ -331,7 +328,6 @@ impl AsContractCall for RejectWithdrawalV1 {
     async fn validate<S>(&self, _storage: &S) -> Result<bool, Error>
     where
         S: DbRead + Send + Sync,
-        Error: From<<S as DbRead>::Error>,
     {
         // TODO(255): Add validation implementation
         Ok(false)
@@ -439,7 +435,6 @@ impl AsContractCall for RotateKeysV1 {
     async fn validate<S>(&self, _storage: &S) -> Result<bool, Error>
     where
         S: DbRead + Send + Sync,
-        Error: From<<S as DbRead>::Error>,
     {
         // TODO(255): Add validation implementation
         Ok(false)

--- a/signer/src/stacks/wallet.rs
+++ b/signer/src/stacks/wallet.rs
@@ -335,7 +335,6 @@ mod tests {
         async fn validate<S>(&self, _: &S) -> Result<bool, Error>
         where
             S: DbRead + Send + Sync,
-            Error: From<<S as DbRead>::Error>,
         {
             Ok(true)
         }

--- a/signer/src/storage/in_memory.rs
+++ b/signer/src/storage/in_memory.rs
@@ -423,6 +423,32 @@ impl super::DbRead for SharedStore {
             .cloned()
             .map(Into::into))
     }
+
+    async fn get_withdrawal_created_event(
+        &self,
+        request_id: u64,
+    ) -> Result<Option<model::WithdrawalCreatedEvent>, Error> {
+        Ok(self
+            .lock()
+            .await
+            .withdrawal_create_events
+            .get(&request_id)
+            .cloned()
+            .map(Into::into))
+    }
+
+    async fn get_withdrawal_accepted_event(
+        &self,
+        request_id: u64,
+    ) -> Result<Option<model::WithdrawalAcceptedEvent>, Error> {
+        Ok(self
+            .lock()
+            .await
+            .withdrawal_accept_events
+            .get(&request_id)
+            .cloned()
+            .map(Into::into))
+    }
 }
 
 #[async_trait]

--- a/signer/src/storage/in_memory.rs
+++ b/signer/src/storage/in_memory.rs
@@ -449,6 +449,19 @@ impl super::DbRead for SharedStore {
             .cloned()
             .map(Into::into))
     }
+
+    async fn get_withdrawal_rejected_event(
+        &self,
+        request_id: u64,
+    ) -> Result<Option<model::WithdrawalRejectedEvent>, Error> {
+        Ok(self
+            .lock()
+            .await
+            .withdrawal_reject_events
+            .get(&request_id)
+            .cloned()
+            .map(Into::into))
+    }
 }
 
 #[async_trait]

--- a/signer/src/storage/mod.rs
+++ b/signer/src/storage/mod.rs
@@ -10,243 +10,289 @@ pub mod in_memory;
 pub mod model;
 pub mod postgres;
 pub mod sqlx;
+use std::sync::Arc;
 
-use std::future::Future;
-
+use async_trait::async_trait;
 use blockstack_lib::types::chainstate::StacksBlockId;
+use in_memory::Store;
 
+use crate::error::Error;
 use crate::keys::PublicKey;
 use crate::stacks::events::CompletedDepositEvent;
 use crate::stacks::events::WithdrawalAcceptEvent;
 use crate::stacks::events::WithdrawalCreateEvent;
 use crate::stacks::events::WithdrawalRejectEvent;
 
-/// Represents the ability to read data from the signer storage.
-pub trait DbRead {
-    /// Read error.
-    type Error: std::error::Error;
+/// Represents a connection to one of the supported databases.
+pub enum DbConnection {
+    /// In-memory database.
+    InMemory(in_memory::SharedStore),
+    /// PostgreSQL database.
+    Postgres(Arc<postgres::PgStore>),
+}
 
+/// Represents a connection to a database that can read and write data.
+pub trait DbReadWrite: DbRead + DbWrite {
+    /// Convert the connection to a read-only connection.
+    fn as_read(self: Arc<Self>) -> Arc<dyn DbRead>;
+    /// Convert the connection to a write-only connection.
+    fn as_write(self: Arc<Self>) -> Arc<dyn DbWrite>;
+}
+
+impl<T: DbRead + DbWrite + Sized + 'static> DbReadWrite for T {
+    fn as_read(self: Arc<Self>) -> Arc<dyn DbRead> {
+        self as Arc<dyn DbRead>
+    }
+    fn as_write(self: Arc<Self>) -> Arc<dyn DbWrite> {
+        self as Arc<dyn DbWrite>
+    }
+
+}
+
+impl DbConnection {
+    /// Connect to the database.
+    pub async fn connect(uri: url::Url) -> Result<Self, crate::error::Error> {
+        let kind = uri.scheme();
+        match kind {
+            "memory" => {
+                Ok(DbConnection::InMemory(Store::new_shared()))
+            }
+            "pgsql" => {
+                let db = postgres::PgStore::connect(&uri.to_string())
+                    .await
+                    .map_err(crate::error::Error::SqlxConnect)?;
+                Ok(DbConnection::Postgres(Arc::new(db)))
+            }
+            _ => {
+                Err(crate::error::Error::SqlxUnsupportedDatabase(format!("Unsupported database kind: {}", kind)))
+            }
+        }
+    }
+}
+
+/// Represents the ability to read data from the signer storage.
+#[async_trait]
+pub trait DbRead {
     /// Get the bitcoin block with the given block hash.
-    fn get_bitcoin_block(
+    async fn get_bitcoin_block(
         &self,
         block_hash: &model::BitcoinBlockHash,
-    ) -> impl Future<Output = Result<Option<model::BitcoinBlock>, Self::Error>> + Send;
+    ) -> Result<Option<model::BitcoinBlock>, Error>;
 
     /// Get the stacks block with the given block hash.
-    fn get_stacks_block(
+    async fn get_stacks_block(
         &self,
         block_hash: &model::StacksBlockHash,
-    ) -> impl Future<Output = Result<Option<model::StacksBlock>, Self::Error>> + Send;
+    ) -> Result<Option<model::StacksBlock>, Error>;
 
     /// Get the bitcoin canonical chain tip.
-    fn get_bitcoin_canonical_chain_tip(
+    async fn get_bitcoin_canonical_chain_tip(
         &self,
-    ) -> impl Future<Output = Result<Option<model::BitcoinBlockHash>, Self::Error>> + Send;
+    ) -> Result<Option<model::BitcoinBlockHash>, Error>;
 
     /// Get the stacks chain tip, defined as the highest stacks block
     /// confirmed by the bitcoin chain tip.
-    fn get_stacks_chain_tip(
+    async fn get_stacks_chain_tip(
         &self,
         bitcoin_chain_tip: &model::BitcoinBlockHash,
-    ) -> impl Future<Output = Result<Option<model::StacksBlock>, Self::Error>> + Send;
+    ) -> Result<Option<model::StacksBlock>, Error>;
 
     /// Get pending deposit requests
-    fn get_pending_deposit_requests(
+    async fn get_pending_deposit_requests(
         &self,
         chain_tip: &model::BitcoinBlockHash,
         context_window: u16,
-    ) -> impl Future<Output = Result<Vec<model::DepositRequest>, Self::Error>> + Send;
+    ) -> Result<Vec<model::DepositRequest>, Error>;
 
     /// Get pending deposit requests that have been accepted by at least `threshold` signers and has no responses
-    fn get_pending_accepted_deposit_requests(
+    async fn get_pending_accepted_deposit_requests(
         &self,
         chain_tip: &model::BitcoinBlockHash,
         context_window: u16,
         threshold: u16,
-    ) -> impl Future<Output = Result<Vec<model::DepositRequest>, Self::Error>> + Send;
+    ) -> Result<Vec<model::DepositRequest>, Error>;
 
     /// Get the deposit requests that the signer has accepted to sign
-    fn get_accepted_deposit_requests(
+    async fn get_accepted_deposit_requests(
         &self,
         signer: &PublicKey,
-    ) -> impl Future<Output = Result<Vec<model::DepositRequest>, Self::Error>> + Send;
+    ) -> Result<Vec<model::DepositRequest>, Error>;
 
     /// Get signer decisions for a deposit request
-    fn get_deposit_signers(
+    async fn get_deposit_signers(
         &self,
         txid: &model::BitcoinTxId,
         output_index: u32,
-    ) -> impl Future<Output = Result<Vec<model::DepositSigner>, Self::Error>> + Send;
+    ) -> Result<Vec<model::DepositSigner>, Error>;
 
     /// Get signer decisions for a withdraw request
-    fn get_withdraw_signers(
+    async fn get_withdraw_signers(
         &self,
         request_id: u64,
         block_hash: &model::StacksBlockHash,
-    ) -> impl Future<Output = Result<Vec<model::WithdrawSigner>, Self::Error>> + Send;
+    ) -> Result<Vec<model::WithdrawSigner>, Error>;
 
     /// Get pending withdraw requests
-    fn get_pending_withdraw_requests(
+    async fn get_pending_withdraw_requests(
         &self,
         chain_tip: &model::BitcoinBlockHash,
         context_window: u16,
-    ) -> impl Future<Output = Result<Vec<model::WithdrawRequest>, Self::Error>> + Send;
+    ) -> Result<Vec<model::WithdrawRequest>, Error>;
 
     /// Get pending withdraw requests that have been accepted by at least `threshold` signers and has no responses
-    fn get_pending_accepted_withdraw_requests(
+    async fn get_pending_accepted_withdraw_requests(
         &self,
         chain_tip: &model::BitcoinBlockHash,
         context_window: u16,
         threshold: u16,
-    ) -> impl Future<Output = Result<Vec<model::WithdrawRequest>, Self::Error>> + Send;
+    ) -> Result<Vec<model::WithdrawRequest>, Error>;
 
     /// Get bitcoin blocks that include a particular transaction
-    fn get_bitcoin_blocks_with_transaction(
+    async fn get_bitcoin_blocks_with_transaction(
         &self,
         txid: &model::BitcoinTxId,
-    ) -> impl Future<Output = Result<Vec<model::BitcoinBlockHash>, Self::Error>> + Send;
+    ) -> Result<Vec<model::BitcoinBlockHash>, Error>;
 
     /// Returns whether the given block ID is stored.
-    fn stacks_block_exists(
+    async fn stacks_block_exists(
         &self,
         block_id: StacksBlockId,
-    ) -> impl Future<Output = Result<bool, Self::Error>> + Send;
+    ) -> Result<bool, Error>;
 
     /// Return the applicable DKG shares for the
     /// given aggregate key
-    fn get_encrypted_dkg_shares(
+    async fn get_encrypted_dkg_shares(
         &self,
         aggregate_key: &PublicKey,
-    ) -> impl Future<Output = Result<Option<model::EncryptedDkgShares>, Self::Error>> + Send;
+    ) -> Result<Option<model::EncryptedDkgShares>, Error>;
 
     /// Return the latest rotate-keys transaction confirmed by the given `chain-tip`.
-    fn get_last_key_rotation(
+    async fn get_last_key_rotation(
         &self,
         chain_tip: &model::BitcoinBlockHash,
-    ) -> impl Future<Output = Result<Option<model::RotateKeysTransaction>, Self::Error>> + Send;
+    ) -> Result<Option<model::RotateKeysTransaction>, Error>;
 
     /// Get the last 365 days worth of the signers' `scriptPubkey`s.
-    fn get_signers_script_pubkeys(
+    async fn get_signers_script_pubkeys(
         &self,
-    ) -> impl Future<Output = Result<Vec<model::Bytes>, Self::Error>> + Send;
+    ) -> Result<Vec<model::Bytes>, Error>;
 }
 
 /// Represents the ability to write data to the signer storage.
+#[async_trait]
 pub trait DbWrite {
-    /// Write error.
-    type Error: std::error::Error;
 
     /// Write a bitcoin block.
-    fn write_bitcoin_block(
+    async fn write_bitcoin_block(
         &self,
         block: &model::BitcoinBlock,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+    ) -> Result<(), Error>;
 
     /// Write a stacks block.
-    fn write_stacks_block(
+    async fn write_stacks_block(
         &self,
         block: &model::StacksBlock,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+    ) -> Result<(), Error>;
 
     /// Write a deposit request.
-    fn write_deposit_request(
+    async fn write_deposit_request(
         &self,
         deposit_request: &model::DepositRequest,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+    ) -> Result<(), Error>;
 
     /// Write many deposit requests.
-    fn write_deposit_requests(
+    async fn write_deposit_requests(
         &self,
         deposit_requests: Vec<model::DepositRequest>,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+    ) -> Result<(), Error>;
 
     /// Write a withdrawal request.
-    fn write_withdraw_request(
+    async fn write_withdraw_request(
         &self,
         withdraw_request: &model::WithdrawRequest,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+    ) -> Result<(), Error>;
 
     /// Write a signer decision for a deposit request.
-    fn write_deposit_signer_decision(
+    async fn write_deposit_signer_decision(
         &self,
         decision: &model::DepositSigner,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+    ) -> Result<(), Error>;
 
     /// Write a signer decision for a withdrawal request.
-    fn write_withdraw_signer_decision(
+    async fn write_withdraw_signer_decision(
         &self,
         decision: &model::WithdrawSigner,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+    ) -> Result<(), Error>;
 
     /// Write a raw transaction.
-    fn write_transaction(
+    async fn write_transaction(
         &self,
         transaction: &model::Transaction,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+    ) -> Result<(), Error>;
 
     /// Write a connection between a bitcoin block and a transaction
-    fn write_bitcoin_transaction(
+    async fn write_bitcoin_transaction(
         &self,
         bitcoin_transaction: &model::BitcoinTransaction,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+    ) -> Result<(), Error>;
 
     /// Write the bitcoin transactions to the data store.
-    fn write_bitcoin_transactions(
+    async fn write_bitcoin_transactions(
         &self,
         txs: Vec<model::Transaction>,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+    ) -> Result<(), Error>;
 
     /// Write a connection between a stacks block and a transaction
-    fn write_stacks_transaction(
+    async fn write_stacks_transaction(
         &self,
         stacks_transaction: &model::StacksTransaction,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+    ) -> Result<(), Error>;
 
     /// Write the stacks transactions to the data store.
-    fn write_stacks_transactions(
+    async fn write_stacks_transactions(
         &self,
         txs: Vec<model::Transaction>,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+    ) -> Result<(), Error>;
 
     /// Write the stacks block ids and their parent block ids.
-    fn write_stacks_block_headers(
+    async fn write_stacks_block_headers(
         &self,
         headers: Vec<model::StacksBlock>,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+    ) -> Result<(), Error>;
 
     /// Write encrypted DKG shares
-    fn write_encrypted_dkg_shares(
+    async fn write_encrypted_dkg_shares(
         &self,
         shares: &model::EncryptedDkgShares,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+    ) -> Result<(), Error>;
 
     /// Write rotate-keys transaction
-    fn write_rotate_keys_transaction(
+    async fn write_rotate_keys_transaction(
         &self,
         key_rotation: &model::RotateKeysTransaction,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+    ) -> Result<(), Error>;
 
     /// Write the withdrawal-reject event to the database.
-    fn write_withdrawal_reject_event(
+    async fn write_withdrawal_reject_event(
         &self,
         event: &WithdrawalRejectEvent,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+    ) -> Result<(), Error>;
 
     /// Write the withdrawal-accept event to the database.
-    fn write_withdrawal_accept_event(
+    async fn write_withdrawal_accept_event(
         &self,
         event: &WithdrawalAcceptEvent,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+    ) -> Result<(), Error>;
 
     /// Write the withdrawal-create event to the database.
-    fn write_withdrawal_create_event(
+    async fn write_withdrawal_create_event(
         &self,
         event: &WithdrawalCreateEvent,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+    ) -> Result<(), Error>;
 
     /// Write the completed deposit event to the database.
-    fn write_completed_deposit_event(
+    async fn write_completed_deposit_event(
         &self,
         event: &CompletedDepositEvent,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+    ) -> Result<(), Error>;
 }

--- a/signer/src/storage/mod.rs
+++ b/signer/src/storage/mod.rs
@@ -140,11 +140,21 @@ pub trait DbRead: Sync + Send {
 
     /// Get the last 365 days worth of the signers' `scriptPubkey`s.
     async fn get_signers_script_pubkeys(&self) -> Result<Vec<model::Bytes>, Error>;
-    /// Get all completed deposit events.
+    /// Get the deposit-completed event for the given outpoint (if it exists).
     async fn get_completed_deposit_event(
         &self,
         outpoint: &bitcoin::OutPoint,
     ) -> Result<Option<model::CompletedDepositEvent>, Error>;
+    /// Get the withdrawal-created event for the given outpoint (if it exists).
+    async fn get_withdrawal_created_event(
+        &self,
+        request_id: u64,
+    ) -> Result<Option<model::WithdrawalCreatedEvent>, Error>;
+    /// Get the withdrawal-accepted event for the given outpoint (if it exists).
+    async fn get_withdrawal_accepted_event(
+        &self,
+        request_id: u64,
+    ) -> Result<Option<model::WithdrawalAcceptedEvent>, Error>;
 }
 
 /// Represents the ability to write data to the signer storage.

--- a/signer/src/storage/mod.rs
+++ b/signer/src/storage/mod.rs
@@ -155,6 +155,11 @@ pub trait DbRead: Sync + Send {
         &self,
         request_id: u64,
     ) -> Result<Option<model::WithdrawalAcceptedEvent>, Error>;
+    /// Get the withdrawal-rejected event for the given outpoint (if it exists).
+    async fn get_withdrawal_rejected_event(
+        &self,
+        request_id: u64,
+    ) -> Result<Option<model::WithdrawalRejectedEvent>, Error>;
 }
 
 /// Represents the ability to write data to the signer storage.

--- a/signer/src/storage/model.rs
+++ b/signer/src/storage/model.rs
@@ -99,7 +99,7 @@ pub struct WithdrawalAcceptedEvent {
     pub request_id: u64,
 
     /// The bitmap of signers which signed this request.
-    #[sqlx(skip)] // TODO: sqlx decode
+    #[sqlx(try_from = "[u8; 16]")]
     pub signer_bitmap: BitArray<[u8; 16]>,
 
     /// The bitcoin transaction ID of the withdrawal.
@@ -138,7 +138,7 @@ pub struct WithdrawalRejectedEvent {
     pub request_id: u64,
 
     /// The bitmap of signers which signed this request.
-    #[sqlx(skip)] // TODO: sqlx decode
+    #[sqlx(try_from = "[u8; 16]")]
     pub signer_bitmap: BitArray<[u8; 16]>,
 }
 

--- a/signer/src/storage/model.rs
+++ b/signer/src/storage/model.rs
@@ -375,19 +375,19 @@ pub struct RotateKeysTransaction {
 #[strum(serialize_all = "snake_case")]
 pub enum TransactionType {
     /// An sBTC transaction on Bitcoin.
-    SbtcTransaction,
+    SbtcTransaction = 1,
     /// A deposit request transaction on Bitcoin.
-    DepositRequest,
+    DepositRequest = 2,
     /// A withdrawal request transaction on Stacks.
-    WithdrawRequest,
+    WithdrawRequest = 3,
     /// A deposit accept transaction on Stacks.
-    DepositAccept,
+    DepositAccept = 4,
     /// A withdrawal accept transaction on Stacks.
-    WithdrawAccept,
+    WithdrawAccept = 5,
     /// A withdraw reject transaction on Stacks.
-    WithdrawReject,
+    WithdrawReject = 6,
     /// A rotate keys call on Stacks.
-    RotateKeys,
+    RotateKeys = 7,
 }
 
 /// The bitcoin transaction ID

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -812,6 +812,29 @@ impl super::DbRead for PgStore {
         .await
         .map_err(Error::SqlxQuery)
     }
+
+    /*txid          BYTEA  NOT NULL,
+    request_id    BIGINT NOT NULL,
+    signer_bitmap BYTEA  NOT NULL, */
+    async fn get_withdrawal_rejected_event(
+        &self,
+        request_id: u64,
+    ) -> Result<Option<model::WithdrawalRejectedEvent>, Error> {
+        //TODO: Add back signer_bitmap column when we can deserialize it
+        sqlx::query_as::<_, model::WithdrawalRejectedEvent>(
+            r#"
+            SELECT
+                txid
+                , request_id
+            FROM sbtc_signer.withdrawal_reject_events
+            WHERE request_id = $1
+            "#,
+        )
+        .bind(request_id as i64)
+        .fetch_optional(&self.0)
+        .await
+        .map_err(Error::SqlxQuery)
+    }
 }
 
 #[async_trait]

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -794,13 +794,13 @@ impl super::DbRead for PgStore {
         &self,
         request_id: u64,
     ) -> Result<Option<model::WithdrawalAcceptedEvent>, Error> {
-        //TODO: Add back signer_bitmap column when we can deserialize it
         sqlx::query_as::<_, model::WithdrawalAcceptedEvent>(
             r#"
             SELECT
                 txid
                 , request_id
                 , bitcoin_txid
+                , signer_bitmap
                 , output_index
                 , fee
             FROM sbtc_signer.withdrawal_accept_events
@@ -820,12 +820,12 @@ impl super::DbRead for PgStore {
         &self,
         request_id: u64,
     ) -> Result<Option<model::WithdrawalRejectedEvent>, Error> {
-        //TODO: Add back signer_bitmap column when we can deserialize it
         sqlx::query_as::<_, model::WithdrawalRejectedEvent>(
             r#"
             SELECT
                 txid
                 , request_id
+                , signer_bitmap
             FROM sbtc_signer.withdrawal_reject_events
             WHERE request_id = $1
             "#,

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -765,6 +765,53 @@ impl super::DbRead for PgStore {
         .await
         .map_err(Error::SqlxQuery)
     }
+
+    async fn get_withdrawal_created_event(
+        &self,
+        request_id: u64,
+    ) -> Result<Option<model::WithdrawalCreatedEvent>, Error> {
+        sqlx::query_as::<_, model::WithdrawalCreatedEvent>(
+            r#"
+            SELECT
+                txid
+                , request_id
+                , amount
+                , sender
+                , recipient
+                , max_fee
+                , block_height
+            FROM sbtc_signer.withdrawal_created_events
+            WHERE request_id = $1
+            "#,
+        )
+        .bind(request_id as i64)
+        .fetch_optional(&self.0)
+        .await
+        .map_err(Error::SqlxQuery)
+    }
+
+    async fn get_withdrawal_accepted_event(
+        &self,
+        request_id: u64,
+    ) -> Result<Option<model::WithdrawalAcceptedEvent>, Error> {
+        //TODO: Add back signer_bitmap column when we can deserialize it
+        sqlx::query_as::<_, model::WithdrawalAcceptedEvent>(
+            r#"
+            SELECT
+                txid
+                , request_id
+                , bitcoin_txid
+                , output_index
+                , fee
+            FROM sbtc_signer.withdrawal_accept_events
+            WHERE request_id = $1
+            "#,
+        )
+        .bind(request_id as i64)
+        .fetch_optional(&self.0)
+        .await
+        .map_err(Error::SqlxQuery)
+    }
 }
 
 #[async_trait]

--- a/signer/src/testing/transaction_coordinator.rs
+++ b/signer/src/testing/transaction_coordinator.rs
@@ -23,8 +23,6 @@ struct EventLoopHarness<S, C> {
 impl<S, C> EventLoopHarness<S, C>
 where
     S: storage::DbRead + storage::DbWrite + Clone + Send + 'static,
-    error::Error: From<<S as storage::DbRead>::Error>,
-    error::Error: From<<S as storage::DbWrite>::Error>,
     C: crate::bitcoin::BitcoinInteract + Send + 'static,
     error::Error: From<C::Error>,
 {
@@ -111,8 +109,6 @@ impl<C, S> TestEnvironment<C>
 where
     C: FnMut() -> S,
     S: storage::DbRead + storage::DbWrite + Clone + Send + 'static,
-    error::Error: From<<S as storage::DbRead>::Error>,
-    error::Error: From<<S as storage::DbWrite>::Error>,
 {
     /// Assert that a coordinator should be able to coordiante a signing round
     pub async fn assert_should_be_able_to_coordinate_signing_rounds(mut self) {

--- a/signer/src/testing/transaction_signer.rs
+++ b/signer/src/testing/transaction_signer.rs
@@ -33,8 +33,6 @@ struct EventLoopHarness<S, Rng> {
 impl<S, Rng> EventLoopHarness<S, Rng>
 where
     S: storage::DbRead + storage::DbWrite + Clone + Send + Sync + 'static,
-    error::Error: From<<S as storage::DbRead>::Error>,
-    error::Error: From<<S as storage::DbWrite>::Error>,
     Rng: rand::RngCore + rand::CryptoRng + Send + 'static,
 {
     fn create(
@@ -152,8 +150,6 @@ impl<C, S> TestEnvironment<C>
 where
     C: FnMut() -> S,
     S: storage::DbRead + storage::DbWrite + Clone + Send + Sync + 'static,
-    error::Error: From<<S as storage::DbRead>::Error>,
-    error::Error: From<<S as storage::DbWrite>::Error>,
 {
     /// Assert that the transaction signer will make and store decisions
     /// for pending deposit requests.

--- a/signer/src/testing/wallet.rs
+++ b/signer/src/testing/wallet.rs
@@ -154,7 +154,6 @@ impl AsContractCall for InitiateWithdrawalRequest {
     async fn validate<S>(&self, _: &S) -> Result<bool, Error>
     where
         S: crate::storage::DbRead + Send + Sync,
-        Error: From<<S as crate::storage::DbRead>::Error>,
     {
         Ok(true)
     }

--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -120,8 +120,6 @@ where
     S: storage::DbRead + storage::DbWrite,
     B: BitcoinInteract,
     error::Error: From<N::Error>,
-    error::Error: From<<S as storage::DbRead>::Error>,
-    error::Error: From<<S as storage::DbWrite>::Error>,
     error::Error: From<B::Error>,
 {
     /// Run the coordinator event loop

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -554,10 +554,9 @@ where
         &mut self,
         chain_tip: &model::BitcoinBlockHash,
     ) -> Result<Vec<model::DepositRequest>, error::Error> {
-        Ok(self
-            .storage
+        self.storage
             .get_pending_deposit_requests(chain_tip, self.context_window)
-            .await?)
+            .await
     }
 
     #[tracing::instrument(skip(self))]
@@ -565,10 +564,9 @@ where
         &mut self,
         chain_tip: &model::BitcoinBlockHash,
     ) -> Result<Vec<model::WithdrawRequest>, error::Error> {
-        Ok(self
-            .storage
+        self.storage
             .get_pending_withdraw_requests(chain_tip, self.context_window)
-            .await?)
+            .await
     }
 
     #[tracing::instrument(skip(self))]

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -144,8 +144,6 @@ where
     error::Error: From<N::Error>,
     B: blocklist_client::BlocklistChecker,
     S: storage::DbRead + storage::DbWrite + Send + Sync,
-    error::Error: From<<S as storage::DbRead>::Error>,
-    error::Error: From<<S as storage::DbWrite>::Error>,
     Rng: rand::RngCore + rand::CryptoRng,
 {
     /// Run the signer event loop

--- a/signer/src/wsts_state_machine.rs
+++ b/signer/src/wsts_state_machine.rs
@@ -87,8 +87,6 @@ impl SignerStateMachine {
     ) -> Result<Self, error::Error>
     where
         S: storage::DbRead + storage::DbWrite,
-        error::Error: From<<S as storage::DbRead>::Error>,
-        error::Error: From<<S as storage::DbWrite>::Error>,
     {
         let encrypted_shares = storage
             .get_encrypted_dkg_shares(&aggregate_key)
@@ -225,8 +223,6 @@ impl CoordinatorStateMachine {
     where
         I: IntoIterator<Item = PublicKey>,
         S: storage::DbRead + storage::DbWrite,
-        Error: From<<S as storage::DbRead>::Error>,
-        Error: From<<S as storage::DbWrite>::Error>,
     {
         let encrypted_shares = storage
             .get_encrypted_dkg_shares(&aggregate_key)

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -95,7 +95,6 @@ impl AsContractCall for InitiateWithdrawalRequest {
     async fn validate<S>(&self, _: &S) -> Result<bool, Error>
     where
         S: DbRead + Send + Sync,
-        Error: From<<S as DbRead>::Error>,
     {
         Ok(true)
     }


### PR DESCRIPTION
## Description

This PR is the skeleton of a _suggestion_ on how we could handle DB connections at runtime. Was something I played with over the weekend but when wiring things up in `main()` it started to feel more relevant (i.e. being able to run the signer locally without pgsql running).

## Changes

- Removes the `Error` associated type from `DbRead` and `DbWrite`: I don't really see the point of having them since these are traits which are contained within the signer binary themselves where we can use the crate's `Error` type. Also interferes with trait objects when the associated type differs.
- Introduces a new `DbReadWrite` trait which represents both a `DbRead` and `DbWrite`.
- Changes database access to use trait objects instead of static generics. This is unfortunately required to support multiple databases at runtime (i.e. if we want to allow in-memory/file-based for running the program locally vs. production which may choose pgsql).
- Centralizes the `DbReadWrite` impl to the `SignerContext` which is then responsible for handing out new handles to the underlying database.
  - This can be simplified if/when we implement sqlite, at least as an in-memory database in place of the current `vec`-based in-memory db. The issue is that the in-memory DB doesn't implement `sqlx::Pool` or `sqlx::Database` so we're forced to lift the abstraction up one level as it is today. Otherwise we could find a more elegant solution around the `sqlx` traits exclusively.
- My big hope is that we can abolish the current in-memory DB and use SQLite in-memory which will much more closely represent db access to pgsql etc.  The big issue with the current in-mem DB is that it won't accurately represent ANSI transactions (i.e. shared vs. exclusive read locks, exclusive write locks, page vs. row vs. column-level locks, etc.) nor will it fail on constraint violations. The current in-mem DB also uses a Mutex which will lock/block in situations where a traditional RDBMS won't.

## Testing Information

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
