### PR TITLE
refactor: remove associated error types from internal traits

### DIFF
--- a/signer/src/bitcoin/mod.rs
+++ b/signer/src/bitcoin/mod.rs
@@ -2,8 +2,8 @@
 
 use std::future::Future;
 
-use crate::keys::PublicKey;
 use crate::error::Error;
+use crate::keys::PublicKey;
 
 pub mod fees;
 pub mod packaging;
@@ -13,7 +13,6 @@ pub mod zmq;
 /// Represents the ability to interact with the bitcoin blockchain
 #[cfg_attr(any(test, feature = "testing"), mockall::automock())]
 pub trait BitcoinInteract {
-
     /// Get block
     fn get_block(
         &mut self,
@@ -22,9 +21,8 @@ pub trait BitcoinInteract {
 
     /// Estimate fee rate
     // This should be implemented with the help of the `fees::EstimateFees` trait
-    fn estimate_fee_rate(
-        &mut self,
-    ) -> impl std::future::Future<Output = Result<f64, Error>> + Send;
+    fn estimate_fee_rate(&mut self)
+        -> impl std::future::Future<Output = Result<f64, Error>> + Send;
 
     /// Get the outstanding signer UTXO
     fn get_signer_utxo(

--- a/signer/src/bitcoin/mod.rs
+++ b/signer/src/bitcoin/mod.rs
@@ -3,6 +3,7 @@
 use std::future::Future;
 
 use crate::keys::PublicKey;
+use crate::error::Error;
 
 pub mod fees;
 pub mod packaging;
@@ -10,39 +11,37 @@ pub mod utxo;
 pub mod zmq;
 
 /// Represents the ability to interact with the bitcoin blockchain
-#[cfg_attr(any(test, feature = "testing"), mockall::automock(type Error=crate::error::Error;))]
+#[cfg_attr(any(test, feature = "testing"), mockall::automock())]
 pub trait BitcoinInteract {
-    /// Error type
-    type Error;
 
     /// Get block
     fn get_block(
         &mut self,
         block_hash: &bitcoin::BlockHash,
-    ) -> impl Future<Output = Result<Option<bitcoin::Block>, Self::Error>> + Send;
+    ) -> impl Future<Output = Result<Option<bitcoin::Block>, Error>> + Send;
 
     /// Estimate fee rate
     // This should be implemented with the help of the `fees::EstimateFees` trait
     fn estimate_fee_rate(
         &mut self,
-    ) -> impl std::future::Future<Output = Result<f64, Self::Error>> + Send;
+    ) -> impl std::future::Future<Output = Result<f64, Error>> + Send;
 
     /// Get the outstanding signer UTXO
     fn get_signer_utxo(
         &mut self,
         aggregate_key: &PublicKey,
-    ) -> impl Future<Output = Result<Option<utxo::SignerUtxo>, Self::Error>> + Send;
+    ) -> impl Future<Output = Result<Option<utxo::SignerUtxo>, Error>> + Send;
 
     /// Get the total fee amount and the fee rate for the last transaction that
     /// used the given UTXO as an input.
     fn get_last_fee(
         &mut self,
         utxo: bitcoin::OutPoint,
-    ) -> impl Future<Output = Result<Option<utxo::Fees>, Self::Error>> + Send;
+    ) -> impl Future<Output = Result<Option<utxo::Fees>, Error>> + Send;
 
     /// Broadcast transaction
     fn broadcast_transaction(
         &mut self,
         tx: &bitcoin::Transaction,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+    ) -> impl Future<Output = Result<(), Error>> + Send;
 }

--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -20,7 +20,6 @@
 use std::collections::HashMap;
 
 use crate::bitcoin::BitcoinInteract;
-use crate::error;
 use crate::error::Error;
 use crate::stacks::api::StacksInteract;
 use crate::storage;
@@ -71,13 +70,11 @@ where
     EC: EmilyInteract,
     S: DbWrite + DbRead + Send + Sync,
     BHS: futures::stream::Stream<Item = bitcoin::BlockHash> + Unpin,
