### PR TITLE
feat: config cleanup + db config + url parsing error

### DIFF
--- a/devenv/local/docker-compose/docker-compose.yml
+++ b/devenv/local/docker-compose/docker-compose.yml
@@ -56,8 +56,9 @@ services:
     ports:
       - 5432:5432
     environment:
-      - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD=postgres
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: signer
 
   mariadb:
     image: mariadb:10.5.21

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -29,7 +29,8 @@ services:
     image: postgres:16.3
     container_name: postgres
     environment:
-      POSTGRES_USER: user
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
       POSTGRES_DB: signer
       POSTGRES_HOST_AUTH_METHOD: trust
     ports:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -46,6 +46,7 @@ services:
     command: >-
       -url=jdbc:postgresql://postgres:5432/signer
       -user=postgres
+      -password=postgres
       -sqlMigrationPrefix=""
       -connectRetries=60
       migrate

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -36,7 +36,7 @@ services:
     ports:
       - "5432:5432"
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready --username=user --dbname=signer"]
+      test: ["CMD-SHELL", "pg_isready --username=postgres --dbname=signer"]
       interval: 2s
       timeout: 1s
       retries: 5
@@ -45,7 +45,7 @@ services:
     image: flyway/flyway:10.13.0
     command: >-
       -url=jdbc:postgresql://postgres:5432/signer
-      -user=user
+      -user=postgres
       -sqlMigrationPrefix=""
       -connectRetries=60
       migrate

--- a/signer/src/bitcoin/utxo.rs
+++ b/signer/src/bitcoin/utxo.rs
@@ -36,9 +36,9 @@ use crate::bitcoin::packaging::Weighted;
 use crate::error::Error;
 use crate::keys::SignerScriptPubKey as _;
 use crate::storage::model;
+use crate::storage::model::SignerVote;
 use crate::storage::model::StacksBlockHash;
 use crate::storage::model::StacksTxId;
-use crate::storage::model::SignerVote;
 use crate::MAX_KEYS;
 
 /// The minimum incremental fee rate in sats per virtual byte for RBF

--- a/signer/src/config/default.toml
+++ b/signer/src/config/default.toml
@@ -43,16 +43,14 @@ ping_interval = 60
 subscribe_interval = 10
 
 # !! ==============================================================================
-# !! Stacks RPC-API Configuration
-# !! ==============================================================================
-[stacks.api]
-endpoint = "http://localhost:3999"
-
-# !! ==============================================================================
 # !! Stacks Node Configuration
 # !! ==============================================================================
 [stacks.node]
+# The RPC URL(s) of the Stacks node(s) to connect to. At least one must be
+# provided. If multiple nodes are provided they will be tried in order when
+# making requests.
 endpoints = ["http://localhost:20443"]
+
 # This is the start height of the first EPOCH 3.0 block on the stacks
 # blockchain.
 nakamoto_start_height = 31
@@ -64,8 +62,16 @@ nakamoto_start_height = 31
 # The private key associated with the signer. This is used to generate the
 # signers associated public key and sign messages to other signers.
 #
+# This may be either in 32- or 33-byte format. If you generated the key using
+# `stacks-cli` or other ecosystem tools, it is likely that the key is in 33-byte
+# format which includes a stacks-proprietary suffix byte. The sBTC signer doesn't
+# make use of this byte and it will be trimmed automatically if provided.
+#
+# Format: "<hex-encoded-private-key>" (64 or 66 hex-characters)
 # Required: true
+# Environment: SIGNER_SIGNER__PRIVATE_KEY
 private_key = "8183dc385a7a1fc8353b9e781ee0859a71e57abea478a5bca679334094f7adb5"
+
 # Specifies which network to use when constructing and sending transactions
 # on stacks and bitcoin. This cooresponds to the `chain` flag in the
 # bitcoin.conf file of the connected bitcoin-core node, and the
@@ -81,6 +87,12 @@ network = "regtest"
 #
 # Required: true
 deployer = "SN2V7WTJ7BHR03MPHZ1C9A9ZR6NZGR4WM8HT4V67Y"
+
+# The signer database endpoint (pgsql connection string)
+#
+# Required: true
+# Environment: SIGNER_SIGNER__DB_ENDPOINT
+db_endpoint = "postgresql://postgres:postgres@localhost:5432/signer"
 
 # !! ==============================================================================
 # !! Stacks Event Observer Configuration

