### PR TITLE
ci: more integration tests

### DIFF
--- a/sbtc/tests/integration/validation.rs
+++ b/sbtc/tests/integration/validation.rs
@@ -178,9 +178,8 @@ fn minimal_push_check() {
         }],
     };
     // We just created a transaction that spends the P2SH UTXO where we
-    // spend a deposit that did not adhere to the non-minimal push rule.
-    // When bicoin-core attempts to validate the transaction it should
-    // fail.
+    // spend a deposit that did not adhere to the minimal push rule. When
+    // bicoin-core attempts to validate the transaction it should fail.
     match rpc.send_raw_transaction(&tx1).unwrap_err() {
         BtcRpcError::JsonRpc(JsonRpcError::Rpc(RpcError { code: -26, message, .. })) => {
             let expected_message =

--- a/sbtc/tests/integration/validation.rs
+++ b/sbtc/tests/integration/validation.rs
@@ -180,12 +180,10 @@ fn minimal_push_check() {
     // We just created a transaction that spends the P2SH UTXO where we
     // spend a deposit that did not adhere to the minimal push rule. When
     // bicoin-core attempts to validate the transaction it should fail.
+    let expected = "non-mandatory-script-verify-flag (Data push larger than necessary)";
     match rpc.send_raw_transaction(&tx1).unwrap_err() {
-        BtcRpcError::JsonRpc(JsonRpcError::Rpc(RpcError { code: -26, message, .. })) => {
-            let expected_message =
-                "non-mandatory-script-verify-flag (Data push larger than necessary)";
-            assert_eq!(message, expected_message);
-        }
+        BtcRpcError::JsonRpc(JsonRpcError::Rpc(RpcError { code: -26, message, .. }))
+            if message == expected => {}
         err => panic!("{err}"),
     };
 }
@@ -382,12 +380,10 @@ fn op_csv_disabled() {
         }],
     };
 
+    let expected = "mandatory-script-verify-flag-failed (Locktime requirement not satisfied)";
     match rpc.send_raw_transaction(&tx3).unwrap_err() {
-        BtcRpcError::JsonRpc(JsonRpcError::Rpc(RpcError { code: -26, message, .. })) => {
-            let expected_message =
-                "mandatory-script-verify-flag-failed (Locktime requirement not satisfied)";
-            assert_eq!(message, expected_message);
-        }
+        BtcRpcError::JsonRpc(JsonRpcError::Rpc(RpcError { code: -26, message, .. }))
+            if message == expected => {}
         err => panic!("{err}"),
     };
 }

--- a/sbtc/tests/integration/validation.rs
+++ b/sbtc/tests/integration/validation.rs
@@ -81,6 +81,116 @@ fn tx_validation_from_mempool() {
     assert_eq!(parsed.recipient, setup.deposit.recipient);
 }
 
