### PR TITLE
feat: check contract origin webhook handler

### DIFF
--- a/signer/src/api/mod.rs
+++ b/signer/src/api/mod.rs
@@ -17,3 +17,6 @@ pub struct ApiState<S> {
     /// The runtime settings of the system.
     pub settings: Settings,
 }
+
+/// The name of the sbtc registry smart contract.
+const SBTC_REGISTRY_CONTRACT_NAME: &str = "sbtc-registry";

--- a/signer/src/api/new_block.rs
+++ b/signer/src/api/new_block.rs
@@ -55,7 +55,7 @@ where
     let registry_address = SBTC_REGISTRY_IDENTIFIER.get_or_init(|| {
         // Although the following line can panic, our unit tests hit this
         // code path so if tests pass then this will work in production.
-        let contract_name = ContractName::try_from("sbtc-registry").unwrap();
+        let contract_name = ContractName::from("sbtc-registry");
         let issuer = StandardPrincipalData::from(api.settings.signer.deployer);
         QualifiedContractIdentifier::new(issuer, contract_name)
     });

--- a/signer/src/api/new_block.rs
+++ b/signer/src/api/new_block.rs
@@ -15,6 +15,7 @@ use crate::stacks::webhooks::NewBlockEvent;
 use crate::storage::DbWrite;
 
 use super::ApiState;
+use super::SBTC_REGISTRY_CONTRACT_NAME;
 
 /// The address for the sbtc-registry smart contract. This value is
 /// populated using the deployer variable in the config.
@@ -55,7 +56,7 @@ where
     let registry_address = SBTC_REGISTRY_IDENTIFIER.get_or_init(|| {
         // Although the following line can panic, our unit tests hit this
         // code path so if tests pass then this will work in production.
-        let contract_name = ContractName::from("sbtc-registry");
+        let contract_name = ContractName::from(SBTC_REGISTRY_CONTRACT_NAME);
         let issuer = StandardPrincipalData::from(api.settings.signer.deployer);
         QualifiedContractIdentifier::new(issuer, contract_name)
     });