--- a/signer/src/config/error.rs
+++ b/signer/src/config/error.rs
@@ -1,0 +1,55 @@
+/// Configuration error variants.
+#[derive(Debug, thiserror::Error)]
+pub enum SignerConfigError {
+    /// Invalid Stacks private key length
+    #[error("The Stacks private key provided is invalid, it must be either 64 or 66 hex characters long, got {0}")]
+    InvalidStacksPrivateKeyLength(usize),
+
+    /// Invalid Stacks private key compression byte marker
+    #[error("The Stacks private key provided contains an invalid compression byte marker: {0}")]
+    InvalidStacksPrivateKeyCompressionByte(String),
+
+    /// Invalid P2P URI
+    #[error("Invalid P2P URI: Failed to parse: {0}")]
+    InvalidP2PUri(#[from] url::ParseError),
+
+    /// The NetworkKind set in the config must match the network kind of
+    /// the deployer address.
+    #[error("The network set in the config must match the network kind of the deployer address")]
+    NetworkDeployerMismatch,
+
+    /// Invalid P2P URI
+    #[error("Invalid P2P URI: Only schemes 'tcp' and 'quic-v1' are supported; got '{0}'")]
+    InvalidP2PScheme(String),
+
+    /// P2P port is required
+    #[error("Invalid P2P URI: Port is required")]
+    P2PPortRequired,
+
+    /// P2P paths not supported
+    #[error("Invalid P2P URI: Paths are not supported: '{0}'")]
+    P2PPathsNotSupported(String),
+
+    /// Usernames are not supported in P2P URIs
+    #[error("Invalid P2P URI: Usernames are not supported: '{0}'")]
+    P2PUsernameNotSupported(String),
+
+    /// Passwords are not supported in P2P URIs
+    #[error("Invalid P2P URI: Passwords are not supported: '{0}'")]
+    P2PPasswordNotSupported(String),
+
+    /// Query strings are not supported in P2P URIs
+    #[error("Invalid P2P URI: Query strings are not supported: '{0}'")]
+    P2PQueryStringsNotSupported(String),
+
+    /// When the network kind is 'mainnet' or 'testnet', at least one P2P seed peer is required.
+    /// Otherwise, we'll allow mDNS to discover any local peers (for testing).
+    #[error(
+        "At least one P2P seed peer is required when the network kind is 'mainnet' or 'testnet'."
+    )]
+    P2PSeedPeerRequired,
+
+    /// Unsupported database driver
+    #[error("Unsupported database driver: {0}. Supported drivers are: 'postgresql'.")]
+    UnsupportedDatabaseDriver(String),
+}