+/// This validates that we need to reject deposit scripts that do not
+/// follow the minimal push rule in their deposit scripts.
+///
+/// The test proceeds as follows:
+/// 1. Create and submit a transaction where the lock script has a
+///    non-minimal push for the deposit.
+/// 2. Confirm the transaction and try spend it immediately. The
+///    transaction spending the "deposit" should be rejected.
+///
+/// We do not attempt to create an actual P2TR deposit, but an
+/// (unsupported) P2SH deposit.
+#[cfg_attr(not(feature = "integration-tests"), ignore)]
+#[test]
+fn minimal_push_check() {
+    let fee = regtest::BITCOIN_CORE_FALLBACK_FEE.to_sat();
+
+    let (rpc, faucet) = regtest::initialize_blockchain();
+    let depositor = Recipient::new(AddressType::P2tr);
+
+    // Start off with some initial UTXOs to work with.
+    let _ = faucet.send_to(50_000_000, &depositor.address);
+    faucet.generate_blocks(1);
+
+    // There is only one UTXO under the depositor's name, so let's get it
+    let utxos = depositor.get_utxos(rpc, None);
+    let utxo = utxos.first().cloned().unwrap();
+    let amount = 30_000_000;
+
+    // 1. Create and submit a transaction where the lock script has a
+    //    non-minimal push for the deposit.
+    //
+    // We're going to create a P2SH UTXO with a script that has a
+    // non-minimal push of data. Anyone can spend this script immediately.
+    let deposit_data = [0; 44];
+
+    // This is non-standard script because it does not follow the minimal
+    // push rule. We use the OP_PUSHDATA1 when we can use fewer bytes for
+    // the same outcome in the script by removing the OP_PUSHDATA1 opcode
+    // from the script.
+    let script_pubkey = ScriptBuf::builder()
+        .push_opcode(bitcoin::opcodes::all::OP_PUSHDATA1)
+        .push_slice(deposit_data)
+        .push_opcode(bitcoin::opcodes::all::OP_DROP)
+        .push_opcode(bitcoin::opcodes::OP_TRUE)
+        .into_script();
+
+    let mut tx0 = Transaction {
+        version: Version::ONE,
+        lock_time: LockTime::ZERO,
+        input: vec![TxIn {
+            previous_output: utxo.outpoint(),
+            sequence: Sequence::ZERO,
+            script_sig: ScriptBuf::new(),
+            witness: Witness::new(),
+        }],
+        output: vec![
+            TxOut {
+                value: Amount::from_sat(amount),
+                script_pubkey: ScriptBuf::new_p2sh(&script_pubkey.script_hash()),
+            },
+            TxOut {
+                value: utxo.amount() - Amount::from_sat(amount + fee),
+                script_pubkey: depositor.address.script_pubkey(),
+            },
+        ],
+    };
+
+    regtest::p2tr_sign_transaction(&mut tx0, 0, &[utxo], &depositor.keypair);
+    rpc.send_raw_transaction(&tx0).unwrap();
+
+    // 2. Confirm the transaction and try spend it immediately. The
+    //    transaction spending the "deposit" should be rejected.
+    faucet.generate_blocks(1);
+
+    // The Builder::push_slice wants to make sure that the length of the
+    // pushed data is within the limits, hence the conversion into this
+    // PushBytes thing.
+    let locking_script: &PushBytes = script_pubkey.as_bytes().try_into().unwrap();
+    let script_sig = ScriptBuf::builder()
+        .push_slice(locking_script)
+        .into_script();
+
+    let tx1 = Transaction {
+        version: Version::TWO,
+        lock_time: LockTime::ZERO,
+        input: vec![TxIn {
+            previous_output: OutPoint::new(tx0.compute_txid(), 0),
+            sequence: Sequence::ZERO,
+            script_sig,
+            witness: Witness::new(),
+        }],
+        output: vec![TxOut {
+            value: Amount::from_sat(amount - fee),
+            script_pubkey: depositor.address.script_pubkey(),
+        }],
+    };
+    // We just created a transaction that spends the P2SH UTXO where we
+    // spend a deposit that did not adhere to the non-minimal push rule.
+    // When bicoin-core attempts to validate the transaction it should
+    // fail.
+    match rpc.send_raw_transaction(&tx1).unwrap_err() {
+        BtcRpcError::JsonRpc(JsonRpcError::Rpc(RpcError { code: -26, message, .. })) => {
+            let expected_message =
+                "non-mandatory-script-verify-flag (Data push larger than necessary)";
+            assert_eq!(message, expected_message);
+        }
+        err => panic!("{err}"),
+    };
+}
+
 /// This validates that a user can disable OP_CSV checks if we allow them
 /// to submit any lock-time. It doesn't test much of the code in this
 /// crate, just that bitcoin-core will treat OP_CSV like a no-op if the

