### PR TITLE
fix: pass on validatated script when validating deposit scripts

### DIFF
--- a/sbtc/src/deposits.rs
+++ b/sbtc/src/deposits.rs
@@ -182,7 +182,8 @@ impl CreateDepositRequest {
         debug_assert_eq!(deposit_script, self.deposit_script);
         debug_assert_eq!(reclaim_script, self.reclaim_script);
 
-        let expected_script_pubkey = to_script_pubkey(deposit_script, reclaim_script);
+        let expected_script_pubkey =
+            to_script_pubkey(deposit_script.clone(), reclaim_script.clone());
         // Check that the expected scriptPubkey matches the actual public
         // key of our parsed UTXO.
         if expected_script_pubkey != tx_out.script_pubkey {
@@ -191,8 +192,8 @@ impl CreateDepositRequest {
 
         Ok(DepositInfo {
             max_fee: deposit.max_fee,
-            deposit_script: self.deposit_script.clone(),
-            reclaim_script: self.reclaim_script.clone(),
+            deposit_script,
+            reclaim_script,
             signers_public_key: deposit.signers_public_key,
             recipient: deposit.recipient,
             lock_time: reclaim.lock_time as u64,

--- a/signer/src/bitcoin/utxo.rs
+++ b/signer/src/bitcoin/utxo.rs
@@ -36,9 +36,9 @@ use crate::bitcoin::packaging::Weighted;
 use crate::error::Error;
 use crate::keys::SignerScriptPubKey as _;
 use crate::storage::model;
+use crate::storage::model::SignerVote;
 use crate::storage::model::StacksBlockHash;
 use crate::storage::model::StacksTxId;
-use crate::storage::model::SignerVote;
 use crate::MAX_KEYS;
 
 /// The minimum incremental fee rate in sats per virtual byte for RBF


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/514

## Changes

* Use the regenerated deposit and reclaim scripts when passing on the validated deposit info.

## Testing Information

There isn't really a new test for this change, since it involves constructing a collision in a merkle tree. So if the existing tests pass then we should be good.

## Checklist:

- [x] I have performed a self-review of my code