--- a/signer/src/config/error.rs
+++ b/signer/src/config/error.rs
@@ -42,6 +42,10 @@ pub enum SignerConfigError {
     #[error("Invalid P2P URI: Query strings are not supported: '{0}'")]
     P2PQueryStringsNotSupported(String),
 
+    /// P2P host is required
+    #[error("Invalid P2P URI: Host is required")]
+    P2PHostRequired,
+
     /// When the network kind is 'mainnet' or 'testnet', at least one P2P seed peer is required.
     /// Otherwise, we'll allow mDNS to discover any local peers (for testing).
     #[error(

--- a/signer/src/config/mod.rs
+++ b/signer/src/config/mod.rs
@@ -1,74 +1,21 @@
 //! Configuration management for the signer
-use std::str::FromStr as _;
-
-use clarity::vm::types::PrincipalData;
 use config::{Config, ConfigError, Environment, File};
 use libp2p::Multiaddr;
 use serde::Deserialize;
-use serde::Deserializer;
 use stacks_common::types::chainstate::StacksAddress;
 use std::path::Path;
 use url::Url;
 
 use crate::error::Error;
 use crate::keys::PrivateKey;
+use error::SignerConfigError;
+use serialization::{
+    p2p_multiaddr_deserializer_vec, parse_stacks_address, private_key_deserializer,
+    url_deserializer_single, url_deserializer_vec,
+};
 
-/// The default signer network listen-on address.
-pub const DEFAULT_P2P_HOST: &str = "0.0.0.0";
-/// The default signer network listen-on port.
-pub const DEFAULT_P2P_PORT: u16 = 4122;
-
-/// Configuration error variants.
-#[derive(Debug, thiserror::Error)]
-pub enum SignerConfigError {
-    /// Invalid Stacks private key length
-    #[error("The Stacks private key provided is invalid, it must be either 64 or 66 hex characters long, got {0}")]
-    InvalidStacksPrivateKeyLength(usize),
-
-    /// Invalid Stacks private key compression byte marker
-    #[error("The Stacks private key provided contains an invalid compression byte marker: {0}")]
-    InvalidStacksPrivateKeyCompressionByte(String),
-
-    /// Invalid P2P URI
-    #[error("Invalid P2P URI: Failed to parse: {0}")]
-    InvalidP2PUri(#[from] url::ParseError),
-
-    /// The NetworkKind set in the config must match the network kind of
-    /// the deployer address.
-    #[error("The network set in the config must match the network kind of the deployer address")]
-    NetworkDeployerMismatch,
-
-    /// Invalid P2P URI
-    #[error("Invalid P2P URI: Only schemes 'tcp' and 'quic-v1' are supported; got '{0}'")]
-    InvalidP2PScheme(String),
-
-    /// P2P port is required
-    #[error("Invalid P2P URI: Port is required")]
-    P2PPortRequired,
-
-    /// P2P paths not supported
-    #[error("Invalid P2P URI: Paths are not supported: '{0}'")]
-    P2PPathsNotSupported(String),
-
-    /// Usernames are not supported in P2P URIs
-    #[error("Invalid P2P URI: Usernames are not supported: '{0}'")]
-    P2PUsernameNotSupported(String),
-
-    /// Passwords are not supported in P2P URIs
-    #[error("Invalid P2P URI: Passwords are not supported: '{0}'")]
-    P2PPasswordNotSupported(String),
-
-    /// Query strings are not supported in P2P URIs
-    #[error("Invalid P2P URI: Query strings are not supported: '{0}'")]
-    P2PQueryStringsNotSupported(String),
-
-    /// When the network kind is 'mainnet' or 'testnet', at least one P2P seed peer is required.
-    /// Otherwise, we'll allow mDNS to discover any local peers (for testing).
-    #[error(
-        "At least one P2P seed peer is required when the network kind is 'mainnet' or 'testnet'."
-    )]
-    P2PSeedPeerRequired,
-}
+mod error;
+mod serialization;
 
 /// Trait for validating configuration values.
 trait Validatable {
@@ -133,7 +80,7 @@ pub struct Settings {
 #[derive(Deserialize, Clone, Debug)]
 pub struct BitcoinConfig {
     /// Bitcoin RPC endpoints.
-    #[serde(deserialize_with = "url_deserializer_vec")]
+    #[serde(deserialize_with = "serialization::url_deserializer_vec")]
     pub endpoints: Vec<url::Url>,
 }
 
@@ -238,6 +185,9 @@ pub struct SignerConfig {
     /// The address of the deployer of the sBTC smart contracts.
     #[serde(deserialize_with = "parse_stacks_address")]
     pub deployer: StacksAddress,
+    /// The postgres database endpoint
+    #[serde(deserialize_with = "url_deserializer_single")]
+    pub db_endpoint: Url,
 }
 
 impl Validatable for SignerConfig {
@@ -247,6 +197,17 @@ impl Validatable for SignerConfig {
             let err = SignerConfigError::NetworkDeployerMismatch;
             return Err(ConfigError::Message(err.to_string()));
         }
+        // At least perform a simple check to see if the database endpoint is
+        // valid for the supported database drivers. We only support PostgreSQL
+        // for now. The rest of the URI we delegate to the database driver for
+        // validation (which will fail fast on startup).
+        if self.db_endpoint.scheme() != "postgresql" {
+            let err =
+                SignerConfigError::UnsupportedDatabaseDriver(self.db_endpoint.scheme().to_string());
+            return Err(ConfigError::Message(err.to_string()));
+        }
+        // db_endpoint note: we don't validate the host because we will never
+        // get here; the URL deserializer will fail if the host is empty.
         Ok(())
     }
 }
@@ -377,138 +338,11 @@ impl StacksSettings {
     }
 }
 
