### PR TITLE
feat: populate signer bitmap in deposit requests

### DIFF
--- a/signer/src/bitcoin/utxo.rs
+++ b/signer/src/bitcoin/utxo.rs
@@ -361,7 +361,11 @@ impl DepositRequest {
                 // The BitArray::<[u8; 16]>::set function panics if the
                 // index is out of bounds but that cannot be the case here
                 // because we only take 128 values.
-                signer_bitmap.set(index, vote.is_rejected);
+                //
+                // Note that the signer bitmap here is true for votes
+                // *against*, and a missing vote is an implicit vote
+                // against.
+                signer_bitmap.set(index, !vote.is_accepted.unwrap_or(false));
             });
 
         Self {

--- a/signer/src/bitcoin/utxo.rs
+++ b/signer/src/bitcoin/utxo.rs
@@ -343,6 +343,9 @@ impl DepositRequest {
     }
 
     /// Try convert from a model::DepositRequest with some additional info.
+    ///
+    /// TODO: derive the signer public key from the public keys in the
+    /// votes.
     pub fn from_model(
         request: model::DepositRequest,
         signers_public_key: XOnlyPublicKey,

--- a/signer/src/keys.rs
+++ b/signer/src/keys.rs
@@ -49,15 +49,15 @@ impl From<&secp256k1::PublicKey> for PublicKey {
     }
 }
 
-impl From<&PublicKey> for secp256k1::PublicKey {
-    fn from(value: &PublicKey) -> Self {
-        value.0
-    }
-}
-
 impl From<secp256k1::PublicKey> for PublicKey {
     fn from(value: secp256k1::PublicKey) -> Self {
         Self(value)
+    }
+}
+
+impl From<&PublicKey> for secp256k1::PublicKey {
+    fn from(value: &PublicKey) -> Self {
+        value.0
     }
 }
 
@@ -69,6 +69,12 @@ impl From<PublicKey> for secp256k1::PublicKey {
 
 impl From<&PublicKey> for secp256k1::XOnlyPublicKey {
     fn from(value: &PublicKey) -> Self {
+        value.0.x_only_public_key().0
+    }
+}
+
+impl From<PublicKey> for secp256k1::XOnlyPublicKey {
+    fn from(value: PublicKey) -> Self {
         value.0.x_only_public_key().0
     }
 }
@@ -147,17 +153,17 @@ impl From<&PublicKey> for p256k1::keys::PublicKey {
     }
 }
 
+impl From<PublicKey> for p256k1::keys::PublicKey {
+    fn from(value: PublicKey) -> Self {
+        Self::from(&value)
+    }
+}
+
 impl From<&p256k1::keys::PublicKey> for PublicKey {
     fn from(value: &p256k1::keys::PublicKey) -> Self {
         secp256k1::PublicKey::from_slice(&value.to_bytes())
             .map(Self)
             .expect("BUG: p256k1 public keys should map to rust-secp265k1 public keys")
-    }
-}
-
-impl From<PublicKey> for p256k1::keys::PublicKey {
-    fn from(value: PublicKey) -> Self {
-        Self::from(&value)
     }
 }
 

--- a/signer/src/stacks/wallet.rs
+++ b/signer/src/stacks/wallet.rs
@@ -59,6 +59,9 @@ pub struct SignerWallet {
     address: StacksAddress,
     /// The next nonce for the StacksAddress associated with the address of
     /// the wallet.
+    ///
+    /// TODO: remove the nonce, it should be set when the signer creates
+    /// each transaction.
     nonce: AtomicU64,
 }
 

--- a/signer/src/storage/in_memory.rs
+++ b/signer/src/storage/in_memory.rs
@@ -414,7 +414,7 @@ impl super::DbRead for SharedStore {
         &self,
         _txid: &model::BitcoinTxId,
         _output_index: u32,
-        _aggregate_key: PublicKey,
+        _aggregate_key: &PublicKey,
     ) -> Result<Vec<model::SignerVote>, Self::Error> {
         unimplemented!()
     }

--- a/signer/src/storage/in_memory.rs
+++ b/signer/src/storage/in_memory.rs
@@ -409,6 +409,15 @@ impl super::DbRead for SharedStore {
             .map(|share| share.script_pubkey.clone())
             .collect())
     }
