### PR TITLE
refactor: use the `ScriptPubKey` as recipient

### DIFF
--- a/signer/migrations/0003__create_tables.sql
+++ b/signer/migrations/0003__create_tables.sql
@@ -31,7 +31,7 @@ CREATE TABLE sbtc_signer.deposit_requests (
     recipient TEXT NOT NULL,
     amount BIGINT NOT NULL,
     max_fee BIGINT NOT NULL,
-    sender_addresses TEXT[] NOT NULL,
+    sender_script_pub_keys BYTEA[] NOT NULL,
     created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
     PRIMARY KEY (txid, output_index)
 );
@@ -46,27 +46,28 @@ CREATE TABLE sbtc_signer.deposit_signers (
     FOREIGN KEY (txid, output_index) REFERENCES sbtc_signer.deposit_requests(txid, output_index) ON DELETE CASCADE
 );
 
-CREATE TABLE sbtc_signer.withdraw_requests (
+CREATE TABLE sbtc_signer.withdrawal_requests (
     request_id BIGINT NOT NULL,
     txid BYTEA NOT NULL,
     block_hash BYTEA NOT NULL,
-    recipient TEXT NOT NULL,
+    recipient BYTEA NOT NULL,
     amount BIGINT NOT NULL,
     max_fee BIGINT NOT NULL,
     sender_address TEXT NOT NULL,
     created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    PRIMARY KEY (request_id, block_hash),
+    PRIMARY KEY (request_id, txid, block_hash),
     FOREIGN KEY (block_hash) REFERENCES sbtc_signer.stacks_blocks(block_hash) ON DELETE CASCADE
 );
 
-CREATE TABLE sbtc_signer.withdraw_signers (
+CREATE TABLE sbtc_signer.withdrawal_signers (
     request_id BIGINT NOT NULL,
+    txid BYTEA NOT NULL,
     block_hash BYTEA NOT NULL,
     signer_pub_key BYTEA NOT NULL,
     is_accepted BOOL NOT NULL,
     created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    PRIMARY KEY (request_id, block_hash, signer_pub_key),
-    FOREIGN KEY (request_id, block_hash) REFERENCES sbtc_signer.withdraw_requests(request_id, block_hash) ON DELETE CASCADE
+    PRIMARY KEY (request_id, txid, block_hash, signer_pub_key),
+    FOREIGN KEY (request_id, txid, block_hash) REFERENCES sbtc_signer.withdrawal_requests(request_id, txid, block_hash) ON DELETE CASCADE
 );
 
 CREATE TABLE sbtc_signer.transactions (
@@ -127,7 +128,7 @@ CREATE TABLE sbtc_signer.deposit_responses (
     deposit_output_index INTEGER NOT NULL
 );
 
-CREATE TABLE sbtc_signer.withdraw_responses (
+CREATE TABLE sbtc_signer.withdrawal_responses (
     response_txid BYTEA NOT NULL,
     withdraw_txid BYTEA NOT NULL,
     withdraw_request_id BIGINT NOT NULL

--- a/signer/migrations/0003__create_tables.sql
+++ b/signer/migrations/0003__create_tables.sql
@@ -55,7 +55,7 @@ CREATE TABLE sbtc_signer.withdrawal_requests (
     max_fee BIGINT NOT NULL,
     sender_address TEXT NOT NULL,
     created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    PRIMARY KEY (request_id, txid, block_hash),
+    PRIMARY KEY (request_id, block_hash),
     FOREIGN KEY (block_hash) REFERENCES sbtc_signer.stacks_blocks(block_hash) ON DELETE CASCADE
 );
 
@@ -66,8 +66,8 @@ CREATE TABLE sbtc_signer.withdrawal_signers (
     signer_pub_key BYTEA NOT NULL,
     is_accepted BOOL NOT NULL,
     created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    PRIMARY KEY (request_id, txid, block_hash, signer_pub_key),
-    FOREIGN KEY (request_id, txid, block_hash) REFERENCES sbtc_signer.withdrawal_requests(request_id, txid, block_hash) ON DELETE CASCADE
+    PRIMARY KEY (request_id, block_hash, signer_pub_key),
+    FOREIGN KEY (request_id, block_hash) REFERENCES sbtc_signer.withdrawal_requests(request_id, block_hash) ON DELETE CASCADE
 );
 
 CREATE TABLE sbtc_signer.transactions (

--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -177,7 +177,7 @@ where
             .iter()
             .filter_map(|tx| self.deposit_requests.remove(&tx.compute_txid()))
             .flatten()
-            .map(|deposit| model::DepositRequest::from_deposit(&deposit, self.network))
+            .map(model::DepositRequest::from)
             .collect();
 
         self.storage.write_deposit_requests(deposit_request).await?;

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -330,6 +330,14 @@ pub enum Error {
     #[error("bitcoin address parse error")]
     BitcoinAddressParse(#[source] bitcoin::address::ParseError),
 
+    /// Bitcoin error when attempting to construct an address from a
+    /// scriptPubKey.
+    #[error("bitcoin address parse error")]
+    BitcoinAddressFromScript(
+        #[source] bitcoin::address::FromScriptError,
+        bitcoin::OutPoint,
+    ),
+
     /// Parsing address failed
     #[error("failed to parse address")]
     ParseAddress(#[source] bitcoin::address::ParseError),

--- a/signer/src/message.rs
+++ b/signer/src/message.rs
@@ -7,6 +7,7 @@ use crate::keys::PublicKey;
 use crate::signature::RecoverableEcdsaSignature as _;
 use crate::stacks::contracts::ContractCall;
 use crate::storage::model::BitcoinBlockHash;
+use crate::storage::model::StacksTxId;
 
 /// Messages exchanged between signers
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -107,6 +108,9 @@ pub struct SignerWithdrawDecision {
     pub request_id: u64,
     /// ID of the Stacks block containing the request.
     pub block_hash: StacksBlockHash,
+    /// The stacks transaction ID that lead to the creation of the
+    /// withdrawal request.
+    pub txid: StacksTxId,
     /// Whether or not the signer has accepted the deposit request.
     pub accepted: bool,
 }

--- a/signer/src/storage/in_memory.rs
+++ b/signer/src/storage/in_memory.rs
@@ -19,7 +19,7 @@ use crate::storage::model;
 pub type SharedStore = Arc<Mutex<Store>>;
 
 type DepositRequestPk = (model::BitcoinTxId, u32);
-type WithdrawRequestPk = (u64, model::StacksBlockHash);
+type WithdrawalRequestPk = (u64, model::StacksBlockHash);
 
 /// In-memory store
 #[derive(Debug, Default)]
@@ -34,7 +34,7 @@ pub struct Store {
     pub deposit_requests: HashMap<DepositRequestPk, model::DepositRequest>,
 
     /// Deposit requests
-    pub withdraw_requests: HashMap<WithdrawRequestPk, model::WithdrawalRequest>,
+    pub withdrawal_requests: HashMap<WithdrawalRequestPk, model::WithdrawalRequest>,
 
     /// Deposit request to signers
     pub deposit_request_to_signers: HashMap<DepositRequestPk, Vec<model::DepositSigner>>,
@@ -43,7 +43,7 @@ pub struct Store {
     pub signer_to_deposit_request: HashMap<PublicKey, Vec<DepositRequestPk>>,
 
     /// Withdraw signers
-    pub withdraw_request_to_signers: HashMap<WithdrawRequestPk, Vec<model::WithdrawalSigner>>,
+    pub withdrawal_request_to_signers: HashMap<WithdrawalRequestPk, Vec<model::WithdrawalSigner>>,
 
     /// Bitcoin blocks to transactions
     pub bitcoin_block_to_transactions: HashMap<model::BitcoinBlockHash, Vec<model::BitcoinTxId>>,
@@ -58,7 +58,7 @@ pub struct Store {
     pub stacks_transactions_to_blocks: HashMap<model::StacksTxId, Vec<model::StacksBlockHash>>,
 
     /// Stacks blocks to withdraw requests
-    pub stacks_block_to_withdraw_requests: HashMap<model::StacksBlockHash, Vec<WithdrawRequestPk>>,
+    pub stacks_block_to_withdraw_requests: HashMap<model::StacksBlockHash, Vec<WithdrawalRequestPk>>,
 
     /// Stacks blocks under nakamoto
     pub stacks_nakamoto_blocks: HashMap<model::StacksBlockHash, model::StacksBlock>,
@@ -254,13 +254,13 @@ impl super::DbRead for SharedStore {
         Ok(self
             .lock()
             .await
-            .withdraw_request_to_signers
+            .withdrawal_request_to_signers
             .get(&(request_id, *block_hash))
             .cloned()
             .unwrap_or_default())
     }
 
-    async fn get_pending_withdraw_requests(
+    async fn get_pending_withdrawal_requests(
         &self,
         chain_tip: &model::BitcoinBlockHash,
         context_window: u16,
@@ -304,7 +304,7 @@ impl super::DbRead for SharedStore {
                     .into_iter()
                     .map(|pk| {
                         store
-                            .withdraw_requests
+                            .withdrawal_requests
                             .get(&pk)
                             .expect("missing withdraw request")
                             .clone()
@@ -314,14 +314,14 @@ impl super::DbRead for SharedStore {
         )
     }
 
-    async fn get_pending_accepted_withdraw_requests(
+    async fn get_pending_accepted_withdrawal_requests(
         &self,
         chain_tip: &model::BitcoinBlockHash,
         context_window: u16,
         threshold: u16,
     ) -> Result<Vec<model::WithdrawalRequest>, Self::Error> {
         let pending_withdraw_requests = self
-            .get_pending_withdraw_requests(chain_tip, context_window)
+            .get_pending_withdrawal_requests(chain_tip, context_window)
             .await?;
         let store = self.lock().await;
 
@@ -331,7 +331,7 @@ impl super::DbRead for SharedStore {
             .into_iter()
             .filter(|withdraw_request| {
                 store
-                    .withdraw_request_to_signers
+                    .withdrawal_request_to_signers
                     .get(&(withdraw_request.request_id, withdraw_request.block_hash))
                     .map(|signers| {
                         signers.iter().filter(|signer| signer.is_accepted).count() >= threshold
@@ -523,7 +523,7 @@ impl super::DbWrite for SharedStore {
             .or_default()
             .push(pk);
 
-        store.withdraw_requests.insert(pk, withdraw_request.clone());
+        store.withdrawal_requests.insert(pk, withdraw_request.clone());
 
         Ok(())
     }
@@ -557,7 +557,7 @@ impl super::DbWrite for SharedStore {
     ) -> Result<(), Self::Error> {
         self.lock()
             .await
-            .withdraw_request_to_signers
+            .withdrawal_request_to_signers
             .entry((decision.request_id, decision.block_hash))
             .or_default()
             .push(decision.clone());

--- a/signer/src/storage/in_memory.rs
+++ b/signer/src/storage/in_memory.rs
@@ -34,7 +34,7 @@ pub struct Store {
     pub deposit_requests: HashMap<DepositRequestPk, model::DepositRequest>,
 
     /// Deposit requests
-    pub withdraw_requests: HashMap<WithdrawRequestPk, model::WithdrawRequest>,
+    pub withdraw_requests: HashMap<WithdrawRequestPk, model::WithdrawalRequest>,
 
     /// Deposit request to signers
     pub deposit_request_to_signers: HashMap<DepositRequestPk, Vec<model::DepositSigner>>,
@@ -43,7 +43,7 @@ pub struct Store {
     pub signer_to_deposit_request: HashMap<PublicKey, Vec<DepositRequestPk>>,
 
     /// Withdraw signers
-    pub withdraw_request_to_signers: HashMap<WithdrawRequestPk, Vec<model::WithdrawSigner>>,
+    pub withdraw_request_to_signers: HashMap<WithdrawRequestPk, Vec<model::WithdrawalSigner>>,
 
     /// Bitcoin blocks to transactions
     pub bitcoin_block_to_transactions: HashMap<model::BitcoinBlockHash, Vec<model::BitcoinTxId>>,
@@ -246,11 +246,11 @@ impl super::DbRead for SharedStore {
             .unwrap_or_default())
     }
 
-    async fn get_withdraw_signers(
+    async fn get_withdrawal_signers(
         &self,
         request_id: u64,
         block_hash: &model::StacksBlockHash,
-    ) -> Result<Vec<model::WithdrawSigner>, Self::Error> {
+    ) -> Result<Vec<model::WithdrawalSigner>, Self::Error> {
         Ok(self
             .lock()
             .await
@@ -264,7 +264,7 @@ impl super::DbRead for SharedStore {
         &self,
         chain_tip: &model::BitcoinBlockHash,
         context_window: u16,
-    ) -> Result<Vec<model::WithdrawRequest>, Self::Error> {
+    ) -> Result<Vec<model::WithdrawalRequest>, Self::Error> {
         let Some(bitcoin_chain_tip) = self.get_bitcoin_block(chain_tip).await? else {
             return Ok(Vec::new());
         };
@@ -319,7 +319,7 @@ impl super::DbRead for SharedStore {
         chain_tip: &model::BitcoinBlockHash,
         context_window: u16,
         threshold: u16,
-    ) -> Result<Vec<model::WithdrawRequest>, Self::Error> {
+    ) -> Result<Vec<model::WithdrawalRequest>, Self::Error> {
         let pending_withdraw_requests = self
             .get_pending_withdraw_requests(chain_tip, context_window)
             .await?;
@@ -509,9 +509,9 @@ impl super::DbWrite for SharedStore {
         Ok(())
     }
 
-    async fn write_withdraw_request(
+    async fn write_withdrawal_request(
         &self,
-        withdraw_request: &model::WithdrawRequest,
+        withdraw_request: &model::WithdrawalRequest,
     ) -> Result<(), Self::Error> {
         let mut store = self.lock().await;
 
@@ -551,9 +551,9 @@ impl super::DbWrite for SharedStore {
         Ok(())
     }
 
-    async fn write_withdraw_signer_decision(
+    async fn write_withdrawal_signer_decision(
         &self,
-        decision: &model::WithdrawSigner,
+        decision: &model::WithdrawalSigner,
     ) -> Result<(), Self::Error> {
         self.lock()
             .await

--- a/signer/src/storage/mod.rs
+++ b/signer/src/storage/mod.rs
@@ -79,18 +79,18 @@ pub trait DbRead {
     ) -> impl Future<Output = Result<Vec<model::DepositSigner>, Self::Error>> + Send;
 
     /// Get signer decisions for a withdraw request
-    fn get_withdraw_signers(
+    fn get_withdrawal_signers(
         &self,
         request_id: u64,
         block_hash: &model::StacksBlockHash,
-    ) -> impl Future<Output = Result<Vec<model::WithdrawSigner>, Self::Error>> + Send;
+    ) -> impl Future<Output = Result<Vec<model::WithdrawalSigner>, Self::Error>> + Send;
 
     /// Get pending withdraw requests
     fn get_pending_withdraw_requests(
         &self,
         chain_tip: &model::BitcoinBlockHash,
         context_window: u16,
-    ) -> impl Future<Output = Result<Vec<model::WithdrawRequest>, Self::Error>> + Send;
+    ) -> impl Future<Output = Result<Vec<model::WithdrawalRequest>, Self::Error>> + Send;
 
     /// Get pending withdraw requests that have been accepted by at least `threshold` signers and has no responses
     fn get_pending_accepted_withdraw_requests(
@@ -98,7 +98,7 @@ pub trait DbRead {
         chain_tip: &model::BitcoinBlockHash,
         context_window: u16,
         threshold: u16,
-    ) -> impl Future<Output = Result<Vec<model::WithdrawRequest>, Self::Error>> + Send;
+    ) -> impl Future<Output = Result<Vec<model::WithdrawalRequest>, Self::Error>> + Send;
 
     /// Get bitcoin blocks that include a particular transaction
     fn get_bitcoin_blocks_with_transaction(
@@ -170,9 +170,9 @@ pub trait DbWrite {
     ) -> impl Future<Output = Result<(), Self::Error>> + Send;
 
     /// Write a withdrawal request.
-    fn write_withdraw_request(
+    fn write_withdrawal_request(
         &self,
-        withdraw_request: &model::WithdrawRequest,
+        withdraw_request: &model::WithdrawalRequest,
     ) -> impl Future<Output = Result<(), Self::Error>> + Send;
 
     /// Write a signer decision for a deposit request.
@@ -182,9 +182,9 @@ pub trait DbWrite {
     ) -> impl Future<Output = Result<(), Self::Error>> + Send;
 
     /// Write a signer decision for a withdrawal request.
-    fn write_withdraw_signer_decision(
+    fn write_withdrawal_signer_decision(
         &self,
-        decision: &model::WithdrawSigner,
+        decision: &model::WithdrawalSigner,
     ) -> impl Future<Output = Result<(), Self::Error>> + Send;
 
     /// Write a raw transaction.

--- a/signer/src/storage/mod.rs
+++ b/signer/src/storage/mod.rs
@@ -85,15 +85,16 @@ pub trait DbRead {
         block_hash: &model::StacksBlockHash,
     ) -> impl Future<Output = Result<Vec<model::WithdrawalSigner>, Self::Error>> + Send;
 
-    /// Get pending withdraw requests
-    fn get_pending_withdraw_requests(
+    /// Get pending withdrawal requests
+    fn get_pending_withdrawal_requests(
         &self,
         chain_tip: &model::BitcoinBlockHash,
         context_window: u16,
     ) -> impl Future<Output = Result<Vec<model::WithdrawalRequest>, Self::Error>> + Send;
 
-    /// Get pending withdraw requests that have been accepted by at least `threshold` signers and has no responses
-    fn get_pending_accepted_withdraw_requests(
+    /// Get pending withdrawal requests that have been accepted by at least
+    /// `threshold` signers and has no responses
+    fn get_pending_accepted_withdrawal_requests(
         &self,
         chain_tip: &model::BitcoinBlockHash,
         context_window: u16,
@@ -172,7 +173,7 @@ pub trait DbWrite {
     /// Write a withdrawal request.
     fn write_withdrawal_request(
         &self,
-        withdraw_request: &model::WithdrawalRequest,
+        request: &model::WithdrawalRequest,
     ) -> impl Future<Output = Result<(), Self::Error>> + Send;
 
     /// Write a signer decision for a deposit request.

--- a/signer/src/storage/model.rs
+++ b/signer/src/storage/model.rs
@@ -122,8 +122,11 @@ pub struct DepositSigner {
 /// Withdraw request.
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, sqlx::FromRow)]
 #[cfg_attr(feature = "testing", derive(fake::Dummy))]
-pub struct WithdrawRequest {
-    /// Request ID of the withdrawal request.
+pub struct WithdrawalRequest {
+    /// Request ID of the withdrawal request. These are supposed to be
+    /// unique, but there can be duplicates if there is a reorg that
+    /// affects a transaction that calls the initiate-withdrawal-request
+    /// public function.
     #[sqlx(try_from = "i64")]
     pub request_id: u64,
     /// The stacks transaction ID that lead to the creation of the
@@ -150,10 +153,13 @@ pub struct WithdrawRequest {
 /// A signer acknowledging a withdrawal request.
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, sqlx::FromRow)]
 #[cfg_attr(feature = "testing", derive(fake::Dummy))]
-pub struct WithdrawSigner {
+pub struct WithdrawalSigner {
     /// Request ID of the withdrawal request.
     #[sqlx(try_from = "i64")]
     pub request_id: u64,
+    /// The stacks transaction ID that lead to the creation of the
+    /// withdrawal request.
+    pub txid: StacksTxId,
     /// Stacks block hash of the withdrawal request.
     pub block_hash: StacksBlockHash,
     /// Public key of the signer.

--- a/signer/src/storage/model.rs
+++ b/signer/src/storage/model.rs
@@ -1,5 +1,6 @@
 //! Database models for the signer.
 
+use std::collections::BTreeSet;
 use std::ops::Deref;
 
 use bitcoin::hashes::Hash as _;

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -499,7 +499,7 @@ impl super::DbRead for PgStore {
         .map_err(Error::SqlxQuery)
     }
 
-    async fn get_pending_withdraw_requests(
+    async fn get_pending_withdrawal_requests(
         &self,
         chain_tip: &model::BitcoinBlockHash,
         context_window: u16,
@@ -578,7 +578,7 @@ impl super::DbRead for PgStore {
         .map_err(Error::SqlxQuery)
     }
 
-    async fn get_pending_accepted_withdraw_requests(
+    async fn get_pending_accepted_withdrawal_requests(
         &self,
         chain_tip: &model::BitcoinBlockHash,
         context_window: u16,
@@ -960,7 +960,7 @@ impl super::DbWrite for PgStore {
 
     async fn write_withdrawal_request(
         &self,
-        withdraw_request: &model::WithdrawalRequest,
+        request: &model::WithdrawalRequest,
     ) -> Result<(), Self::Error> {
         sqlx::query(
             "INSERT INTO sbtc_signer.withdrawal_requests
@@ -975,13 +975,13 @@ impl super::DbWrite for PgStore {
             VALUES ($1, $2, $3, $4, $5, $6, $7)
             ON CONFLICT DO NOTHING",
         )
-        .bind(i64::try_from(withdraw_request.request_id).map_err(Error::ConversionDatabaseInt)?)
-        .bind(withdraw_request.txid)
-        .bind(withdraw_request.block_hash)
-        .bind(&withdraw_request.recipient)
-        .bind(i64::try_from(withdraw_request.amount).map_err(Error::ConversionDatabaseInt)?)
-        .bind(i64::try_from(withdraw_request.max_fee).map_err(Error::ConversionDatabaseInt)?)
-        .bind(&withdraw_request.sender_address)
+        .bind(i64::try_from(request.request_id).map_err(Error::ConversionDatabaseInt)?)
+        .bind(request.txid)
+        .bind(request.block_hash)
+        .bind(&request.recipient)
+        .bind(i64::try_from(request.amount).map_err(Error::ConversionDatabaseInt)?)
+        .bind(i64::try_from(request.max_fee).map_err(Error::ConversionDatabaseInt)?)
+        .bind(&request.sender_address)
         .execute(&self.0)
         .await
         .map_err(Error::SqlxQuery)?;

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -310,7 +310,7 @@ impl super::DbRead for PgStore {
               , deposit_requests.recipient
               , deposit_requests.amount
               , deposit_requests.max_fee
-              , deposit_requests.sender_addresses
+              , deposit_requests.sender_script_pub_keys
             FROM transactions_in_window transactions
             JOIN sbtc_signer.deposit_requests deposit_requests ON
                 deposit_requests.txid = transactions.txid
@@ -364,7 +364,7 @@ impl super::DbRead for PgStore {
               , deposit_requests.recipient
               , deposit_requests.amount
               , deposit_requests.max_fee
-              , deposit_requests.sender_addresses
+              , deposit_requests.sender_script_pub_keys
             FROM transactions_in_window transactions
             JOIN sbtc_signer.deposit_requests deposit_requests USING(txid)
             JOIN sbtc_signer.deposit_signers signers USING(txid, output_index)
@@ -439,7 +439,7 @@ impl super::DbRead for PgStore {
               , requests.recipient
               , requests.amount
               , requests.max_fee
-              , requests.sender_addresses
+              , requests.sender_script_pub_keys
             FROM sbtc_signer.deposit_requests requests
                  JOIN sbtc_signer.deposit_signers signers
                    ON requests.txid = signers.txid
@@ -476,19 +476,20 @@ impl super::DbRead for PgStore {
         .map_err(Error::SqlxQuery)
     }
 
-    async fn get_withdraw_signers(
+    async fn get_withdrawal_signers(
         &self,
         request_id: u64,
         block_hash: &model::StacksBlockHash,
-    ) -> Result<Vec<model::WithdrawSigner>, Self::Error> {
-        sqlx::query_as::<_, model::WithdrawSigner>(
+    ) -> Result<Vec<model::WithdrawalSigner>, Self::Error> {
+        sqlx::query_as::<_, model::WithdrawalSigner>(
             "SELECT
                 request_id
+              , txid
               , block_hash
               , signer_pub_key
               , is_accepted
               , created_at
-            FROM sbtc_signer.withdraw_signers
+            FROM sbtc_signer.withdrawal_signers
             WHERE request_id = $1 AND block_hash = $2",
         )
         .bind(i64::try_from(request_id).map_err(Error::ConversionDatabaseInt)?)
@@ -502,11 +503,11 @@ impl super::DbRead for PgStore {
         &self,
         chain_tip: &model::BitcoinBlockHash,
         context_window: u16,
-    ) -> Result<Vec<model::WithdrawRequest>, Self::Error> {
+    ) -> Result<Vec<model::WithdrawalRequest>, Self::Error> {
         let Some(stacks_chain_tip) = self.get_stacks_chain_tip(chain_tip).await? else {
             return Ok(Vec::new());
         };
-        sqlx::query_as::<_, model::WithdrawRequest>(
+        sqlx::query_as::<_, model::WithdrawalRequest>(
             r#"
             WITH RECURSIVE extended_context_window AS (
                 SELECT 
@@ -565,7 +566,7 @@ impl super::DbRead for PgStore {
               , wr.amount
               , wr.max_fee
               , wr.sender_address
-            FROM sbtc_signer.withdraw_requests wr
+            FROM sbtc_signer.withdrawal_requests wr
             JOIN stacks_context_window sc ON wr.block_hash = sc.block_hash
             "#,
         )
@@ -582,11 +583,11 @@ impl super::DbRead for PgStore {
         chain_tip: &model::BitcoinBlockHash,
         context_window: u16,
         threshold: u16,
-    ) -> Result<Vec<model::WithdrawRequest>, Self::Error> {
+    ) -> Result<Vec<model::WithdrawalRequest>, Self::Error> {
         let Some(stacks_chain_tip) = self.get_stacks_chain_tip(chain_tip).await? else {
             return Ok(Vec::new());
         };
-        sqlx::query_as::<_, model::WithdrawRequest>(
+        sqlx::query_as::<_, model::WithdrawalRequest>(
             r#"
             WITH RECURSIVE extended_context_window AS (
                 SELECT 
@@ -645,14 +646,15 @@ impl super::DbRead for PgStore {
               , wr.amount
               , wr.max_fee
               , wr.sender_address
-            FROM sbtc_signer.withdraw_requests wr
+            FROM sbtc_signer.withdrawal_requests wr
             JOIN stacks_context_window sc ON wr.block_hash = sc.block_hash
-            JOIN sbtc_signer.withdraw_signers signers ON
+            JOIN sbtc_signer.withdrawal_signers signers ON
+                wr.txid = signers.txid AND
                 wr.request_id = signers.request_id AND
                 wr.block_hash = signers.block_hash
             WHERE
                 signers.is_accepted
-            GROUP BY wr.request_id, wr.block_hash
+            GROUP BY wr.request_id, wr.block_hash, wr.txid
             HAVING COUNT(wr.request_id) >= $4
             "#,
         )
@@ -845,7 +847,7 @@ impl super::DbWrite for PgStore {
               , recipient
               , amount
               , max_fee
-              , sender_addresses
+              , sender_script_pub_keys
               )
             VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
             ON CONFLICT DO NOTHING",
@@ -857,7 +859,7 @@ impl super::DbWrite for PgStore {
         .bind(&deposit_request.recipient)
         .bind(i64::try_from(deposit_request.amount).map_err(Error::ConversionDatabaseInt)?)
         .bind(i64::try_from(deposit_request.max_fee).map_err(Error::ConversionDatabaseInt)?)
-        .bind(&deposit_request.sender_addresses)
+        .bind(&deposit_request.sender_script_pub_keys)
         .execute(&self.0)
         .await
         .map_err(Error::SqlxQuery)?;
@@ -880,7 +882,7 @@ impl super::DbWrite for PgStore {
         let mut recipient = Vec::with_capacity(deposit_requests.len());
         let mut amount = Vec::with_capacity(deposit_requests.len());
         let mut max_fee = Vec::with_capacity(deposit_requests.len());
-        let mut sender_addresses = Vec::with_capacity(deposit_requests.len());
+        let mut sender_script_pubkeys = Vec::with_capacity(deposit_requests.len());
 
         for req in deposit_requests {
             txid.push(req.txid);
@@ -895,7 +897,12 @@ impl super::DbWrite for PgStore {
             // postgres is tough. The naive approach of doing
             // UNNEST($1::VARCHAR[][]) doesn't work, since that completely
             // flattens the array.
-            sender_addresses.push(req.sender_addresses.join(","));
+            let addresses: Vec<String> = req
+                .sender_script_pub_keys
+                .iter()
+                .map(|x| x.to_hex_string())
+                .collect();
+            sender_script_pubkeys.push(addresses.join(","));
         }
 
         sqlx::query(
@@ -907,7 +914,7 @@ impl super::DbWrite for PgStore {
             , recipient       AS (SELECT ROW_NUMBER() OVER (), recipient FROM UNNEST($5::BYTEA[]) AS recipient)
             , amount          AS (SELECT ROW_NUMBER() OVER (), amount FROM UNNEST($6::BIGINT[]) AS amount)
             , max_fee         AS (SELECT ROW_NUMBER() OVER (), max_fee FROM UNNEST($7::BIGINT[]) AS max_fee)
-            , sender_address  AS (SELECT ROW_NUMBER() OVER (), sender_address FROM UNNEST($8::VARCHAR[]) AS sender_address)
+            , script_pub_keys AS (SELECT ROW_NUMBER() OVER (), senders FROM UNNEST($8::VARCHAR[]) AS senders)
             INSERT INTO sbtc_signer.deposit_requests (
                   txid
                 , output_index
@@ -916,7 +923,7 @@ impl super::DbWrite for PgStore {
                 , recipient
                 , amount
                 , max_fee
-                , sender_addresses)
+                , sender_script_pub_keys)
             SELECT
                 txid
               , output_index
@@ -925,7 +932,7 @@ impl super::DbWrite for PgStore {
               , recipient
               , amount
               , max_fee
-              , regexp_split_to_array(sender_address, ',')
+              , ARRAY(SELECT decode(UNNEST(regexp_split_to_array(senders, ',')), 'hex'))
             FROM tx_ids
             JOIN output_index USING (row_number)
             JOIN spend_script USING (row_number)
@@ -933,7 +940,7 @@ impl super::DbWrite for PgStore {
             JOIN recipient USING (row_number)
             JOIN amount USING (row_number)
             JOIN max_fee USING (row_number)
-            JOIN sender_address USING (row_number)
+            JOIN script_pub_keys USING (row_number)
             ON CONFLICT DO NOTHING"#,
         )
         .bind(txid)
@@ -943,7 +950,7 @@ impl super::DbWrite for PgStore {
         .bind(recipient)
         .bind(amount)
         .bind(max_fee)
-        .bind(sender_addresses)
+        .bind(sender_script_pubkeys)
         .execute(&self.0)
         .await
         .map_err(Error::SqlxQuery)?;
@@ -951,12 +958,12 @@ impl super::DbWrite for PgStore {
         Ok(())
     }
 
-    async fn write_withdraw_request(
+    async fn write_withdrawal_request(
         &self,
-        withdraw_request: &model::WithdrawRequest,
+        withdraw_request: &model::WithdrawalRequest,
     ) -> Result<(), Self::Error> {
         sqlx::query(
-            "INSERT INTO sbtc_signer.withdraw_requests
+            "INSERT INTO sbtc_signer.withdrawal_requests
               ( request_id
               , txid
               , block_hash
@@ -1008,21 +1015,23 @@ impl super::DbWrite for PgStore {
         Ok(())
     }
 
-    async fn write_withdraw_signer_decision(
+    async fn write_withdrawal_signer_decision(
         &self,
-        decision: &model::WithdrawSigner,
+        decision: &model::WithdrawalSigner,
     ) -> Result<(), Self::Error> {
         sqlx::query(
-            "INSERT INTO sbtc_signer.withdraw_signers
+            "INSERT INTO sbtc_signer.withdrawal_signers
               ( request_id
+              , txid
               , block_hash
               , signer_pub_key
               , is_accepted
               )
-            VALUES ($1, $2, $3, $4)
+            VALUES ($1, $2, $3, $4, $5)
             ON CONFLICT DO NOTHING",
         )
         .bind(i64::try_from(decision.request_id).map_err(Error::ConversionDatabaseInt)?)
+        .bind(decision.txid)
         .bind(decision.block_hash)
         .bind(decision.signer_pub_key)
         .bind(decision.is_accepted)

--- a/signer/src/testing/storage/model.rs
+++ b/signer/src/testing/storage/model.rs
@@ -1,6 +1,5 @@
 //! Test data generation utilities
 
-use bitcoin::hashes::Hash;
 use fake::Fake;
 
 use crate::storage::model;
@@ -311,7 +310,7 @@ impl WithdrawData {
     fn generate(
         rng: &mut impl rand::RngCore,
         stacks_blocks: &[model::StacksBlock],
-        withdraw_requests: &[model::WithdrawRequest],
+        withdraw_requests: &[model::WithdrawalRequest],
         num_withdraw_requests: usize,
         num_signers_per_request: usize,
     ) -> Self {
@@ -328,16 +327,12 @@ impl WithdrawData {
                 |(mut withdraw_requests, next_withdraw_request_id), _| {
                     let stacks_block_hash = stacks_blocks.choose(rng).unwrap().block_hash; // Guaranteed to be non-empty
 
-                    let mut withdraw_request: model::WithdrawRequest =
+                    let mut withdraw_request: model::WithdrawalRequest =
                         fake::Faker.fake_with_rng(rng);
 
                     withdraw_request.block_hash = stacks_block_hash;
                     withdraw_request.request_id = next_withdraw_request_id;
-                    withdraw_request.recipient = bitcoin::Address::p2pkh(
-                        bitcoin::PubkeyHash::from_byte_array([0; 20]),
-                        bitcoin::Network::Testnet,
-                    )
-                    .to_string();
+                    withdraw_request.recipient = fake::Faker.fake_with_rng(rng);
 
                     let mut raw_transaction: model::Transaction = fake::Faker.fake_with_rng(rng);
                     raw_transaction.tx_type = model::TransactionType::WithdrawRequest;

--- a/signer/src/testing/storage/model.rs
+++ b/signer/src/testing/storage/model.rs
@@ -24,7 +24,7 @@ pub struct TestData {
     pub deposit_requests: Vec<model::DepositRequest>,
 
     /// Deposit requests
-    pub withdraw_requests: Vec<model::WithdrawRequest>,
+    pub withdraw_requests: Vec<model::WithdrawalRequest>,
 
     /// Raw transaction data
     pub transactions: Vec<model::Transaction>,
@@ -39,7 +39,7 @@ pub struct TestData {
     pub deposit_signers: Vec<model::DepositSigner>,
 
     /// Withdraw signers
-    pub withdraw_signers: Vec<model::WithdrawSigner>,
+    pub withdraw_signers: Vec<model::WithdrawalSigner>,
 }
 
 impl TestData {
@@ -157,7 +157,7 @@ impl TestData {
 
         for req in self.withdraw_requests.iter() {
             storage
-                .write_withdraw_request(req)
+                .write_withdrawal_request(req)
                 .await
                 .expect("failed to write withdraw request");
         }
@@ -185,7 +185,7 @@ impl TestData {
 
         for decision in self.withdraw_signers.iter() {
             storage
-                .write_withdraw_signer_decision(decision)
+                .write_withdrawal_signer_decision(decision)
                 .await
                 .expect("failed to write signer decision");
         }
@@ -297,8 +297,8 @@ impl DepositData {
 
 #[derive(Debug, Clone, Default)]
 struct WithdrawData {
-    pub withdraw_requests: Vec<model::WithdrawRequest>,
-    pub withdraw_signers: Vec<model::WithdrawSigner>,
+    pub withdraw_requests: Vec<model::WithdrawalRequest>,
+    pub withdraw_signers: Vec<model::WithdrawalSigner>,
     pub transactions: Vec<model::Transaction>,
     pub stacks_transactions: Vec<model::StacksTransaction>,
 }
@@ -349,7 +349,7 @@ impl WithdrawData {
 
                     let withdraw_signers: Vec<_> = (0..num_signers_per_request)
                         .map(|_| {
-                            let mut signer: model::WithdrawSigner = fake::Faker.fake_with_rng(rng);
+                            let mut signer: model::WithdrawalSigner = fake::Faker.fake_with_rng(rng);
                             signer.request_id = withdraw_request.request_id;
                             signer.block_hash = withdraw_request.block_hash;
                             signer

--- a/signer/src/testing/storage/model.rs
+++ b/signer/src/testing/storage/model.rs
@@ -347,6 +347,7 @@ impl WithdrawData {
                             let mut signer: model::WithdrawalSigner = fake::Faker.fake_with_rng(rng);
                             signer.request_id = withdraw_request.request_id;
                             signer.block_hash = withdraw_request.block_hash;
+                            signer.txid = withdraw_request.txid;
                             signer
                         })
                         .collect();

--- a/signer/src/testing/transaction_signer.rs
+++ b/signer/src/testing/transaction_signer.rs
@@ -687,7 +687,7 @@ where
     async fn assert_only_withdraw_requests_in_context_window_has_decisions(
         storage: &S,
         context_window: u16,
-        withdraw_requests: &[model::WithdrawRequest],
+        withdraw_requests: &[model::WithdrawalRequest],
         num_expected_decisions: usize,
     ) {
         let context_window_block_hashes =
@@ -695,7 +695,7 @@ where
 
         for withdraw_request in withdraw_requests {
             let signer_decisions = storage
-                .get_withdraw_signers(withdraw_request.request_id, &withdraw_request.block_hash)
+                .get_withdrawal_signers(withdraw_request.request_id, &withdraw_request.block_hash)
                 .await
                 .unwrap();
 

--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -450,7 +450,7 @@ where
 
         let pending_withdraw_requests = self
             .storage
-            .get_pending_accepted_withdraw_requests(bitcoin_chain_tip, context_window, threshold)
+            .get_pending_accepted_withdrawal_requests(bitcoin_chain_tip, context_window, threshold)
             .await?;
 
         let signers_public_key = bitcoin::XOnlyPublicKey::from(&aggregate_key);

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -569,7 +569,7 @@ where
     ) -> Result<Vec<model::WithdrawalRequest>, error::Error> {
         Ok(self
             .storage
-            .get_pending_withdraw_requests(chain_tip, self.context_window)
+            .get_pending_withdrawal_requests(chain_tip, self.context_window)
             .await?)
     }
 

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -566,7 +566,7 @@ where
     async fn get_pending_withdraw_requests(
         &mut self,
         chain_tip: &model::BitcoinBlockHash,
-    ) -> Result<Vec<model::WithdrawRequest>, error::Error> {
+    ) -> Result<Vec<model::WithdrawalRequest>, error::Error> {
         Ok(self
             .storage
             .get_pending_withdraw_requests(chain_tip, self.context_window)
@@ -576,27 +576,37 @@ where
     #[tracing::instrument(skip(self))]
     async fn handle_pending_deposit_request(
         &mut self,
-        deposit_request: model::DepositRequest,
+        request: model::DepositRequest,
         bitcoin_chain_tip: &model::BitcoinBlockHash,
     ) -> Result<(), error::Error> {
-        let is_accepted = futures::stream::iter(&deposit_request.sender_addresses)
+        let params = self.network_kind.params();
+        let addresses = request
+            .sender_script_pub_keys
+            .iter()
+            .map(|script_pubkey| {
+                bitcoin::Address::from_script(script_pubkey, params)
+                    .map_err(|err| Error::BitcoinAddressFromScript(err, request.outpoint()))
+            })
+            .collect::<Result<Vec<bitcoin::Address>, _>>()?;
+
+        let is_accepted = futures::stream::iter(&addresses)
             .any(|address| async {
                 self.blocklist_checker
-                    .can_accept(address)
+                    .can_accept(&address.to_string())
                     .await
                     .unwrap_or(false)
             })
             .await;
 
         let msg = message::SignerDepositDecision {
-            txid: deposit_request.txid.into(),
-            output_index: deposit_request.output_index,
+            txid: request.txid.into(),
+            output_index: request.output_index,
             accepted: is_accepted,
         };
 
         let signer_decision = model::DepositSigner {
-            txid: deposit_request.txid,
-            output_index: deposit_request.output_index,
+            txid: request.txid,
+            output_index: request.output_index,
             signer_pub_key: self.signer_pub_key(),
             is_accepted,
         };
@@ -613,7 +623,7 @@ where
     #[tracing::instrument(skip(self))]
     async fn handle_pending_withdraw_request(
         &mut self,
-        withdraw_request: model::WithdrawRequest,
+        withdraw_request: model::WithdrawalRequest,
     ) -> Result<(), error::Error> {
         // TODO: Do we want to do this on the sender address of the
         // recipient address?
@@ -623,15 +633,16 @@ where
             .await
             .unwrap_or(false);
 
-        let signer_decision = model::WithdrawSigner {
+        let signer_decision = model::WithdrawalSigner {
             request_id: withdraw_request.request_id,
             block_hash: withdraw_request.block_hash,
             signer_pub_key: self.signer_pub_key(),
             is_accepted,
+            txid: withdraw_request.txid,
         };
 
         self.storage
-            .write_withdraw_signer_decision(&signer_decision)
+            .write_withdrawal_signer_decision(&signer_decision)
             .await?;
 
         Ok(())
@@ -670,15 +681,16 @@ where
         decision: &message::SignerWithdrawDecision,
         signer_pub_key: PublicKey,
     ) -> Result<(), error::Error> {
-        let signer_decision = model::WithdrawSigner {
+        let signer_decision = model::WithdrawalSigner {
             request_id: decision.request_id,
             block_hash: decision.block_hash.into(),
             signer_pub_key,
             is_accepted: decision.accepted,
+            txid: decision.txid,
         };
 
         self.storage
-            .write_withdraw_signer_decision(&signer_decision)
+            .write_withdrawal_signer_decision(&signer_decision)
             .await?;
 
         #[cfg(feature = "testing")]

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -372,14 +372,14 @@ async fn should_return_the_same_pending_withdraw_requests_as_in_memory_store() {
     );
 
     let mut pending_withdraw_requests = in_memory_store
-        .get_pending_withdraw_requests(&chain_tip, context_window)
+        .get_pending_withdrawal_requests(&chain_tip, context_window)
         .await
         .expect("failed to get pending deposit requests");
 
     pending_withdraw_requests.sort();
 
     let mut pg_pending_withdraw_requests = pg_store
-        .get_pending_withdraw_requests(&chain_tip, context_window)
+        .get_pending_withdrawal_requests(&chain_tip, context_window)
         .await
         .expect("failed to get pending deposit requests");
 
@@ -497,7 +497,7 @@ async fn should_return_the_same_pending_accepted_withdraw_requests_as_in_memory_
     );
 
     let mut pending_accepted_withdraw_requests = in_memory_store
-        .get_pending_accepted_withdraw_requests(&chain_tip, context_window, threshold)
+        .get_pending_accepted_withdrawal_requests(&chain_tip, context_window, threshold)
         .await
         .expect("failed to get pending_accepted deposit requests");
 
@@ -506,7 +506,7 @@ async fn should_return_the_same_pending_accepted_withdraw_requests_as_in_memory_
     assert!(!pending_accepted_withdraw_requests.is_empty());
 
     let mut pg_pending_accepted_withdraw_requests = pg_store
-        .get_pending_accepted_withdraw_requests(&chain_tip, context_window, threshold)
+        .get_pending_accepted_withdrawal_requests(&chain_tip, context_window, threshold)
         .await
         .expect("failed to get pending_accepted deposit requests");
 

--- a/signer/tests/integration/utxo_construction.rs
+++ b/signer/tests/integration/utxo_construction.rs
@@ -41,7 +41,7 @@ pub fn generate_withdrawal() -> (WithdrawalRequest, Recipient) {
     let req = WithdrawalRequest {
         amount: OsRng.sample(Uniform::new(100_000, 250_000)),
         max_fee: 250_000,
-        address: recipient.address.clone(),
+        script_pubkey: recipient.script_pubkey.clone().into(),
         signer_bitmap: BitArray::ZERO,
         request_id: REQUEST_IDS.fetch_add(1, Ordering::Relaxed),
         txid: fake::Faker.fake_with_rng(&mut OsRng),


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/527.

## Changes

* Update 'recipient' column names and their type to expect a `bytea` for a `ScriptPubKey`. This makes it more consistent with the code base, as well as reduces overall complexity (using an address is incorrect).
* Use `WithdrawalX` instead of `WithdrawX` for table, function, and struct names.
* Add the transaction ID to the `withdrawal_request` and `withdrawal_signer` tables.
* Add an internal `ScriptPubKey` type for interacting with the database.

## Testing Information

This is a refactor, so if tests pass then we're good.

## Checklist:

- [x] I have performed a self-review of my code