-/// A deserializer for the url::Url type. This will return an empty [`Vec`] if
-/// there are no URLs to deserialize.
-fn url_deserializer_vec<'de, D>(deserializer: D) -> Result<Vec<url::Url>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let mut v = Vec::new();
-    for s in Vec::<String>::deserialize(deserializer)? {
-        v.push(s.parse().map_err(serde::de::Error::custom)?);
-    }
-    Ok(v)
-}
-
-fn p2p_multiaddr_deserializer_vec<'de, D>(deserializer: D) -> Result<Vec<Multiaddr>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let mut addrs = Vec::new();
-
-    let items = Vec::<String>::deserialize(deserializer)?;
-
-    for s in items.iter().filter(|s| !s.is_empty()) {
-        let addr = try_parse_p2p_multiaddr(s).map_err(serde::de::Error::custom)?;
-        addrs.push(addr);
-    }
-
-    Ok(addrs)
-}
-
-/// A deserializer for the [`PrivateKey`] type. Returns an error if the private
-/// key is not valid hex or is not the correct length.
-fn private_key_deserializer<'de, D>(deserializer: D) -> Result<PrivateKey, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let s = String::deserialize(deserializer)?;
-    let len = s.len();
-
-    if ![64, 66].contains(&len) {
-        Err(serde::de::Error::custom(
-            SignerConfigError::InvalidStacksPrivateKeyLength(len),
-        ))
-    } else if len == 66 && &s[64..] != "01" {
-        Err(serde::de::Error::custom(
-            SignerConfigError::InvalidStacksPrivateKeyCompressionByte(s[64..].to_string()),
-        ))
-    } else {
-        PrivateKey::from_str(&s[..64]).map_err(serde::de::Error::custom)
-    }
-}
-
-fn try_parse_p2p_multiaddr(s: &str) -> Result<Multiaddr, SignerConfigError> {
-    // Keeping these local here as this is the only place these should need to be used.
-    use libp2p::multiaddr::Protocol;
-    use SignerConfigError::{
-        InvalidP2PScheme, InvalidP2PUri, P2PPasswordNotSupported, P2PPathsNotSupported,
-        P2PPortRequired, P2PQueryStringsNotSupported, P2PUsernameNotSupported,
-    };
-
-    // We parse to a Url first to take advantage of its initial validation
-    // and so that we can more easily work with the URI components below.
-    // Note that this will catch missing host errors.
-    let url: Url = s.parse().map_err(InvalidP2PUri)?;
-
-    if !["/", ""].contains(&url.path()) {
-        return Err(P2PPathsNotSupported(url.path().into()));
-    }
-
-    let port = url.port().ok_or(P2PPortRequired)?;
-
-    // We only support tcp and quic-v1 schemes as these are the only relevant
-    // protocols (quic is a UDP-based protocol).
-    if !["tcp", "quic-v1"].contains(&url.scheme()) {
-        return Err(InvalidP2PScheme(url.scheme().into()));
-    }
-
-    // We don't currently support usernames. The signer pub key is used as the
-    // peer identifier.
-    if !url.username().is_empty() {
-        return Err(P2PUsernameNotSupported(url.username().into()));
-    }
-
-    // We don't currently support passwords.
-    if let Some(pass) = url.password() {
-        return Err(P2PPasswordNotSupported(pass.into()));
-    }
-
-    // We don't currently support query strings. This could be extended in the
-    // future if we need to add additional P2P configuration options.
-    if let Some(query) = url.query() {
-        return Err(P2PQueryStringsNotSupported(query.into()));
-    }
-
-    // Initialize the Multiaddr using the host. We support IPv4, IPv6, and
-    // DNS host types.
-    let mut addr = match url.host() {
-        Some(url::Host::Ipv4(ip)) => Multiaddr::empty().with(Protocol::from(ip)),
-        Some(url::Host::Ipv6(ip)) => Multiaddr::empty().with(Protocol::from(ip)),
-        Some(url::Host::Domain(host)) => Multiaddr::empty().with(Protocol::Dns(host.into())),
-        None => unreachable!("this will have been caught by the Url parsing above"),
-    };
-
-    // Update the Multiaddr with the correct protocol.
-    match url.scheme() {
-        "tcp" => addr = addr.with(Protocol::Tcp(port)),
-        "quic-v1" => addr = addr.with(Protocol::Udp(port)).with(Protocol::QuicV1),
-        s => return Err(InvalidP2PScheme(s.to_string())),
-    };
-
-    Ok(addr)
-}
-
-/// Parse the string into a StacksAddress.
-///
-/// The [`StacksAddress`] struct does not implement any string parsing or
-/// c32 decoding. However, the [`PrincipalData::parse_standard_principal`]
-/// function does the expected c32 decoding and the validation, so we go
-/// through that.
-pub fn parse_stacks_address<'de, D>(des: D) -> Result<StacksAddress, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let literal = <String>::deserialize(des)?;
-
-    PrincipalData::parse_standard_principal(&literal)
-        .map(StacksAddress::from)
-        .map_err(serde::de::Error::custom)
-}
-
 #[cfg(test)]
 mod tests {
-    use std::net::SocketAddr;
+    use std::{net::SocketAddr, str::FromStr};
+
+    use serialization::try_parse_p2p_multiaddr;
 
     use crate::testing::clear_env;
 
@@ -833,6 +667,55 @@ mod tests {
         ))
     }
 