-    error::Error: From<<S as DbRead>::Error>,
-    error::Error: From<<S as DbWrite>::Error>,
-    error::Error: From<<BC as BitcoinInteract>::Error>,
+    Error: From<<BC as BitcoinInteract>::Error>,
 {
     /// Run the block observer
     #[tracing::instrument(skip(self))]
-    pub async fn run(mut self) -> Result<(), error::Error> {
+    pub async fn run(mut self) -> Result<(), Error> {
         while let Some(new_block_hash) = self.bitcoin_blocks.next().await {
             self.load_latest_deposit_requests().await;
 
@@ -119,7 +116,7 @@ where
     async fn next_blocks_to_process(
         &mut self,
         mut block_hash: bitcoin::BlockHash,
-    ) -> Result<Vec<bitcoin::Block>, error::Error> {
+    ) -> Result<Vec<bitcoin::Block>, Error> {
         let mut blocks = Vec::new();
 
         for _ in 0..self.horizon {
@@ -131,7 +128,7 @@ where
                 .bitcoin_client
                 .get_block(&block_hash)
                 .await?
-                .ok_or(error::Error::MissingBlock)?;
+                .ok_or(Error::MissingBlock)?;
 
             block_hash = block.header.prev_blockhash;
             blocks.push(block);
@@ -146,7 +143,7 @@ where
     async fn have_already_processed_block(
         &mut self,
         block_hash: bitcoin::BlockHash,
-    ) -> Result<bool, error::Error> {
+    ) -> Result<bool, Error> {
         Ok(self
             .storage
             .get_bitcoin_block(&block_hash.to_byte_array().into())
@@ -155,7 +152,7 @@ where
     }
 
     #[tracing::instrument(skip(self))]
-    async fn process_bitcoin_block(&mut self, block: bitcoin::Block) -> Result<(), error::Error> {
+    async fn process_bitcoin_block(&mut self, block: bitcoin::Block) -> Result<(), Error> {
         let info = self.stacks_client.get_tenure_info().await?;
         let stacks_blocks = crate::stacks::api::fetch_unknown_ancestors(
             &mut self.stacks_client,
@@ -241,7 +238,7 @@ where
     async fn write_stacks_blocks(
         &mut self,
         blocks: &[nakamoto::NakamotoBlock],
-    ) -> Result<(), error::Error> {
+    ) -> Result<(), Error> {
         let txs = storage::postgres::extract_relevant_transactions(blocks);
         let headers = blocks
             .iter()
@@ -255,7 +252,7 @@ where
 
     /// Write the bitcoin block to the database. We also write any
     /// transactions that are spend to any of the signers `scriptPubKey`s
-    async fn write_bitcoin_block(&mut self, block: &bitcoin::Block) -> Result<(), error::Error> {
+    async fn write_bitcoin_block(&mut self, block: &bitcoin::Block) -> Result<(), Error> {
         let db_block = model::BitcoinBlock {
             block_hash: block.block_hash().into(),
             block_height: block
@@ -717,7 +714,7 @@ mod tests {
     }
 
     impl BitcoinInteract for TestHarness {
-        type Error = error::Error;
+        type Error = Error;
         async fn get_block(
             &mut self,
             block_hash: &bitcoin::BlockHash,
@@ -782,25 +779,25 @@ mod tests {
         async fn get_block(
             &mut self,
             block_id: StacksBlockId,
-        ) -> Result<NakamotoBlock, error::Error> {
+        ) -> Result<NakamotoBlock, Error> {
             self.stacks_blocks
                 .iter()
                 .skip_while(|(id, _, _)| &block_id != id)
                 .map(|(_, block, _)| block)
                 .next()
                 .cloned()
-                .ok_or(error::Error::MissingBlock)
+                .ok_or(Error::MissingBlock)
         }
         async fn get_tenure(
             &mut self,
             block_id: StacksBlockId,
-        ) -> Result<Vec<NakamotoBlock>, error::Error> {
+        ) -> Result<Vec<NakamotoBlock>, Error> {
             let (stx_block_id, stx_block, btc_block_id) = self
                 .stacks_blocks
                 .iter()
                 .skip_while(|(id, _, _)| &block_id != id)
                 .next()
-                .ok_or(error::Error::MissingBlock)?;
+                .ok_or(Error::MissingBlock)?;
 
             let blocks: Vec<NakamotoBlock> = self
                 .stacks_blocks
@@ -814,7 +811,7 @@ mod tests {
 
             Ok(blocks)
         }
-        async fn get_tenure_info(&mut self) -> Result<RPCGetTenureInfo, error::Error> {
+        async fn get_tenure_info(&mut self) -> Result<RPCGetTenureInfo, Error> {
             let (_, _, btc_block_id) = self.stacks_blocks.last().unwrap();
 
             Ok(RPCGetTenureInfo {
@@ -844,7 +841,7 @@ mod tests {
                 .map(|(_, block, _)| block.header.chain_length)
                 .unwrap_or_default()
         }
-        async fn estimate_fees<T>(&self, _: &T, _: FeePriority) -> Result<u64, error::Error>
+        async fn estimate_fees<T>(&self, _: &T, _: FeePriority) -> Result<u64, Error>
         where
             T: crate::stacks::contracts::AsTxPayload,
         {

--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -70,7 +70,6 @@ where
     EC: EmilyInteract,
     S: DbWrite + DbRead + Send + Sync,
     BHS: futures::stream::Stream<Item = bitcoin::BlockHash> + Unpin,
-    Error: From<<BC as BitcoinInteract>::Error>,
 {
     /// Run the block observer
     #[tracing::instrument(skip(self))]
@@ -714,11 +713,10 @@ mod tests {
     }
 
     impl BitcoinInteract for TestHarness {
-        type Error = Error;
         async fn get_block(
             &mut self,
             block_hash: &bitcoin::BlockHash,
-        ) -> Result<Option<bitcoin::Block>, Self::Error> {
+        ) -> Result<Option<bitcoin::Block>, Error> {
             Ok(self
                 .bitcoin_blocks
                 .iter()
@@ -726,27 +724,27 @@ mod tests {
                 .cloned())
         }
 
-        async fn estimate_fee_rate(&mut self) -> Result<f64, Self::Error> {
+        async fn estimate_fee_rate(&mut self) -> Result<f64, Error> {
             unimplemented!()
         }
 
         async fn get_signer_utxo(
             &mut self,
             _point: &PublicKey,
-        ) -> Result<Option<utxo::SignerUtxo>, Self::Error> {
+        ) -> Result<Option<utxo::SignerUtxo>, Error> {
             unimplemented!()
         }
         async fn get_last_fee(
             &mut self,
             _utxo: bitcoin::OutPoint,
-        ) -> Result<Option<utxo::Fees>, Self::Error> {
+        ) -> Result<Option<utxo::Fees>, Error> {
             unimplemented!()
         }
 
         async fn broadcast_transaction(
             &mut self,
             _tx: &bitcoin::Transaction,
-        ) -> Result<(), Self::Error> {
+        ) -> Result<(), Error> {
             unimplemented!()
         }
     }

--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -741,10 +741,7 @@ mod tests {
             unimplemented!()
         }
 
-        async fn broadcast_transaction(
-            &mut self,
-            _tx: &bitcoin::Transaction,
-        ) -> Result<(), Error> {
+        async fn broadcast_transaction(&mut self, _tx: &bitcoin::Transaction) -> Result<(), Error> {
             unimplemented!()
         }
     }
@@ -774,10 +771,7 @@ mod tests {
             todo!()
         }
 
-        async fn get_block(
-            &mut self,
-            block_id: StacksBlockId,
-        ) -> Result<NakamotoBlock, Error> {
+        async fn get_block(&mut self, block_id: StacksBlockId) -> Result<NakamotoBlock, Error> {
             self.stacks_blocks
                 .iter()
                 .skip_while(|(id, _, _)| &block_id != id)

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -65,6 +65,14 @@ pub enum Error {
     #[error("Could not parse the string into PrincipalData: {0}")]
     ParsePrincipalData(#[source] clarity::vm::errors::Error),
 
+    /// Could not send a message
+    #[error("Could not send a message from the in-memory MessageTransfer broadcast function")]
+    SendMessage,
+
+    /// Could not receive a message from the channel.
+    #[error("{0}")]
+    ChannelReceive(#[source] tokio::sync::broadcast::error::RecvError),
+
     /// Thrown when doing [`i64::try_from`] or [`i32::try_from`] before
     /// inserting a value into the database. This only happens if the value
     /// is greater than MAX for the signed type.

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -21,6 +21,10 @@ pub enum Error {
     #[error("tokio i/o error: {0}")]
     TokioIo(#[from] tokio::io::Error),
 
+    /// The error used in the [`Encode`] and [`Decode`] trait.
+    #[error("error serializing type: {0}")]
+    Bincode(#[source] bincode::Error),
+
     /// Error when breaking out the ZeroMQ message into three parts.
     #[error("bitcoin messages should have a three part layout, received {0} parts")]
     BitcoinCoreZmqMessageLayout(usize),
@@ -257,10 +261,6 @@ pub enum Error {
     /// Codec error
     #[error("codec error: {0}")]
     Codec(#[source] codec::Error),
-
-    /// In-memory network error
-    #[error("in-memory network error: {0}")]
-    InMemoryNetwork(#[from] network::in_memory::Error),
 
     /// GRPC relay network error
     #[error("GRPC relay network error: {0}")]

--- a/signer/src/network/in_memory.rs
+++ b/signer/src/network/in_memory.rs
@@ -8,6 +8,8 @@ use std::collections::VecDeque;
 
 use tokio::sync::broadcast;
 
+use crate::error::Error;
+
 const BROADCAST_CHANNEL_CAPACITY: usize = 10_000;
 
 type MsgId = [u8; 32];
@@ -55,32 +57,21 @@ impl Default for Network {
 }
 
 impl super::MessageTransfer for MpmcBroadcaster {
-    type Error = Error;
-    async fn broadcast(&mut self, msg: super::Msg) -> Result<(), Self::Error> {
+    async fn broadcast(&mut self, msg: super::Msg) -> Result<(), Error> {
         self.recently_sent.push_back(msg.id());
-        self.sender.send(msg).map_err(|_| Error::Send)?;
+        self.sender.send(msg).unwrap();
         Ok(())
     }
 
-    async fn receive(&mut self) -> Result<super::Msg, Self::Error> {
-        let mut msg = self.receiver.recv().await?;
+    async fn receive(&mut self) -> Result<super::Msg, Error> {
+        let mut msg = self.receiver.recv().await.unwrap();
 
         while Some(&msg.id()) == self.recently_sent.front() {
             self.recently_sent.pop_front();
-            msg = self.receiver.recv().await?;
+            msg = self.receiver.recv().await.unwrap();
         }
 
         Ok(msg)
     }
 }
 
-/// In memory network error
-#[derive(Debug, thiserror::Error)]
-pub enum Error {
-    /// Send error
-    #[error("send error")]
-    Send,
-    #[error("receive error")]
-    /// Receive error
-    Recv(#[from] broadcast::error::RecvError),
-}

--- a/signer/src/stacks/api.rs
+++ b/signer/src/stacks/api.rs
@@ -764,7 +764,6 @@ pub async fn fetch_unknown_ancestors<S, D>(
 where
     S: StacksInteract,
     D: DbRead + Send + Sync,
-    Error: From<<D as DbRead>::Error>,
 {
     let mut blocks = vec![stacks.get_block(block_id).await?];
 

--- a/signer/src/stacks/contracts.rs
+++ b/signer/src/stacks/contracts.rs
@@ -130,8 +130,7 @@ pub trait AsContractCall {
     /// stacks and bitcoin blockchains.
     fn validate<S>(&self, _: &S) -> impl Future<Output = Result<bool, Error>> + Send
     where
-        S: DbRead + Send + Sync,
-        Error: From<<S as DbRead>::Error>;
+        S: DbRead + Send + Sync;
 }
 
 /// An enum representing all contract calls that the signers can make.
@@ -222,7 +221,6 @@ impl AsContractCall for CompleteDepositV1 {
     async fn validate<S>(&self, _storage: &S) -> Result<bool, Error>
     where
         S: DbRead + Send + Sync,
-        Error: From<<S as DbRead>::Error>,
     {
         // TODO(255): Add validation implementation
         Ok(false)
@@ -284,7 +282,6 @@ impl AsContractCall for AcceptWithdrawalV1 {
     async fn validate<S>(&self, _storage: &S) -> Result<bool, Error>
     where
         S: DbRead + Send + Sync,
-        Error: From<<S as DbRead>::Error>,
     {
         // TODO(255): Add validation implementation
         Ok(false)
@@ -331,7 +328,6 @@ impl AsContractCall for RejectWithdrawalV1 {
     async fn validate<S>(&self, _storage: &S) -> Result<bool, Error>
     where
         S: DbRead + Send + Sync,
-        Error: From<<S as DbRead>::Error>,
     {
         // TODO(255): Add validation implementation
         Ok(false)
@@ -439,7 +435,6 @@ impl AsContractCall for RotateKeysV1 {
     async fn validate<S>(&self, _storage: &S) -> Result<bool, Error>
     where
         S: DbRead + Send + Sync,
-        Error: From<<S as DbRead>::Error>,
     {
         // TODO(255): Add validation implementation
         Ok(false)

--- a/signer/src/stacks/wallet.rs
+++ b/signer/src/stacks/wallet.rs
@@ -338,7 +338,6 @@ mod tests {
         async fn validate<S>(&self, _: &S) -> Result<bool, Error>
         where
             S: DbRead + Send + Sync,
-            Error: From<<S as DbRead>::Error>,
         {
             Ok(true)
         }

--- a/signer/src/storage/in_memory.rs
+++ b/signer/src/storage/in_memory.rs
@@ -14,6 +14,7 @@ use crate::stacks::events::WithdrawalAcceptEvent;
 use crate::stacks::events::WithdrawalCreateEvent;
 use crate::stacks::events::WithdrawalRejectEvent;
 use crate::storage::model;
+use crate::error::Error;
 
 /// A store wrapped in an Arc<Mutex<...>> for interior mutability
 pub type SharedStore = Arc<Mutex<Store>>;
@@ -108,25 +109,23 @@ impl Store {
 }
 
 impl super::DbRead for SharedStore {
-    type Error = std::convert::Infallible;
-
     async fn get_bitcoin_block(
         &self,
         block_hash: &model::BitcoinBlockHash,
-    ) -> Result<Option<model::BitcoinBlock>, Self::Error> {
+    ) -> Result<Option<model::BitcoinBlock>, Error> {
         Ok(self.lock().await.bitcoin_blocks.get(block_hash).cloned())
     }
 
     async fn get_stacks_block(
         &self,
         block_hash: &model::StacksBlockHash,
-    ) -> Result<Option<model::StacksBlock>, Self::Error> {
+    ) -> Result<Option<model::StacksBlock>, Error> {
         Ok(self.lock().await.stacks_blocks.get(block_hash).cloned())
     }
 
     async fn get_bitcoin_canonical_chain_tip(
         &self,
-    ) -> Result<Option<model::BitcoinBlockHash>, Self::Error> {
+    ) -> Result<Option<model::BitcoinBlockHash>, Error> {
         Ok(self
             .lock()
             .await
@@ -139,7 +138,7 @@ impl super::DbRead for SharedStore {
     async fn get_stacks_chain_tip(
         &self,
         bitcoin_chain_tip: &model::BitcoinBlockHash,
-    ) -> Result<Option<model::StacksBlock>, Self::Error> {
+    ) -> Result<Option<model::StacksBlock>, Error> {
         let store = self.lock().await;
         let Some(bitcoin_chain_tip) = store.bitcoin_blocks.get(bitcoin_chain_tip) else {
             return Ok(None);
@@ -157,7 +156,7 @@ impl super::DbRead for SharedStore {
         &self,
         chain_tip: &model::BitcoinBlockHash,
         context_window: u16,
-    ) -> Result<Vec<model::DepositRequest>, Self::Error> {
+    ) -> Result<Vec<model::DepositRequest>, Error> {
         let store = self.lock().await;
 
         Ok((0..context_window)
@@ -191,7 +190,7 @@ impl super::DbRead for SharedStore {
         chain_tip: &model::BitcoinBlockHash,
         context_window: u16,
         threshold: u16,
-    ) -> Result<Vec<model::DepositRequest>, Self::Error> {
+    ) -> Result<Vec<model::DepositRequest>, Error> {
         let pending_deposit_requests = self
             .get_pending_deposit_requests(chain_tip, context_window)
             .await?;
@@ -216,7 +215,7 @@ impl super::DbRead for SharedStore {
     async fn get_accepted_deposit_requests(
         &self,
         signer: &PublicKey,
-    ) -> Result<Vec<model::DepositRequest>, Self::Error> {
+    ) -> Result<Vec<model::DepositRequest>, Error> {
         let store = self.lock().await;
 
         let accepted_deposit_pks = store
@@ -241,7 +240,7 @@ impl super::DbRead for SharedStore {
         &self,
         txid: &model::BitcoinTxId,
         output_index: u32,
-    ) -> Result<Vec<model::DepositSigner>, Self::Error> {
+    ) -> Result<Vec<model::DepositSigner>, Error> {
         Ok(self
             .lock()
             .await
@@ -255,7 +254,7 @@ impl super::DbRead for SharedStore {
         &self,
         request_id: u64,
         block_hash: &model::StacksBlockHash,
-    ) -> Result<Vec<model::WithdrawalSigner>, Self::Error> {
+    ) -> Result<Vec<model::WithdrawalSigner>, Error> {
         Ok(self
             .lock()
             .await
@@ -269,7 +268,7 @@ impl super::DbRead for SharedStore {
         &self,
         chain_tip: &model::BitcoinBlockHash,
         context_window: u16,
-    ) -> Result<Vec<model::WithdrawalRequest>, Self::Error> {
+    ) -> Result<Vec<model::WithdrawalRequest>, Error> {
         let Some(bitcoin_chain_tip) = self.get_bitcoin_block(chain_tip).await? else {
             return Ok(Vec::new());
         };
@@ -324,7 +323,7 @@ impl super::DbRead for SharedStore {
         chain_tip: &model::BitcoinBlockHash,
         context_window: u16,
         threshold: u16,
-    ) -> Result<Vec<model::WithdrawalRequest>, Self::Error> {
+    ) -> Result<Vec<model::WithdrawalRequest>, Error> {
         let pending_withdraw_requests = self
             .get_pending_withdrawal_requests(chain_tip, context_window)
             .await?;
@@ -349,7 +348,7 @@ impl super::DbRead for SharedStore {
     async fn get_bitcoin_blocks_with_transaction(
         &self,
         txid: &model::BitcoinTxId,
-    ) -> Result<Vec<model::BitcoinBlockHash>, Self::Error> {
+    ) -> Result<Vec<model::BitcoinBlockHash>, Error> {
         Ok(self
             .lock()
             .await
@@ -359,7 +358,7 @@ impl super::DbRead for SharedStore {
             .unwrap_or_else(Vec::new))
     }
 
-    async fn stacks_block_exists(&self, block_id: StacksBlockId) -> Result<bool, Self::Error> {
+    async fn stacks_block_exists(&self, block_id: StacksBlockId) -> Result<bool, Error> {
         Ok(self
             .lock()
             .await
@@ -370,7 +369,7 @@ impl super::DbRead for SharedStore {
     async fn get_encrypted_dkg_shares(
         &self,
         aggregate_key: &PublicKey,
-    ) -> Result<Option<model::EncryptedDkgShares>, Self::Error> {
+    ) -> Result<Option<model::EncryptedDkgShares>, Error> {
         Ok(self
             .lock()
             .await
@@ -382,7 +381,7 @@ impl super::DbRead for SharedStore {
     async fn get_last_key_rotation(
         &self,
         chain_tip: &model::BitcoinBlockHash,
-    ) -> Result<Option<model::RotateKeysTransaction>, Self::Error> {
+    ) -> Result<Option<model::RotateKeysTransaction>, Error> {
         let Some(stacks_chain_tip) = self.get_stacks_chain_tip(chain_tip).await? else {
             return Ok(None);
         };
@@ -405,7 +404,7 @@ impl super::DbRead for SharedStore {
         )
     }
 
-    async fn get_signers_script_pubkeys(&self) -> Result<Vec<model::Bytes>, Self::Error> {
+    async fn get_signers_script_pubkeys(&self) -> Result<Vec<model::Bytes>, Error> {
         Ok(self
             .lock()
             .await
@@ -420,7 +419,7 @@ impl super::DbRead for SharedStore {
         txid: &model::BitcoinTxId,
         output_index: u32,
         aggregate_key: &PublicKey,
-    ) -> Result<Vec<model::SignerVote>, Self::Error> {
+    ) -> Result<Vec<model::SignerVote>, Error> {
         // Let's fetch the votes for the outpoint
         let signers = self.get_deposit_signers(txid, output_index).await?;
         let mut signer_votes: HashMap<PublicKey, bool> = signers
@@ -456,7 +455,7 @@ impl super::DbRead for SharedStore {
         &self,
         id: &model::QualifiedRequestId,
         aggregate_key: &PublicKey,
-    ) -> Result<Vec<model::SignerVote>, Self::Error> {
+    ) -> Result<Vec<model::SignerVote>, Error> {
         // Let's fetch the votes for the outpoint
         let signers = self
             .get_withdrawal_signers(id.request_id, &id.block_hash)
@@ -494,7 +493,7 @@ impl super::DbRead for SharedStore {
         &self,
         chain_tip: &model::BitcoinBlockRef,
         block_ref: &model::BitcoinBlockRef,
-    ) -> Result<bool, Self::Error> {
+    ) -> Result<bool, Error> {
         let store = self.lock().await;
         let bitcoin_blocks = &store.bitcoin_blocks;
         let first = bitcoin_blocks.get(&chain_tip.block_hash);
@@ -512,7 +511,7 @@ impl super::DbRead for SharedStore {
         &self,
         txid: &model::BitcoinTxId,
         block_hash: &model::BitcoinBlockHash,
-    ) -> Result<Option<model::BitcoinTx>, Self::Error> {
+    ) -> Result<Option<model::BitcoinTx>, Error> {
         let store = self.lock().await;
         let maybe_tx = store
             .bitcoin_transactions
@@ -524,9 +523,7 @@ impl super::DbRead for SharedStore {
 }
 
 impl super::DbWrite for SharedStore {
-    type Error = std::convert::Infallible;
-
-    async fn write_bitcoin_block(&self, block: &model::BitcoinBlock) -> Result<(), Self::Error> {
+    async fn write_bitcoin_block(&self, block: &model::BitcoinBlock) -> Result<(), Error> {
         self.lock()
             .await
             .bitcoin_blocks
@@ -538,7 +535,7 @@ impl super::DbWrite for SharedStore {
     async fn write_bitcoin_transactions(
         &self,
         txs: Vec<model::Transaction>,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), Error> {
         for tx in txs {
             let bitcoin_transaction = model::BitcoinTransaction {
                 txid: tx.txid.into(),
@@ -550,7 +547,7 @@ impl super::DbWrite for SharedStore {
         Ok(())
     }
 
-    async fn write_stacks_block(&self, block: &model::StacksBlock) -> Result<(), Self::Error> {
+    async fn write_stacks_block(&self, block: &model::StacksBlock) -> Result<(), Error> {
         self.lock()
             .await
             .stacks_blocks
@@ -562,7 +559,7 @@ impl super::DbWrite for SharedStore {
     async fn write_deposit_request(
         &self,
         deposit_request: &model::DepositRequest,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), Error> {
         self.lock().await.deposit_requests.insert(
             (deposit_request.txid, deposit_request.output_index),
             deposit_request.clone(),
@@ -574,7 +571,7 @@ impl super::DbWrite for SharedStore {
     async fn write_deposit_requests(
         &self,
         deposit_requests: Vec<model::DepositRequest>,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), Error> {
         let mut store = self.lock().await;
         for req in deposit_requests.into_iter() {
             store
@@ -587,7 +584,7 @@ impl super::DbWrite for SharedStore {
     async fn write_withdrawal_request(
         &self,
         withdraw_request: &model::WithdrawalRequest,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), Error> {
         let mut store = self.lock().await;
 
         let pk = (withdraw_request.request_id, withdraw_request.block_hash);
@@ -608,7 +605,7 @@ impl super::DbWrite for SharedStore {
     async fn write_deposit_signer_decision(
         &self,
         decision: &model::DepositSigner,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), Error> {
         let mut store = self.lock().await;
 
         let deposit_request_pk = (decision.txid, decision.output_index);
@@ -631,7 +628,7 @@ impl super::DbWrite for SharedStore {
     async fn write_withdrawal_signer_decision(
         &self,
         decision: &model::WithdrawalSigner,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), Error> {
         self.lock()
             .await
             .withdrawal_request_to_signers
@@ -645,7 +642,7 @@ impl super::DbWrite for SharedStore {
     async fn write_transaction(
         &self,
         _transaction: &model::Transaction,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), Error> {
         // Currently not needed in-memory since it's not required by any queries
         Ok(())
     }
@@ -653,7 +650,7 @@ impl super::DbWrite for SharedStore {
     async fn write_bitcoin_transaction(
         &self,
         bitcoin_transaction: &model::BitcoinTransaction,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), Error> {
         let mut store = self.lock().await;
 
         store
@@ -674,7 +671,7 @@ impl super::DbWrite for SharedStore {
     async fn write_stacks_transaction(
         &self,
         stacks_transaction: &model::StacksTransaction,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), Error> {
         let mut store = self.lock().await;
 
         store
@@ -695,7 +692,7 @@ impl super::DbWrite for SharedStore {
     async fn write_stacks_transactions(
         &self,
         stacks_transactions: Vec<model::Transaction>,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), Error> {
         for tx in stacks_transactions {
             let stacks_transaction = model::StacksTransaction {
                 txid: tx.txid.into(),
@@ -710,7 +707,7 @@ impl super::DbWrite for SharedStore {
     async fn write_stacks_block_headers(
         &self,
         blocks: Vec<model::StacksBlock>,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), Error> {
         let mut store = self.lock().await;
         blocks.iter().for_each(|block| {
             store
@@ -724,7 +721,7 @@ impl super::DbWrite for SharedStore {
     async fn write_encrypted_dkg_shares(
         &self,
         shares: &model::EncryptedDkgShares,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), Error> {
         self.lock()
             .await
             .encrypted_dkg_shares
@@ -736,7 +733,7 @@ impl super::DbWrite for SharedStore {
     async fn write_rotate_keys_transaction(
         &self,
         key_rotation: &model::RotateKeysTransaction,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), Error> {
         self.lock()
             .await
             .rotate_keys_transactions
@@ -748,7 +745,7 @@ impl super::DbWrite for SharedStore {
     async fn write_withdrawal_create_event(
         &self,
         event: &WithdrawalCreateEvent,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), Error> {
         self.lock()
             .await
             .withdrawal_create_events
@@ -760,7 +757,7 @@ impl super::DbWrite for SharedStore {
     async fn write_withdrawal_accept_event(
         &self,
         event: &WithdrawalAcceptEvent,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), Error> {
         self.lock()
             .await
             .withdrawal_accept_events
@@ -772,7 +769,7 @@ impl super::DbWrite for SharedStore {
     async fn write_withdrawal_reject_event(
         &self,
         event: &WithdrawalRejectEvent,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), Error> {
         self.lock()
             .await
             .withdrawal_reject_events
@@ -784,7 +781,7 @@ impl super::DbWrite for SharedStore {
     async fn write_completed_deposit_event(
         &self,
         event: &CompletedDepositEvent,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), Error> {
         self.lock()
             .await
             .completed_deposit_events

--- a/signer/src/storage/in_memory.rs
+++ b/signer/src/storage/in_memory.rs
@@ -8,13 +8,13 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
+use crate::error::Error;
 use crate::keys::PublicKey;
 use crate::stacks::events::CompletedDepositEvent;
 use crate::stacks::events::WithdrawalAcceptEvent;
 use crate::stacks::events::WithdrawalCreateEvent;
 use crate::stacks::events::WithdrawalRejectEvent;
 use crate::storage::model;
-use crate::error::Error;
 
 /// A store wrapped in an Arc<Mutex<...>> for interior mutability
 pub type SharedStore = Arc<Mutex<Store>>;
@@ -532,10 +532,7 @@ impl super::DbWrite for SharedStore {
         Ok(())
     }
 
-    async fn write_bitcoin_transactions(
-        &self,
-        txs: Vec<model::Transaction>,
-    ) -> Result<(), Error> {
+    async fn write_bitcoin_transactions(&self, txs: Vec<model::Transaction>) -> Result<(), Error> {
         for tx in txs {
             let bitcoin_transaction = model::BitcoinTransaction {
                 txid: tx.txid.into(),
@@ -639,10 +636,7 @@ impl super::DbWrite for SharedStore {
         Ok(())
     }
 
-    async fn write_transaction(
-        &self,
-        _transaction: &model::Transaction,
-    ) -> Result<(), Error> {
+    async fn write_transaction(&self, _transaction: &model::Transaction) -> Result<(), Error> {
         // Currently not needed in-memory since it's not required by any queries
         Ok(())
     }

--- a/signer/src/storage/mod.rs
+++ b/signer/src/storage/mod.rs
@@ -11,11 +11,11 @@ pub mod model;
 pub mod postgres;
 pub mod sqlx;
 
-use std::fmt::Display;
 use std::future::Future;
 
 use blockstack_lib::types::chainstate::StacksBlockId;
 
+use crate::error::Error;
 use crate::keys::PublicKey;
 use crate::stacks::events::CompletedDepositEvent;
 use crate::stacks::events::WithdrawalAcceptEvent;
@@ -24,39 +24,36 @@ use crate::stacks::events::WithdrawalRejectEvent;
 
 /// Represents the ability to read data from the signer storage.
 pub trait DbRead {
-    /// Read error.
-    type Error: std::error::Error + Display;
-
     /// Get the bitcoin block with the given block hash.
     fn get_bitcoin_block(
         &self,
         block_hash: &model::BitcoinBlockHash,
-    ) -> impl Future<Output = Result<Option<model::BitcoinBlock>, Self::Error>> + Send;
+    ) -> impl Future<Output = Result<Option<model::BitcoinBlock>, Error>> + Send;
 
     /// Get the stacks block with the given block hash.
     fn get_stacks_block(
         &self,
         block_hash: &model::StacksBlockHash,
-    ) -> impl Future<Output = Result<Option<model::StacksBlock>, Self::Error>> + Send;
+    ) -> impl Future<Output = Result<Option<model::StacksBlock>, Error>> + Send;
 
     /// Get the bitcoin canonical chain tip.
     fn get_bitcoin_canonical_chain_tip(
         &self,
-    ) -> impl Future<Output = Result<Option<model::BitcoinBlockHash>, Self::Error>> + Send;
+    ) -> impl Future<Output = Result<Option<model::BitcoinBlockHash>, Error>> + Send;
 
     /// Get the stacks chain tip, defined as the highest stacks block
     /// confirmed by the bitcoin chain tip.
     fn get_stacks_chain_tip(
         &self,
         bitcoin_chain_tip: &model::BitcoinBlockHash,
-    ) -> impl Future<Output = Result<Option<model::StacksBlock>, Self::Error>> + Send;
+    ) -> impl Future<Output = Result<Option<model::StacksBlock>, Error>> + Send;
 
     /// Get pending deposit requests
     fn get_pending_deposit_requests(
         &self,
         chain_tip: &model::BitcoinBlockHash,
         context_window: u16,
-    ) -> impl Future<Output = Result<Vec<model::DepositRequest>, Self::Error>> + Send;
+    ) -> impl Future<Output = Result<Vec<model::DepositRequest>, Error>> + Send;
 
     /// Get pending deposit requests that have been accepted by at least
     /// `signatures_required` signers and has no responses
@@ -65,34 +62,34 @@ pub trait DbRead {
         chain_tip: &model::BitcoinBlockHash,
         context_window: u16,
         signatures_required: u16,
-    ) -> impl Future<Output = Result<Vec<model::DepositRequest>, Self::Error>> + Send;
+    ) -> impl Future<Output = Result<Vec<model::DepositRequest>, Error>> + Send;
 
     /// Get the deposit requests that the signer has accepted to sign
     fn get_accepted_deposit_requests(
         &self,
         signer: &PublicKey,
-    ) -> impl Future<Output = Result<Vec<model::DepositRequest>, Self::Error>> + Send;
+    ) -> impl Future<Output = Result<Vec<model::DepositRequest>, Error>> + Send;
 
     /// Get signer decisions for a deposit request
     fn get_deposit_signers(
         &self,
         txid: &model::BitcoinTxId,
         output_index: u32,
-    ) -> impl Future<Output = Result<Vec<model::DepositSigner>, Self::Error>> + Send;
+    ) -> impl Future<Output = Result<Vec<model::DepositSigner>, Error>> + Send;
 
     /// Get signer decisions for a withdrawal request
     fn get_withdrawal_signers(
         &self,
         request_id: u64,
         block_hash: &model::StacksBlockHash,
-    ) -> impl Future<Output = Result<Vec<model::WithdrawalSigner>, Self::Error>> + Send;
+    ) -> impl Future<Output = Result<Vec<model::WithdrawalSigner>, Error>> + Send;
 
     /// Get pending withdrawal requests
     fn get_pending_withdrawal_requests(
         &self,
         chain_tip: &model::BitcoinBlockHash,
         context_window: u16,
-    ) -> impl Future<Output = Result<Vec<model::WithdrawalRequest>, Self::Error>> + Send;
+    ) -> impl Future<Output = Result<Vec<model::WithdrawalRequest>, Error>> + Send;
 
     /// Get pending withdrawal requests that have been accepted by at least
     /// `threshold` signers and has no responses
@@ -101,37 +98,37 @@ pub trait DbRead {
         chain_tip: &model::BitcoinBlockHash,
         context_window: u16,
         threshold: u16,
-    ) -> impl Future<Output = Result<Vec<model::WithdrawalRequest>, Self::Error>> + Send;
+    ) -> impl Future<Output = Result<Vec<model::WithdrawalRequest>, Error>> + Send;
 
     /// Get bitcoin blocks that include a particular transaction
     fn get_bitcoin_blocks_with_transaction(
         &self,
         txid: &model::BitcoinTxId,
-    ) -> impl Future<Output = Result<Vec<model::BitcoinBlockHash>, Self::Error>> + Send;
+    ) -> impl Future<Output = Result<Vec<model::BitcoinBlockHash>, Error>> + Send;
 
     /// Returns whether the given block ID is stored.
     fn stacks_block_exists(
         &self,
         block_id: StacksBlockId,
-    ) -> impl Future<Output = Result<bool, Self::Error>> + Send;
+    ) -> impl Future<Output = Result<bool, Error>> + Send;
 
     /// Return the applicable DKG shares for the
     /// given aggregate key
     fn get_encrypted_dkg_shares(
         &self,
         aggregate_key: &PublicKey,
-    ) -> impl Future<Output = Result<Option<model::EncryptedDkgShares>, Self::Error>> + Send;
+    ) -> impl Future<Output = Result<Option<model::EncryptedDkgShares>, Error>> + Send;
 
     /// Return the latest rotate-keys transaction confirmed by the given `chain-tip`.
     fn get_last_key_rotation(
         &self,
         chain_tip: &model::BitcoinBlockHash,
-    ) -> impl Future<Output = Result<Option<model::RotateKeysTransaction>, Self::Error>> + Send;
+    ) -> impl Future<Output = Result<Option<model::RotateKeysTransaction>, Error>> + Send;
 
     /// Get the last 365 days worth of the signers' `scriptPubkey`s.
     fn get_signers_script_pubkeys(
         &self,
-    ) -> impl Future<Output = Result<Vec<model::Bytes>, Self::Error>> + Send;
+    ) -> impl Future<Output = Result<Vec<model::Bytes>, Error>> + Send;
 
     /// For the given outpoint and aggregate key, get the list all signer
     /// votes in the signer set.
@@ -140,7 +137,7 @@ pub trait DbRead {
         txid: &model::BitcoinTxId,
         output_index: u32,
         aggregate_key: &PublicKey,
-    ) -> impl Future<Output = Result<Vec<model::SignerVote>, Self::Error>> + Send;
+    ) -> impl Future<Output = Result<Vec<model::SignerVote>, Error>> + Send;
 
     /// For the given withdrawal request identifier, and aggregate key, get
     /// the list for how the signers voted against the request.
@@ -148,7 +145,7 @@ pub trait DbRead {
         &self,
         id: &model::QualifiedRequestId,
         aggregate_key: &PublicKey,
-    ) -> impl Future<Output = Result<Vec<model::SignerVote>, Self::Error>> + Send;
+    ) -> impl Future<Output = Result<Vec<model::SignerVote>, Error>> + Send;
 
     /// Check that the given block hash is included in the canonical
     /// bitcoin blockchain, where the canonical blockchain is identified by
@@ -157,7 +154,7 @@ pub trait DbRead {
         &self,
         chain_tip: &model::BitcoinBlockRef,
         block_ref: &model::BitcoinBlockRef,
-    ) -> impl Future<Output = Result<bool, Self::Error>> + Send;
+    ) -> impl Future<Output = Result<bool, Error>> + Send;
 
     /// Fetch the bitcoin transaction that is included in the block
     /// identified by the block hash.
@@ -165,125 +162,122 @@ pub trait DbRead {
         &self,
         txid: &model::BitcoinTxId,
         block_hash: &model::BitcoinBlockHash,
-    ) -> impl Future<Output = Result<Option<model::BitcoinTx>, Self::Error>> + Send;
+    ) -> impl Future<Output = Result<Option<model::BitcoinTx>, Error>> + Send;
 }
 
 /// Represents the ability to write data to the signer storage.
 pub trait DbWrite {
-    /// Write error.
-    type Error: std::error::Error + Display;
-
     /// Write a bitcoin block.
     fn write_bitcoin_block(
         &self,
         block: &model::BitcoinBlock,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+    ) -> impl Future<Output = Result<(), Error>> + Send;
 
     /// Write a stacks block.
     fn write_stacks_block(
         &self,
         block: &model::StacksBlock,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+    ) -> impl Future<Output = Result<(), Error>> + Send;
 
     /// Write a deposit request.
     fn write_deposit_request(
         &self,
         deposit_request: &model::DepositRequest,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+    ) -> impl Future<Output = Result<(), Error>> + Send;
 
     /// Write many deposit requests.
     fn write_deposit_requests(
         &self,
         deposit_requests: Vec<model::DepositRequest>,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+    ) -> impl Future<Output = Result<(), Error>> + Send;
 
     /// Write a withdrawal request.
     fn write_withdrawal_request(
         &self,
         request: &model::WithdrawalRequest,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+    ) -> impl Future<Output = Result<(), Error>> + Send;
 
     /// Write a signer decision for a deposit request.
     fn write_deposit_signer_decision(
         &self,
         decision: &model::DepositSigner,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+    ) -> impl Future<Output = Result<(), Error>> + Send;
 
     /// Write a signer decision for a withdrawal request.
     fn write_withdrawal_signer_decision(
         &self,
         decision: &model::WithdrawalSigner,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+    ) -> impl Future<Output = Result<(), Error>> + Send;
 
     /// Write a raw transaction.
     fn write_transaction(
         &self,
         transaction: &model::Transaction,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+    ) -> impl Future<Output = Result<(), Error>> + Send;
 
     /// Write a connection between a bitcoin block and a transaction
     fn write_bitcoin_transaction(
         &self,
         bitcoin_transaction: &model::BitcoinTransaction,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+    ) -> impl Future<Output = Result<(), Error>> + Send;
 
     /// Write the bitcoin transactions to the data store.
     fn write_bitcoin_transactions(
         &self,
         txs: Vec<model::Transaction>,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+    ) -> impl Future<Output = Result<(), Error>> + Send;
 
     /// Write a connection between a stacks block and a transaction
     fn write_stacks_transaction(
         &self,
         stacks_transaction: &model::StacksTransaction,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+    ) -> impl Future<Output = Result<(), Error>> + Send;
 
     /// Write the stacks transactions to the data store.
     fn write_stacks_transactions(
         &self,
         txs: Vec<model::Transaction>,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+    ) -> impl Future<Output = Result<(), Error>> + Send;
 
     /// Write the stacks block ids and their parent block ids.
     fn write_stacks_block_headers(
         &self,
         headers: Vec<model::StacksBlock>,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+    ) -> impl Future<Output = Result<(), Error>> + Send;
 
     /// Write encrypted DKG shares
     fn write_encrypted_dkg_shares(
         &self,
         shares: &model::EncryptedDkgShares,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+    ) -> impl Future<Output = Result<(), Error>> + Send;
 
     /// Write rotate-keys transaction
     fn write_rotate_keys_transaction(
         &self,
         key_rotation: &model::RotateKeysTransaction,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+    ) -> impl Future<Output = Result<(), Error>> + Send;
 
     /// Write the withdrawal-reject event to the database.
     fn write_withdrawal_reject_event(
         &self,
         event: &WithdrawalRejectEvent,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+    ) -> impl Future<Output = Result<(), Error>> + Send;
 
     /// Write the withdrawal-accept event to the database.
     fn write_withdrawal_accept_event(
         &self,
         event: &WithdrawalAcceptEvent,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+    ) -> impl Future<Output = Result<(), Error>> + Send;
 
     /// Write the withdrawal-create event to the database.
     fn write_withdrawal_create_event(
         &self,
         event: &WithdrawalCreateEvent,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+    ) -> impl Future<Output = Result<(), Error>> + Send;
 
     /// Write the completed deposit event to the database.
     fn write_completed_deposit_event(
         &self,
         event: &CompletedDepositEvent,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+    ) -> impl Future<Output = Result<(), Error>> + Send;
 }

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -1324,10 +1324,7 @@ impl super::DbWrite for PgStore {
         Ok(())
     }
 
-    async fn write_bitcoin_transactions(
-        &self,
-        txs: Vec<model::Transaction>,
-    ) -> Result<(), Error> {
+    async fn write_bitcoin_transactions(&self, txs: Vec<model::Transaction>) -> Result<(), Error> {
         let summary = self.write_transactions(txs).await?;
         if summary.tx_ids.is_empty() {
             return Ok(());
@@ -1377,10 +1374,7 @@ impl super::DbWrite for PgStore {
         Ok(())
     }
 
-    async fn write_stacks_transactions(
-        &self,
-        txs: Vec<model::Transaction>,
-    ) -> Result<(), Error> {
+    async fn write_stacks_transactions(&self, txs: Vec<model::Transaction>) -> Result<(), Error> {
         let summary = self.write_transactions(txs).await?;
         if summary.tx_ids.is_empty() {
             return Ok(());

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -86,7 +86,7 @@ pub struct PgStore(sqlx::PgPool);
 
 impl TryFrom<&NakamotoBlock> for model::StacksBlock {
     type Error = Error;
-    fn try_from(block: &NakamotoBlock) -> Result<Self, Self::Error> {
+    fn try_from(block: &NakamotoBlock) -> Result<Self, Error> {
         Ok(Self {
             block_hash: block.block_id().into(),
             block_height: block.header.chain_length,
@@ -330,12 +330,10 @@ impl From<sqlx::PgPool> for PgStore {
 }
 
 impl super::DbRead for PgStore {
-    type Error = Error;
-
     async fn get_bitcoin_block(
         &self,
         block_hash: &model::BitcoinBlockHash,
-    ) -> Result<Option<model::BitcoinBlock>, Self::Error> {
+    ) -> Result<Option<model::BitcoinBlock>, Error> {
         sqlx::query_as::<_, model::BitcoinBlock>(
             "SELECT
                 block_hash
@@ -354,7 +352,7 @@ impl super::DbRead for PgStore {
     async fn get_stacks_block(
         &self,
         block_hash: &model::StacksBlockHash,
-    ) -> Result<Option<model::StacksBlock>, Self::Error> {
+    ) -> Result<Option<model::StacksBlock>, Error> {
         sqlx::query_as::<_, model::StacksBlock>(
             "SELECT
                 block_hash
@@ -371,7 +369,7 @@ impl super::DbRead for PgStore {
 
     async fn get_bitcoin_canonical_chain_tip(
         &self,
-    ) -> Result<Option<model::BitcoinBlockHash>, Self::Error> {
+    ) -> Result<Option<model::BitcoinBlockHash>, Error> {
         sqlx::query_as::<_, model::BitcoinBlock>(
             "SELECT
                 block_hash
@@ -416,7 +414,7 @@ impl super::DbRead for PgStore {
         &self,
         chain_tip: &model::BitcoinBlockHash,
         context_window: u16,
-    ) -> Result<Vec<model::DepositRequest>, Self::Error> {
+    ) -> Result<Vec<model::DepositRequest>, Error> {
         sqlx::query_as::<_, model::DepositRequest>(
             r#"
             WITH RECURSIVE context_window AS (
@@ -466,7 +464,7 @@ impl super::DbRead for PgStore {
         chain_tip: &model::BitcoinBlockHash,
         context_window: u16,
         threshold: u16,
-    ) -> Result<Vec<model::DepositRequest>, Self::Error> {
+    ) -> Result<Vec<model::DepositRequest>, Error> {
         // TODO(543): Make sure we get only pending deposits, don't include
         // ones where we have a completed-deposit event on the canonical
         // stacks blockchain.
@@ -528,7 +526,7 @@ impl super::DbRead for PgStore {
         txid: &model::BitcoinTxId,
         output_index: u32,
         aggregate_key: &PublicKey,
-    ) -> Result<Vec<model::SignerVote>, Self::Error> {
+    ) -> Result<Vec<model::SignerVote>, Error> {
         sqlx::query_as::<_, model::SignerVote>(
             r#"
             WITH signer_set_rows AS (
@@ -570,7 +568,7 @@ impl super::DbRead for PgStore {
         &self,
         id: &model::QualifiedRequestId,
         aggregate_key: &PublicKey,
-    ) -> Result<Vec<model::SignerVote>, Self::Error> {
+    ) -> Result<Vec<model::SignerVote>, Error> {
         sqlx::query_as::<_, model::SignerVote>(
             r#"
             WITH signer_set_rows AS (
@@ -608,7 +606,7 @@ impl super::DbRead for PgStore {
     async fn get_accepted_deposit_requests(
         &self,
         signer: &PublicKey,
-    ) -> Result<Vec<model::DepositRequest>, Self::Error> {
+    ) -> Result<Vec<model::DepositRequest>, Error> {
         sqlx::query_as::<_, model::DepositRequest>(
             r#"
             SELECT
@@ -638,7 +636,7 @@ impl super::DbRead for PgStore {
         &self,
         txid: &model::BitcoinTxId,
         output_index: u32,
-    ) -> Result<Vec<model::DepositSigner>, Self::Error> {
+    ) -> Result<Vec<model::DepositSigner>, Error> {
         sqlx::query_as::<_, model::DepositSigner>(
             "SELECT
                 txid
@@ -660,7 +658,7 @@ impl super::DbRead for PgStore {
         &self,
         request_id: u64,
         block_hash: &model::StacksBlockHash,
-    ) -> Result<Vec<model::WithdrawalSigner>, Self::Error> {
+    ) -> Result<Vec<model::WithdrawalSigner>, Error> {
         sqlx::query_as::<_, model::WithdrawalSigner>(
             "SELECT
                 request_id
@@ -683,7 +681,7 @@ impl super::DbRead for PgStore {
         &self,
         chain_tip: &model::BitcoinBlockHash,
         context_window: u16,
-    ) -> Result<Vec<model::WithdrawalRequest>, Self::Error> {
+    ) -> Result<Vec<model::WithdrawalRequest>, Error> {
         let Some(stacks_chain_tip) = self.get_stacks_chain_tip(chain_tip).await? else {
             return Ok(Vec::new());
         };
@@ -763,7 +761,7 @@ impl super::DbRead for PgStore {
         chain_tip: &model::BitcoinBlockHash,
         context_window: u16,
         threshold: u16,
-    ) -> Result<Vec<model::WithdrawalRequest>, Self::Error> {
+    ) -> Result<Vec<model::WithdrawalRequest>, Error> {
         let Some(stacks_chain_tip) = self.get_stacks_chain_tip(chain_tip).await? else {
             return Ok(Vec::new());
         };
@@ -850,7 +848,7 @@ impl super::DbRead for PgStore {
     async fn get_bitcoin_blocks_with_transaction(
         &self,
         txid: &model::BitcoinTxId,
-    ) -> Result<Vec<model::BitcoinBlockHash>, Self::Error> {
+    ) -> Result<Vec<model::BitcoinBlockHash>, Error> {
         sqlx::query_as::<_, model::BitcoinTransaction>(
             "SELECT txid, block_hash FROM sbtc_signer.bitcoin_transactions WHERE txid = $1",
         )
@@ -865,7 +863,7 @@ impl super::DbRead for PgStore {
         .map_err(Error::SqlxQuery)
     }
 
-    async fn stacks_block_exists(&self, block_id: StacksBlockId) -> Result<bool, Self::Error> {
+    async fn stacks_block_exists(&self, block_id: StacksBlockId) -> Result<bool, Error> {
         sqlx::query_scalar::<_, bool>(
             r#"
             SELECT TRUE AS exists
@@ -882,7 +880,7 @@ impl super::DbRead for PgStore {
     async fn get_encrypted_dkg_shares(
         &self,
         aggregate_key: &PublicKey,
-    ) -> Result<Option<model::EncryptedDkgShares>, Self::Error> {
+    ) -> Result<Option<model::EncryptedDkgShares>, Error> {
         sqlx::query_as::<_, model::EncryptedDkgShares>(
             r#"
             SELECT
@@ -911,7 +909,7 @@ impl super::DbRead for PgStore {
     async fn get_last_key_rotation(
         &self,
         chain_tip: &model::BitcoinBlockHash,
-    ) -> Result<Option<model::RotateKeysTransaction>, Self::Error> {
+    ) -> Result<Option<model::RotateKeysTransaction>, Error> {
         let Some(stacks_chain_tip) = self.get_stacks_chain_tip(chain_tip).await? else {
             return Ok(None);
         };
@@ -955,7 +953,7 @@ impl super::DbRead for PgStore {
         .map_err(Error::SqlxQuery)
     }
 
-    async fn get_signers_script_pubkeys(&self) -> Result<Vec<model::Bytes>, Self::Error> {
+    async fn get_signers_script_pubkeys(&self) -> Result<Vec<model::Bytes>, Error> {
         sqlx::query_scalar::<_, model::Bytes>(
             r#"
             SELECT script_pubkey
@@ -1038,9 +1036,7 @@ impl super::DbRead for PgStore {
 }
 
 impl super::DbWrite for PgStore {
-    type Error = Error;
-
-    async fn write_bitcoin_block(&self, block: &model::BitcoinBlock) -> Result<(), Self::Error> {
+    async fn write_bitcoin_block(&self, block: &model::BitcoinBlock) -> Result<(), Error> {
         sqlx::query(
             "INSERT INTO sbtc_signer.bitcoin_blocks
               ( block_hash
@@ -1062,7 +1058,7 @@ impl super::DbWrite for PgStore {
         Ok(())
     }
 
-    async fn write_stacks_block(&self, block: &model::StacksBlock) -> Result<(), Self::Error> {
+    async fn write_stacks_block(&self, block: &model::StacksBlock) -> Result<(), Error> {
         sqlx::query(
             "INSERT INTO sbtc_signer.stacks_blocks
               ( block_hash
@@ -1085,7 +1081,7 @@ impl super::DbWrite for PgStore {
     async fn write_deposit_request(
         &self,
         deposit_request: &model::DepositRequest,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), Error> {
         sqlx::query(
             "INSERT INTO sbtc_signer.deposit_requests
               ( txid
@@ -1118,7 +1114,7 @@ impl super::DbWrite for PgStore {
     async fn write_deposit_requests(
         &self,
         deposit_requests: Vec<model::DepositRequest>,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), Error> {
         if deposit_requests.is_empty() {
             return Ok(());
         }
@@ -1209,7 +1205,7 @@ impl super::DbWrite for PgStore {
     async fn write_withdrawal_request(
         &self,
         request: &model::WithdrawalRequest,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), Error> {
         sqlx::query(
             "INSERT INTO sbtc_signer.withdrawal_requests
               ( request_id
@@ -1241,7 +1237,7 @@ impl super::DbWrite for PgStore {
     async fn write_deposit_signer_decision(
         &self,
         decision: &model::DepositSigner,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), Error> {
         sqlx::query(
             "INSERT INTO sbtc_signer.deposit_signers
               ( txid
@@ -1266,7 +1262,7 @@ impl super::DbWrite for PgStore {
     async fn write_withdrawal_signer_decision(
         &self,
         decision: &model::WithdrawalSigner,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), Error> {
         sqlx::query(
             "INSERT INTO sbtc_signer.withdrawal_signers
               ( request_id
@@ -1290,7 +1286,7 @@ impl super::DbWrite for PgStore {
         Ok(())
     }
 
-    async fn write_transaction(&self, transaction: &model::Transaction) -> Result<(), Self::Error> {
+    async fn write_transaction(&self, transaction: &model::Transaction) -> Result<(), Error> {
         sqlx::query(
             "INSERT INTO sbtc_signer.transactions
               ( txid
@@ -1313,7 +1309,7 @@ impl super::DbWrite for PgStore {
     async fn write_bitcoin_transaction(
         &self,
         bitcoin_transaction: &model::BitcoinTransaction,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), Error> {
         sqlx::query(
             "INSERT INTO sbtc_signer.bitcoin_transactions (txid, block_hash) 
             VALUES ($1, $2)
@@ -1331,7 +1327,7 @@ impl super::DbWrite for PgStore {
     async fn write_bitcoin_transactions(
         &self,
         txs: Vec<model::Transaction>,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), Error> {
         let summary = self.write_transactions(txs).await?;
         if summary.tx_ids.is_empty() {
             return Ok(());
@@ -1366,7 +1362,7 @@ impl super::DbWrite for PgStore {
     async fn write_stacks_transaction(
         &self,
         stacks_transaction: &model::StacksTransaction,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), Error> {
         sqlx::query(
             "INSERT INTO sbtc_signer.stacks_transactions (txid, block_hash) 
             VALUES ($1, $2)
@@ -1384,7 +1380,7 @@ impl super::DbWrite for PgStore {
     async fn write_stacks_transactions(
         &self,
         txs: Vec<model::Transaction>,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), Error> {
         let summary = self.write_transactions(txs).await?;
         if summary.tx_ids.is_empty() {
             return Ok(());
@@ -1420,7 +1416,7 @@ impl super::DbWrite for PgStore {
     async fn write_stacks_block_headers(
         &self,
         blocks: Vec<model::StacksBlock>,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), Error> {
         if blocks.is_empty() {
             return Ok(());
         }
@@ -1474,7 +1470,7 @@ impl super::DbWrite for PgStore {
     async fn write_encrypted_dkg_shares(
         &self,
         shares: &model::EncryptedDkgShares,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), Error> {
         sqlx::query(
             r#"
             INSERT INTO sbtc_signer.dkg_shares (
@@ -1502,7 +1498,7 @@ impl super::DbWrite for PgStore {
     async fn write_rotate_keys_transaction(
         &self,
         key_rotation: &model::RotateKeysTransaction,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), Error> {
         sqlx::query(
             r#"
             INSERT INTO sbtc_signer.rotate_keys_transactions (

--- a/signer/src/testing/transaction_coordinator.rs
+++ b/signer/src/testing/transaction_coordinator.rs
@@ -28,8 +28,6 @@ struct EventLoopHarness<S, C> {
 impl<S, C> EventLoopHarness<S, C>
 where
     S: storage::DbRead + storage::DbWrite + Clone + Send + 'static,
-    error::Error: From<<S as storage::DbRead>::Error>,
-    error::Error: From<<S as storage::DbWrite>::Error>,
     C: crate::bitcoin::BitcoinInteract + Send + 'static,
     error::Error: From<C::Error>,
 {
@@ -117,8 +115,6 @@ impl<C, S> TestEnvironment<C>
 where
     C: FnMut() -> S,
     S: storage::DbRead + storage::DbWrite + Clone + Send + 'static,
-    error::Error: From<<S as storage::DbRead>::Error>,
-    error::Error: From<<S as storage::DbWrite>::Error>,
 {
     /// Assert that a coordinator should be able to coordiante a signing round
     pub async fn assert_should_be_able_to_coordinate_signing_rounds(mut self) {

--- a/signer/src/testing/transaction_coordinator.rs
+++ b/signer/src/testing/transaction_coordinator.rs
@@ -29,7 +29,6 @@ impl<S, C> EventLoopHarness<S, C>
 where
     S: storage::DbRead + storage::DbWrite + Clone + Send + 'static,
     C: crate::bitcoin::BitcoinInteract + Send + 'static,
-    error::Error: From<C::Error>,
 {
     fn create(
         network: network::in_memory::MpmcBroadcaster,

--- a/signer/src/testing/transaction_signer.rs
+++ b/signer/src/testing/transaction_signer.rs
@@ -36,8 +36,6 @@ struct EventLoopHarness<S, Rng> {
 impl<S, Rng> EventLoopHarness<S, Rng>
 where
     S: storage::DbRead + storage::DbWrite + Clone + Send + Sync + 'static,
-    error::Error: From<<S as storage::DbRead>::Error>,
-    error::Error: From<<S as storage::DbWrite>::Error>,
     Rng: rand::RngCore + rand::CryptoRng + Send + 'static,
 {
     fn create(
@@ -157,8 +155,6 @@ impl<C, S> TestEnvironment<C>
 where
     C: FnMut() -> S,
     S: storage::DbRead + storage::DbWrite + Clone + Send + Sync + 'static,
-    error::Error: From<<S as storage::DbRead>::Error>,
-    error::Error: From<<S as storage::DbWrite>::Error>,
 {
     /// Assert that the transaction signer will make and store decisions
     /// for pending deposit requests.

--- a/signer/src/testing/wallet.rs
+++ b/signer/src/testing/wallet.rs
@@ -154,7 +154,6 @@ impl AsContractCall for InitiateWithdrawalRequest {
     async fn validate<S>(&self, _: &S) -> Result<bool, Error>
     where
         S: crate::storage::DbRead + Send + Sync,
-        Error: From<<S as crate::storage::DbRead>::Error>,
     {
         Ok(true)
     }

--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -121,7 +121,6 @@ where
     S: storage::DbRead + storage::DbWrite,
     B: BitcoinInteract,
     Error: From<N::Error>,
-    Error: From<B::Error>,
 {
     /// Run the coordinator event loop
     #[tracing::instrument(skip(self))]

--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -11,7 +11,7 @@ use sha2::Digest;
 
 use crate::bitcoin::utxo;
 use crate::bitcoin::BitcoinInteract;
-use crate::error;
+use crate::error::Error;
 use crate::keys::PrivateKey;
 use crate::keys::PublicKey;
 use crate::message;
@@ -19,7 +19,6 @@ use crate::network;
 use crate::storage;
 use crate::storage::model;
 use crate::wsts_state_machine;
-use crate::error::Error;
 
 use crate::ecdsa::SignEcdsa as _;
 use bitcoin::hashes::Hash as _;
@@ -120,11 +119,10 @@ where
     N: network::MessageTransfer,
     S: storage::DbRead + storage::DbWrite,
     B: BitcoinInteract,
-    Error: From<N::Error>,
 {
     /// Run the coordinator event loop
     #[tracing::instrument(skip(self))]
-    pub async fn run(mut self) -> Result<(), error::Error> {
+    pub async fn run(mut self) -> Result<(), Error> {
         loop {
             match self.block_observer_notifications.changed().await {
                 Ok(()) => self.process_new_blocks().await?,
@@ -140,12 +138,12 @@ where
     }
 
     #[tracing::instrument(skip(self))]
-    async fn process_new_blocks(&mut self) -> Result<(), error::Error> {
+    async fn process_new_blocks(&mut self) -> Result<(), Error> {
         let bitcoin_chain_tip = self
             .storage
             .get_bitcoin_canonical_chain_tip()
             .await?
-            .ok_or(error::Error::NoChainTip)?;
+            .ok_or(Error::NoChainTip)?;
 
         let (aggregate_key, signer_public_keys) = self
             .get_signer_public_keys_and_aggregate_key(&bitcoin_chain_tip)
@@ -178,7 +176,7 @@ where
         bitcoin_chain_tip: &model::BitcoinBlockHash,
         aggregate_key: PublicKey,
         signer_public_keys: &BTreeSet<PublicKey>,
-    ) -> Result<(), error::Error> {
+    ) -> Result<(), Error> {
         let signer_btc_state = self.get_btc_state(&aggregate_key).await?;
 
         let pending_requests = self
@@ -213,7 +211,7 @@ where
         bitcoin_chain_tip: &model::BitcoinBlockHash,
         aggregate_key: PublicKey,
         signer_public_keys: &BTreeSet<PublicKey>,
-    ) -> Result<(), error::Error> {
+    ) -> Result<(), Error> {
         // TODO(320): Implement
         Ok(())
     }
@@ -227,7 +225,7 @@ where
         aggregate_key: PublicKey,
         signer_public_keys: &BTreeSet<PublicKey>,
         mut transaction: utxo::UnsignedTransaction<'_>,
-    ) -> Result<(), error::Error> {
+    ) -> Result<(), Error> {
         let mut coordinator_state_machine = wsts_state_machine::CoordinatorStateMachine::load(
             &mut self.storage,
             aggregate_key,
@@ -253,7 +251,7 @@ where
 
         let signature = bitcoin::taproot::Signature {
             signature: secp256k1::schnorr::Signature::from_slice(&signature.to_bytes())
-                .map_err(|_| error::Error::TypeConversion)?,
+                .map_err(|_| Error::TypeConversion)?,
             sighash_type: bitcoin::TapSighashType::Default,
         };
         let signer_witness = bitcoin::Witness::p2tr_key_spend(&signature);
@@ -274,7 +272,7 @@ where
 
             let signature = bitcoin::taproot::Signature {
                 signature: secp256k1::schnorr::Signature::from_slice(&signature.to_bytes())
-                    .map_err(|_| error::Error::TypeConversion)?,
+                    .map_err(|_| Error::TypeConversion)?,
                 sighash_type: bitcoin::TapSighashType::Default,
             };
 
@@ -310,7 +308,7 @@ where
         coordinator_state_machine: &mut wsts_state_machine::CoordinatorStateMachine,
         txid: bitcoin::Txid,
         msg: &[u8],
-    ) -> Result<wsts::taproot::SchnorrProof, error::Error> {
+    ) -> Result<wsts::taproot::SchnorrProof, Error> {
         let outbound = coordinator_state_machine
             .start_signing_round(msg, true, None)
             .map_err(wsts_state_machine::coordinator_error)?;
@@ -327,9 +325,7 @@ where
 
         tokio::time::timeout(max_duration, run_signing_round)
             .await
-            .map_err(|_| {
-                error::Error::CoordinatorTimeout(self.signing_round_max_duration.as_secs())
-            })?
+            .map_err(|_| Error::CoordinatorTimeout(self.signing_round_max_duration.as_secs()))?
     }
 
     #[tracing::instrument(skip(self))]
@@ -338,7 +334,7 @@ where
         bitcoin_chain_tip: &model::BitcoinBlockHash,
         coordinator_state_machine: &mut wsts_state_machine::CoordinatorStateMachine,
         txid: bitcoin::Txid,
-    ) -> Result<wsts::taproot::SchnorrProof, error::Error> {
+    ) -> Result<wsts::taproot::SchnorrProof, Error> {
         loop {
             let msg = self.network.receive().await?;
 
@@ -375,7 +371,7 @@ where
                     return Ok(signature)
                 }
                 None => continue,
-                Some(_) => return Err(error::Error::UnexpectedOperationResult),
+                Some(_) => return Err(Error::UnexpectedOperationResult),
             }
         }
     }
@@ -396,7 +392,7 @@ where
         &self,
         bitcoin_chain_tip: &model::BitcoinBlockHash,
         signer_public_keys: &BTreeSet<PublicKey>,
-    ) -> Result<bool, error::Error> {
+    ) -> Result<bool, Error> {
         given_key_is_coordinator(self.pub_key(), bitcoin_chain_tip, signer_public_keys)
     }
 
@@ -404,13 +400,13 @@ where
     async fn get_btc_state(
         &mut self,
         aggregate_key: &PublicKey,
-    ) -> Result<utxo::SignerBtcState, error::Error> {
+    ) -> Result<utxo::SignerBtcState, Error> {
         let fee_rate = self.bitcoin_client.estimate_fee_rate().await?;
         let utxo = self
             .bitcoin_client
             .get_signer_utxo(aggregate_key)
             .await?
-            .ok_or(error::Error::MissingSignerUtxo)?;
+            .ok_or(Error::MissingSignerUtxo)?;
         let last_fees = self.bitcoin_client.get_last_fee(utxo.outpoint).await?;
 
         Ok(utxo::SignerBtcState {
@@ -433,11 +429,11 @@ where
         signer_btc_state: utxo::SignerBtcState,
         aggregate_key: PublicKey,
         signer_public_keys: &BTreeSet<PublicKey>,
-    ) -> Result<utxo::SbtcRequests, error::Error> {
+    ) -> Result<utxo::SbtcRequests, Error> {
         let context_window = self
             .context_window
             .try_into()
-            .map_err(|_| error::Error::TypeConversion)?;
+            .map_err(|_| Error::TypeConversion)?;
 
         let threshold = self.threshold;
 
@@ -481,7 +477,7 @@ where
         let num_signers = signer_public_keys
             .len()
             .try_into()
-            .map_err(|_| error::Error::TypeConversion)?;
+            .map_err(|_| Error::TypeConversion)?;
 
         Ok(utxo::SbtcRequests {
             deposits,
@@ -496,12 +492,12 @@ where
     async fn get_signer_public_keys_and_aggregate_key(
         &mut self,
         bitcoin_chain_tip: &model::BitcoinBlockHash,
-    ) -> Result<(PublicKey, BTreeSet<PublicKey>), error::Error> {
+    ) -> Result<(PublicKey, BTreeSet<PublicKey>), Error> {
         let last_key_rotation = self
             .storage
             .get_last_key_rotation(bitcoin_chain_tip)
             .await?
-            .ok_or(error::Error::MissingKeyRotation)?;
+            .ok_or(Error::MissingKeyRotation)?;
 
         let aggregate_key = last_key_rotation.aggregate_key;
         let signer_set = last_key_rotation.signer_set.into_iter().collect();
@@ -517,7 +513,7 @@ where
         &mut self,
         msg: impl Into<message::Payload>,
         bitcoin_chain_tip: &model::BitcoinBlockHash,
-    ) -> Result<(), error::Error> {
+    ) -> Result<(), Error> {
         let msg = msg
             .into()
             .to_message(*bitcoin_chain_tip)
@@ -534,7 +530,7 @@ pub fn given_key_is_coordinator(
     pub_key: PublicKey,
     bitcoin_chain_tip: &model::BitcoinBlockHash,
     signer_public_keys: &BTreeSet<PublicKey>,
-) -> Result<bool, error::Error> {
+) -> Result<bool, Error> {
     Ok(
         coordinator_public_key(bitcoin_chain_tip, signer_public_keys)?
             .map(|coordinator_pub_key| coordinator_pub_key == pub_key)
@@ -546,11 +542,11 @@ pub fn given_key_is_coordinator(
 pub fn coordinator_public_key(
     bitcoin_chain_tip: &model::BitcoinBlockHash,
     signer_public_keys: &BTreeSet<PublicKey>,
-) -> Result<Option<PublicKey>, error::Error> {
+) -> Result<Option<PublicKey>, Error> {
     let mut hasher = sha2::Sha256::new();
     hasher.update(bitcoin_chain_tip.into_bytes());
     let digest = hasher.finalize();
-    let index = usize::from_be_bytes(*digest.first_chunk().ok_or(error::Error::TypeConversion)?);
+    let index = usize::from_be_bytes(*digest.first_chunk().ok_or(Error::TypeConversion)?);
 
     Ok(signer_public_keys
         .iter()

--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -19,6 +19,7 @@ use crate::network;
 use crate::storage;
 use crate::storage::model;
 use crate::wsts_state_machine;
+use crate::error::Error;
 
 use crate::ecdsa::SignEcdsa as _;
 use bitcoin::hashes::Hash as _;
@@ -119,10 +120,8 @@ where
     N: network::MessageTransfer,
     S: storage::DbRead + storage::DbWrite,
     B: BitcoinInteract,
-    error::Error: From<N::Error>,
-    error::Error: From<<S as storage::DbRead>::Error>,
-    error::Error: From<<S as storage::DbWrite>::Error>,
-    error::Error: From<B::Error>,
+    Error: From<N::Error>,
+    Error: From<B::Error>,
 {
     /// Run the coordinator event loop
     #[tracing::instrument(skip(self))]

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -11,7 +11,6 @@ use std::collections::HashMap;
 use crate::blocklist_client;
 use crate::config::NetworkKind;
 use crate::ecdsa::SignEcdsa as _;
-use crate::error;
 use crate::error::Error;
 use crate::keys;
 use crate::keys::PrivateKey;
@@ -141,14 +140,13 @@ pub enum TxSignerEvent {
 impl<N, S, B, Rng> TxSignerEventLoop<N, S, B, Rng>
 where
     N: network::MessageTransfer,
-    error::Error: From<N::Error>,
     B: blocklist_client::BlocklistChecker,
     S: storage::DbRead + storage::DbWrite + Send + Sync,
     Rng: rand::RngCore + rand::CryptoRng,
 {
     /// Run the signer event loop
     #[tracing::instrument(skip(self))]
-    pub async fn run(mut self) -> Result<(), error::Error> {
+    pub async fn run(mut self) -> Result<(), Error> {
         loop {
             tokio::select! {
                 result = self.block_observer_notifications.changed() => {
@@ -167,7 +165,7 @@ where
                             let res = self.handle_signer_message(&msg).await;
                             match res {
                                 Ok(()) => (),
-                                Err(error::Error::InvalidSignature) => (),
+                                Err(Error::InvalidSignature) => (),
                                 Err(error) => {
                                     tracing::error!(%error, "fatal signer error");
                                     return Err(error)}
@@ -187,12 +185,12 @@ where
     }
 
     #[tracing::instrument(skip(self))]
-    async fn handle_new_requests(&mut self) -> Result<(), error::Error> {
+    async fn handle_new_requests(&mut self) -> Result<(), Error> {
         let bitcoin_chain_tip = self
             .storage
             .get_bitcoin_canonical_chain_tip()
             .await?
-            .ok_or(error::Error::NoChainTip)?;
+            .ok_or(Error::NoChainTip)?;
 
         for deposit_request in self
             .get_pending_deposit_requests(&bitcoin_chain_tip)
@@ -214,10 +212,10 @@ where
     }
 
     #[tracing::instrument(skip(self))]
-    async fn handle_signer_message(&mut self, msg: &network::Msg) -> Result<(), error::Error> {
+    async fn handle_signer_message(&mut self, msg: &network::Msg) -> Result<(), Error> {
         if !msg.verify() {
             tracing::warn!("unable to verify message");
-            return Err(error::Error::InvalidSignature);
+            return Err(Error::InvalidSignature);
         }
 
         let chain_tip_report = self
@@ -281,7 +279,7 @@ where
         &mut self,
         msg_sender: keys::PublicKey,
         bitcoin_chain_tip: &model::BitcoinBlockHash,
-    ) -> Result<MsgChainTipReport, error::Error> {
+    ) -> Result<MsgChainTipReport, Error> {
         let is_known = self
             .storage
             .get_bitcoin_block(bitcoin_chain_tip)
@@ -329,7 +327,7 @@ where
         &mut self,
         request: &message::BitcoinTransactionSignRequest,
         bitcoin_chain_tip: &model::BitcoinBlockHash,
-    ) -> Result<(), error::Error> {
+    ) -> Result<(), Error> {
         let is_valid_sign_request = self
             .is_valid_bitcoin_transaction_sign_request(request)
             .await?;
@@ -365,7 +363,7 @@ where
     async fn is_valid_bitcoin_transaction_sign_request(
         &mut self,
         _request: &message::BitcoinTransactionSignRequest,
-    ) -> Result<bool, error::Error> {
+    ) -> Result<bool, Error> {
         let signer_pub_key = self.signer_pub_key();
         let _accepted_deposit_requests = self
             .storage
@@ -423,7 +421,7 @@ where
             .storage
             .get_last_key_rotation(bitcoin_chain_tip)
             .await?
-            .ok_or(error::Error::MissingKeyRotation)?;
+            .ok_or(Error::MissingKeyRotation)?;
 
         let public_keys = last_key_rotation.signer_set.as_slice();
         let signatures_required = last_key_rotation.signatures_required;
@@ -458,7 +456,7 @@ where
         &mut self,
         msg: &message::WstsMessage,
         bitcoin_chain_tip: &model::BitcoinBlockHash,
-    ) -> Result<(), error::Error> {
+    ) -> Result<(), Error> {
         tracing::info!("handling message");
         match &msg.inner {
             wsts::net::Message::DkgBegin(_) => {
@@ -519,19 +517,19 @@ where
         txid: bitcoin::Txid,
         msg: &wsts::net::Message,
         bitcoin_chain_tip: &model::BitcoinBlockHash,
-    ) -> Result<(), error::Error> {
+    ) -> Result<(), Error> {
         let Some(state_machine) = self.wsts_state_machines.get_mut(&txid) else {
             tracing::warn!("missing signing round");
             return Ok(());
         };
 
-        let outbound_messages = state_machine.process(msg).map_err(error::Error::Wsts)?;
+        let outbound_messages = state_machine.process(msg).map_err(Error::Wsts)?;
 
         for outbound_message in outbound_messages.iter() {
             // The WSTS state machine assume we read our own messages
             state_machine
                 .process(outbound_message)
-                .map_err(error::Error::Wsts)?;
+                .map_err(Error::Wsts)?;
         }
 
         for outbound_message in outbound_messages {
@@ -553,22 +551,20 @@ where
     async fn get_pending_deposit_requests(
         &mut self,
         chain_tip: &model::BitcoinBlockHash,
-    ) -> Result<Vec<model::DepositRequest>, error::Error> {
-        Ok(self
-            .storage
+    ) -> Result<Vec<model::DepositRequest>, Error> {
+        self.storage
             .get_pending_deposit_requests(chain_tip, self.context_window)
-            .await?)
+            .await
     }
 
     #[tracing::instrument(skip(self))]
     async fn get_pending_withdraw_requests(
         &mut self,
         chain_tip: &model::BitcoinBlockHash,
-    ) -> Result<Vec<model::WithdrawalRequest>, error::Error> {
-        Ok(self
-            .storage
+    ) -> Result<Vec<model::WithdrawalRequest>, Error> {
+        self.storage
             .get_pending_withdrawal_requests(chain_tip, self.context_window)
-            .await?)
+            .await
     }
 
     #[tracing::instrument(skip(self))]
@@ -576,7 +572,7 @@ where
         &mut self,
         request: model::DepositRequest,
         bitcoin_chain_tip: &model::BitcoinBlockHash,
-    ) -> Result<(), error::Error> {
+    ) -> Result<(), Error> {
         let params = self.network_kind.params();
         let addresses = request
             .sender_script_pub_keys
@@ -622,7 +618,7 @@ where
     async fn handle_pending_withdraw_request(
         &mut self,
         withdraw_request: model::WithdrawalRequest,
-    ) -> Result<(), error::Error> {
+    ) -> Result<(), Error> {
         // TODO: Do we want to do this on the sender address of the
         // recipient address?
         let is_accepted = self
@@ -651,7 +647,7 @@ where
         &mut self,
         decision: &message::SignerDepositDecision,
         signer_pub_key: PublicKey,
-    ) -> Result<(), error::Error> {
+    ) -> Result<(), Error> {
         let signer_decision = model::DepositSigner {
             txid: decision.txid.into(),
             output_index: decision.output_index,
@@ -667,7 +663,7 @@ where
         if let Some(ref tx) = self.test_observer_tx {
             tx.send(TxSignerEvent::ReceivedDepositDecision)
                 .await
-                .map_err(|_| error::Error::ObserverDropped)?;
+                .map_err(|_| Error::ObserverDropped)?;
         }
 
         Ok(())
@@ -678,7 +674,7 @@ where
         &mut self,
         decision: &message::SignerWithdrawDecision,
         signer_pub_key: PublicKey,
-    ) -> Result<(), error::Error> {
+    ) -> Result<(), Error> {
         let signer_decision = model::WithdrawalSigner {
             request_id: decision.request_id,
             block_hash: decision.block_hash.into(),
@@ -695,18 +691,18 @@ where
         if let Some(ref tx) = self.test_observer_tx {
             tx.send(TxSignerEvent::ReceivedWithdrawalDecision)
                 .await
-                .map_err(|_| error::Error::ObserverDropped)?;
+                .map_err(|_| Error::ObserverDropped)?;
         }
 
         Ok(())
     }
 
     #[tracing::instrument(skip(self))]
-    async fn store_dkg_shares(&mut self, txid: &bitcoin::Txid) -> Result<(), error::Error> {
+    async fn store_dkg_shares(&mut self, txid: &bitcoin::Txid) -> Result<(), Error> {
         let state_machine = self
             .wsts_state_machines
             .get(txid)
-            .ok_or(error::Error::MissingStateMachine)?;
+            .ok_or(Error::MissingStateMachine)?;
 
         let encrypted_dkg_shares = state_machine.get_encrypted_dkg_shares(&mut self.rng)?;
 
@@ -722,7 +718,7 @@ where
         &mut self,
         msg: impl Into<message::Payload>,
         bitcoin_chain_tip: &model::BitcoinBlockHash,
-    ) -> Result<(), error::Error> {
+    ) -> Result<(), Error> {
         let payload: message::Payload = msg.into();
         let msg = payload
             .to_message(*bitcoin_chain_tip)
@@ -737,12 +733,12 @@ where
     async fn get_signer_public_keys(
         &mut self,
         bitcoin_chain_tip: &model::BitcoinBlockHash,
-    ) -> Result<BTreeSet<PublicKey>, error::Error> {
+    ) -> Result<BTreeSet<PublicKey>, Error> {
         let last_key_rotation = self
             .storage
             .get_last_key_rotation(bitcoin_chain_tip)
             .await?
-            .ok_or(error::Error::MissingKeyRotation)?;
+            .ok_or(Error::MissingKeyRotation)?;
 
         let signer_set = last_key_rotation.signer_set.into_iter().collect();
 

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -144,8 +144,6 @@ where
     error::Error: From<N::Error>,
     B: blocklist_client::BlocklistChecker,
     S: storage::DbRead + storage::DbWrite + Send + Sync,
-    error::Error: From<<S as storage::DbRead>::Error>,
-    error::Error: From<<S as storage::DbWrite>::Error>,
     Rng: rand::RngCore + rand::CryptoRng,
 {
     /// Run the signer event loop

--- a/signer/src/wsts_state_machine.rs
+++ b/signer/src/wsts_state_machine.rs
@@ -87,8 +87,6 @@ impl SignerStateMachine {
     ) -> Result<Self, error::Error>
     where
         S: storage::DbRead + storage::DbWrite,
-        error::Error: From<<S as storage::DbRead>::Error>,
-        error::Error: From<<S as storage::DbWrite>::Error>,
     {
         let encrypted_shares = storage
             .get_encrypted_dkg_shares(&aggregate_key)
@@ -225,8 +223,6 @@ impl CoordinatorStateMachine {
     where
         I: IntoIterator<Item = PublicKey>,
         S: storage::DbRead + storage::DbWrite,
-        Error: From<<S as storage::DbRead>::Error>,
-        Error: From<<S as storage::DbWrite>::Error>,
     {
         let encrypted_shares = storage
             .get_encrypted_dkg_shares(&aggregate_key)

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -124,7 +124,6 @@ impl AsContractCall for InitiateWithdrawalRequest {
     async fn validate<S>(&self, _: &S) -> Result<bool, Error>
     where
         S: DbRead + Send + Sync,
-        Error: From<<S as DbRead>::Error>,
     {
         Ok(true)
     }
@@ -1145,7 +1144,7 @@ async fn fetching_withdrawal_request_votes() {
 #[tokio::test]
 async fn block_in_canonical_bitcoin_blockchain_in_other_block_chain() {
     let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let pg_store = signer::testing::storage::new_test_database(db_num).await;
+    let pg_store = signer::testing::storage::new_test_database(db_num, true).await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
 
     // This is just a sql test, where we use the `TestData` struct to help
@@ -1220,7 +1219,7 @@ async fn block_in_canonical_bitcoin_blockchain_in_other_block_chain() {
 #[tokio::test]
 async fn we_can_fetch_bitcoin_txs_from_db() {
     let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let pg_store = signer::testing::storage::new_test_database(db_num).await;
+    let pg_store = signer::testing::storage::new_test_database(db_num, true).await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
 
     // This is just a sql test, where we use the `TestData` struct to help


### PR DESCRIPTION
## Description

Implements part of the work done in https://github.com/stacks-network/sbtc/pull/507.

## Changes

* Remove the associated error type from the `DbRead`, `DbWrite`, `BitcoinInteract`, and `MessageTransfer` traits.
* Fixes bug/typo in the tests that may have caused tests in `main` to fail.

## Testing Information

This is just a refactor, so if the tests pass then all should be well.

## Checklist:

- [ ] I have performed a self-review of my code

