### PR TITLE
feat: reject non-standard deposit scripts and problematic lock-times

### DIFF
--- a/sbtc/src/deposits.rs
+++ b/sbtc/src/deposits.rs
@@ -56,7 +56,7 @@ const STANDARD_SCRIPT_LENGTH: usize =
 /// [^1]: <https://github.com/bitcoin/bitcoin/blob/v27.1/src/script/interpreter.cpp#L560-L592>
 /// [^2]: <https://github.com/bitcoin/bitcoin/blob/v27.1/src/script/interpreter.cpp#L1737-L1782>
 /// [^3]: <https://github.com/bitcoin/bitcoin/blob/v27.1/src/primitives/transaction.h#L89-L98>
-const SEQUENCE_LOCKTIME_DISABLE_FLAG: i64 = 1 << 31;
+pub const SEQUENCE_LOCKTIME_DISABLE_FLAG: i64 = 1 << 31;
 
 /// Script opcodes as the bytes in bitcoin Script.
 ///

--- a/sbtc/src/deposits.rs
+++ b/sbtc/src/deposits.rs
@@ -901,7 +901,7 @@ mod tests {
         };
 
         let error = request.validate_tx(&setup.tx).unwrap_err();
-        assert!(matches!(error, Error::InvalidDepositScript));
+        assert!(matches!(error, Error::InvalidDepositScriptLength));
 
         let request = CreateDepositRequest {
             outpoint: OutPoint::new(setup.tx.compute_txid(), 0),

--- a/sbtc/src/deposits.rs
+++ b/sbtc/src/deposits.rs
@@ -620,10 +620,18 @@ mod tests {
         let secret_key = SecretKey::new(&mut OsRng);
         let public_key = secret_key.x_only_public_key(SECP256K1).0;
 
-        let data = [0; 50];
+        let recipient = PrincipalData::parse(CONTRACT_ADDRESS).unwrap();
+        let max_fee: u64 = 15000;
+
+        let mut deposit_data = [0; 44];
+        deposit_data[..8].copy_from_slice(&max_fee.to_be_bytes());
+        deposit_data[8..].copy_from_slice(&recipient.serialize_to_vec());
+
+        // This is non-standard script, because it does not follow the
+        // minimal push rule.
         let deposit_script = ScriptBuf::builder()
             .push_opcode(opcodes::OP_PUSHDATA1)
-            .push_slice(data)
+            .push_slice(deposit_data)
             .push_opcode(opcodes::OP_DROP)
             .push_slice(public_key.serialize())
             .push_opcode(opcodes::OP_CHECKSIG)

--- a/sbtc/src/deposits.rs
+++ b/sbtc/src/deposits.rs
@@ -143,7 +143,7 @@ impl CreateDepositRequest {
     /// Validate this deposit request from the transaction.
     ///
     /// This function fetches the transaction using the given client and
-    /// checks that the transaction has been confirmed. The transaction
+    /// checks that the transaction has been submitted. The transaction
     /// need not be confirmed.
     pub fn validate<C>(&self, client: &C) -> Result<Deposit, Error>
     where
@@ -359,7 +359,7 @@ impl DepositScriptInputs {
         // here starts with the 8 byte max fee.
         let deposit_data = match params {
             // This branch represents a contract address. We reject scripts
-            // that use OP_PUSHDATA1 to push less than 75 bytes of data
+            // that use OP_PUSHDATA1 to push less than 76 bytes of data
             // because those scripts, while valid and do not break
             // consensus rules, are non-standard. Accepting them would make
             // it very difficult for the signers to accept the deposit

--- a/sbtc/src/error.rs
+++ b/sbtc/src/error.rs
@@ -30,9 +30,16 @@ pub enum Error {
     /// Received an error in response to getrawtransaction RPC call
     #[error("failed to retrieve the raw transaction for txid {1} from bitcoin-core. {0}")]
     GetTransactionBitcoinCore(#[source] bitcoincore_rpc::Error, Txid),
+    /// The end of the deposit script has a fixed format that is very
+    /// similar to a P2PK check_sig script, the script violated that format
+    #[error("script is CHECKSIG part of script")]
+    InvalidDepositCheckSigPart,
     /// The deposit script was invalid
     #[error("invalid deposit script")]
     InvalidDepositScript,
+    /// Length of the deposit script is necessarily too short.
+    #[error("script is invalid, it is too short")]
+    InvalidDepositScriptLength,
     /// The lock time included in the reclaim script was invalid.
     #[error("the lock time included in the reclaim script was invalid: {0}")]
     InvalidReclaimScriptLockTime(i64),
@@ -49,6 +56,10 @@ pub enum Error {
     /// The X-only public key was invalid
     #[error("the x-only public key in the script was invalid: {0}")]
     InvalidXOnlyPublicKey(#[source] secp256k1::Error),
+    /// The deposit script was non-standard because it did not follow the
+    /// minimal push rule.
+    #[error("deposit script did not follow the minimal push rule")]
+    NonMinimalPushDepositScript,
     /// Could not parse the Stacks principal address.
     #[error("could not parse the stacks principal address: {0}")]
     ParseStacksAddress(#[source] stacks_common::codec::Error),

--- a/sbtc/src/error.rs
+++ b/sbtc/src/error.rs
@@ -40,7 +40,9 @@ pub enum Error {
     /// Length of the deposit script is necessarily too short.
     #[error("script is invalid, it is too short")]
     InvalidDepositScriptLength,
-    /// The lock time included in the reclaim script was invalid.
+    /// The lock time included in the reclaim script was invalid. This
+    /// could be because the number is out of range for an acceptable lock
+    /// time, or because the 32nd bit has been set.
     #[error("the lock time included in the reclaim script was invalid: {0}")]
     InvalidReclaimScriptLockTime(i64),
     /// The reclaim script was invalid.

--- a/sbtc/src/testing/regtest.rs
+++ b/sbtc/src/testing/regtest.rs
@@ -316,6 +316,10 @@ pub trait AsUtxo {
             script_pubkey: self.script_pubkey().clone(),
         }
     }
+    /// The outpoint of this UTXO
+    fn outpoint(&self) -> OutPoint {
+        OutPoint::new(self.txid(), self.vout())
+    }
 }
 
 impl AsUtxo for Utxo {

--- a/sbtc/tests/integration/validation.rs
+++ b/sbtc/tests/integration/validation.rs
@@ -1,6 +1,7 @@
 //! Test deposit validation against bitcoin-core
 
 use bitcoin::absolute::LockTime;
+use bitcoin::script::PushBytes;
 use bitcoin::transaction::Version;
 use bitcoin::AddressType;
 use bitcoin::Amount;
@@ -156,10 +157,10 @@ fn op_csv_disabled() {
     //    OP_CSV was disabled.
     faucet.generate_blocks(1);
 
-    // The Builder::push_slice function takes mainly fixed size arrays, so
-    // we convert the locking script to an array first.
-    let locking_script: [u8; 9] = script_pubkey.as_bytes().try_into().unwrap();
-
+    // The Builder::push_slice wants to make sure that the length of the
+    // pushed data is within the limits, hence the conversion into this
+    // PushBytes thing.
+    let locking_script: &PushBytes = script_pubkey.as_bytes().try_into().unwrap();
     let script_sig = ScriptBuf::builder()
         .push_slice(locking_script)
         .into_script();
@@ -250,9 +251,9 @@ fn op_csv_disabled() {
     //    be rejected.
     faucet.generate_blocks(1);
 
-    // Remember, Builder::push_slice likes fixed sized arrays, so we have
-    // to do this dance.
-    let locking_script: [u8; 5] = script_pubkey.as_bytes().try_into().unwrap();
+    // Remember, Builder::push_slice wants to make sure that the length of
+    // the pushed data is within the limits, so we have to do this dance.
+    let locking_script: &PushBytes = script_pubkey.as_bytes().try_into().unwrap();
     let script_sig = ScriptBuf::builder()
         .push_slice(&locking_script)
         .into_script();

--- a/sbtc/tests/integration/validation.rs
+++ b/sbtc/tests/integration/validation.rs
@@ -1,17 +1,27 @@
 //! Test deposit validation against bitcoin-core
 
+use bitcoin::absolute::LockTime;
+use bitcoin::transaction::Version;
 use bitcoin::AddressType;
+use bitcoin::Amount;
 use bitcoin::OutPoint;
 use bitcoin::ScriptBuf;
 use bitcoin::Sequence;
+use bitcoin::Transaction;
 use bitcoin::TxIn;
+use bitcoin::TxOut;
 use bitcoin::Witness;
+use bitcoincore_rpc::jsonrpc::error::Error as JsonRpcError;
+use bitcoincore_rpc::jsonrpc::error::RpcError;
+use bitcoincore_rpc::Error as BtcRpcError;
 use bitcoincore_rpc::RpcApi;
 
 use sbtc::deposits::CreateDepositRequest;
+use sbtc::deposits::ReclaimScriptInputs;
 use sbtc::rpc::BitcoinCoreClient;
 use sbtc::testing::deposits::TxSetup;
 use sbtc::testing::regtest;
+use sbtc::testing::regtest::AsUtxo;
 use sbtc::testing::regtest::Recipient;
 
 /// Test the CreateDepositRequest::validate function.
@@ -68,4 +78,192 @@ fn tx_validation_from_mempool() {
     assert_eq!(parsed.signers_public_key, setup.deposit.signers_public_key);
     assert_eq!(parsed.lock_time, lock_time as u64);
     assert_eq!(parsed.recipient, setup.deposit.recipient);
+}
+
+/// This validates that a user can disable OP_CSV checks if we allow then
+/// to submit any lock-time that they want. It doesn't test much of the code in this crate, just that the
+///
+/// The test proceeds as follows.
+/// 1. Create and submit a transaction where the lock script uses a
+///    lock-time that disables OP_CSV.
+/// 2. Confirm the transaction and spend it immediately, proving that
+///    OP_CSV was disabled.
+/// 3. Create and submit another transaction where the lock script uses a
+///    lock-time where OP_CSV is not disabled.
+/// 4. Confirm that transaction and try to spend it immediately. The
+///    transaction that tries to spend the transaction from (3) should be
+///    rejected.
+#[cfg_attr(not(feature = "integration-tests"), ignore)]
+#[test]
+fn op_csv_disabled() {
+    let fee = regtest::BITCOIN_CORE_FALLBACK_FEE.to_sat();
+
+    let (rpc, faucet) = regtest::initialize_blockchain();
+    let depositor = Recipient::new(AddressType::P2tr);
+
+    // Start off with some initial UTXOs to work with.
+    let _ = faucet.send_to(50_000_000, &depositor.address);
+    faucet.generate_blocks(1);
+
+    // There is only one UTXO under the depositor's name, so let's get it
+    let utxos = depositor.get_utxos(rpc, None);
+    let utxo = utxos.first().cloned().unwrap();
+    let amount = 30_000_000;
+
+    // 1. Create and submit a transaction where the lock script uses a
+    //    lock-time that disables OP_CSV.
+    let lock_time = 50 | sbtc::deposits::SEQUENCE_LOCKTIME_DISABLE_FLAG;
+    assert!(lock_time > 50);
+
+    let script_pubkey = ScriptBuf::builder()
+        .push_int(lock_time)
+        .push_opcode(bitcoin::opcodes::all::OP_CSV)
+        .push_opcode(bitcoin::opcodes::all::OP_DROP)
+        .push_opcode(bitcoin::opcodes::OP_TRUE)
+        .into_script();
+
+    let mut tx = Transaction {
+        version: Version::ONE,
+        lock_time: LockTime::ZERO,
+        input: vec![TxIn {
+            previous_output: utxo.outpoint(),
+            sequence: Sequence::ZERO,
+            script_sig: ScriptBuf::new(),
+            witness: Witness::new(),
+        }],
+        output: vec![
+            TxOut {
+                value: Amount::from_sat(amount),
+                script_pubkey: ScriptBuf::new_p2sh(&script_pubkey.script_hash()),
+            },
+            TxOut {
+                value: utxo.amount() - Amount::from_sat(amount + fee),
+                script_pubkey: depositor.address.script_pubkey(),
+            },
+        ],
+    };
+
+    regtest::p2tr_sign_transaction(&mut tx, 0, &[utxo], &depositor.keypair);
+    rpc.send_raw_transaction(&tx).unwrap();
+
+    // 2. Confirm the transaction and spend it immediately, proving that
+    //    OP_CSV was disabled.
+    faucet.generate_blocks(1);
+
+    // rust-bitcoin takes mainly fixed size arrays here, so we convert the
+    // locking script to an array first.
+    let locking_script: [u8; 9] = script_pubkey.as_bytes().try_into().unwrap();
+
+    let script_sig = ScriptBuf::builder()
+        .push_slice(locking_script)
+        .into_script();
+
+    let tx2 = Transaction {
+        version: Version::TWO,
+        lock_time: LockTime::ZERO,
+        input: vec![TxIn {
+            previous_output: OutPoint::new(tx.compute_txid(), 0),
+            sequence: Sequence::ZERO,
+            script_sig,
+            witness: Witness::new(),
+        }],
+        output: vec![TxOut {
+            value: Amount::from_sat(amount - fee),
+            script_pubkey: depositor.address.script_pubkey(),
+        }],
+    };
+
+    rpc.send_raw_transaction(&tx2).unwrap();
+    faucet.generate_blocks(1);
+
+    // Note that the above script_sig is equivalent to this one, which
+    // would be rejected as a reclaim script.
+    let reclaim = ScriptBuf::builder()
+        .push_opcode(bitcoin::opcodes::all::OP_DROP)
+        .push_opcode(bitcoin::opcodes::OP_TRUE)
+        .into_script();
+    assert!(ReclaimScriptInputs::try_new(lock_time, reclaim).is_err());
+
+    // 3. Create and submit another transaction where the lock script uses a
+    //    lock-time where OP_CSV is not disabled.
+    let lock_time = 50;
+
+    let reclaim = ScriptBuf::builder()
+        .push_opcode(bitcoin::opcodes::all::OP_DROP)
+        .push_opcode(bitcoin::opcodes::OP_TRUE)
+        .into_script();
+    let script_pubkey = ReclaimScriptInputs::try_new(lock_time, reclaim)
+        .unwrap()
+        .reclaim_script();
+    // The reclaim script function above is quite simple, it should produce
+    // this:
+    let script_pubkey2 = ScriptBuf::builder()
+        .push_int(lock_time)
+        .push_opcode(bitcoin::opcodes::all::OP_CSV)
+        .push_opcode(bitcoin::opcodes::all::OP_DROP)
+        .push_opcode(bitcoin::opcodes::OP_TRUE)
+        .into_script();
+    assert_eq!(script_pubkey, script_pubkey2);
+
+    let utxos = depositor.get_utxos(rpc, Some(10_000_000));
+    let utxo = utxos.first().cloned().unwrap();
+    let amount = 8_000_000;
+
+    let mut tx = Transaction {
+        version: Version::ONE,
+        lock_time: LockTime::ZERO,
+        input: vec![TxIn {
+            previous_output: utxo.outpoint(),
+            sequence: Sequence::ZERO,
+            script_sig: ScriptBuf::new(),
+            witness: Witness::new(),
+        }],
+        output: vec![
+            TxOut {
+                value: Amount::from_sat(amount),
+                script_pubkey: ScriptBuf::new_p2sh(&script_pubkey.script_hash()),
+            },
+            TxOut {
+                value: utxo.amount() - Amount::from_sat(amount + fee),
+                script_pubkey: depositor.address.script_pubkey(),
+            },
+        ],
+    };
+
+    regtest::p2tr_sign_transaction(&mut tx, 0, &[utxo], &depositor.keypair);
+    rpc.send_raw_transaction(&tx).unwrap();
+
+    // 4. Confirm that transaction and try to spend it immediately. The
+    //    transaction that tries to spend the transaction from (3) should be
+    //    rejected.
+    faucet.generate_blocks(1);
+
+    let locking_script: [u8; 5] = script_pubkey.as_bytes().try_into().unwrap();
+    let script_sig = ScriptBuf::builder()
+        .push_slice(&locking_script)
+        .into_script();
+
+    let tx2 = Transaction {
+        version: Version::TWO,
+        lock_time: LockTime::ZERO,
+        input: vec![TxIn {
+            previous_output: OutPoint::new(tx.compute_txid(), 0),
+            sequence: Sequence::ZERO,
+            script_sig,
+            witness: Witness::new(),
+        }],
+        output: vec![TxOut {
+            value: Amount::from_sat(amount - fee),
+            script_pubkey: depositor.address.script_pubkey(),
+        }],
+    };
+
+    match rpc.send_raw_transaction(&tx2).unwrap_err() {
+        BtcRpcError::JsonRpc(JsonRpcError::Rpc(RpcError { code: -26, message, .. })) => {
+            let expected_message =
+                "mandatory-script-verify-flag-failed (Locktime requirement not satisfied)";
+            assert_eq!(message, expected_message);
+        }
+        err => panic!("{err}"),
+    };
 }


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/516 and addresses an issue pointed out in https://github.com/stacks-network/sbtc/issues/514#issuecomment-2350054724.

## Changes

* Reject deposits where the reclaim script uses a lock-time that would disable the OP_CSV opcode. I'm still in disbelief at the design of that opcode, so I wouldn't be surprised if my understanding is just plain wrong.
* Fix an issue where `DepositScriptInputs::parse(script).deposit_script() != script`. Although it is very unlikely that this issue would sneak past validation, it could be problematic in other scenarios. Also, the intent is that `DepositScriptInputs::parse(script).deposit_script() == script` so let's make it so.

## Testing Information

I'd like to add an integration test and I may still do so, but what is here is good enough for review.

## Checklist:

- [x] I have performed a self-review of my code