+
+    async fn get_deposit_request_signer_votes(
+        &self,
+        _txid: &model::BitcoinTxId,
+        _output_index: u32,
+        _aggregate_key: PublicKey,
+    ) -> Result<Vec<model::SignerVote>, Self::Error> {
+        unimplemented!()
+    }
 }
 
 impl super::DbWrite for SharedStore {

--- a/signer/src/storage/in_memory.rs
+++ b/signer/src/storage/in_memory.rs
@@ -412,11 +412,39 @@ impl super::DbRead for SharedStore {
 
     async fn get_deposit_request_signer_votes(
         &self,
-        _txid: &model::BitcoinTxId,
-        _output_index: u32,
-        _aggregate_key: &PublicKey,
+        txid: &model::BitcoinTxId,
+        output_index: u32,
+        aggregate_key: &PublicKey,
     ) -> Result<Vec<model::SignerVote>, Self::Error> {
-        unimplemented!()
+        // Let's fetch the votes for the outpoint
+        let signers = self.get_deposit_signers(txid, output_index).await?;
+        let signer_votes: HashMap<PublicKey, bool> = signers
+            .iter()
+            .map(|vote| (vote.signer_pub_key, vote.is_accepted))
+            .collect();
+
+        // Now we might not have votes from every signer, so lets get the
+        // full signer set.
+        let store = self.lock().await;
+        let ans = store
+            .rotate_keys_transactions
+            .iter()
+            .find(|(_, tx)| &tx.aggregate_key == aggregate_key);
+
+        // Let's merge the signer set with the actual votes.
+        if let Some((_, rotate_keys_tx)) = ans {
+            let votes = rotate_keys_tx
+                .signer_set
+                .iter()
+                .map(|public_key| model::SignerVote {
+                    signer_public_key: *public_key,
+                    is_accepted: signer_votes.get(public_key).copied(),
+                })
+                .collect();
+            Ok(votes)
+        } else {
+            Ok(Vec::new())
+        }
     }
 }
 

--- a/signer/src/storage/mod.rs
+++ b/signer/src/storage/mod.rs
@@ -129,6 +129,18 @@ pub trait DbRead {
     fn get_signers_script_pubkeys(
         &self,
     ) -> impl Future<Output = Result<Vec<model::Bytes>, Self::Error>> + Send;
+
+    /// For the given outpoint, and aggregate key, get the list for how the
+    /// signers voted against the transaction. Here, `true` means the
+    /// signer voted against it. If we have not received a vote from a
+    /// particular signer we assume that they voted against the
+    /// transaction.
+    fn get_deposit_request_signer_votes(
+        &self,
+        txid: &model::BitcoinTxId,
+        output_index: u32,
+        aggregate_key: PublicKey,
+    ) -> impl Future<Output = Result<Vec<model::SignerVote>, Self::Error>> + Send;
 }
 
 /// Represents the ability to write data to the signer storage.

--- a/signer/src/storage/mod.rs
+++ b/signer/src/storage/mod.rs
@@ -130,11 +130,8 @@ pub trait DbRead {
         &self,
     ) -> impl Future<Output = Result<Vec<model::Bytes>, Self::Error>> + Send;
 
-    /// For the given outpoint, and aggregate key, get the list for how the
-    /// signers voted against the transaction. Here, `true` means the
-    /// signer voted against it. If we have not received a vote from a
-    /// particular signer we assume that they voted against the
-    /// transaction.
+    /// For the given outpoint and aggregate key, get the list all signer
+    /// votes in the signer set.
     fn get_deposit_request_signer_votes(
         &self,
         txid: &model::BitcoinTxId,

--- a/signer/src/storage/mod.rs
+++ b/signer/src/storage/mod.rs
@@ -139,7 +139,7 @@ pub trait DbRead {
         &self,
         txid: &model::BitcoinTxId,
         output_index: u32,
-        aggregate_key: PublicKey,
+        aggregate_key: &PublicKey,
     ) -> impl Future<Output = Result<Vec<model::SignerVote>, Self::Error>> + Send;
 }
 

--- a/signer/src/storage/model.rs
+++ b/signer/src/storage/model.rs
@@ -241,8 +241,8 @@ pub struct RotateKeysTransaction {
 pub struct SignerVote {
     /// The public key of the signer that casted the vote.
     pub signer_public_key: PublicKey,
-    /// How the signers voted.
-    pub is_rejected: bool,
+    /// How the signer voted. None is retuend if we do not have a record of how the signer voted
+    pub is_accepted: Option<bool>,
 }
 
 /// The types of transactions the signer is interested in.

--- a/signer/src/storage/model.rs
+++ b/signer/src/storage/model.rs
@@ -244,7 +244,8 @@ pub struct RotateKeysTransaction {
 pub struct SignerVote {
     /// The public key of the signer that casted the vote.
     pub signer_public_key: PublicKey,
-    /// How the signer voted. None is retuend if we do not have a record of how the signer voted
+    /// How the signer voted for a transaction. None is returned if we do
+    /// not have a record of how the signer voted
     pub is_accepted: Option<bool>,
 }
 

--- a/signer/src/storage/model.rs
+++ b/signer/src/storage/model.rs
@@ -234,6 +234,17 @@ pub struct RotateKeysTransaction {
     pub signatures_required: u16,
 }
 
+/// A struct containing how a signer voted for a deposit or withdrawal
+/// request.
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, sqlx::FromRow)]
+#[cfg_attr(feature = "testing", derive(fake::Dummy))]
+pub struct SignerVote {
+    /// The public key of the signer that casted the vote.
+    pub signer_public_key: PublicKey,
+    /// How the signers voted.
+    pub is_rejected: bool,
+}
+
 /// The types of transactions the signer is interested in.
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, sqlx::Type, strum::Display)]
 #[sqlx(type_name = "sbtc_signer.transaction_type", rename_all = "snake_case")]

