### PR TITLE
refactor: move db into context

### DIFF
--- a/signer/src/api/mod.rs
+++ b/signer/src/api/mod.rs
@@ -7,15 +7,13 @@ pub mod status;
 pub use new_block::new_block_handler;
 pub use status::status_handler;
 
-use crate::config::Settings;
+use crate::context::Context;
 
 /// A struct with state data necessary for runtime operation.
 #[derive(Debug, Clone)]
-pub struct ApiState<S> {
+pub struct ApiState<C: Context> {
     /// For writing to the database.
-    pub db: S,
-    /// The runtime settings of the system.
-    pub settings: Settings,
+    pub ctx: C,
 }
 
 /// The name of the sbtc registry smart contract.

--- a/signer/src/api/new_block.rs
+++ b/signer/src/api/new_block.rs
@@ -10,6 +10,7 @@ use clarity::vm::representations::ContractName;
 use clarity::vm::types::QualifiedContractIdentifier;
 use clarity::vm::types::StandardPrincipalData;
 
+use crate::context::Context;
 use crate::stacks::events::RegistryEvent;
 use crate::stacks::events::TxInfo;
 use crate::stacks::webhooks::NewBlockEvent;
@@ -46,10 +47,7 @@ static SBTC_REGISTRY_IDENTIFIER: OnceLock<QualifiedContractIdentifier> = OnceLoc
 /// fixed number of times.
 ///
 /// [^1]: <https://github.com/stacks-network/stacks-core/blob/09c4b066e25104be8b066e8f7530ff0c6df4ccd5/testnet/stacks-node/src/event_dispatcher.rs#L317-L385>
-pub async fn new_block_handler<S>(state: State<ApiState<S>>, body: String) -> StatusCode
-where
-    S: DbWrite,
-{
+pub async fn new_block_handler(state: State<ApiState<impl Context>>, body: String) -> StatusCode {
     tracing::debug!("Received a new block event from stacks-core");
     let api = state.0;
 
@@ -57,7 +55,7 @@ where
         // Although the following line can panic, our unit tests hit this
         // code path so if tests pass then this will work in production.
         let contract_name = ContractName::from(SBTC_REGISTRY_CONTRACT_NAME);
-        let issuer = StandardPrincipalData::from(api.settings.signer.deployer);
+        let issuer = StandardPrincipalData::from(api.ctx.config().signer.deployer);
         QualifiedContractIdentifier::new(issuer, contract_name)
     });
 
@@ -68,7 +66,7 @@ where
         // will lead to success, so we log the error and return `200 OK` so
         // that the node does not retry the webhook.
         Err(error) => {
-            tracing::error!("could not deserialize POST /new_block webhook: {body}, error {error}");
+            tracing::error!(%body, %error, "could not deserialize POST /new_block webhook:");
             return StatusCode::OK;
         }
     };
@@ -83,25 +81,27 @@ where
         .filter_map(|x| x.contract_event.map(|ev| (ev, x.txid)))
         .filter(|(ev, _)| &ev.contract_identifier == registry_address && ev.topic == "print");
 