@@ -185,7 +186,7 @@ mod tests {
     {
         let api = ApiState {
             db: Store::new_shared(),
-            settings: Settings::new(crate::testing::DEFAULT_CONFIG_PATH).unwrap(),
+            settings: Settings::new_from_default_config().unwrap(),
         };
 
         // Hey look, there is nothing here!
@@ -194,9 +195,10 @@ mod tests {
 
         // Okay, we want to make sure that events that are from an
         // unexpected contract are filtered out. So we manually switch the
-        // address to some random one and check the output.
+        // address to some random one and check the output. To do that we
+        // do a string replace for the expected one with the fishy one.
         let issuer = StandardPrincipalData::from(api.settings.signer.deployer);
-        let contract_name = ContractName::from("sbtc-registry");
+        let contract_name = ContractName::from(SBTC_REGISTRY_CONTRACT_NAME);
         let identifier = QualifiedContractIdentifier::new(issuer, contract_name.clone());
 
         let fishy_principal: StacksPrincipal = fake::Faker.fake_with_rng(&mut OsRng);

--- a/signer/src/config.rs
+++ b/signer/src/config.rs
@@ -338,7 +338,7 @@ pub struct StacksNodeSettings {
     /// The endpoint to use when making requests to a stacks node.
     #[serde(deserialize_with = "url_deserializer_vec")]
     pub endpoints: Vec<url::Url>,
-    /// This is the start height of the first EPOCH 3.0 block on the stacks
+    /// This is the start height of the first EPOCH 3.0 block on the Stacks
     /// blockchain.
     pub nakamoto_start_height: u64,
 }
@@ -493,7 +493,7 @@ fn try_parse_p2p_multiaddr(s: &str) -> Result<Multiaddr, SignerConfigError> {
 ///
 /// The [`StacksAddress`] struct does not implement any string parsing or
 /// c32 decoding. However, the [`PrincipalData::parse_standard_principal`]
-/// function does the expected c32 decoding and the validation so we go
+/// function does the expected c32 decoding and the validation, so we go
 /// through that.
 pub fn parse_stacks_address<'de, D>(des: D) -> Result<StacksAddress, D::Error>
 where
@@ -609,7 +609,7 @@ mod tests {
 
         let settings = Settings::new_from_default_config().unwrap();
 
-        assert!(settings.bitcoin.endpoints.len() == 2);
+        assert_eq!(settings.bitcoin.endpoints.len(), 2);
         assert!(settings
             .bitcoin
             .endpoints

--- a/signer/src/config.rs
+++ b/signer/src/config.rs
@@ -35,7 +35,7 @@ pub enum SignerConfigError {
 
     /// The NetworkKind set in the config must match the network kind of
     /// the deployer address.
-    #[error("Network kind must match network of the deployer")]
+    #[error("The network set in the config must match the network kind of the deployer address")]
     NetworkDeployerMismatch,
 
     /// Invalid P2P URI
@@ -106,6 +106,13 @@ impl From<NetworkKind> for bitcoin::KnownHrp {
             NetworkKind::Testnet => bitcoin::KnownHrp::Testnets,
             NetworkKind::Regtest => bitcoin::KnownHrp::Regtest,
         }
+    }
+}
+
+impl NetworkKind {
+    /// Returns whether the network variant is Mainnet.
+    pub fn is_mainnet(&self) -> bool {
+        self == &NetworkKind::Mainnet
     }
 }
 
@@ -236,7 +243,7 @@ pub struct SignerConfig {
 impl Validatable for SignerConfig {
     fn validate(&self, cfg: &Settings) -> Result<(), ConfigError> {
         self.p2p.validate(cfg)?;
-        if self.deployer.is_mainnet() != (self.network == NetworkKind::Mainnet) {
+        if self.deployer.is_mainnet() != self.network.is_mainnet() {
             let err = SignerConfigError::NetworkDeployerMismatch;
             return Err(ConfigError::Message(err.to_string()));
         }

--- a/signer/src/config/default.toml
+++ b/signer/src/config/default.toml
@@ -77,6 +77,11 @@ private_key = "8183dc385a7a1fc8353b9e781ee0859a71e57abea478a5bca679334094f7adb5"
 # Environment: SIGNER_SIGNER__NETWORK
 network = "regtest"
 
+# The address that deployed the sbtc smart contracts.
+#
+# Required: true
+deployer = "SN2V7WTJ7BHR03MPHZ1C9A9ZR6NZGR4WM8HT4V67Y"
+
 # !! ==============================================================================
 # !! Stacks Event Observer Configuration
 # !!

--- a/signer/src/lib.rs
+++ b/signer/src/lib.rs
@@ -26,6 +26,7 @@ pub mod wsts_state_machine;
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// The maximum number of keys in the signers multi-sig wallet on Stacks.
+///
 /// There are a few practical limits on the maximum number of distinct
 /// public keys:
 /// 1. The maximum number of signatures allowed in a stacks transaction is

--- a/signer/src/stacks/webhooks.rs
+++ b/signer/src/stacks/webhooks.rs
@@ -84,7 +84,7 @@ pub struct NewBlockEvent {
 }
 
 /// This matches the json value that is defined in stacks-core[^1]. It
-/// contains the raw tranaction and the result of the transaction.
+/// contains the raw transaction and the result of the transaction.
 ///
 /// <https://github.com/stacks-network/stacks-core/blob/09c4b066e25104be8b066e8f7530ff0c6df4ccd5/testnet/stacks-node/src/event_dispatcher.rs#L499-L511>
 #[derive(Debug, Deserialize)]
@@ -158,12 +158,12 @@ pub struct TransactionEvent {
 }
 
 /// Smart contracts emit events when they are executed. This represents
-/// such an event. The expected type is taken from stackss-core[^1].
+/// such an event. The expected type is taken from stacks-core[^1].
 ///
 /// [^1]: <https://github.com/stacks-network/stacks-core/blob/09c4b066e25104be8b066e8f7530ff0c6df4ccd5/clarity/src/vm/events.rs#L358-L363>
 #[derive(Debug, Deserialize)]
 pub struct SmartContractEvent {
-    /// Identifies the smart contract that generated event.
+    /// Identifies the smart contract that generated the event.
     #[serde(deserialize_with = "parse_contract_name")]
     pub contract_identifier: QualifiedContractIdentifier,
     /// The specific topic of the event. This is placed in the stacks node
@@ -223,7 +223,7 @@ where
 /// # Notes
 ///
 /// This returns [`Ok(None)`] whenever the "raw_tx" is "0x00", which
-/// corresponds to a burnchain operation.
+/// corresponds to a burn-chain operation.
 pub fn deserialize_tx<'de, D>(deserializer: D) -> Result<Option<StacksTransaction>, D::Error>
 where
     D: serde::Deserializer<'de>,


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/501.

## Changes

* Filter `new_block` webhook events on the `sbtc-registry` contract address.
* Add the sbtc contract deployer to the signer's config. Check that the network embedded in the address matches the network set in the config.
 
 
I'm not 100% happy with adding the deployer address to the config, since it's not _really_ a configuration option. We do not expect signer operators to set this once the contracts have been deployed. While we develop the application we kinda need the option to change it so it makes sense to have this configurable, which is why I added it. I'm open to suggestions though.

## Testing Information

The existing webhook tests need the value that is added to the config in order to function correctly (the address in the fixture needs to match the value loaded in the config).

## Checklist:

- [x] I have performed a self-review of my code
