### PR TITLE
refactor: move context into its own dir and related updates

### DIFF
--- a/signer/src/context/messaging.rs
+++ b/signer/src/context/messaging.rs
@@ -22,10 +22,6 @@ pub enum SignerCommand {
 pub enum SignerEvent {
     /// Signals that a P2P event has occurred.
     P2P(P2PEvent),
-    /// Signals that the block observer database has been updated.
-    BlockObserverDbUpdated,
-    /// Signals that a transaction signer event has occurred.
-    TxSigner(TxSignerEvent),
 }
 
 /// Events that can be triggered from the P2P network.
@@ -49,12 +45,6 @@ pub enum TxSignerEvent {
     ReceivedDepositDecision,
     /// Received a withdrawal decision
     ReceivedWithdrawalDecision,
-}
-
-impl From<TxSignerEvent> for SignerSignal {
-    fn from(event: TxSignerEvent) -> Self {
-        SignerSignal::Event(SignerEvent::TxSigner(event))
-    }
 }
 
 impl From<SignerEvent> for SignerSignal {

--- a/signer/src/context/messaging.rs
+++ b/signer/src/context/messaging.rs
@@ -1,0 +1,70 @@
+//! This module contains types related to the application's internal
+//! messaging via the [`Context`].
+
+/// Signals that can be sent within the signer binary.
+#[derive(Debug, Clone)]
+pub enum SignerSignal {
+    /// Send a command to the application.
+    Command(SignerCommand),
+    /// Signal an event to the application.
+    Event(SignerEvent),
+}
+
+/// Commands that can be sent on the signalling channel.
+#[derive(Debug, Clone)]
+pub enum SignerCommand {
+    /// Signals to the application to publish a message to the P2P network.
+    P2PPublish(crate::network::Msg),
+}
+
+/// Events that can be received on the signalling channel.
+#[derive(Debug, Clone)]
+pub enum SignerEvent {
+    /// Signals that a P2P event has occurred.
+    P2P(P2PEvent),
+    /// Signals that the block observer database has been updated.
+    BlockObserverDbUpdated,
+    /// Signals that a transaction signer event has occurred.
+    TxSigner(TxSignerEvent),
+}
+
+/// Events that can be triggered from the P2P network.
+#[derive(Debug, Clone)]
+pub enum P2PEvent {
+    /// Signals to the application that the P2P publish failed for the given message.
+    PublishFailure(crate::network::MsgId),
+    /// Signals to the application that the P2P publish for the given message id
+    /// was successful.
+    PublishSuccess(crate::network::MsgId),
+    /// Signals to the application that a message was received from the P2P network.
+    MessageReceived(crate::network::Msg),
+    /// Signals to the application that a new peer has connected to the P2P network.
+    PeerConnected(libp2p::PeerId),
+}
+
+/// Events that can be triggered from the transaction signer.
+#[derive(Debug, Clone)]
+pub enum TxSignerEvent {
+    /// Received a deposit decision
+    ReceivedDepositDecision,
+    /// Received a withdrawal decision
+    ReceivedWithdrawalDecision,
+}
+
+impl From<TxSignerEvent> for SignerSignal {
+    fn from(event: TxSignerEvent) -> Self {
+        SignerSignal::Event(SignerEvent::TxSigner(event))
+    }
+}
+
+impl From<SignerEvent> for SignerSignal {
+    fn from(event: SignerEvent) -> Self {
+        SignerSignal::Event(event)
+    }
+}
+
+impl From<P2PEvent> for SignerSignal {
+    fn from(event: P2PEvent) -> Self {
+        SignerSignal::Event(SignerEvent::P2P(event))
+    }
+}

--- a/signer/src/context/mod.rs
+++ b/signer/src/context/mod.rs
@@ -37,7 +37,7 @@ pub trait Context: Clone + Sync + Send {
     /// Get a read-write handle to the signer storage.
     fn get_storage_mut(&self) -> impl DbRead + DbWrite + Clone + Sync + Send;
     /// Get a handle to a Bitcoin client.
-    fn get_bitcoin_client(&self) -> impl BitcoinClient + BitcoinInteract + Clone + Sync + Send;
+    fn get_bitcoin_client(&self) -> impl BitcoinClient + BitcoinInteract + Clone;
 }
 
 /// Signer context which is passed to different components within the

--- a/signer/src/context/mod.rs
+++ b/signer/src/context/mod.rs
@@ -1,10 +1,16 @@
 //! Context module for the signer binary.
 
+pub mod messaging;
+pub mod termination;
+
 use std::sync::Arc;
 
 use sbtc::rpc::BitcoinClient;
 use tokio::sync::broadcast::Sender;
 use url::Url;
+
+pub use messaging::*;
+pub use termination::*;
 
 use crate::{
     bitcoin::BitcoinInteract,
@@ -31,7 +37,7 @@ pub trait Context: Clone + Sync + Send {
     /// Get a read-write handle to the signer storage.
     fn get_storage_mut(&self) -> impl DbRead + DbWrite + Clone + Sync + Send;
     /// Get a handle to a Bitcoin client.
-    fn get_bitcoin_client(&self) -> impl BitcoinClient + BitcoinInteract + Clone;
+    fn get_bitcoin_client(&self) -> impl BitcoinClient + BitcoinInteract + Clone + Sync + Send;
 }
 
 /// Signer context which is passed to different components within the
@@ -80,72 +86,6 @@ pub struct InnerSignerContext<S, BC> {
     //emily_client: ApiFallbackClient<EM>,
     // /// Handle to a Blocklist-API fallback-client.
     //blocklist_client: ApiFallbackClient<BL>,
-}
-
-/// Signals that can be sent within the signer binary.
-#[derive(Debug, Clone)]
-pub enum SignerSignal {
-    /// Send a command to the application.
-    Command(SignerCommand),
-    /// Signal an event to the application.
-    Event(SignerEvent),
-}
-
-/// Commands that can be sent on the signalling channel.
-#[derive(Debug, Clone)]
-pub enum SignerCommand {
-    /// Signals to the application to publish a message to the P2P network.
-    P2PPublish(crate::network::Msg),
-}
-
-/// Events that can be received on the signalling channel.
-#[derive(Debug, Clone)]
-pub enum SignerEvent {
-    /// Signals to the application that the P2P publish failed for the given message.
-    P2PPublishFailure(crate::network::MsgId),
-    /// Signals to the application that the P2P publish for the given message id
-    /// was successful.
-    P2PPublishSuccess(crate::network::MsgId),
-    /// Signals to the application that a message was received from the P2P network.
-    P2PMessageReceived(crate::network::Msg),
-    /// Signals to the application that a new peer has connected to the P2P network.
-    P2PPeerConnected(libp2p::PeerId),
-}
-
-/// Handle to the termination signal. This can be used to signal the application
-/// to shutdown or to wait for a shutdown signal.
-pub struct TerminationHandle(
-    tokio::sync::watch::Sender<bool>,
-    tokio::sync::watch::Receiver<bool>,
-);
-
-impl TerminationHandle {
-    /// Signal the application to shutdown.
-    pub fn signal_shutdown(&self) {
-        // We ignore the result here, as if all receivers have been dropped,
-        // we're on our way down anyway.
-        self.0.send_if_modified(|x| {
-            if !(*x) {
-                *x = true;
-                true
-            } else {
-                false
-            }
-        });
-    }
-    /// Blocks until a shutdown signal is received.
-    pub async fn wait_for_shutdown(&mut self) {
-        loop {
-            // Wait for the termination channel to be updated. If it's updated
-            // and the value is true, we break out of the loop.
-            // We ignore the result here because it's impossible for the sender
-            // to be dropped while this instance is alive (it holds its own sender).
-            let _ = self.1.changed().await;
-            if *self.1.borrow_and_update() {
-                break;
-            }
-        }
-    }
 }
 
 impl<'a, S, BC> SignerContext<S, BC>
@@ -220,7 +160,7 @@ where
     }
 
     fn get_termination_handle(&self) -> TerminationHandle {
-        TerminationHandle(self.term_tx.clone(), self.term_tx.subscribe())
+        TerminationHandle::new(self.term_tx.clone(), self.term_tx.subscribe())
     }
 
     fn get_storage(&self) -> impl DbRead + Clone + Sync + Send {

--- a/signer/src/context/termination.rs
+++ b/signer/src/context/termination.rs
@@ -1,0 +1,45 @@
+//! Module that contains termination-related code for the [`Context`].
+
+/// Handle to the termination signal. This can be used to signal the application
+/// to shutdown or to wait for a shutdown signal.
+pub struct TerminationHandle(
+    tokio::sync::watch::Sender<bool>,
+    tokio::sync::watch::Receiver<bool>,
+);
+
+impl TerminationHandle {
+    /// Create a new termination handle.
+    pub fn new(
+        tx: tokio::sync::watch::Sender<bool>,
+        rx: tokio::sync::watch::Receiver<bool>,
+    ) -> Self {
+        Self(tx, rx)
+    }
+
+    /// Signal the application to shutdown.
+    pub fn signal_shutdown(&self) {
+        // We ignore the result here, as if all receivers have been dropped,
+        // we're on our way down anyway.
+        self.0.send_if_modified(|x| {
+            if !(*x) {
+                *x = true;
+                true
+            } else {
+                false
+            }
+        });
+    }
+    /// Blocks until a shutdown signal is received.
+    pub async fn wait_for_shutdown(&mut self) {
+        loop {
+            // Wait for the termination channel to be updated. If it's updated
+            // and the value is true, we break out of the loop.
+            // We ignore the result here because it's impossible for the sender
+            // to be dropped while this instance is alive (it holds its own sender).
+            let _ = self.1.changed().await;
+            if *self.1.borrow_and_update() {
+                break;
+            }
+        }
+    }
+}

--- a/signer/src/network/mod.rs
+++ b/signer/src/network/mod.rs
@@ -14,6 +14,7 @@ use tokio::sync::broadcast::Receiver;
 use tokio::sync::broadcast::Sender;
 
 use crate::context::Context;
+use crate::context::P2PEvent;
 use crate::context::SignerCommand;
 use crate::context::SignerEvent;
 use crate::context::SignerSignal;
@@ -99,7 +100,7 @@ impl MessageTransfer for P2PNetwork {
                 },
                 recv = self.signal_rx.recv() => {
                     match recv {
-                        Ok(SignerSignal::Event(SignerEvent::P2PMessageReceived(msg))) => {
+                        Ok(SignerSignal::Event(SignerEvent::P2P(P2PEvent::MessageReceived(msg)))) => {
                             return Ok(msg);
                         },
                         // We're only interested in the above messages, so we ignore


### PR DESCRIPTION
## Description

The `context.rs` was starting to get a little big, so I split it up a little bit to help keep code cohesion high. This was a pretty isolated change from one of my local branches and should help reduce conflicts from coming PRs.

## Changes

No real functional changes, just organizational and convenience:

- Moves `context.rs` into `context/mod.rs` and refactors out messaging and termination types into `context/messaging.rs` and `context/termination.rs`.
- Consolidates the `P2P` events under a new variant.
- Adds a few `From<>`s on message variants to make it easier to read/write commands/events.

## Testing Information

Nothing special, everything as before.

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
