### PR TITLE
feat: add `complete-deposit` queries

### DIFF
--- a/signer/src/storage/in_memory.rs
+++ b/signer/src/storage/in_memory.rs
@@ -51,6 +51,10 @@ pub struct Store {
     /// Bitcoin transactions to blocks
     pub bitcoin_transactions_to_blocks: HashMap<model::BitcoinTxId, Vec<model::BitcoinBlockHash>>,
 
+    /// Bitcoin transactions to blocks
+    pub bitcoin_transactions:
+        HashMap<(model::BitcoinTxId, model::BitcoinBlockHash), model::BitcoinTx>,
+
     /// Stacks blocks to transactions
     pub stacks_block_to_transactions: HashMap<model::StacksBlockHash, Vec<model::StacksTxId>>,
 
@@ -506,10 +510,16 @@ impl super::DbRead for SharedStore {
 
     async fn get_bitcoin_tx(
         &self,
-        _txid: &model::BitcoinTxId,
-        _block_hash: &model::BitcoinBlockHash,
+        txid: &model::BitcoinTxId,
+        block_hash: &model::BitcoinBlockHash,
     ) -> Result<Option<model::BitcoinTx>, Self::Error> {
-        unimplemented!()
+        let store = self.lock().await;
+        let maybe_tx = store
+            .bitcoin_transactions
+            .get(&(*txid, *block_hash))
+            .cloned();
+
+        Ok(maybe_tx)
     }
 }
 

--- a/signer/src/storage/mod.rs
+++ b/signer/src/storage/mod.rs
@@ -57,12 +57,13 @@ pub trait DbRead {
         context_window: u16,
     ) -> impl Future<Output = Result<Vec<model::DepositRequest>, Self::Error>> + Send;
 
-    /// Get pending deposit requests that have been accepted by at least `threshold` signers and has no responses
+    /// Get pending deposit requests that have been accepted by at least
+    /// `signatures_required` signers and has no responses
     fn get_pending_accepted_deposit_requests(
         &self,
         chain_tip: &model::BitcoinBlockHash,
         context_window: u16,
-        threshold: u16,
+        signatures_required: u16,
     ) -> impl Future<Output = Result<Vec<model::DepositRequest>, Self::Error>> + Send;
 
     /// Get the deposit requests that the signer has accepted to sign
@@ -147,6 +148,23 @@ pub trait DbRead {
         id: &model::QualifiedRequestId,
         aggregate_key: &PublicKey,
     ) -> impl Future<Output = Result<Vec<model::SignerVote>, Self::Error>> + Send;
+
+    /// Check that the given block hash is included in the canonical
+    /// bitcoin blockchain, where the canonical blockchain is identified by
+    /// the given `chain_tip`.
+    fn in_canonical_bitcoin_blockchain(
+        &self,
+        chain_tip: &model::BitcoinBlockRef,
+        block_ref: &model::BitcoinBlockRef,
+    ) -> impl Future<Output = Result<bool, Self::Error>> + Send;
+
+    /// Fetch the bitcoin transaction that is included in the block
+    /// identified by the block hash.
+    fn get_bitcoin_tx(
+        &self,
+        txid: &model::BitcoinTxId,
+        block_hash: &model::BitcoinBlockHash,
+    ) -> impl Future<Output = Result<Option<model::BitcoinTx>, Self::Error>> + Send;
 }
 
 /// Represents the ability to write data to the signer storage.

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -329,6 +329,9 @@ impl super::DbRead for PgStore {
         context_window: u16,
         threshold: u16,
     ) -> Result<Vec<model::DepositRequest>, Self::Error> {
+        // TODO: Make sure we get only pending deposits, don't include ones
+        // where we have a completed-deposit event on the canonical stacks
+        // blockchain.
         sqlx::query_as::<_, model::DepositRequest>(
             r#"
             WITH RECURSIVE context_window AS (
@@ -823,6 +826,74 @@ impl super::DbRead for PgStore {
             "#,
         )
         .fetch_all(&self.0)
+        .await
+        .map_err(Error::SqlxQuery)
+    }
+
+    async fn in_canonical_bitcoin_blockchain(
+        &self,
+        chain_tip: &model::BitcoinBlockRef,
+        block_ref: &model::BitcoinBlockRef,
+    ) -> Result<bool, Error> {
+        let heigh_diff = chain_tip
+            .block_height
+            .saturating_sub(block_ref.block_height);
+
+        sqlx::query_scalar::<_, bool>(
+            r#"
+            WITH RECURSIVE tx_block_chain AS (
+                SELECT 
+                    block_hash
+                  , block_height
+                  , parent_hash
+                  , 0 AS counter
+                FROM sbtc_signer.bitcoin_blocks
+                WHERE block_hash = $2
+
+                UNION ALL
+
+                SELECT
+                    child.block_hash
+                  , child.block_height
+                  , child.parent_hash
+                  , parent.counter + 1
+                FROM sbtc_signer.bitcoin_blocks AS child
+                JOIN tx_block_chain AS parent
+                  ON child.parent_hash = parent.block_hash
+                WHERE parent.counter <= $3
+            )
+            SELECT EXISTS (
+                SELECT TRUE
+                FROM tx_block_chain AS tbc
+                WHERE tbc.block_hash = $1
+            );
+        "#,
+        )
+        .bind(chain_tip.block_hash)
+        .bind(block_ref.block_hash)
+        .bind(heigh_diff as i64)
+        .fetch_one(&self.0)
+        .await
+        .map_err(Error::SqlxQuery)
+    }
+
+    async fn get_bitcoin_tx(
+        &self,
+        txid: &model::BitcoinTxId,
+        block_hash: &model::BitcoinBlockHash,
+    ) -> Result<Option<model::BitcoinTx>, Error> {
+        sqlx::query_scalar::<_, model::BitcoinTx>(
+            r#"
+            SELECT txs.tx
+            FROM sbtc_signer.bitcoin_transactions AS bt
+            JOIN sbtc_signer.transactions AS txs USING (txid)
+            WHERE bt.block_hash = $1
+              AND bt.txid = $2
+        "#,
+        )
+        .bind(block_hash)
+        .bind(txid)
+        .fetch_optional(&self.0)
         .await
         .map_err(Error::SqlxQuery)
     }

--- a/signer/src/storage/sqlx.rs
+++ b/signer/src/storage/sqlx.rs
@@ -6,6 +6,8 @@
 use std::ops::Deref;
 use std::str::FromStr as _;
 
+use bitcoin::consensus::Decodable as _;
+use bitcoin::consensus::Encodable as _;
 use bitcoin::ScriptBuf;
 use sqlx::encode::IsNull;
 use sqlx::error::BoxDynError;
@@ -13,6 +15,7 @@ use sqlx::postgres::PgArgumentBuffer;
 
 use crate::keys::PublicKey;
 use crate::storage::model::BitcoinBlockHash;
+use crate::storage::model::BitcoinTx;
 use crate::storage::model::BitcoinTxId;
 use crate::storage::model::ScriptPubKey;
 use crate::storage::model::StacksBlockHash;
@@ -72,6 +75,37 @@ impl<'r> sqlx::Encode<'r, sqlx::Postgres> for BitcoinBlockHash {
 impl sqlx::postgres::PgHasArrayType for BitcoinBlockHash {
     fn array_type_info() -> sqlx::postgres::PgTypeInfo {
         <[u8; 32] as sqlx::postgres::PgHasArrayType>::array_type_info()
+    }
+}
+
+/// For the [`BitcoinTx`]
+
+impl<'r> sqlx::Decode<'r, sqlx::Postgres> for BitcoinTx {
+    fn decode(value: sqlx::postgres::PgValueRef<'r>) -> Result<Self, BoxDynError> {
+        let bytes = <Vec<u8> as sqlx::Decode<sqlx::Postgres>>::decode(value)?;
+        let mut reader = bytes.as_slice();
+        let tx = bitcoin::Transaction::consensus_decode(&mut reader)?;
+        Ok(BitcoinTx::from(tx))
+    }
+}
+
+impl sqlx::Type<sqlx::Postgres> for BitcoinTx {
+    fn type_info() -> sqlx::postgres::PgTypeInfo {
+        <Vec<u8> as sqlx::Type<sqlx::Postgres>>::type_info()
+    }
+}
+
+impl<'r> sqlx::Encode<'r, sqlx::Postgres> for BitcoinTx {
+    fn encode_by_ref(&self, buf: &mut PgArgumentBuffer) -> Result<IsNull, BoxDynError> {
+        let mut writer: Vec<u8> = Vec::<u8>::new();
+        self.consensus_encode(&mut writer)?;
+        <Vec<u8> as sqlx::Encode<'r, sqlx::Postgres>>::encode_by_ref(&writer, buf)
+    }
+}
+
+impl sqlx::postgres::PgHasArrayType for BitcoinTx {
+    fn array_type_info() -> sqlx::postgres::PgTypeInfo {
+        <Vec<u8> as sqlx::postgres::PgHasArrayType>::array_type_info()
     }
 }
 

--- a/signer/src/testing/storage/model.rs
+++ b/signer/src/testing/storage/model.rs
@@ -4,7 +4,11 @@ use fake::Fake;
 
 use crate::keys::PublicKey;
 use crate::storage::model;
+use crate::storage::model::BitcoinBlock;
+use crate::storage::model::BitcoinBlockHash;
+use crate::storage::model::BitcoinBlockRef;
 use crate::storage::DbWrite;
+use crate::testing::dummy::DepositTxConfig;
 
 use rand::seq::SliceRandom;
 
@@ -131,7 +135,7 @@ impl TestData {
     }
 
     /// Write the test data to the given store.
-    pub async fn write_to<Db>(&self, storage: &mut Db)
+    pub async fn write_to<Db>(&self, storage: &Db)
     where
         Db: DbWrite,
     {
@@ -204,8 +208,8 @@ impl TestData {
         let parent_block_summary = self
             .bitcoin_blocks
             .choose(rng)
-            .map(BlockSummary::summarize)
-            .unwrap_or_else(|| BlockSummary::hallucinate_parent(&block));
+            .map(BitcoinBlockRef::summarize)
+            .unwrap_or_else(|| BitcoinBlockRef::hallucinate_parent(&block));
 
         block.parent_hash = parent_block_summary.block_hash;
         block.block_height = parent_block_summary.block_height + 1;
@@ -251,6 +255,14 @@ impl TestData {
 
         stacks_blocks
     }
+
+    /// Fetch the parent block given the hash.
+    pub fn get_parent_bitcoin_block(&self, parent: &BitcoinBlockHash) -> Option<BitcoinBlock> {
+        self.bitcoin_blocks
+            .iter()
+            .find(|x| &x.block_hash == parent)
+            .cloned()
+    }
 }
 
 #[derive(Debug, Clone, Default)]
@@ -274,7 +286,17 @@ impl DepositData {
         num_signers_per_request: usize,
     ) -> Self {
         (0..num_deposit_requests).fold(Self::new(), |mut deposit_data, _| {
-            let deposit_request: model::DepositRequest = fake::Faker.fake_with_rng(rng);
+            let mut deposit_request: model::DepositRequest = fake::Faker.fake_with_rng(rng);
+
+            let deposit_config = DepositTxConfig {
+                signer_public_key: PublicKey::combine_keys(signer_keys)
+                    .unwrap_or_else(|_| fake::Faker.fake_with_rng(rng)),
+                ..fake::Faker.fake_with_rng(rng)
+            };
+
+            let mut raw_transaction: model::Transaction = deposit_config.fake_with_rng(rng);
+            raw_transaction.block_hash = *bitcoin_block.block_hash.as_ref();
+            deposit_request.txid = raw_transaction.txid.into();
 
             let deposit_signers: Vec<_> = signer_keys
                 .iter()
@@ -287,10 +309,6 @@ impl DepositData {
                     is_accepted: fake::Faker.fake_with_rng(rng),
                 })
                 .collect();
-
-            let mut raw_transaction: model::Transaction = fake::Faker.fake_with_rng(rng);
-            raw_transaction.txid = deposit_request.txid.into_bytes();
-            raw_transaction.tx_type = model::TransactionType::DepositRequest;
 
             let bitcoin_transaction = model::BitcoinTransaction {
                 txid: raw_transaction.txid.into(),
@@ -398,13 +416,7 @@ pub struct Params {
     pub num_signers_per_request: usize,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct BlockSummary {
-    block_hash: model::BitcoinBlockHash,
-    block_height: u64,
-}
-
-impl BlockSummary {
+impl BitcoinBlockRef {
     fn summarize(block: &model::BitcoinBlock) -> Self {
         Self {
             block_hash: block.block_hash,

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -10,6 +10,7 @@ use blockstack_lib::clarity::vm::Value as ClarityValue;
 use blockstack_lib::codec::StacksMessageCodec;
 use blockstack_lib::types::chainstate::StacksAddress;
 use futures::StreamExt;
+use rand::seq::SliceRandom;
 
 use signer::error::Error;
 use signer::keys::PublicKey;
@@ -26,6 +27,7 @@ use signer::stacks::events::WithdrawalCreateEvent;
 use signer::stacks::events::WithdrawalRejectEvent;
 use signer::storage;
 use signer::storage::model;
+use signer::storage::model::BitcoinBlockHash;
 use signer::storage::model::BitcoinTxId;
 use signer::storage::model::QualifiedRequestId;
 use signer::storage::model::RotateKeysTransaction;
@@ -1134,4 +1136,140 @@ async fn fetching_withdrawal_request_votes() {
     assert!(actual_signer_vote_map.values().all(Option::is_none));
 
     signer::testing::storage::drop_db(store).await;
+}
+
+/// For this test we check that the `block_in_canonical_bitcoin_blockchain`
+/// function returns false when the input block is not in the canonical
+/// bitcoin blockchain.
+#[cfg_attr(not(feature = "integration-tests"), ignore)]
+#[tokio::test]
+async fn block_in_canonical_bitcoin_blockchain_in_other_block_chain() {
+    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
+    let pg_store = signer::testing::storage::new_test_database(db_num).await;
+    let mut rng = rand::rngs::StdRng::seed_from_u64(51);
+
+    // This is just a sql test, where we use the `TestData` struct to help
+    // populate the database with test data. We set all of the other
+    // unnecessary parameters to zero.
+    let num_signers = 0;
+    let test_model_params = testing::storage::model::Params {
+        num_bitcoin_blocks: 50,
+        num_stacks_blocks_per_bitcoin_block: 0,
+        num_deposit_requests_per_block: 0,
+        num_withdraw_requests_per_block: 0,
+        num_signers_per_request: num_signers,
+    };
+
+    let signer_set = generate_signer_set(&mut rng, num_signers);
+    // Okay now we generate one blockchain and get its chain tip
+    let test_data1 = TestData::generate(&mut rng, &signer_set, &test_model_params);
+    // And we generate another blockchain and get its chain tip
+    let test_data2 = TestData::generate(&mut rng, &signer_set, &test_model_params);
+
+    test_data1.write_to(&pg_store).await;
+    test_data2.write_to(&pg_store).await;
+
+    let chain_tip1 = test_data1
+        .bitcoin_blocks
+        .iter()
+        .max_by_key(|x| (x.block_height, x.block_hash))
+        .unwrap();
+    let chain_tip2 = test_data2
+        .bitcoin_blocks
+        .iter()
+        .max_by_key(|x| (x.block_height, x.block_hash))
+        .unwrap();
+
+    // These shouldn't be equal
+    assert_ne!(chain_tip1, chain_tip2);
+
+    // Now for the moment of truth, these chains should have nothing to do
+    // with one another.
+    let is_in_chain = pg_store
+        .in_canonical_bitcoin_blockchain(&chain_tip2.into(), &chain_tip1.into())
+        .await
+        .unwrap();
+    assert!(!is_in_chain);
+    let is_in_chain = pg_store
+        .in_canonical_bitcoin_blockchain(&chain_tip1.into(), &chain_tip2.into())
+        .await
+        .unwrap();
+    assert!(!is_in_chain);
+
+    // Okay, now let's get a block that we know is in the blockchain.
+    let block_ref = {
+        let tmp = test_data1
+            .get_parent_bitcoin_block(&chain_tip1.parent_hash)
+            .unwrap();
+        test_data1
+            .get_parent_bitcoin_block(&tmp.parent_hash)
+            .unwrap()
+    };
+
+    let is_in_chain = pg_store
+        .in_canonical_bitcoin_blockchain(&chain_tip1.into(), &block_ref.into())
+        .await
+        .unwrap();
+    assert!(is_in_chain);
+
+    signer::testing::storage::drop_db(pg_store).await;
+}
+
+/// For this test we check that the `get_bitcoin_tx` function returns a
+/// transaction when the transaction exists in the block, and returns None
+/// otherwise.
+#[cfg_attr(not(feature = "integration-tests"), ignore)]
+#[tokio::test]
+async fn we_can_fetch_bitcoin_txs_from_db() {
+    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
+    let pg_store = signer::testing::storage::new_test_database(db_num).await;
+    let mut rng = rand::rngs::StdRng::seed_from_u64(51);
+
+    // This is just a sql test, where we use the `TestData` struct to help
+    // populate the database with test data. We set all of the other
+    // unnecessary parameters to zero.
+    let num_signers = 0;
+    let test_model_params = testing::storage::model::Params {
+        num_bitcoin_blocks: 10,
+        num_stacks_blocks_per_bitcoin_block: 0,
+        num_deposit_requests_per_block: 2,
+        num_withdraw_requests_per_block: 0,
+        num_signers_per_request: num_signers,
+    };
+
+    let signer_set = generate_signer_set(&mut rng, num_signers);
+    let test_data = TestData::generate(&mut rng, &signer_set, &test_model_params);
+    test_data.write_to(&pg_store).await;
+
+    let tx = test_data.bitcoin_transactions.choose(&mut rng).unwrap();
+
+    // Now let's try fecthing this transaction
+    let btc_tx = pg_store
+        .get_bitcoin_tx(&tx.txid, &tx.block_hash)
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(btc_tx.compute_txid(), tx.txid.into());
+
+    // Now let's try fecthing this transaction when we know it is missing.
+    let txid: BitcoinTxId = fake::Faker.fake_with_rng(&mut rng);
+    let block_hash: BitcoinBlockHash = fake::Faker.fake_with_rng(&mut rng);
+    // Actual block but missing txid
+    let btc_tx = pg_store
+        .get_bitcoin_tx(&txid, &tx.block_hash)
+        .await
+        .unwrap();
+    assert!(btc_tx.is_none());
+    // Actual txid but missing block
+    let btc_tx = pg_store
+        .get_bitcoin_tx(&tx.txid, &block_hash)
+        .await
+        .unwrap();
+    assert!(btc_tx.is_none());
+    // Now everything is missing
+    let btc_tx = pg_store.get_bitcoin_tx(&txid, &block_hash).await.unwrap();
+    assert!(btc_tx.is_none());
+
+    signer::testing::storage::drop_db(pg_store).await;
 }


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/539.

## Changes

* Add two queries that fetch necessary data from the database.
* Add an internal `BitcoinTx` type for ease of writing to and reading from the database.

## Testing Information

This PR adds integration tests for the queries. The in-memory implementation of the same queries have been added as well, but right now they go unused and so we skip their tests.

## Checklist:

- [x] I have performed a self-review of my code