### PR TITLE
Chore: remove duplicated get_stacks_chain_tip

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ echo "\n--- sBTC tool versions ---" \
     && cargo lambda --version \
     && echo "pnpm $(pnpm --version)" \
     && echo "smithy $(smithy --version)" \
-    && make --version | head -n 1 \
+    && make --version | head -n 1
 ```
 
 Below is the output on a machine that is able to build and run all the sources and tests.


### PR DESCRIPTION
## Description

Remove duplicated logic for `get_stacks_chain_tip`.

## Testing Information

Existing tests pass (`cargo nextest r && make integration-test-full`).

## Checklist:

- [X] I have performed a self-review of my code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