--- a/signer/src/storage/model.rs
+++ b/signer/src/storage/model.rs
@@ -226,6 +226,9 @@ pub struct RotateKeysTransaction {
     /// Transaction ID.
     pub txid: StacksTxId,
     /// The aggregate key for these shares.
+    ///
+    /// TODO: maybe make the aggregate key private. Se itt using the
+    /// `signer_set`, ensuring that it cannot drift from the given keys.
     pub aggregate_key: PublicKey,
     /// The public keys of the signers.
     pub signer_set: Vec<PublicKey>,

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -386,11 +386,11 @@ impl super::DbRead for PgStore {
         &self,
         txid: &model::BitcoinTxId,
         output_index: u32,
-        aggregate_key: PublicKey,
+        aggregate_key: &PublicKey,
     ) -> Result<Vec<model::SignerVote>, Self::Error> {
         sqlx::query_as::<_, model::SignerVote>(
             r#"
-            WITH signer_set_row AS (
+            WITH signer_set_rows AS (
                 -- Note that we could have multiple rotate keys transaction
                 -- with the same aggregate key, but every time we see the
                 -- same aggragate key it is very likely that it is
@@ -412,8 +412,8 @@ impl super::DbRead for PgStore {
             )
             SELECT
                 signer_public_key
-              , COALESCE(NOT is_accepted, TRUE) AS is_rejected
-            FROM signer_set AS ss
+              , is_accepted
+            FROM signer_set_rows AS ss
             LEFT JOIN deposit_votes AS ds USING(signer_public_key)
             "#,
         )

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -391,10 +391,12 @@ impl super::DbRead for PgStore {
         sqlx::query_as::<_, model::SignerVote>(
             r#"
             WITH signer_set_row AS (
-                -- We could have multiple rotate keys transaction with the
-                -- same aggregate key, each of aggragate key is very likely
-                -- to have the same signer set. So we use DISTINCT to
-                -- remove any duplicates.
+                -- Note that we could have multiple rotate keys transaction
+                -- with the same aggregate key, but every time we see the
+                -- same aggragate key it is very likely that it is
+                -- associated with the same set of public keys. So we match
+                -- on the aggregate key, assume we get the same set of
+                -- public keys, and use DISTINCT to remove duplicates.
                 SELECT DISTINCT UNNEST(signer_set) AS signer_public_key
                 FROM sbtc_signer.rotate_keys_transactions
                 WHERE aggregate_key = $1

--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -460,7 +460,7 @@ where
         for req in pending_deposit_requests {
             let votes = self
                 .storage
-                .get_deposit_request_signer_votes(&req.txid, req.output_index, aggregate_key)
+                .get_deposit_request_signer_votes(&req.txid, req.output_index, &aggregate_key)
                 .await?;
 
             let deposit = utxo::DepositRequest::from_model(req, signers_public_key, votes);

--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -455,13 +455,17 @@ where
 
         let signers_public_key = bitcoin::XOnlyPublicKey::from(&aggregate_key);
 
-        let convert_deposit =
-            |request| utxo::DepositRequest::try_from_model(request, signers_public_key);
+        let mut deposits: Vec<utxo::DepositRequest> = Vec::new();
 
-        let deposits: Vec<utxo::DepositRequest> = pending_deposit_requests
-            .into_iter()
-            .map(convert_deposit)
-            .collect::<Result<_, _>>()?;
+        for req in pending_deposit_requests {
+            let votes = self
+                .storage
+                .get_deposit_request_signer_votes(&req.txid, req.output_index, aggregate_key)
+                .await?;
+
+            let deposit = utxo::DepositRequest::from_model(req, signers_public_key, votes);
+            deposits.push(deposit);
+        }
 
         let convert_withdraw =
             |request| utxo::WithdrawalRequest::try_from_model(request, self.bitcoin_network);


### PR DESCRIPTION
## Description

Closes part of https://github.com/stacks-network/sbtc/issues/326.

A left some TODOs without tickets, I apologize. I'll fix that tomorrow.

## Changes

* Add a query that fetches how the signers voted on a deposit.
* Populate the signer bitmap when constructing the `utxo::DepositRequest` struct.

## Testing Information

This PR adds an integration test for the query and a unit test to make sure the bitmap is constructed correctly.

## Checklist:

- [x] I have performed a self-review of my code