+    let db = api.ctx.get_storage_mut();
+
     let block_id = new_block_event.index_block_hash;
 
     for (ev, txid) in events {
         let tx_info = TxInfo { txid, block_id };
         let res = match RegistryEvent::try_new(ev.value, tx_info) {
             Ok(RegistryEvent::CompletedDeposit(event)) => {
-                api.db.write_completed_deposit_event(&event).await
+                db.write_completed_deposit_event(&event).await
             }
             Ok(RegistryEvent::WithdrawalAccept(event)) => {
-                api.db.write_withdrawal_accept_event(&event).await
+                db.write_withdrawal_accept_event(&event).await
             }
             Ok(RegistryEvent::WithdrawalCreate(event)) => {
-                api.db.write_withdrawal_create_event(&event).await
+                db.write_withdrawal_create_event(&event).await
             }
             Ok(RegistryEvent::WithdrawalReject(event)) => {
-                api.db.write_withdrawal_reject_event(&event).await
+                db.write_withdrawal_reject_event(&event).await
             }
-            Err(err) => {
-                tracing::error!("Got an error when transforming the event ClarityValue: {err}");
+            Err(error) => {
+                tracing::error!(%error, "Got an error when transforming the event ClarityValue");
                 return StatusCode::OK;
             }
         };
@@ -109,8 +109,8 @@ where
         // issue that will resolve itself if we try again in a few moments.
         // So we return a non success status code so that the node retries
         // in a second.
-        if let Err(err) = res {
-            tracing::error!("Got an error when writing event to database: {err}");
+        if let Err(error) = res {
+            tracing::error!(%error, "Got an error when writing event to database");
             return StatusCode::INTERNAL_SERVER_ERROR;
         }
     }
@@ -129,6 +129,7 @@ mod tests {
     use test_case::test_case;
 
     use crate::config::Settings;
+    use crate::context::SignerContext;
     use crate::storage::in_memory::Store;
     use crate::storage::model::StacksPrincipal;
 
@@ -158,24 +159,25 @@ mod tests {
     where
         F: Fn(tokio::sync::MutexGuard<'_, Store>) -> bool,
     {
-        let api = ApiState {
-            db: Store::new_shared(),
-            settings: Settings::new(crate::testing::DEFAULT_CONFIG_PATH).unwrap(),
-        };
+        let db = Store::new_shared();
+
+        let ctx = SignerContext::init(Settings::new_from_default_config().unwrap(), db.clone())
+            .await
+            .expect("failed to init context");
+
+        let api = ApiState { ctx: ctx.clone() };
 
         // Hey look, there is nothing here!
-        let db = api.db.lock().await;
-        assert!(table_is_empty(db));
+        assert!(table_is_empty(db.lock().await));
 
-        let state = State(api.clone());
+        let state = State(api);
         let body = body_str.to_string();
 
         let res = new_block_handler(state, body).await;
         assert_eq!(res, StatusCode::OK);
 
         // Now there should be something here
-        let db = api.db.lock().await;
-        assert!(!table_is_empty(db));
+        assert!(!table_is_empty(db.lock().await));
     }
 
     #[test_case(COMPLETED_DEPOSIT_WEBHOOK, |db| db.completed_deposit_events.get(&OutPoint::null()).is_none(); "completed-deposit")]
@@ -187,20 +189,22 @@ mod tests {
     where
         F: Fn(tokio::sync::MutexGuard<'_, Store>) -> bool,
     {
-        let api = ApiState {
-            db: Store::new_shared(),
-            settings: Settings::new_from_default_config().unwrap(),
-        };
+        let db = Store::new_shared();
+
+        let ctx = SignerContext::init(Settings::new_from_default_config().unwrap(), db.clone())
+            .await
+            .expect("failed to init context");
+
+        let api = ApiState { ctx: ctx.clone() };
 
         // Hey look, there is nothing here!
-        let db = api.db.lock().await;
-        assert!(table_is_empty(db));
+        assert!(table_is_empty(db.lock().await));
 
         // Okay, we want to make sure that events that are from an
         // unexpected contract are filtered out. So we manually switch the
         // address to some random one and check the output. To do that we
         // do a string replace for the expected one with the fishy one.
-        let issuer = StandardPrincipalData::from(api.settings.signer.deployer);
+        let issuer = StandardPrincipalData::from(ctx.config().signer.deployer);
         let contract_name = ContractName::from(SBTC_REGISTRY_CONTRACT_NAME);
         let identifier = QualifiedContractIdentifier::new(issuer, contract_name.clone());
 
@@ -238,7 +242,6 @@ mod tests {
 
         // This event should be filtered out, so the table should still be
         // empty.
-        let db = api.db.lock().await;
-        assert!(table_is_empty(db));
+        assert!(table_is_empty(db.lock().await));
     }
 }

--- a/signer/src/context.rs
+++ b/signer/src/context.rs
@@ -4,14 +4,14 @@ use std::sync::Arc;
 
 use tokio::sync::broadcast::Sender;
 
-use crate::{config::Settings, error::Error};
+use crate::{
+    config::Settings,
+    error::Error,
+    storage::{DbRead, DbWrite},
+};
 
 /// Context trait that is implemented by the [`SignerContext`].
-pub trait Context {
-    /// Initialize a new signer context.
-    fn init(config: Settings) -> Result<Self, crate::error::Error>
-    where
-        Self: Sized;
+pub trait Context: Clone + Sync + Send {
     /// Get the current configuration for the signer.
     fn config(&self) -> &Settings;
     /// Subscribe to the application signalling channel, returning a receiver
@@ -23,16 +23,21 @@ pub trait Context {
     fn signal(&self, signal: SignerSignal) -> Result<(), Error>;
     /// Returns a handle to the application's termination signal.
     fn get_termination_handle(&self) -> TerminationHandle;
+    /// Get a read-only handle to the signer storage.
+    fn get_storage(&self) -> impl DbRead + Clone + Sync + Send;
+    /// Get a read-write handle to the signer storage.
+    fn get_storage_mut(&self) -> impl DbRead + DbWrite + Clone + Sync + Send;
 }
 
 /// Signer context which is passed to different components within the
 /// signer binary.
-pub struct SignerContext {
-    inner: Arc<InnerSignerContext>,
+#[derive(Clone)]
+pub struct SignerContext<S> {
+    inner: Arc<InnerSignerContext<S>>,
 }
 
-impl std::ops::Deref for SignerContext {
-    type Target = InnerSignerContext;
+impl<S> std::ops::Deref for SignerContext<S> {
+    type Target = InnerSignerContext<S>;
 
     fn deref(&self) -> &Self::Target {
         &self.inner
@@ -40,7 +45,7 @@ impl std::ops::Deref for SignerContext {
 }
 
 /// Inner signer context which holds the configuration and signalling channels.
-pub struct InnerSignerContext {
+pub struct InnerSignerContext<S> {
     config: Settings,
     // Handle to the app signalling channel. This keeps the channel alive
     // for the duration of the program and is used both to send messages
@@ -50,6 +55,8 @@ pub struct InnerSignerContext {
     /// for the duration of the program and is used to provide new senders
     /// and receivers for a [`TerminationHandle`].
     term_tx: tokio::sync::watch::Sender<bool>,
+    /// Handle to the signer storage.
+    storage: S,
 }
 
 /// Signals that can be sent within the signer binary.
@@ -118,9 +125,12 @@ impl TerminationHandle {
     }
 }
 
-impl Context for SignerContext {
+impl<S> SignerContext<S>
+where
+    S: DbRead + DbWrite + Clone + Sync + Send,
+{
     /// Create a new signer context.
-    fn init(config: Settings) -> Result<Self, Error> {
+    pub async fn init(config: Settings, db: S) -> Result<Self, Error> {
         // TODO: Decide on the channel capacity and how we should handle slow consumers.
         // NOTE: Ideally consumers which require processing time should pull the relevent
         // messages into a local VecDequeue and process them in their own time.
@@ -128,10 +138,20 @@ impl Context for SignerContext {
         let (term_tx, _) = tokio::sync::watch::channel(false);
 
         Ok(Self {
-            inner: Arc::new(InnerSignerContext { config, signal_tx, term_tx }),
+            inner: Arc::new(InnerSignerContext {
+                config,
+                signal_tx,
+                term_tx,
+                storage: db,
+            }),
         })
     }
+}
 
+impl<S> Context for SignerContext<S>
+where
+    S: DbRead + DbWrite + Clone + Sync + Send,
+{
     fn config(&self) -> &Settings {
         &self.config
     }
@@ -160,5 +180,13 @@ impl Context for SignerContext {
 
     fn get_termination_handle(&self) -> TerminationHandle {
         TerminationHandle(self.term_tx.clone(), self.term_tx.subscribe())
+    }
+
+    fn get_storage(&self) -> impl DbRead + Clone + Sync + Send {
+        self.storage.clone()
+    }
+
+    fn get_storage_mut(&self) -> impl DbRead + DbWrite + Clone + Sync + Send {
+        self.storage.clone()
     }
 }

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -156,6 +156,10 @@ pub enum Error {
     #[error("received an error when attempting to query the database: {0}")]
     SqlxQuery(#[source] sqlx::Error),
 
+    /// An error occurred while attempting to connect to the database.
+    #[error("received an error when attempting to connect to the database: {0}")]
+    SqlxConnect(#[source] sqlx::Error),
+
     /// An error when attempting to generically decode bytes using the
     /// trait implementation.
     #[error("got an error wen attempting to call StacksMessageCodec::consensus_deserialize {0}")]

--- a/signer/src/main.rs
+++ b/signer/src/main.rs
@@ -15,13 +15,6 @@ use signer::network::libp2p::SignerSwarmBuilder;
 use signer::storage::postgres::PgStore;
 use tokio::signal;
 
-// TODO: Should this be part of the SignerContext?
-fn get_connection_pool(uri: &url::Url) -> sqlx::PgPool {
-    sqlx::postgres::PgPoolOptions::new()
-        .connect_lazy(uri.as_str())
-        .unwrap()
-}
-
 /// Command line arguments for the signer.
 #[derive(Debug, Parser)]
 #[clap(name = "sBTC Signer")]
@@ -45,10 +38,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Parse the command line arguments.
     let args = SignerArgs::parse();
 
+    // Load the configuration file and/or environment variables.
     let settings = Settings::new(args.config)?;
 
+    // Open a connection to the signer db.
+    let db = PgStore::connect(settings.signer.db_endpoint.as_str()).await?;
+
     // Initialize the signer context.
-    let context = SignerContext::init(settings)?;
+    let context = SignerContext::init(settings, db).await?;
 
     // Run the application components concurrently. We're `join!`ing them
     // here so that every component can shut itself down gracefully when
@@ -63,7 +60,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let _ = tokio::join!(
         // Our global termination signal watcher. This does not run using `run_checked`
         // as it sends its own shutdown signal.
-        run_shutdown_signal_watcher(&context),
+        run_shutdown_signal_watcher(context.clone()),
         // The rest of our services which run concurrently, and must all be
         // running for the signer to be operational.
         run_checked(run_stacks_event_observer, &context),
@@ -77,13 +74,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// shutdown signal to the application if an error is encountered. This is needed
 /// as otherwise the application would continue running indefinitely (since no
 /// shutdown signal is sent automatically on error).
-async fn run_checked<'a, F, Fut, C>(f: F, ctx: &'a C) -> Result<(), Error>
+async fn run_checked<F, Fut, C>(f: F, ctx: &C) -> Result<(), Error>
 where
-    C: Context + 'a,
-    F: FnOnce(&'a C) -> Fut,
-    Fut: std::future::Future<Output = Result<(), Error>> + 'a,
+    C: Context,
+    F: FnOnce(C) -> Fut,
+    Fut: std::future::Future<Output = Result<(), Error>>,
 {
-    if let Err(error) = f(ctx).await {
+    if let Err(error) = f(ctx.clone()).await {
         tracing::error!(%error, "a fatal error occurred; shutting down the application");
         ctx.get_termination_handle().signal_shutdown();
         return Err(error);
@@ -95,7 +92,7 @@ where
 /// Runs the shutdown-signal watcher. On Unix systems, this listens for SIGHUP,
 /// SIGTERM, and SIGINT. On other systems, it listens for Ctrl-C.
 #[tracing::instrument(skip(ctx))]
-async fn run_shutdown_signal_watcher(ctx: &impl Context) -> Result<(), Error> {
+async fn run_shutdown_signal_watcher(ctx: impl Context) -> Result<(), Error> {
     let mut term = ctx.get_termination_handle();
 
     cfg_if! {
@@ -153,7 +150,7 @@ async fn run_shutdown_signal_watcher(ctx: &impl Context) -> Result<(), Error> {
 
 /// Runs the libp2p swarm.
 #[tracing::instrument(skip(ctx))]
-async fn run_libp2p_swarm(ctx: &impl Context) -> Result<(), Error> {
+async fn run_libp2p_swarm(ctx: impl Context) -> Result<(), Error> {
     tracing::info!("initializing the p2p network");
 
     // Build the swarm.
@@ -166,30 +163,26 @@ async fn run_libp2p_swarm(ctx: &impl Context) -> Result<(), Error> {
     // Start the libp2p swarm. This will run until either the shutdown signal is
     // received, or an unrecoverable error has occurred.
     tracing::info!("starting the libp2p swarm");
-    swarm.start(ctx).await.map_err(Error::SignerSwarm)
+    swarm.start(&ctx).await.map_err(Error::SignerSwarm)
 }
 
 /// Runs the Stacks event observer server.
 #[tracing::instrument(skip(ctx))]
-async fn run_stacks_event_observer(ctx: &impl Context) -> Result<(), Error> {
+async fn run_stacks_event_observer(ctx: impl Context + 'static) -> Result<(), Error> {
     tracing::info!("initializing the Stacks event observer server");
 
-    let pool = get_connection_pool(&ctx.config().signer.db_endpoint);
+    let state = ApiState { ctx: ctx.clone() };
 
-    let state = ApiState {
-        db: PgStore::from(pool),
-        settings: ctx.config().clone(),
-    };
     // Build the signer API application
     let app = Router::new()
         .route("/", get(api::status_handler))
         .route("/new_block", post(api::new_block_handler))
         .with_state(state);
 
-    let config = ctx.config().signer.event_observer.clone();
-
     // Bind to the configured address and port
-    let listener = tokio::net::TcpListener::bind(config.bind).await.unwrap();
+    let listener = tokio::net::TcpListener::bind(ctx.config().signer.event_observer.bind)
+        .await
+        .expect("failed to retrieve event observer bind address from config");
 
     // Get the termination signal handle.
     let mut term = ctx.get_termination_handle();

--- a/signer/src/network/libp2p/swarm.rs
+++ b/signer/src/network/libp2p/swarm.rs
@@ -218,7 +218,7 @@ impl SignerSwarm {
 
 #[cfg(test)]
 mod tests {
-    use crate::{config::Settings, context::SignerContext};
+    use crate::{config::Settings, context::SignerContext, storage::in_memory::Store};
 
     use super::*;
 
@@ -247,7 +247,9 @@ mod tests {
         let mut swarm = builder.build().unwrap();
 
         let settings = Settings::new_from_default_config().unwrap();
-        let ctx = SignerContext::init(settings).unwrap();
+        let ctx = SignerContext::init(settings, Store::new_shared())
+            .await
+            .unwrap();
         let term = ctx.get_termination_handle();
 
         let timeout = tokio::time::timeout(Duration::from_secs(10), async {

--- a/signer/src/network/mod.rs
+++ b/signer/src/network/mod.rs
@@ -126,6 +126,7 @@ mod tests {
         config::Settings,
         context::SignerContext,
         keys::PrivateKey,
+        storage::in_memory::Store,
         testing::{self, clear_env},
     };
 
@@ -148,8 +149,12 @@ mod tests {
 
         let settings = Settings::new_from_default_config().unwrap();
 
-        let context1 = SignerContext::init(settings.clone()).unwrap();
-        let context2 = SignerContext::init(settings).unwrap();
+        let context1 = SignerContext::init(settings.clone(), Store::new_shared())
+            .await
+            .unwrap();
+        let context2 = SignerContext::init(settings, Store::new_shared())
+            .await
+            .unwrap();
 
         let term1 = context1.get_termination_handle();
         let term2 = context2.get_termination_handle();

--- a/signer/src/storage/mod.rs
+++ b/signer/src/storage/mod.rs
@@ -11,6 +11,7 @@ pub mod model;
 pub mod postgres;
 pub mod sqlx;
 
+use std::fmt::Display;
 use std::future::Future;
 
 use blockstack_lib::types::chainstate::StacksBlockId;
@@ -24,7 +25,7 @@ use crate::stacks::events::WithdrawalRejectEvent;
 /// Represents the ability to read data from the signer storage.
 pub trait DbRead {
     /// Read error.
-    type Error: std::error::Error;
+    type Error: std::error::Error + Display;
 
     /// Get the bitcoin block with the given block hash.
     fn get_bitcoin_block(
@@ -152,7 +153,7 @@ pub trait DbRead {
 /// Represents the ability to write data to the signer storage.
 pub trait DbWrite {
     /// Write error.
-    type Error: std::error::Error;
+    type Error: std::error::Error + Display;
 
     /// Write a bitcoin block.
     fn write_bitcoin_block(


### PR DESCRIPTION
## Description

Moves the database into the `SignerContext` so that we have a central place to manage the connection pool. This is a much-slimmed-down version of the other suggestion PR for supporting multiple databases -- this only supports pgsql and is the direction I think we should take for _right now_.

## Changes
- Moves the database into `SignerContext` and provides methods for retrieving a storage handle (`get_storage()` for read-only, `get_storage_mut()` for read/write).
- Refactorings to make use of these new methods and the context throughout the program.

## Testing Information
Nothing specific.

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