--- a/signer/src/bitcoin/utxo.rs
+++ b/signer/src/bitcoin/utxo.rs
@@ -1011,6 +1011,7 @@ mod tests {
     use super::*;
     use bitcoin::CompressedPublicKey;
     use bitcoin::Txid;
+    use clarity::vm::types::PrincipalData;
     use fake::Fake as _;
     use rand::distributions::Distribution;
     use rand::distributions::Uniform;
@@ -1018,9 +1019,11 @@ mod tests {
     use rand::Rng;
     use rand::SeedableRng as _;
     use ripemd::Ripemd160;
+    use sbtc::deposits::DepositScriptInputs;
     use secp256k1::SecretKey;
     use sha2::Digest as _;
     use sha2::Sha256;
+    use stacks_common::types::chainstate::StacksAddress;
     use test_case::test_case;
 
     use crate::keys::PublicKey;
@@ -1069,12 +1072,18 @@ mod tests {
         let mut signer_bitmap: BitArray<[u8; 16]> = BitArray::ZERO;
         signer_bitmap[..votes_against].fill(true);
 
+        let deposit_inputs = DepositScriptInputs {
+            signers_public_key,
+            max_fee: 10000,
+            recipient: PrincipalData::from(StacksAddress::burn_address(false)),
+        };
+
         DepositRequest {
             outpoint: generate_outpoint(amount, 1),
             max_fee,
             signer_bitmap,
             amount,
-            deposit_script: testing::peg_in_deposit_script(&signers_public_key),
+            deposit_script: deposit_inputs.deposit_script(),
             reclaim_script: ScriptBuf::new(),
             signers_public_key,
         }

--- a/signer/src/testing/mod.rs
+++ b/signer/src/testing/mod.rs
@@ -9,15 +9,13 @@ pub mod transaction_signer;
 pub mod wallet;
 pub mod wsts;
 
-use crate::bitcoin::utxo::UnsignedTransaction;
-use crate::config::Settings;
 use bitcoin::key::TapTweak;
-use bitcoin::opcodes;
-use bitcoin::ScriptBuf;
 use bitcoin::TapSighashType;
 use bitcoin::Witness;
-use bitcoin::XOnlyPublicKey;
 use secp256k1::SECP256K1;
+
+use crate::bitcoin::utxo::UnsignedTransaction;
+use crate::config::Settings;
 
 /// The path for the configuration file that we should use during testing.
 pub const DEFAULT_CONFIG_PATH: Option<&str> = Some("./src/config/default");
@@ -74,20 +72,4 @@ pub fn set_witness_data(unsigned: &mut UnsignedTransaction, keypair: secp256k1::
         .for_each(|(tx_in, witness)| {
             tx_in.witness = witness;
         });
-}
-
-/// Create a dummy deposit script assuming the signer's public key is the
-/// input.
-pub fn peg_in_deposit_script(signers_public_key: &XOnlyPublicKey) -> ScriptBuf {
-    ScriptBuf::builder()
-        // Just some dummy data representing the stacks address the user
-        // wants the sBTC deposited to and their max fee. We encoded
-        // standard stacks addresses as 22 bytes, following the principal
-        // encoding detailed in SIP-05, and the max fee is an 8 byte
-        // unsigned integer. So the total is a 30 byte long data slice.
-        .push_slice([0u8; 30])
-        .push_opcode(opcodes::all::OP_DROP)
-        .push_slice(signers_public_key.serialize())
-        .push_opcode(opcodes::all::OP_CHECKSIG)
-        .into_script()
 }


### PR DESCRIPTION
## Description

Closes nothing.

This is a quick follow-up to https://github.com/stacks-network/sbtc/pull/535.

## Changes

* Adds an integration test that checks the minimal-push-rule (to show that https://github.com/stacks-network/sbtc/pull/535 was necessary).
* Update some of our integration tests helper functions to go through the types in the `sbtc` crate.

## Testing Information

This is a refactor that uses more internal types in the integration tests. The idea is that transactions that conform to the internal types will be accepted by bitcoin-core and make things work smoothly.

## Checklist:

- [x] I have performed a self-review of my code