+    #[test]
+    fn p2p_ip4_uri_works() {
+        use libp2p::multiaddr::Protocol;
+
+        clear_env();
+
+        std::env::set_var("SIGNER_SIGNER__P2P__LISTEN_ON", "tcp://0.0.0.0:4122");
+        let settings = Settings::new_from_default_config().expect("failed to load default config");
+
+        let actual = settings
+            .signer
+            .p2p
+            .listen_on
+            .first()
+            .expect("listen_on is empty");
+        let expected = Multiaddr::empty()
+            .with(Protocol::Ip4(
+                "0.0.0.0".parse().expect("failed to parse ipaddr"),
+            ))
+            .with(Protocol::Tcp(4122));
+
+        assert_eq!(*actual, expected);
+    }
+
+    #[test]
+    #[ignore] // TODO(513): Problem parsing ipv6 addresses
+    fn p2p_ip6_uri_works() {
+        use libp2p::multiaddr::Protocol;
+
+        clear_env();
+
+        std::env::set_var("SIGNER_SIGNER__P2P__LISTEN_ON", "tcp://ff06::c3:4122");
+        let settings = Settings::new_from_default_config().expect("failed to load default config");
+
+        let actual = settings
+            .signer
+            .p2p
+            .listen_on
+            .first()
+            .expect("listen_on is empty");
+        let expected = Multiaddr::empty()
+            .with(Protocol::Ip6(
+                "ff06::c3".parse().expect("failed to parse ipaddr"),
+            ))
+            .with(Protocol::Tcp(4122));
+
+        assert_eq!(*actual, expected);
+    }
+
     #[test_case::test_case(NetworkKind::Mainnet; "mainnet network, testnet deployer")]
     #[test_case::test_case(NetworkKind::Testnet; "testnet network, mainnet deployer")]
     fn network_mismatch_network_of_deployer(network: NetworkKind) {
@@ -879,5 +762,33 @@ mod tests {
         std::env::set_var("SIGNER_SIGNER__P2P__SEEDS", "tcp://localhost:4122");
 
         assert!(Settings::new_from_default_config().is_ok());
+    }
+
+    #[test]
+    fn db_endpoint_postgresql_works() {
+        clear_env();
+
+        let driver = "postgresql";
+        let endpoint = format!("{driver}://user:pass@localhost:1234/abc123");
+
+        std::env::set_var("SIGNER_SIGNER__DB_ENDPOINT", &endpoint);
+        let settings = Settings::new_from_default_config().unwrap();
+        assert_eq!(url(&endpoint), settings.signer.db_endpoint);
+    }
+
+    #[test]
+    fn db_endpoint_invalid_driver_returns_correct_error() {
+        clear_env();
+
+        let driver = "somedb";
+        let endpoint = format!("{driver}://user:pass@localhost:1234/abc123");
+
+        std::env::set_var("SIGNER_SIGNER__DB_ENDPOINT", &endpoint);
+        let settings = Settings::new_from_default_config();
+        assert!(settings.is_err());
+        assert!(matches!(
+            settings.unwrap_err(),
+            ConfigError::Message(msg) if msg == SignerConfigError::UnsupportedDatabaseDriver(driver.to_string()).to_string()
+        ));
     }
 }

--- a/signer/src/config/mod.rs
+++ b/signer/src/config/mod.rs
@@ -80,7 +80,7 @@ pub struct Settings {
 #[derive(Deserialize, Clone, Debug)]
 pub struct BitcoinConfig {
     /// Bitcoin RPC endpoints.
-    #[serde(deserialize_with = "serialization::url_deserializer_vec")]
+    #[serde(deserialize_with = "url_deserializer_vec")]
     pub endpoints: Vec<url::Url>,
 }
 

--- a/signer/src/config/mod.rs
+++ b/signer/src/config/mod.rs
@@ -201,7 +201,7 @@ impl Validatable for SignerConfig {
         // valid for the supported database drivers. We only support PostgreSQL
         // for now. The rest of the URI we delegate to the database driver for
         // validation (which will fail fast on startup).
-        if self.db_endpoint.scheme() != "postgresql" {
+        if !["postgres", "postgresql"].contains(&self.db_endpoint.scheme()) {
             let err =
                 SignerConfigError::UnsupportedDatabaseDriver(self.db_endpoint.scheme().to_string());
             return Err(ConfigError::Message(err.to_string()));

--- a/signer/src/config/mod.rs
+++ b/signer/src/config/mod.rs
@@ -692,13 +692,12 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // TODO(513): Problem parsing ipv6 addresses
     fn p2p_ip6_uri_works() {
         use libp2p::multiaddr::Protocol;
 
         clear_env();
 
-        std::env::set_var("SIGNER_SIGNER__P2P__LISTEN_ON", "tcp://ff06::c3:4122");
+        std::env::set_var("SIGNER_SIGNER__P2P__LISTEN_ON", "tcp://[ff06::c3]:4122");
         let settings = Settings::new_from_default_config().expect("failed to load default config");
 
         let actual = settings

--- a/signer/src/config/serialization.rs
+++ b/signer/src/config/serialization.rs
@@ -128,13 +128,6 @@ pub fn try_parse_p2p_multiaddr(s: &str) -> Result<Multiaddr, SignerConfigError> 
         Multiaddr::empty().with(Protocol::Dns(url.host_str().unwrap().into()))
     };
 
-    // let mut addr = match url.host() {
-    //     Some(url::Host::Ipv4(ip)) => Multiaddr::empty().with(Protocol::from(ip)),
-    //     Some(url::Host::Ipv6(ip)) => Multiaddr::empty().with(Protocol::from(ip)),
-    //     Some(url::Host::Domain(host)) => Multiaddr::empty().with(Protocol::Dnsaddr(host.into())),
-    //     None => unreachable!("this will have been caught by the Url parsing above"),
-    // };
-
     // Update the Multiaddr with the correct protocol.
     match url.scheme() {
         "tcp" => addr = addr.with(Protocol::Tcp(port)),

--- a/signer/src/config/serialization.rs
+++ b/signer/src/config/serialization.rs
@@ -75,8 +75,9 @@ pub fn try_parse_p2p_multiaddr(s: &str) -> Result<Multiaddr, SignerConfigError> 
     // Keeping these local here as this is the only place these should need to be used.
     use libp2p::multiaddr::Protocol;
     use SignerConfigError::{
-        InvalidP2PScheme, InvalidP2PUri, P2PPasswordNotSupported, P2PPathsNotSupported,
-        P2PPortRequired, P2PQueryStringsNotSupported, P2PUsernameNotSupported,
+        InvalidP2PScheme, InvalidP2PUri, P2PHostRequired, P2PPasswordNotSupported,
+        P2PPathsNotSupported, P2PPortRequired, P2PQueryStringsNotSupported,
+        P2PUsernameNotSupported,
     };
 
     // We parse to a Url first to take advantage of its initial validation
@@ -120,8 +121,9 @@ pub fn try_parse_p2p_multiaddr(s: &str) -> Result<Multiaddr, SignerConfigError> 
     // host string directly.
     let host_str = url
         .host_str()
-        .unwrap() // this will have been caught by the Url parsing above
+        .ok_or(P2PHostRequired)?
         .trim_matches(&['[', ']']); // `Url` includes brackets for IPv6 addresses
+
     let mut addr = if let Ok(addr) = IpAddr::from_str(host_str) {
         Multiaddr::empty().with(Protocol::from(addr))
     } else {

--- a/signer/src/config/serialization.rs
+++ b/signer/src/config/serialization.rs
@@ -1,0 +1,213 @@
+use std::{net::IpAddr, str::FromStr};
+
+use clarity::{types::chainstate::StacksAddress, vm::types::PrincipalData};
+use libp2p::Multiaddr;
+use serde::{Deserialize, Deserializer};
+use url::Url;
+
+use crate::keys::PrivateKey;
+
+use super::error::SignerConfigError;
+
+/// A deserializer for the url::Url type. This will return an empty [`Vec`] if
+/// there are no URLs to deserialize.
+pub fn url_deserializer_vec<'de, D>(deserializer: D) -> Result<Vec<url::Url>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let mut v = Vec::new();
+    for s in Vec::<String>::deserialize(deserializer)? {
+        v.push(s.parse().map_err(serde::de::Error::custom)?);
+    }
+    Ok(v)
+}
+
+/// A deserializer for the url::Url type. Does not support deserializing a list,
+/// only a single URL.
+pub fn url_deserializer_single<'de, D>(deserializer: D) -> Result<url::Url, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    String::deserialize(deserializer)?
+        .parse()
+        .map_err(serde::de::Error::custom)
+}
+
+pub fn p2p_multiaddr_deserializer_vec<'de, D>(deserializer: D) -> Result<Vec<Multiaddr>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let mut addrs = Vec::new();
+
+    let items = Vec::<String>::deserialize(deserializer)?;
+
+    for s in items.iter().filter(|s| !s.is_empty()) {
+        let addr = try_parse_p2p_multiaddr(s).map_err(serde::de::Error::custom)?;
+        addrs.push(addr);
+    }
+
+    Ok(addrs)
+}
+
+/// A deserializer for the [`PrivateKey`] type. Returns an error if the private
+/// key is not valid hex or is not the correct length.
+pub fn private_key_deserializer<'de, D>(deserializer: D) -> Result<PrivateKey, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+    let len = s.len();
+
+    if ![64, 66].contains(&len) {
+        Err(serde::de::Error::custom(
+            SignerConfigError::InvalidStacksPrivateKeyLength(len),
+        ))
+    } else if len == 66 && &s[64..] != "01" {
+        Err(serde::de::Error::custom(
+            SignerConfigError::InvalidStacksPrivateKeyCompressionByte(s[64..].to_string()),
+        ))
+    } else {
+        PrivateKey::from_str(&s[..64]).map_err(serde::de::Error::custom)
+    }
+}
+
+pub fn try_parse_p2p_multiaddr(s: &str) -> Result<Multiaddr, SignerConfigError> {
+    // Keeping these local here as this is the only place these should need to be used.
+    use libp2p::multiaddr::Protocol;
+    use SignerConfigError::{
+        InvalidP2PScheme, InvalidP2PUri, P2PPasswordNotSupported, P2PPathsNotSupported,
+        P2PPortRequired, P2PQueryStringsNotSupported, P2PUsernameNotSupported,
+    };
+
+    // We parse to a Url first to take advantage of its initial validation
+    // and so that we can more easily work with the URI components below.
+    // Note that this will catch missing host errors.
+    let url: Url = s.parse().map_err(InvalidP2PUri)?;
+
+    if !["/", ""].contains(&url.path()) {
+        return Err(P2PPathsNotSupported(url.path().into()));
+    }
+
+    let port = url.port().ok_or(P2PPortRequired)?;
+
+    // We only support tcp and quic-v1 schemes as these are the only relevant
+    // protocols (quic is a UDP-based protocol).
+    if !["tcp", "quic-v1"].contains(&url.scheme()) {
+        return Err(InvalidP2PScheme(url.scheme().into()));
+    }
+
+    // We don't currently support usernames. The signer pub key is used as the
+    // peer identifier.
+    if !url.username().is_empty() {
+        return Err(P2PUsernameNotSupported(url.username().into()));
+    }
+
+    // We don't currently support passwords.
+    if let Some(pass) = url.password() {
+        return Err(P2PPasswordNotSupported(pass.into()));
+    }
+
+    // We don't currently support query strings. This could be extended in the
+    // future if we need to add additional P2P configuration options.
+    if let Some(query) = url.query() {
+        return Err(P2PQueryStringsNotSupported(query.into()));
+    }
+
+    // Initialize the Multiaddr using the host. We support IPv4, IPv6, and
+    // DNS host types. The URL parsing in `Url` doesn't seem to return the
+    // correct type of address in `url.host()` (i.e. `0.0.0.0` ends up as a DNS
+    // host), and thus an invalid Multiaddr. We work around this by parsing the
+    // host string directly.
+    let host_str = url
+        .host_str()
+        .unwrap() // this will have been caught by the Url parsing above
+        .trim_matches(&['[', ']']); // `Url` includes brackets for IPv6 addresses
+    let mut addr = if let Ok(addr) = IpAddr::from_str(host_str) {
+        Multiaddr::empty().with(Protocol::from(addr))
+    } else {
+        Multiaddr::empty().with(Protocol::Dns(url.host_str().unwrap().into()))
+    };
+
+    // let mut addr = match url.host() {
+    //     Some(url::Host::Ipv4(ip)) => Multiaddr::empty().with(Protocol::from(ip)),
+    //     Some(url::Host::Ipv6(ip)) => Multiaddr::empty().with(Protocol::from(ip)),
+    //     Some(url::Host::Domain(host)) => Multiaddr::empty().with(Protocol::Dnsaddr(host.into())),
+    //     None => unreachable!("this will have been caught by the Url parsing above"),
+    // };
+
+    // Update the Multiaddr with the correct protocol.
+    match url.scheme() {
+        "tcp" => addr = addr.with(Protocol::Tcp(port)),
+        "quic-v1" => addr = addr.with(Protocol::Udp(port)).with(Protocol::QuicV1),
+        s => return Err(InvalidP2PScheme(s.to_string())),
+    };
+
+    Ok(addr)
+}
+
+/// Parse the string into a StacksAddress.
+///
+/// The [`StacksAddress`] struct does not implement any string parsing or
+/// c32 decoding. However, the [`PrincipalData::parse_standard_principal`]
+/// function does the expected c32 decoding and the validation, so we go
+/// through that.
+pub fn parse_stacks_address<'de, D>(des: D) -> Result<StacksAddress, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let literal = <String>::deserialize(des)?;
+
+    PrincipalData::parse_standard_principal(&literal)
+        .map(StacksAddress::from)
+        .map_err(serde::de::Error::custom)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn try_parse_p2p_multiaddr_ipv6_inaddr_any() {
+        let addr = try_parse_p2p_multiaddr("tcp://[::]:4122/")
+            .expect("failed to parse valid IPv6 address");
+        assert_eq!(addr.to_string(), "/ip6/::/tcp/4122");
+    }
+
+    #[test]
+    fn try_parse_p2p_multiaddr_ipv6_loopback() {
+        let addr = try_parse_p2p_multiaddr("tcp://[::1]:4122/")
+            .expect("failed to parse valid IPv6 address");
+        assert_eq!(addr.to_string(), "/ip6/::1/tcp/4122");
+    }
+
+    #[test]
+    fn try_parse_p2p_multiaddr_ipv6_long() {
+        let addr = try_parse_p2p_multiaddr("tcp://[2001:db8:456:1122:a334:23fe:ff23:9988]:4122/")
+            .expect("failed to parse valid IPv6 address");
+        assert_eq!(
+            addr.to_string(),
+            "/ip6/2001:db8:456:1122:a334:23fe:ff23:9988/tcp/4122"
+        );
+    }
+
+    #[test]
+    fn try_parse_p2p_multiaddr_ipv4() {
+        let addr = try_parse_p2p_multiaddr("tcp://0.0.0.0:4122/")
+            .expect("failed to parse valid IPv4 address");
+        assert_eq!(addr.to_string(), "/ip4/0.0.0.0/tcp/4122");
+    }
+
+    #[test]
+    fn try_parse_p2p_multiaddr_dns_localhost() {
+        let addr = try_parse_p2p_multiaddr("tcp://localhost:4122/")
+            .expect("failed to parse valid DNS address");
+        assert_eq!(addr.to_string(), "/dns/localhost/tcp/4122");
+    }
+
+    #[test]
+    fn try_parse_p2p_multiaddr_dns_domain() {
+        let addr = try_parse_p2p_multiaddr("tcp://example.com:4122/")
+            .expect("failed to parse valid DNS address");
+        assert_eq!(addr.to_string(), "/dns/example.com/tcp/4122");
+    }
+}

--- a/signer/src/testing/storage.rs
+++ b/signer/src/testing/storage.rs
@@ -7,7 +7,7 @@ use crate::storage::postgres::PgStore;
 pub mod model;
 
 /// The postgres connection string to the test database.
-pub const DATABASE_URL: &str = "postgres://user@localhost:5432/signer";
+pub const DATABASE_URL: &str = "postgres://postgres:postgres@localhost:5432/signer";
 
 /// This is needed to make sure that each test has as many isolated
 /// databases as it needs.


### PR DESCRIPTION
## Description
I'm breaking up a larger branch from yesterday re: running the signer, so I decided to clump together the "config-related" changes here that I had made (hope that's okay for this one to save a little time, otherwise I'll need to go back and un-refactor,  apply the changes separately then re-refactor -- the followup PR's are more isolated):

Closes: 
- #520 
- #513 

I added PR comments to make it clear what is what.

Also restructured the `config` module a little as it was starting to feel a little messy/unwieldy.

## Changes
- Restructured the `config` module for better code isolation.
- Removed the `stacks.api` config stanza as I don't see that it's used anywhere.
- Added a little more documentation in `default.toml`
- Added support for db endpoint configuration (#520) via the `db_endpoint` property.
- Fixed an issue with Url parsing for libp2p and added related tests (#513).
- Removed the hardcoded database endpoint in `main.rs` in favor of using the config.
- Updated the devenv `postgres` container to create the signer database (I don't think anything else is using postgres and expecting the default database here?)

## Testing Information

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
