### PR TITLE
refactor: setup bitcoin client use in validation

### DIFF
--- a/signer/src/api/new_block.rs
+++ b/signer/src/api/new_block.rs
@@ -161,9 +161,8 @@ mod tests {
     {
         let db = Store::new_shared();
 
-        let ctx =
-            NoopSignerContext::init(&Settings::new_from_default_config().unwrap(), db.clone())
-                .expect("failed to init context");
+        let ctx = NoopSignerContext::init(Settings::new_from_default_config().unwrap(), db.clone())
+            .expect("failed to init context");
 
         let api = ApiState { ctx: ctx.clone() };
 
@@ -191,9 +190,8 @@ mod tests {
     {
         let db = Store::new_shared();
 
-        let ctx =
-            NoopSignerContext::init(&Settings::new_from_default_config().unwrap(), db.clone())
-                .expect("failed to init context");
+        let ctx = NoopSignerContext::init(Settings::new_from_default_config().unwrap(), db.clone())
+            .expect("failed to init context");
 
         let api = ApiState { ctx: ctx.clone() };
 

--- a/signer/src/bitcoin/client.rs
+++ b/signer/src/bitcoin/client.rs
@@ -66,7 +66,11 @@ impl BitcoinInteract for ApiFallbackClient<BitcoinCoreClient> {
         self.get_client().get_tx(txid)
     }
 
-    fn get_tx_info(&self, txid: &Txid, block_hash: &BlockHash) -> Result<BitcoinTxInfo, Error> {
+    fn get_tx_info(
+        &self,
+        txid: &Txid,
+        block_hash: &BlockHash,
+    ) -> Result<Option<BitcoinTxInfo>, Error> {
         self.get_client().get_tx_info(txid, block_hash)
     }
 

--- a/signer/src/bitcoin/client.rs
+++ b/signer/src/bitcoin/client.rs
@@ -14,6 +14,8 @@
 //! - Example when trying to get a block that doesn't exist:
 //!   JsonRpc(Rpc(RpcError { code: -5, message: "Block not found", data: None }))
 
+use bitcoin::BlockHash;
+use bitcoin::Txid;
 use bitcoincore_rpc::jsonrpc::error::RpcError;
 use bitcoincore_rpc::RpcApi as _;
 use url::Url;
@@ -26,6 +28,7 @@ use crate::keys::PublicKey;
 use crate::util::ApiFallbackClient;
 
 use super::rpc::BitcoinCoreClient;
+use super::rpc::BitcoinTxInfo;
 use super::rpc::GetTxResponse;
 
 /// Implement the [`TryFrom`] trait for a slice of [`Url`]s to allow for a
@@ -59,8 +62,12 @@ impl BitcoinInteract for ApiFallbackClient<BitcoinCoreClient> {
         .await
     }
 
-    fn get_tx(&self, txid: &bitcoin::Txid) -> Result<GetTxResponse, Error> {
+    fn get_tx(&self, txid: &Txid) -> Result<GetTxResponse, Error> {
         self.get_client().get_tx(txid)
+    }
+
+    fn get_tx_info(&self, txid: &Txid, block_hash: &BlockHash) -> Result<BitcoinTxInfo, Error> {
+        self.get_client().get_tx_info(txid, &block_hash)
     }
 
     async fn estimate_fee_rate(&self) -> Result<f64, Error> {

--- a/signer/src/bitcoin/client.rs
+++ b/signer/src/bitcoin/client.rs
@@ -38,7 +38,7 @@ impl TryFrom<&[Url]> for ApiFallbackClient<BitcoinCoreClient> {
     fn try_from(urls: &[Url]) -> Result<Self, Self::Error> {
         let clients = urls
             .iter()
-            .map(|url| BitcoinCoreClient::try_from(url.clone()))
+            .map(BitcoinCoreClient::try_from)
             .collect::<Result<Vec<_>, _>>()?;
 
         Self::new(clients).map_err(Into::into)

--- a/signer/src/bitcoin/client.rs
+++ b/signer/src/bitcoin/client.rs
@@ -62,7 +62,7 @@ impl BitcoinInteract for ApiFallbackClient<BitcoinCoreClient> {
         .await
     }
 
-    fn get_tx(&self, txid: &Txid) -> Result<GetTxResponse, Error> {
+    fn get_tx(&self, txid: &Txid) -> Result<Option<GetTxResponse>, Error> {
         self.get_client().get_tx(txid)
     }
 

--- a/signer/src/bitcoin/client.rs
+++ b/signer/src/bitcoin/client.rs
@@ -16,7 +16,6 @@
 
 use bitcoin::BlockHash;
 use bitcoin::Txid;
-use bitcoincore_rpc::jsonrpc::error::RpcError;
 use bitcoincore_rpc::RpcApi as _;
 use url::Url;
 
@@ -50,16 +49,8 @@ impl BitcoinInteract for ApiFallbackClient<BitcoinCoreClient> {
         &self,
         block_hash: &bitcoin::BlockHash,
     ) -> Result<Option<bitcoin::Block>, Error> {
-        self.exec(|client| async {
-            match client.inner_client().get_block(block_hash) {
-                Ok(block) => Ok(Some(block)),
-                Err(bitcoincore_rpc::Error::JsonRpc(bitcoincore_rpc::jsonrpc::Error::Rpc(
-                    RpcError { code: -5, .. },
-                ))) => Ok(None),
-                Err(error) => Err(Error::BitcoinCoreRpc(error)),
-            }
-        })
-        .await
+        self.exec(|client| async { client.get_block(block_hash) })
+            .await
     }
 
     fn get_tx(&self, txid: &Txid) -> Result<Option<GetTxResponse>, Error> {

--- a/signer/src/bitcoin/client.rs
+++ b/signer/src/bitcoin/client.rs
@@ -67,7 +67,7 @@ impl BitcoinInteract for ApiFallbackClient<BitcoinCoreClient> {
     }
 
     fn get_tx_info(&self, txid: &Txid, block_hash: &BlockHash) -> Result<BitcoinTxInfo, Error> {
-        self.get_client().get_tx_info(txid, &block_hash)
+        self.get_client().get_tx_info(txid, block_hash)
     }
 
     async fn estimate_fee_rate(&self) -> Result<f64, Error> {

--- a/signer/src/bitcoin/mod.rs
+++ b/signer/src/bitcoin/mod.rs
@@ -2,6 +2,10 @@
 
 use std::future::Future;
 
+use bitcoin::BlockHash;
+use bitcoin::Txid;
+
+use rpc::BitcoinTxInfo;
 use rpc::GetTxResponse;
 
 use crate::error::Error;
@@ -20,11 +24,14 @@ pub trait BitcoinInteract {
     /// Get block
     fn get_block(
         &self,
-        block_hash: &bitcoin::BlockHash,
+        block_hash: &BlockHash,
     ) -> impl Future<Output = Result<Option<bitcoin::Block>, Error>> + Send;
 
     /// get tx
-    fn get_tx(&self, txid: &bitcoin::Txid) -> Result<GetTxResponse, Error>;
+    fn get_tx(&self, txid: &Txid) -> Result<GetTxResponse, Error>;
+
+    /// get tx info
+    fn get_tx_info(&self, txid: &Txid, block_hash: &BlockHash) -> Result<BitcoinTxInfo, Error>;
 
     /// Estimate fee rate
     // This should be implemented with the help of the `fees::EstimateFees` trait

--- a/signer/src/bitcoin/mod.rs
+++ b/signer/src/bitcoin/mod.rs
@@ -31,7 +31,11 @@ pub trait BitcoinInteract {
     fn get_tx(&self, txid: &Txid) -> Result<GetTxResponse, Error>;
 
     /// get tx info
-    fn get_tx_info(&self, txid: &Txid, block_hash: &BlockHash) -> Result<BitcoinTxInfo, Error>;
+    fn get_tx_info(
+        &self,
+        txid: &Txid,
+        block_hash: &BlockHash,
+    ) -> Result<Option<BitcoinTxInfo>, Error>;
 
     /// Estimate fee rate
     // This should be implemented with the help of the `fees::EstimateFees` trait

--- a/signer/src/bitcoin/mod.rs
+++ b/signer/src/bitcoin/mod.rs
@@ -28,7 +28,7 @@ pub trait BitcoinInteract {
     ) -> impl Future<Output = Result<Option<bitcoin::Block>, Error>> + Send;
 
     /// get tx
-    fn get_tx(&self, txid: &Txid) -> Result<GetTxResponse, Error>;
+    fn get_tx(&self, txid: &Txid) -> Result<Option<GetTxResponse>, Error>;
 
     /// get tx info
     fn get_tx_info(

--- a/signer/src/bitcoin/rpc.rs
+++ b/signer/src/bitcoin/rpc.rs
@@ -215,14 +215,20 @@ impl BitcoinCoreClient {
     }
 
     /// Fetch and decode raw transaction from bitcoin-core using the
-    /// getrawtransaction RPC with a verbosity of 1.
+    /// getrawtransaction RPC with a verbosity of 1. None is returned if
+    /// the node cannot find the transaction in a bitcoin block or the
+    /// mempool.
     ///
     /// # Notes
     ///
     /// By default, this call only returns a transaction if it is in the
     /// mempool. If -txindex is enabled on bitcoin-core and no blockhash
     /// argument is passed, it will return the transaction if it is in the
-    /// mempool or any block.
+    /// mempool or any block. We require -txindex to be enabled (same with
+    /// stacks-core[^1]) so this should work with transactions in either
+    /// the mempool and a bitcoin block.
+    ///
+    /// [^1]: <https://docs.stacks.co/guides-and-tutorials/run-a-miner/mine-mainnet-stacks-tokens>
     pub fn get_tx(&self, txid: &Txid) -> Result<Option<GetTxResponse>, Error> {
         let args = [
             serde_json::to_value(txid).map_err(Error::JsonSerialize)?,

--- a/signer/src/bitcoin/rpc.rs
+++ b/signer/src/bitcoin/rpc.rs
@@ -3,8 +3,10 @@
 use std::sync::Arc;
 
 use bitcoin::Amount;
+use bitcoin::Block;
 use bitcoin::BlockHash;
 use bitcoin::Denomination;
+use bitcoin::OutPoint;
 use bitcoin::Transaction;
 use bitcoin::Txid;
 use bitcoin::Wtxid;
@@ -279,5 +281,45 @@ impl BitcoinCoreClient {
         };
 
         Ok(FeeEstimate { sats_per_vbyte })
+    }
+}
+
+impl BitcoinInteract for BitcoinCoreClient {
+    async fn broadcast_transaction(&self, _: &Transaction) -> Result<(), Error> {
+        unimplemented!()
+    }
+
+    #[doc = " Get block"]
+    async fn get_block(&self, _: &BlockHash) -> Result<Option<Block>, Error> {
+        unimplemented!()
+    }
+
+    #[doc = " get tx"]
+    fn get_tx(&self, _: &Txid) -> Result<GetTxResponse, Error> {
+        todo!()
+    }
+
+    #[doc = " get tx info"]
+    fn get_tx_info(&self, _: &Txid, _: &BlockHash) -> Result<BitcoinTxInfo, Error> {
+        todo!()
+    }
+
+    #[doc = " Estimate fee rate"]
+    async fn estimate_fee_rate(&self) -> Result<f64, Error> {
+        todo!()
+    }
+
+    #[doc = " Get the outstanding signer UTXO"]
+    async fn get_signer_utxo(
+        &self,
+        _: &PublicKey,
+    ) -> Result<Option<super::utxo::SignerUtxo>, Error> {
+        todo!()
+    }
+
+    #[doc = " Get the total fee amount and the fee rate for the last transaction that"]
+    #[doc = " used the given UTXO as an input."]
+    async fn get_last_fee(&self, _: OutPoint) -> Result<Option<super::utxo::Fees>, Error> {
+        todo!()
     }
 }

--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -776,7 +776,7 @@ mod tests {
             self.deposits.get(txid).cloned().ok_or(Error::Encryption)
         }
 
-        fn get_tx_info(&self, _: &Txid, _: &BlockHash) -> Result<BitcoinTxInfo, Error> {
+        fn get_tx_info(&self, _: &Txid, _: &BlockHash) -> Result<Option<BitcoinTxInfo>, Error> {
             unimplemented!()
         }
 

--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -363,11 +363,10 @@ mod tests {
         let storage = storage::in_memory::Store::new_shared();
         let test_harness = TestHarness::generate(&mut rng, 20, 0..5);
         let ctx = SignerContext::new(
-            &Settings::new_from_default_config().unwrap(),
+            Settings::new_from_default_config().unwrap(),
             storage.clone(),
             test_harness.clone(),
-        )
-        .unwrap();
+        );
         let block_hash_stream = test_harness.spawn_block_hash_stream();
         let (subscribers, subscriber_rx) = tokio::sync::watch::channel(());
 
@@ -470,11 +469,10 @@ mod tests {
         let block_hash_stream = test_harness.spawn_block_hash_stream();
         let (subscribers, _subscriber_rx) = tokio::sync::watch::channel(());
         let ctx = SignerContext::new(
-            &Settings::new_from_default_config().unwrap(),
+            Settings::new_from_default_config().unwrap(),
             storage.clone(),
             test_harness.clone(),
-        )
-        .unwrap();
+        );
 
         let mut block_observer = BlockObserver {
             stacks_client: test_harness.clone(),
@@ -547,11 +545,10 @@ mod tests {
         let block_hash_stream = test_harness.spawn_block_hash_stream();
         let (subscribers, _subscriber_rx) = tokio::sync::watch::channel(());
         let ctx = SignerContext::new(
-            &Settings::new_from_default_config().unwrap(),
+            Settings::new_from_default_config().unwrap(),
             storage.clone(),
             test_harness.clone(),
-        )
-        .unwrap();
+        );
 
         let mut block_observer = BlockObserver {
             stacks_client: test_harness.clone(),

--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -331,6 +331,7 @@ mod tests {
     use rand::seq::IteratorRandom;
     use rand::SeedableRng;
 
+    use crate::bitcoin::rpc::BitcoinTxInfo;
     use crate::bitcoin::rpc::GetTxResponse;
     use crate::bitcoin::utxo;
     use crate::config::Settings;
@@ -777,6 +778,11 @@ mod tests {
         fn get_tx(&self, txid: &bitcoin::Txid) -> Result<GetTxResponse, Error> {
             self.deposits.get(txid).cloned().ok_or(Error::Encryption)
         }
+
+        fn get_tx_info(&self, _: &Txid, _: &BlockHash) -> Result<BitcoinTxInfo, Error> {
+            unimplemented!()
+        }
+
         async fn get_block(
             &self,
             block_hash: &bitcoin::BlockHash,

--- a/signer/src/context/mod.rs
+++ b/signer/src/context/mod.rs
@@ -39,20 +39,6 @@ pub trait Context: Clone + Sync + Send {
 /// signer binary.
 #[derive(Debug, Clone)]
 pub struct SignerContext<S, BC> {
-    inner: InnerSignerContext<S, BC>,
-}
-
-impl<S, BC> std::ops::Deref for SignerContext<S, BC> {
-    type Target = InnerSignerContext<S, BC>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.inner
-    }
-}
-
-/// Inner signer context which holds the configuration and signalling channels.
-#[derive(Debug, Clone)]
-pub struct InnerSignerContext<S, BC> {
     config: Settings,
     // Handle to the app signalling channel. This keeps the channel alive
     // for the duration of the program and is used both to send messages
@@ -106,13 +92,11 @@ where
         let (term_tx, _) = tokio::sync::watch::channel(false);
 
         Self {
-            inner: InnerSignerContext {
-                config,
-                signal_tx,
-                term_tx,
-                storage: db,
-                bitcoin_client,
-            },
+            config,
+            signal_tx,
+            term_tx,
+            storage: db,
+            bitcoin_client,
         }
     }
 }
@@ -131,7 +115,7 @@ where
     }
 
     fn get_signal_sender(&self) -> tokio::sync::broadcast::Sender<SignerSignal> {
-        self.inner.signal_tx.clone()
+        self.signal_tx.clone()
     }
 
     /// Send a signal to the application signalling channel.

--- a/signer/src/context/mod.rs
+++ b/signer/src/context/mod.rs
@@ -3,8 +3,6 @@
 pub mod messaging;
 pub mod termination;
 
-use std::sync::Arc;
-
 use tokio::sync::broadcast::Sender;
 use url::Url;
 
@@ -39,16 +37,9 @@ pub trait Context: Clone + Sync + Send {
 
 /// Signer context which is passed to different components within the
 /// signer binary.
+#[derive(Debug, Clone)]
 pub struct SignerContext<S, BC> {
-    inner: Arc<InnerSignerContext<S, BC>>,
-}
-
-/// We implement [`Clone`] manually to avoid the derive macro adding additional
-/// bounds on the generic types.
-impl<S, BC> Clone for SignerContext<S, BC> {
-    fn clone(&self) -> Self {
-        Self { inner: Arc::clone(&self.inner) }
-    }
+    inner: InnerSignerContext<S, BC>,
 }
 
 impl<S, BC> std::ops::Deref for SignerContext<S, BC> {
@@ -60,6 +51,7 @@ impl<S, BC> std::ops::Deref for SignerContext<S, BC> {
 }
 
 /// Inner signer context which holds the configuration and signalling channels.
+#[derive(Debug, Clone)]
 pub struct InnerSignerContext<S, BC> {
     config: Settings,
     // Handle to the app signalling channel. This keeps the channel alive
@@ -85,18 +77,18 @@ pub struct InnerSignerContext<S, BC> {
     //blocklist_client: ApiFallbackClient<BL>,
 }
 
-impl<'a, S, BC> SignerContext<S, BC>
+impl<S, BC> SignerContext<S, BC>
 where
     S: DbRead + DbWrite + Clone + Sync + Send,
-    BC: TryFrom<&'a [Url]> + BitcoinInteract + Clone + Sync + Send,
-    Error: From<<BC as std::convert::TryFrom<&'a [Url]>>::Error>,
+    BC: for<'a> TryFrom<&'a [Url]> + BitcoinInteract + Clone + Sync + Send + 'static,
+    Error: for<'a> From<<BC as TryFrom<&'a [Url]>>::Error>,
 {
     /// Initializes a new [`SignerContext`], automatically creating clients
     /// based on the provided types.
-    pub fn init(config: &'a Settings, db: S) -> Result<Self, Error> {
+    pub fn init(config: Settings, db: S) -> Result<Self, Error> {
         let bc = BC::try_from(&config.bitcoin.endpoints)?;
 
-        Self::new(config, db, bc)
+        Ok(Self::new(config, db, bc))
     }
 }
 
@@ -106,22 +98,28 @@ where
     BC: BitcoinInteract + Clone + Sync + Send,
 {
     /// Create a new signer context.
-    pub fn new(config: &Settings, db: S, bitcoin_client: BC) -> Result<Self, Error> {
+    pub fn new(config: Settings, db: S, bitcoin_client: BC) -> Self {
         // TODO: Decide on the channel capacity and how we should handle slow consumers.
         // NOTE: Ideally consumers which require processing time should pull the relevent
         // messages into a local VecDequeue and process them in their own time.
         let (signal_tx, _) = tokio::sync::broadcast::channel(128);
         let (term_tx, _) = tokio::sync::watch::channel(false);
 
-        Ok(Self {
-            inner: Arc::new(InnerSignerContext {
-                config: config.clone(),
+        Self {
+            inner: InnerSignerContext {
+                config,
                 signal_tx,
                 term_tx,
                 storage: db,
                 bitcoin_client,
-            }),
-        })
+            },
+        }
+    }
+
+    /// Drop the context and retyur
+    #[cfg(any(test, feature = "testing"))]
+    pub fn into_inner(self) -> InnerSignerContext<S, BC> {
+        self.inner
     }
 }
 

--- a/signer/src/context/mod.rs
+++ b/signer/src/context/mod.rs
@@ -118,8 +118,8 @@ where
 
     /// Drop the context and retyur
     #[cfg(any(test, feature = "testing"))]
-    pub fn into_inner(self) -> InnerSignerContext<S, BC> {
-        self.inner
+    pub fn into_db(self) -> S {
+        self.inner.storage
     }
 }
 

--- a/signer/src/context/mod.rs
+++ b/signer/src/context/mod.rs
@@ -115,12 +115,6 @@ where
             },
         }
     }
-
-    /// Drop the context and retyur
-    #[cfg(any(test, feature = "testing"))]
-    pub fn into_db(self) -> S {
-        self.inner.storage
-    }
 }
 
 impl<S, BC> Context for SignerContext<S, BC>

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -21,16 +21,6 @@ pub enum Error {
     #[error("Transaction is missing from mempool")]
     BitcoinTxMissing(bitcoin::Txid),
 
-    /// Returned when we could not decode the hex into a
-    /// bitcoin::Transaction.
-    #[error("failed to decode the provided hex into a transaction. txid: {1}. {0}")]
-    DecodeTx(#[source] bitcoin::consensus::encode::Error, bitcoin::Txid),
-
-    /// Could not deserialize the "blockchain.transaction.get" response
-    /// into a GetTxResponse.
-    #[error("failed to deserialize the blockchain.transaction.get response. txid: {1}. {0}")]
-    DeserializeGetTransaction(#[source] serde_json::Error, bitcoin::Txid),
-
     /// Received an error in call to estimatesmartfee RPC call
     #[error("failed to get fee estimate from bitcoin-core for target {1}. {0}")]
     EstimateSmartFee(#[source] bitcoincore_rpc::Error, u16),
@@ -67,10 +57,6 @@ pub enum Error {
     /// I/O Error raised by the Tokio runtime.
     #[error("tokio i/o error: {0}")]
     TokioIo(#[from] tokio::io::Error),
-
-    /// The error used in the [`Encode`] and [`Decode`] trait.
-    #[error("error serializing type: {0}")]
-    Bincode(#[source] bincode::Error),
 
     /// Error when breaking out the ZeroMQ message into three parts.
     #[error("bitcoin messages should have a three part layout, received {0} parts")]
@@ -250,10 +236,6 @@ pub enum Error {
     /// An error when attempting to read a migration script.
     #[error("failed to read migration script: {0}")]
     ReadSqlMigration(Cow<'static, str>),
-
-    /// Could not retrieve the current database name.
-    #[error("could not retrieve the current database name")]
-    CurrentDatabaseName,
 
     /// An error when attempting to generically decode bytes using the
     /// trait implementation.

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -11,6 +11,15 @@ use crate::stacks::contracts::WithdrawalAcceptValidationError;
 /// Top-level signer error
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
+    /// Attemmpt to fetch a bitcoin blockhash ended in an unexpected error.
+    /// This is not triggered if the block is missing.
+    #[error("bitcoin-core getblock RPC error for hash {1}: {0}")]
+    BitcoinCoreGetBlock(#[source] bitcoincore_rpc::Error, bitcoin::BlockHash),
+    
+    /// Received an error in response to getrawtransaction RPC call
+    #[error("failed to retrieve the raw transaction for txid {1} from bitcoin-core. {0}")]
+    BitcoinCoreGetTransaction(#[source] bitcoincore_rpc::Error, bitcoin::Txid),
+
     /// Error when creating an RPC client to bitcoin-core
     #[error("could not create RPC client to {1}: {0}")]
     BitcoinCoreRpcClient(#[source] bitcoincore_rpc::Error, String),
@@ -28,10 +37,6 @@ pub enum Error {
     /// Received an error in response to estimatesmartfee RPC call
     #[error("failed to get fee estimate from bitcoin-core for target {1}. {0:?}")]
     EstimateSmartFeeResponse(Option<Vec<String>>, u16),
-
-    /// Received an error in response to getrawtransaction RPC call
-    #[error("failed to retrieve the raw transaction for txid {1} from bitcoin-core. {0}")]
-    GetTransactionBitcoinCore(#[source] bitcoincore_rpc::Error, bitcoin::Txid),
 
     /// Error from the fallback client.
     #[error("fallback client error: {0}")]

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -15,6 +15,12 @@ pub enum Error {
     #[error("could not create RPC client to {1}: {0}")]
     BitcoinCoreRpcClient(#[source] bitcoincore_rpc::Error, String),
 
+    /// The bitcoin tranaction was not found in the mempool or on the
+    /// bitcoin blockchain. This is thrown when we expect the transaction
+    /// to exist in bitcoin core but it does not.
+    #[error("Transaction is missing from mempool")]
+    BitcoinTxMissing(bitcoin::Txid),
+
     /// Returned when we could not decode the hex into a
     /// bitcoin::Transaction.
     #[error("failed to decode the provided hex into a transaction. txid: {1}. {0}")]

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -15,7 +15,7 @@ pub enum Error {
     /// This is not triggered if the block is missing.
     #[error("bitcoin-core getblock RPC error for hash {1}: {0}")]
     BitcoinCoreGetBlock(#[source] bitcoincore_rpc::Error, bitcoin::BlockHash),
-    
+
     /// Received an error in response to getrawtransaction RPC call
     #[error("failed to retrieve the raw transaction for txid {1} from bitcoin-core. {0}")]
     BitcoinCoreGetTransaction(#[source] bitcoincore_rpc::Error, bitcoin::Txid),

--- a/signer/src/main.rs
+++ b/signer/src/main.rs
@@ -58,7 +58,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // Initialize the signer context.
-    let context = SignerContext::<_, ApiFallbackClient<BitcoinCoreClient>>::init(&settings, db)?;
+    let context = SignerContext::<_, ApiFallbackClient<BitcoinCoreClient>>::init(settings, db)?;
 
     // Run the application components concurrently. We're `join!`ing them
     // here so that every component can shut itself down gracefully when

--- a/signer/src/network/libp2p/swarm.rs
+++ b/signer/src/network/libp2p/swarm.rs
@@ -247,7 +247,7 @@ mod tests {
         let mut swarm = builder.build().unwrap();
 
         let settings = Settings::new_from_default_config().unwrap();
-        let ctx = NoopSignerContext::init(&settings, Store::new_shared()).unwrap();
+        let ctx = NoopSignerContext::init(settings, Store::new_shared()).unwrap();
         let term = ctx.get_termination_handle();
 
         let timeout = tokio::time::timeout(Duration::from_secs(10), async {

--- a/signer/src/network/mod.rs
+++ b/signer/src/network/mod.rs
@@ -145,8 +145,8 @@ mod tests {
 
         let settings = Settings::new_from_default_config().unwrap();
 
-        let context1 = NoopSignerContext::init(&settings, Store::new_shared()).unwrap();
-        let context2 = NoopSignerContext::init(&settings, Store::new_shared()).unwrap();
+        let context1 = NoopSignerContext::init(settings.clone(), Store::new_shared()).unwrap();
+        let context2 = NoopSignerContext::init(settings, Store::new_shared()).unwrap();
 
         let term1 = context1.get_termination_handle();
         let term2 = context2.get_termination_handle();

--- a/signer/src/stacks/api.rs
+++ b/signer/src/stacks/api.rs
@@ -279,6 +279,7 @@ impl TryFrom<AccountEntryResponse> for AccountInfo {
 }
 
 /// A client for interacting with Stacks nodes and the Stacks API
+#[derive(Debug, Clone)]
 pub struct StacksClient {
     /// The base URL (with the port) that will be used when making requests
     /// for to a Stacks node.

--- a/signer/src/stacks/contracts.rs
+++ b/signer/src/stacks/contracts.rs
@@ -287,14 +287,14 @@ impl AsContractCall for CompleteDepositV1 {
     /// fortunate, because even if we wanted to, the only view into the
     /// stacks-core mempool is through the `POST /new_mempool_tx` webhooks,
     /// which we do not currently ingest.
-    async fn validate<S>(&self, db: &S, req_ctx: &ReqContext) -> Result<(), Error>
+    async fn validate<C>(&self, ctx: &C, req_ctx: &ReqContext) -> Result<(), Error>
     where
-        S: Context + Send + Sync,
+        C: Context + Send + Sync,
     {
         // Covers points 3 & 4
-        self.validate_sweep_tx(db, req_ctx).await?;
+        self.validate_sweep_tx(ctx, req_ctx).await?;
         // Covers points 1-2 & 5-7
-        self.validate_deposit_vars(db, req_ctx).await
+        self.validate_deposit_vars(ctx, req_ctx).await
     }
 }
 

--- a/signer/src/stacks/contracts.rs
+++ b/signer/src/stacks/contracts.rs
@@ -41,6 +41,7 @@ use blockstack_lib::clarity::vm::ContractName;
 use blockstack_lib::clarity::vm::Value as ClarityValue;
 use blockstack_lib::types::chainstate::StacksAddress;
 
+use crate::context::Context;
 use crate::error::Error;
 use crate::keys::PublicKey;
 use crate::stacks::wallet::SignerWallet;
@@ -162,13 +163,13 @@ pub trait AsContractCall {
     /// Validate that it is okay to sign this contract call transaction,
     /// because the included data matches what this signer knows from the
     /// stacks and bitcoin blockchains.
-    fn validate<S>(
+    fn validate<C>(
         &self,
-        db: &S,
-        ctx: &ReqContext,
+        ctx: &C,
+        req_ctx: &ReqContext,
     ) -> impl Future<Output = Result<(), Error>> + Send
     where
-        S: DbRead + Send + Sync;
+        C: Context + Send + Sync;
 }
 
 /// An enum representing all contract calls that the signers can make.
@@ -286,14 +287,14 @@ impl AsContractCall for CompleteDepositV1 {
     /// fortunate, because even if we wanted to, the only view into the
     /// stacks-core mempool is through the `POST /new_mempool_tx` webhooks,
     /// which we do not currently ingest.
-    async fn validate<S>(&self, db: &S, ctx: &ReqContext) -> Result<(), Error>
+    async fn validate<S>(&self, db: &S, req_ctx: &ReqContext) -> Result<(), Error>
     where
-        S: DbRead + Send + Sync,
+        S: Context + Send + Sync,
     {
         // Covers points 3 & 4
-        self.validate_sweep_tx(db, ctx).await?;
+        self.validate_sweep_tx(db, req_ctx).await?;
         // Covers points 1-2 & 5-7
-        self.validate_deposit_vars(db, ctx).await
+        self.validate_deposit_vars(db, req_ctx).await
     }
 }
 
@@ -311,14 +312,15 @@ impl CompleteDepositV1 {
     ///    deposit request.
     /// 6. That the amount to mint does not exceed the deposit amount.
     /// 7. That the max-fee is less than the desired max-fee.
-    async fn validate_deposit_vars<S>(&self, db: &S, ctx: &ReqContext) -> Result<(), Error>
+    async fn validate_deposit_vars<C>(&self, ctx: &C, req_ctx: &ReqContext) -> Result<(), Error>
     where
-        S: DbRead + Send + Sync,
+        C: Context + Send + Sync,
     {
+        let db = ctx.get_storage();
         // 1. That the smart contract deployer matches the deployer in our
         //    context.
-        if self.deployer != ctx.deployer {
-            return Err(DepositErrorMsg::DeployerMismatch.into_error(ctx, self));
+        if self.deployer != req_ctx.deployer {
+            return Err(DepositErrorMsg::DeployerMismatch.into_error(req_ctx, self));
         }
         // 2. Check that the signer has a record of the deposit request
         //    from our list of pending and accepted deposit requests.
@@ -327,26 +329,26 @@ impl CompleteDepositV1 {
         // request.
         let deposit_requests = db
             .get_pending_accepted_deposit_requests(
-                &ctx.chain_tip.block_hash,
-                ctx.context_window,
-                ctx.signatures_required,
+                &req_ctx.chain_tip.block_hash,
+                req_ctx.context_window,
+                req_ctx.signatures_required,
             )
             .await?;
 
         let deposit_request = deposit_requests
             .into_iter()
             .find(|req| req.outpoint() == self.outpoint)
-            .ok_or_else(|| DepositErrorMsg::RequestMissing.into_error(ctx, self))?;
+            .ok_or_else(|| DepositErrorMsg::RequestMissing.into_error(req_ctx, self))?;
 
         // 5. Check that the recipients in the transaction matches that of
         //    the deposit request.
         if &self.recipient != deposit_request.recipient.deref() {
-            return Err(DepositErrorMsg::RecipientMismatch.into_error(ctx, self));
+            return Err(DepositErrorMsg::RecipientMismatch.into_error(req_ctx, self));
         }
         // 6. Check that the amount to mint does not exceed the deposit
         //    amount.
         if self.amount > deposit_request.amount {
-            return Err(DepositErrorMsg::InvalidMintAmount.into_error(ctx, self));
+            return Err(DepositErrorMsg::InvalidMintAmount.into_error(req_ctx, self));
         }
         // 7. Check that the fee is less than the desired max-fee.
         //
@@ -355,7 +357,7 @@ impl CompleteDepositV1 {
         // TODO(552): The better check is to compute what the fee should be
         // and verify that it matches.
         if deposit_request.amount - self.amount > deposit_request.max_fee {
-            return Err(DepositErrorMsg::InvalidFee.into_error(ctx, self));
+            return Err(DepositErrorMsg::InvalidFee.into_error(req_ctx, self));
         }
 
         Ok(())
@@ -369,15 +371,16 @@ impl CompleteDepositV1 {
     ///    bitcoin blockchain.
     /// 4. Check that the sweep transaction uses the indicated deposit
     ///    outpoint as an input.
-    async fn validate_sweep_tx<S>(&self, db: &S, ctx: &ReqContext) -> Result<(), Error>
+    async fn validate_sweep_tx<C>(&self, ctx: &C, req_ctx: &ReqContext) -> Result<(), Error>
     where
-        S: DbRead + Send + Sync,
+        C: Context + Send + Sync,
     {
+        let db = ctx.get_storage();
         // First we check that we have a record of the transaction.
         let sweep_tx = db
             .get_bitcoin_tx(&self.sweep_txid, &self.sweep_block_hash)
             .await?
-            .ok_or_else(|| DepositErrorMsg::SweepTransactionMissing.into_error(ctx, self))?;
+            .ok_or_else(|| DepositErrorMsg::SweepTransactionMissing.into_error(req_ctx, self))?;
         // 3. Check that the signer sweep transaction is on the canonical
         //    bitcoin blockchain.
         //
@@ -390,10 +393,10 @@ impl CompleteDepositV1 {
         };
 
         let in_canonical_bitcoin_blockchain = db
-            .in_canonical_bitcoin_blockchain(&ctx.chain_tip, &block_ref)
+            .in_canonical_bitcoin_blockchain(&req_ctx.chain_tip, &block_ref)
             .await?;
         if !in_canonical_bitcoin_blockchain {
-            return Err(DepositErrorMsg::SweepTransactionReorged.into_error(ctx, self));
+            return Err(DepositErrorMsg::SweepTransactionReorged.into_error(req_ctx, self));
         }
         // 4. Check that the sweep transaction uses the indicated deposit
         //    outpoint as an input.
@@ -403,7 +406,7 @@ impl CompleteDepositV1 {
         // of the transaction inputs.
         let mut tx_inputs = sweep_tx.input.iter();
         if !tx_inputs.any(|tx_in| tx_in.previous_output == self.outpoint) {
-            return Err(DepositErrorMsg::MissingFromSweep.into_error(ctx, self));
+            return Err(DepositErrorMsg::MissingFromSweep.into_error(req_ctx, self));
         }
 
         Ok(())
@@ -551,14 +554,14 @@ impl AsContractCall for AcceptWithdrawalV1 {
     ///    request.
     /// 7. That the fee is less than the desired max-fee.
     /// 8. That the signer bitmap matches the bitmap from our records.
-    async fn validate<S>(&self, db: &S, ctx: &ReqContext) -> Result<(), Error>
+    async fn validate<C>(&self, db: &C, req_ctx: &ReqContext) -> Result<(), Error>
     where
-        S: DbRead + Send + Sync,
+        C: Context + Send + Sync,
     {
         // Covers points 3 & 4
-        let tx_out = self.validate_sweep(db, ctx).await?;
+        let tx_out = self.validate_sweep(db, req_ctx).await?;
         // Covers points 1-2 & 5-8
-        self.validate_utxo(db, ctx, tx_out).await
+        self.validate_utxo(db, req_ctx, tx_out).await
     }
 }
 
@@ -579,14 +582,20 @@ impl AcceptWithdrawalV1 {
     ///    request.
     /// 7. That the fee is less than the desired max-fee.
     /// 8. That the signer bitmap matches the bitmap from our records.
-    async fn validate_utxo<S>(&self, db: &S, ctx: &ReqContext, tx_out: TxOut) -> Result<(), Error>
+    async fn validate_utxo<C>(
+        &self,
+        ctx: &C,
+        req_ctx: &ReqContext,
+        tx_out: TxOut,
+    ) -> Result<(), Error>
     where
-        S: DbRead + Send + Sync,
+        C: Context + Send + Sync,
     {
+        let db = ctx.get_storage();
         // 1. That the smart contract deployer matches the deployer in our
         //    context.
-        if self.deployer != ctx.deployer {
-            return Err(WithdrawalErrorMsg::DeployerMismatch.into_error(ctx, self));
+        if self.deployer != req_ctx.deployer {
+            return Err(WithdrawalErrorMsg::DeployerMismatch.into_error(req_ctx, self));
         }
         // 2. That the signer has a record of the withdrawal request in its
         //    list of pending and accepted withdrawal requests.
@@ -595,26 +604,26 @@ impl AcceptWithdrawalV1 {
         // request.
         let withdrawal_requests = db
             .get_pending_accepted_withdrawal_requests(
-                &ctx.chain_tip.block_hash,
-                ctx.context_window,
-                ctx.signatures_required,
+                &req_ctx.chain_tip.block_hash,
+                req_ctx.context_window,
+                req_ctx.signatures_required,
             )
             .await?;
 
         let request = withdrawal_requests
             .into_iter()
             .find(|req| req.request_id == self.request_id)
-            .ok_or_else(|| WithdrawalErrorMsg::RequestMissing.into_error(ctx, self))?;
+            .ok_or_else(|| WithdrawalErrorMsg::RequestMissing.into_error(req_ctx, self))?;
 
         // 5. The `scriptPubKey` of the UTXO matches the one in the withdrawal
         //    request.
         if &tx_out.script_pubkey != request.recipient.deref() {
-            return Err(WithdrawalErrorMsg::RecipientMismatch.into_error(ctx, self));
+            return Err(WithdrawalErrorMsg::RecipientMismatch.into_error(req_ctx, self));
         }
         // 6. The `amount` of the UTXO matches the one in the withdrawal
         //    request.
         if tx_out.value.to_sat() != request.amount {
-            return Err(WithdrawalErrorMsg::InvalidAmount.into_error(ctx, self));
+            return Err(WithdrawalErrorMsg::InvalidAmount.into_error(req_ctx, self));
         }
         // 7. Check that the fee is less than the desired max-fee.
         //
@@ -624,15 +633,15 @@ impl AcceptWithdrawalV1 {
         // TODO(552): The better check is to compute what the fee should be
         // and verify that it matches.
         if self.tx_fee > request.max_fee {
-            return Err(WithdrawalErrorMsg::InvalidFee.into_error(ctx, self));
+            return Err(WithdrawalErrorMsg::InvalidFee.into_error(req_ctx, self));
         }
         // 8. That the signer bitmap matches the bitmap formed from our
         //    records.
         let votes = db
-            .get_withdrawal_request_signer_votes(&request.qualified_id(), &ctx.aggregate_key)
+            .get_withdrawal_request_signer_votes(&request.qualified_id(), &req_ctx.aggregate_key)
             .await?;
         if self.signer_bitmap != BitArray::from(votes) {
-            return Err(WithdrawalErrorMsg::BitmapMismatch.into_error(ctx, self));
+            return Err(WithdrawalErrorMsg::BitmapMismatch.into_error(req_ctx, self));
         }
 
         Ok(())
@@ -645,16 +654,17 @@ impl AcceptWithdrawalV1 {
     ///    funds is on the canonical bitcoin blockchain.
     /// 4. That the sweep transaction has the UTXO indicated by the
     ///    outpoint.
-    async fn validate_sweep<S>(&self, db: &S, ctx: &ReqContext) -> Result<TxOut, Error>
+    async fn validate_sweep<C>(&self, ctx: &C, req_ctx: &ReqContext) -> Result<TxOut, Error>
     where
-        S: DbRead + Send + Sync,
+        C: Context + Send + Sync,
     {
+        let db = ctx.get_storage();
         // First we check that we have a record of the transaction.
         let txid = self.outpoint.txid.into();
         let sweep_tx = db
             .get_bitcoin_tx(&txid, &self.sweep_block_hash)
             .await?
-            .ok_or_else(|| WithdrawalErrorMsg::SweepTransactionMissing.into_error(ctx, self))?;
+            .ok_or_else(|| WithdrawalErrorMsg::SweepTransactionMissing.into_error(req_ctx, self))?;
         // 3. That the signer bitcoin transaction sweeping out the users'
         //    funds is on the canonical bitcoin blockchain.
         //
@@ -667,10 +677,10 @@ impl AcceptWithdrawalV1 {
         };
 
         let in_canonical_bitcoin_blockchain = db
-            .in_canonical_bitcoin_blockchain(&ctx.chain_tip, &block_ref)
+            .in_canonical_bitcoin_blockchain(&req_ctx.chain_tip, &block_ref)
             .await?;
         if !in_canonical_bitcoin_blockchain {
-            return Err(WithdrawalErrorMsg::SweepTransactionReorged.into_error(ctx, self));
+            return Err(WithdrawalErrorMsg::SweepTransactionReorged.into_error(req_ctx, self));
         }
         // 4. That the sweep transaction has the UTXO indicated by the
         //    outpoint.
@@ -682,7 +692,7 @@ impl AcceptWithdrawalV1 {
             .output
             .get(self.outpoint.vout as usize)
             .cloned()
-            .ok_or_else(|| WithdrawalErrorMsg::UtxoMissingFromSweep.into_error(ctx, self))
+            .ok_or_else(|| WithdrawalErrorMsg::UtxoMissingFromSweep.into_error(req_ctx, self))
     }
 }
 
@@ -800,9 +810,9 @@ impl AsContractCall for RejectWithdrawalV1 {
     ///    an event on the canonical Stacks blockchain.
     /// 2. That the signer bitmap matches the signer decisions stored in
     ///    this signer's database.
-    async fn validate<S>(&self, _db: &S, _ctx: &ReqContext) -> Result<(), Error>
+    async fn validate<C>(&self, _ctx: &C, _req_ctx: &ReqContext) -> Result<(), Error>
     where
-        S: DbRead + Send + Sync,
+        C: Context + Send + Sync,
     {
         // TODO(255): Add validation implementation
         Ok(())
@@ -907,9 +917,9 @@ impl AsContractCall for RotateKeysV1 {
     ///    threshold is different from the last signature threshold.
     /// 4. That the number of required signatures is strictly greater than
     ///    `new_keys as f64 / 2.0`.
-    async fn validate<S>(&self, _db: &S, _ctx: &ReqContext) -> Result<(), Error>
+    async fn validate<C>(&self, _ctx: &C, _req_ctx: &ReqContext) -> Result<(), Error>
     where
-        S: DbRead + Send + Sync,
+        C: Context + Send + Sync,
     {
         // TODO(255): Add validation implementation
         Ok(())

--- a/signer/src/stacks/wallet.rs
+++ b/signer/src/stacks/wallet.rs
@@ -316,9 +316,9 @@ mod tests {
 
     use test_case::test_case;
 
+    use crate::context::Context;
     use crate::signature::sign_stacks_tx;
     use crate::stacks::contracts::ReqContext;
-    use crate::storage::DbRead;
 
     use super::*;
 
@@ -336,9 +336,9 @@ mod tests {
         fn as_contract_args(&self) -> Vec<ClarityValue> {
             Vec::new()
         }
-        async fn validate<S>(&self, _db: &S, _ctx: &ReqContext) -> Result<(), Error>
+        async fn validate<C>(&self, _db: &C, _ctx: &ReqContext) -> Result<(), Error>
         where
-            S: DbRead + Send + Sync,
+            C: Context + Send + Sync,
         {
             Ok(())
         }

--- a/signer/src/storage/model.rs
+++ b/signer/src/storage/model.rs
@@ -397,6 +397,13 @@ impl From<BitcoinTx> for bitcoin::Transaction {
 #[serde(transparent)]
 pub struct BitcoinTxId(bitcoin::Txid);
 
+impl Deref for BitcoinTxId {
+    type Target = bitcoin::Txid;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 impl BitcoinTxId {
     /// Return the inner bytes for the block hash
     pub fn into_bytes(&self) -> [u8; 32] {
@@ -437,6 +444,13 @@ impl BitcoinBlockHash {
 impl AsRef<[u8; 32]> for BitcoinBlockHash {
     fn as_ref(&self) -> &[u8; 32] {
         self.0.as_ref()
+    }
+}
+
+impl Deref for BitcoinBlockHash {
+    type Target = bitcoin::BlockHash;
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 

--- a/signer/src/testing/api_clients.rs
+++ b/signer/src/testing/api_clients.rs
@@ -2,6 +2,7 @@
 
 use url::Url;
 
+use crate::bitcoin::rpc::BitcoinTxInfo;
 use crate::bitcoin::rpc::GetTxResponse;
 use crate::bitcoin::BitcoinInteract;
 use crate::block_observer::EmilyInteract;
@@ -24,6 +25,13 @@ impl TryFrom<&[Url]> for NoopApiClient {
 /// Noop implementation of the BitcoinInteract trait.
 impl BitcoinInteract for NoopApiClient {
     fn get_tx(&self, _: &bitcoin::Txid) -> Result<GetTxResponse, Error> {
+        unimplemented!()
+    }
+    fn get_tx_info(
+        &self,
+        _: &bitcoin::Txid,
+        _: &bitcoin::BlockHash,
+    ) -> Result<BitcoinTxInfo, Error> {
         unimplemented!()
     }
 

--- a/signer/src/testing/api_clients.rs
+++ b/signer/src/testing/api_clients.rs
@@ -24,7 +24,7 @@ impl TryFrom<&[Url]> for NoopApiClient {
 
 /// Noop implementation of the BitcoinInteract trait.
 impl BitcoinInteract for NoopApiClient {
-    fn get_tx(&self, _: &bitcoin::Txid) -> Result<GetTxResponse, Error> {
+    fn get_tx(&self, _: &bitcoin::Txid) -> Result<Option<GetTxResponse>, Error> {
         unimplemented!()
     }
     fn get_tx_info(

--- a/signer/src/testing/api_clients.rs
+++ b/signer/src/testing/api_clients.rs
@@ -31,7 +31,7 @@ impl BitcoinInteract for NoopApiClient {
         &self,
         _: &bitcoin::Txid,
         _: &bitcoin::BlockHash,
-    ) -> Result<BitcoinTxInfo, Error> {
+    ) -> Result<Option<BitcoinTxInfo>, Error> {
         unimplemented!()
     }
 

--- a/signer/src/testing/wallet.rs
+++ b/signer/src/testing/wallet.rs
@@ -16,13 +16,13 @@ use secp256k1::Keypair;
 use stacks_common::types::chainstate::StacksAddress;
 
 use crate::config::NetworkKind;
+use crate::context::Context;
 use crate::error::Error;
 use crate::stacks::contracts::AsContractCall;
 use crate::stacks::contracts::AsTxPayload;
 use crate::stacks::contracts::ReqContext;
 use crate::stacks::contracts::StacksTxPostConditions;
 use crate::stacks::wallet::SignerWallet;
-use crate::storage::DbRead;
 
 /// A static for a test 2-3 multi-sig wallet. This wallet is loaded with
 /// funds in the local devnet environment.
@@ -153,9 +153,9 @@ impl AsContractCall for InitiateWithdrawalRequest {
             ClarityValue::UInt(self.max_fee as u128),
         ]
     }
-    async fn validate<S>(&self, _db: &S, _ctx: &ReqContext) -> Result<(), Error>
+    async fn validate<C>(&self, _db: &C, _ctx: &ReqContext) -> Result<(), Error>
     where
-        S: DbRead + Send + Sync,
+        C: Context + Send + Sync,
     {
         Ok(())
     }

--- a/signer/src/util.rs
+++ b/signer/src/util.rs
@@ -145,7 +145,7 @@ mod tests {
             } else {
                 // Just picked a random error here (which isn't
                 // a AllFailoverClientsFailed)
-                Err(Error::CurrentDatabaseName)
+                Err(Error::Encryption)
             }
         }
     }

--- a/signer/tests/integration/bitcoin_client.rs
+++ b/signer/tests/integration/bitcoin_client.rs
@@ -12,7 +12,7 @@ use url::Url;
 #[tokio::test]
 async fn test_get_block_not_found() {
     let url: Url = "http://devnet:devnet@localhost:18443".parse().unwrap();
-    let client = BitcoinCoreClient::try_from(url).unwrap();
+    let client = BitcoinCoreClient::try_from(&url).unwrap();
     let result = client.inner_client().get_block(&BlockHash::all_zeros());
 
     // This will return: JsonRpc(Rpc(RpcError { code: -5, message: "Block not found", data: None }))
@@ -35,7 +35,7 @@ async fn test_get_block_works() {
 
     let client =
         ApiFallbackClient::<BitcoinCoreClient>::new(vec![
-            BitcoinCoreClient::try_from(url.clone()).unwrap()
+            BitcoinCoreClient::try_from(&url).unwrap()
         ])
         .unwrap();
 

--- a/signer/tests/integration/bitcoin_rpc.rs
+++ b/signer/tests/integration/bitcoin_rpc.rs
@@ -7,7 +7,6 @@ use rand::rngs::OsRng;
 use sbtc::testing::regtest;
 use sbtc::testing::regtest::Recipient;
 use signer::bitcoin::rpc::BitcoinCoreClient;
-use signer::error::Error;
 use signer::storage::model::BitcoinBlockHash;
 use signer::storage::model::BitcoinTxId;
 
@@ -151,10 +150,7 @@ fn btc_client_unsubmitted_tx() {
     let _ = regtest::initialize_blockchain();
     let txid = bitcoin::Txid::all_zeros();
 
-    match client.get_tx(&txid).unwrap_err() {
-        Error::BitcoinCoreGetTransaction(_, txid1) if txid1 == txid => {}
-        _ => panic!("Incorrect error variants returned"),
-    }
+    assert!(client.get_tx(&txid).unwrap().is_none());
 }
 
 /// bitcoin-core will return a fee rate estimate if there are enough

--- a/signer/tests/integration/bitcoin_rpc.rs
+++ b/signer/tests/integration/bitcoin_rpc.rs
@@ -33,7 +33,7 @@ fn btc_client_getstransaction() {
     let outpoint = faucet.send_to(500_000, &signer.address);
     let vout = outpoint.vout as usize;
 
-    let response = client.get_tx(&outpoint.txid).unwrap();
+    let response = client.get_tx(&outpoint.txid).unwrap().unwrap();
     // Let's make sure we got the right transaction
     assert_eq!(response.tx.compute_txid(), outpoint.txid);
     assert_eq!(response.tx.output[vout].value.to_sat(), 500_000);
@@ -45,7 +45,7 @@ fn btc_client_getstransaction() {
     // Now let's confirm it and try again
     faucet.generate_blocks(1);
 
-    let response = client.get_tx(&outpoint.txid).unwrap();
+    let response = client.get_tx(&outpoint.txid).unwrap().unwrap();
     // Let's make sure we got the right transaction
     assert_eq!(response.tx.compute_txid(), outpoint.txid);
     assert_eq!(response.tx.output[vout].value.to_sat(), 500_000);
@@ -77,7 +77,7 @@ fn btc_client_gets_transaction_info() {
     let outpoint = faucet.send_to(500_000, &signer.address);
     let vout = outpoint.vout as usize;
 
-    let response = client.get_tx(&outpoint.txid).unwrap();
+    let response = client.get_tx(&outpoint.txid).unwrap().unwrap();
     // Let's make sure we got the right transaction
     assert_eq!(response.tx.compute_txid(), outpoint.txid);
     assert_eq!(response.tx.output[vout].value.to_sat(), 500_000);

--- a/signer/tests/integration/bitcoin_rpc.rs
+++ b/signer/tests/integration/bitcoin_rpc.rs
@@ -152,7 +152,7 @@ fn btc_client_unsubmitted_tx() {
     let txid = bitcoin::Txid::all_zeros();
 
     match client.get_tx(&txid).unwrap_err() {
-        Error::GetTransactionBitcoinCore(_, txid1) if txid1 == txid => {}
+        Error::BitcoinCoreGetTransaction(_, txid1) if txid1 == txid => {}
         _ => panic!("Incorrect error variants returned"),
     }
 }

--- a/signer/tests/integration/complete_deposit.rs
+++ b/signer/tests/integration/complete_deposit.rs
@@ -192,11 +192,11 @@ async fn complete_deposit_validation_happy_path() {
     let (complete_deposit_tx, req_ctx) = make_complete_deposit(&deposit_req, &sweep_tx, &chain_tip);
 
     // This should not return an Err.
-    let ctx = TestSignerContext::from_db(db);
+    let ctx = TestSignerContext::from_db(db.clone());
 
     complete_deposit_tx.validate(&ctx, &req_ctx).await.unwrap();
 
-    testing::storage::drop_db(ctx.into_db()).await;
+    testing::storage::drop_db(db).await;
 }
 
 /// For this test we check that the `CompleteDepositV1::validate` function
@@ -247,7 +247,7 @@ async fn complete_deposit_validation_deployer_mismatch() {
     // Different: Okay, let's make sure we get the deployers do not match.
     complete_deposit_tx.deployer = StacksAddress::p2pkh(false, &signer_set[0].into());
     req_ctx.deployer = StacksAddress::p2pkh(false, &signer_set[1].into());
-    let ctx = TestSignerContext::from_db(db);
+    let ctx = TestSignerContext::from_db(db.clone());
 
     let validate_future = complete_deposit_tx.validate(&ctx, &req_ctx);
     match validate_future.await.unwrap_err() {
@@ -257,7 +257,7 @@ async fn complete_deposit_validation_deployer_mismatch() {
         err => panic!("unexpected error during validation {err}"),
     }
 
-    testing::storage::drop_db(ctx.into_db()).await;
+    testing::storage::drop_db(db).await;
 }
 
 /// For this test we check that the `CompleteDepositV1::validate` function
@@ -303,7 +303,7 @@ async fn complete_deposit_validation_missing_deposit_request() {
     db.write_bitcoin_transaction(&bitcoin_tx_ref).await.unwrap();
 
     let (complete_deposit_tx, req_ctx) = make_complete_deposit(&deposit_req, &sweep_tx, &chain_tip);
-    let ctx = TestSignerContext::from_db(db);
+    let ctx = TestSignerContext::from_db(db.clone());
 
     let validation_result = complete_deposit_tx.validate(&ctx, &req_ctx).await;
     match validation_result.unwrap_err() {
@@ -313,7 +313,7 @@ async fn complete_deposit_validation_missing_deposit_request() {
         err => panic!("unexpected error during validation {err}"),
     }
 
-    testing::storage::drop_db(ctx.into_db()).await;
+    testing::storage::drop_db(db).await;
 }
 
 /// For this test we check that the `CompleteDepositV1::validate` function
@@ -366,7 +366,7 @@ async fn complete_deposit_validation_recipient_mismatch() {
     complete_deposit_tx.recipient = fake::Faker
         .fake_with_rng::<StacksPrincipal, _>(&mut rng)
         .into();
-    let ctx = TestSignerContext::from_db(db);
+    let ctx = TestSignerContext::from_db(db.clone());
 
     let validate_future = complete_deposit_tx.validate(&ctx, &req_ctx);
     match validate_future.await.unwrap_err() {
@@ -376,7 +376,7 @@ async fn complete_deposit_validation_recipient_mismatch() {
         err => panic!("unexpected error during validation {err}"),
     }
 
-    testing::storage::drop_db(ctx.into_db()).await;
+    testing::storage::drop_db(db).await;
 }
 
 /// For this test we check that the `CompleteDepositV1::validate` function
@@ -428,7 +428,7 @@ async fn complete_deposit_validation_invalid_mint_amount() {
     // Different: The amount cannot exceed the amount in the deposit
     // request.
     complete_deposit_tx.amount = deposit_req.amount + 1;
-    let ctx = TestSignerContext::from_db(db);
+    let ctx = TestSignerContext::from_db(db.clone());
 
     let validate_future = complete_deposit_tx.validate(&ctx, &req_ctx);
     match validate_future.await.unwrap_err() {
@@ -438,7 +438,7 @@ async fn complete_deposit_validation_invalid_mint_amount() {
         err => panic!("unexpected error during validation {err}"),
     }
 
-    testing::storage::drop_db(ctx.into_db()).await;
+    testing::storage::drop_db(db).await;
 }
 
 /// For this test we check that the `CompleteDepositV1::validate` function
@@ -490,7 +490,7 @@ async fn complete_deposit_validation_invalid_fee() {
     // Different: The amount cannot be less than the deposit amount less
     // the max-fee.
     complete_deposit_tx.amount = deposit_req.amount - deposit_req.max_fee - 1;
-    let ctx = TestSignerContext::from_db(db);
+    let ctx = TestSignerContext::from_db(db.clone());
 
     let validate_future = complete_deposit_tx.validate(&ctx, &req_ctx);
     match validate_future.await.unwrap_err() {
@@ -500,7 +500,7 @@ async fn complete_deposit_validation_invalid_fee() {
         err => panic!("unexpected error during validation {err}"),
     }
 
-    testing::storage::drop_db(ctx.into_db()).await;
+    testing::storage::drop_db(db).await;
 }
 
 /// For this test we check that the `CompleteDepositV1::validate` function
@@ -543,7 +543,7 @@ async fn complete_deposit_validation_sweep_tx_missing() {
 
     // Generate the transaction and corresponding request context.
     let (complete_deposit_tx, req_ctx) = make_complete_deposit(&deposit_req, &sweep_tx, &chain_tip);
-    let ctx = TestSignerContext::from_db(db);
+    let ctx = TestSignerContext::from_db(db.clone());
 
     let validation_result = complete_deposit_tx.validate(&ctx, &req_ctx).await;
     match validation_result.unwrap_err() {
@@ -553,7 +553,7 @@ async fn complete_deposit_validation_sweep_tx_missing() {
         err => panic!("unexpected error during validation {err}"),
     }
 
-    testing::storage::drop_db(ctx.into_db()).await;
+    testing::storage::drop_db(db).await;
 }
 
 /// For this test we check that the `CompleteDepositV1::validate` function
@@ -621,7 +621,7 @@ async fn complete_deposit_validation_sweep_reorged() {
     let (complete_deposit_tx, mut req_ctx) =
         make_complete_deposit(&deposit_req, &sweep_tx, &chain_tip2);
     req_ctx.chain_tip = chain_tip.into();
-    let ctx = TestSignerContext::from_db(db);
+    let ctx = TestSignerContext::from_db(db.clone());
 
     let validation_result = complete_deposit_tx.validate(&ctx, &req_ctx).await;
     match validation_result.unwrap_err() {
@@ -631,7 +631,7 @@ async fn complete_deposit_validation_sweep_reorged() {
         err => panic!("unexpected error during validation {err}"),
     }
 
-    testing::storage::drop_db(ctx.into_db()).await;
+    testing::storage::drop_db(db).await;
 }
 
 /// For this test we check that the `CompleteDepositV1::validate` function
@@ -684,7 +684,7 @@ async fn complete_deposit_validation_deposit_not_in_sweep() {
 
     // Generate the transaction and corresponding request context.
     let (complete_deposit_tx, req_ctx) = make_complete_deposit(&deposit_req, &sweep_tx, &chain_tip);
-    let ctx = TestSignerContext::from_db(db);
+    let ctx = TestSignerContext::from_db(db.clone());
 
     let validation_result = complete_deposit_tx.validate(&ctx, &req_ctx).await;
     match validation_result.unwrap_err() {
@@ -694,5 +694,5 @@ async fn complete_deposit_validation_deposit_not_in_sweep() {
         err => panic!("unexpected error during validation {err}"),
     }
 
-    testing::storage::drop_db(ctx.into_db()).await;
+    testing::storage::drop_db(db).await;
 }

--- a/signer/tests/integration/complete_deposit.rs
+++ b/signer/tests/integration/complete_deposit.rs
@@ -25,6 +25,7 @@ use signer::testing::storage::model::TestData;
 
 use fake::Fake;
 use rand::SeedableRng;
+use signer::testing::TestSignerContext;
 
 use crate::DATABASE_NUM;
 
@@ -60,7 +61,7 @@ fn make_complete_deposit(
     };
 
     // This is what the current signer things of the state of things.
-    let ctx = ReqContext {
+    let req_ctx = ReqContext {
         chain_tip: chain_tip.into(),
         // This value means that the signer will go back 10 blocks when
         // looking for pending and accepted deposit requests.
@@ -77,7 +78,7 @@ fn make_complete_deposit(
         deployer: StacksAddress::burn_address(false),
     };
 
-    (complete_deposit_tx, ctx)
+    (complete_deposit_tx, req_ctx)
 }
 
 /// Generate a signer set, deposit requests and store them into the
@@ -188,12 +189,14 @@ async fn complete_deposit_validation_happy_path() {
     db.write_bitcoin_transaction(&bitcoin_tx_ref).await.unwrap();
 
     // Generate the transaction and corresponding request context.
-    let (complete_deposit_tx, ctx) = make_complete_deposit(&deposit_req, &sweep_tx, &chain_tip);
+    let (complete_deposit_tx, req_ctx) = make_complete_deposit(&deposit_req, &sweep_tx, &chain_tip);
 
     // This should not return an Err.
-    complete_deposit_tx.validate(&db, &ctx).await.unwrap();
+    let ctx = TestSignerContext::from_db(db);
 
-    testing::storage::drop_db(db).await;
+    complete_deposit_tx.validate(&ctx, &req_ctx).await.unwrap();
+
+    testing::storage::drop_db(ctx.into_db()).await;
 }
 
 /// For this test we check that the `CompleteDepositV1::validate` function
@@ -239,13 +242,14 @@ async fn complete_deposit_validation_deployer_mismatch() {
     db.write_bitcoin_transaction(&bitcoin_tx_ref).await.unwrap();
 
     // Generate the transaction and corresponding request context.
-    let (mut complete_deposit_tx, mut ctx) =
+    let (mut complete_deposit_tx, mut req_ctx) =
         make_complete_deposit(&deposit_req, &sweep_tx, &chain_tip);
     // Different: Okay, let's make sure we get the deployers do not match.
     complete_deposit_tx.deployer = StacksAddress::p2pkh(false, &signer_set[0].into());
-    ctx.deployer = StacksAddress::p2pkh(false, &signer_set[1].into());
+    req_ctx.deployer = StacksAddress::p2pkh(false, &signer_set[1].into());
+    let ctx = TestSignerContext::from_db(db);
 
-    let validate_future = complete_deposit_tx.validate(&db, &ctx);
+    let validate_future = complete_deposit_tx.validate(&ctx, &req_ctx);
     match validate_future.await.unwrap_err() {
         Error::DepositValidation(ref err) => {
             assert_eq!(err.error, DepositErrorMsg::DeployerMismatch)
@@ -253,7 +257,7 @@ async fn complete_deposit_validation_deployer_mismatch() {
         err => panic!("unexpected error during validation {err}"),
     }
 
-    testing::storage::drop_db(db).await;
+    testing::storage::drop_db(ctx.into_db()).await;
 }
 
 /// For this test we check that the `CompleteDepositV1::validate` function
@@ -298,9 +302,10 @@ async fn complete_deposit_validation_missing_deposit_request() {
     db.write_transaction(&sweep_tx).await.unwrap();
     db.write_bitcoin_transaction(&bitcoin_tx_ref).await.unwrap();
 
-    let (complete_deposit_tx, ctx) = make_complete_deposit(&deposit_req, &sweep_tx, &chain_tip);
+    let (complete_deposit_tx, req_ctx) = make_complete_deposit(&deposit_req, &sweep_tx, &chain_tip);
+    let ctx = TestSignerContext::from_db(db);
 
-    let validation_result = complete_deposit_tx.validate(&db, &ctx).await;
+    let validation_result = complete_deposit_tx.validate(&ctx, &req_ctx).await;
     match validation_result.unwrap_err() {
         Error::DepositValidation(ref err) => {
             assert_eq!(err.error, DepositErrorMsg::RequestMissing)
@@ -308,7 +313,7 @@ async fn complete_deposit_validation_missing_deposit_request() {
         err => panic!("unexpected error during validation {err}"),
     }
 
-    testing::storage::drop_db(db).await;
+    testing::storage::drop_db(ctx.into_db()).await;
 }
 
 /// For this test we check that the `CompleteDepositV1::validate` function
@@ -355,13 +360,15 @@ async fn complete_deposit_validation_recipient_mismatch() {
     db.write_bitcoin_transaction(&bitcoin_tx_ref).await.unwrap();
 
     // Generate the transaction and corresponding request context.
-    let (mut complete_deposit_tx, ctx) = make_complete_deposit(&deposit_req, &sweep_tx, &chain_tip);
+    let (mut complete_deposit_tx, req_ctx) =
+        make_complete_deposit(&deposit_req, &sweep_tx, &chain_tip);
     // Different: Okay, let's make sure we the recipients do not match.
     complete_deposit_tx.recipient = fake::Faker
         .fake_with_rng::<StacksPrincipal, _>(&mut rng)
         .into();
+    let ctx = TestSignerContext::from_db(db);
 
-    let validate_future = complete_deposit_tx.validate(&db, &ctx);
+    let validate_future = complete_deposit_tx.validate(&ctx, &req_ctx);
     match validate_future.await.unwrap_err() {
         Error::DepositValidation(ref err) => {
             assert_eq!(err.error, DepositErrorMsg::RecipientMismatch)
@@ -369,7 +376,7 @@ async fn complete_deposit_validation_recipient_mismatch() {
         err => panic!("unexpected error during validation {err}"),
     }
 
-    testing::storage::drop_db(db).await;
+    testing::storage::drop_db(ctx.into_db()).await;
 }
 
 /// For this test we check that the `CompleteDepositV1::validate` function
@@ -416,12 +423,14 @@ async fn complete_deposit_validation_invalid_mint_amount() {
     db.write_bitcoin_transaction(&bitcoin_tx_ref).await.unwrap();
 
     // Generate the transaction and corresponding request context.
-    let (mut complete_deposit_tx, ctx) = make_complete_deposit(&deposit_req, &sweep_tx, &chain_tip);
+    let (mut complete_deposit_tx, req_ctx) =
+        make_complete_deposit(&deposit_req, &sweep_tx, &chain_tip);
     // Different: The amount cannot exceed the amount in the deposit
     // request.
     complete_deposit_tx.amount = deposit_req.amount + 1;
+    let ctx = TestSignerContext::from_db(db);
 
-    let validate_future = complete_deposit_tx.validate(&db, &ctx);
+    let validate_future = complete_deposit_tx.validate(&ctx, &req_ctx);
     match validate_future.await.unwrap_err() {
         Error::DepositValidation(ref err) => {
             assert_eq!(err.error, DepositErrorMsg::InvalidMintAmount)
@@ -429,7 +438,7 @@ async fn complete_deposit_validation_invalid_mint_amount() {
         err => panic!("unexpected error during validation {err}"),
     }
 
-    testing::storage::drop_db(db).await;
+    testing::storage::drop_db(ctx.into_db()).await;
 }
 
 /// For this test we check that the `CompleteDepositV1::validate` function
@@ -476,12 +485,14 @@ async fn complete_deposit_validation_invalid_fee() {
     db.write_bitcoin_transaction(&bitcoin_tx_ref).await.unwrap();
 
     // Generate the transaction and corresponding request context.
-    let (mut complete_deposit_tx, ctx) = make_complete_deposit(&deposit_req, &sweep_tx, &chain_tip);
+    let (mut complete_deposit_tx, req_ctx) =
+        make_complete_deposit(&deposit_req, &sweep_tx, &chain_tip);
     // Different: The amount cannot be less than the deposit amount less
     // the max-fee.
     complete_deposit_tx.amount = deposit_req.amount - deposit_req.max_fee - 1;
+    let ctx = TestSignerContext::from_db(db);
 
-    let validate_future = complete_deposit_tx.validate(&db, &ctx);
+    let validate_future = complete_deposit_tx.validate(&ctx, &req_ctx);
     match validate_future.await.unwrap_err() {
         Error::DepositValidation(ref err) => {
             assert_eq!(err.error, DepositErrorMsg::InvalidFee)
@@ -489,7 +500,7 @@ async fn complete_deposit_validation_invalid_fee() {
         err => panic!("unexpected error during validation {err}"),
     }
 
-    testing::storage::drop_db(db).await;
+    testing::storage::drop_db(ctx.into_db()).await;
 }
 
 /// For this test we check that the `CompleteDepositV1::validate` function
@@ -531,9 +542,10 @@ async fn complete_deposit_validation_sweep_tx_missing() {
     // not do that here.
 
     // Generate the transaction and corresponding request context.
-    let (complete_deposit_tx, ctx) = make_complete_deposit(&deposit_req, &sweep_tx, &chain_tip);
+    let (complete_deposit_tx, req_ctx) = make_complete_deposit(&deposit_req, &sweep_tx, &chain_tip);
+    let ctx = TestSignerContext::from_db(db);
 
-    let validation_result = complete_deposit_tx.validate(&db, &ctx).await;
+    let validation_result = complete_deposit_tx.validate(&ctx, &req_ctx).await;
     match validation_result.unwrap_err() {
         Error::DepositValidation(ref err) => {
             assert_eq!(err.error, DepositErrorMsg::SweepTransactionMissing)
@@ -541,7 +553,7 @@ async fn complete_deposit_validation_sweep_tx_missing() {
         err => panic!("unexpected error during validation {err}"),
     }
 
-    testing::storage::drop_db(db).await;
+    testing::storage::drop_db(ctx.into_db()).await;
 }
 
 /// For this test we check that the `CompleteDepositV1::validate` function
@@ -606,11 +618,12 @@ async fn complete_deposit_validation_sweep_reorged() {
     db.write_bitcoin_transaction(&bitcoin_tx_ref).await.unwrap();
 
     // Generate the transaction and corresponding request context.
-    let (complete_deposit_tx, mut ctx) =
+    let (complete_deposit_tx, mut req_ctx) =
         make_complete_deposit(&deposit_req, &sweep_tx, &chain_tip2);
-    ctx.chain_tip = chain_tip.into();
+    req_ctx.chain_tip = chain_tip.into();
+    let ctx = TestSignerContext::from_db(db);
 
-    let validation_result = complete_deposit_tx.validate(&db, &ctx).await;
+    let validation_result = complete_deposit_tx.validate(&ctx, &req_ctx).await;
     match validation_result.unwrap_err() {
         Error::DepositValidation(ref err) => {
             assert_eq!(err.error, DepositErrorMsg::SweepTransactionReorged)
@@ -618,7 +631,7 @@ async fn complete_deposit_validation_sweep_reorged() {
         err => panic!("unexpected error during validation {err}"),
     }
 
-    testing::storage::drop_db(db).await;
+    testing::storage::drop_db(ctx.into_db()).await;
 }
 
 /// For this test we check that the `CompleteDepositV1::validate` function
@@ -670,9 +683,10 @@ async fn complete_deposit_validation_deposit_not_in_sweep() {
     db.write_bitcoin_transaction(&bitcoin_tx_ref).await.unwrap();
 
     // Generate the transaction and corresponding request context.
-    let (complete_deposit_tx, ctx) = make_complete_deposit(&deposit_req, &sweep_tx, &chain_tip);
+    let (complete_deposit_tx, req_ctx) = make_complete_deposit(&deposit_req, &sweep_tx, &chain_tip);
+    let ctx = TestSignerContext::from_db(db);
 
-    let validation_result = complete_deposit_tx.validate(&db, &ctx).await;
+    let validation_result = complete_deposit_tx.validate(&ctx, &req_ctx).await;
     match validation_result.unwrap_err() {
         Error::DepositValidation(ref err) => {
             assert_eq!(err.error, DepositErrorMsg::MissingFromSweep)
@@ -680,5 +694,5 @@ async fn complete_deposit_validation_deposit_not_in_sweep() {
         err => panic!("unexpected error during validation {err}"),
     }
 
-    testing::storage::drop_db(db).await;
+    testing::storage::drop_db(ctx.into_db()).await;
 }

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -12,6 +12,7 @@ use blockstack_lib::types::chainstate::StacksAddress;
 use futures::StreamExt;
 use rand::seq::SliceRandom;
 
+use signer::context::Context;
 use signer::error::Error;
 use signer::keys::PublicKey;
 use signer::network;
@@ -107,9 +108,9 @@ impl AsContractCall for InitiateWithdrawalRequest {
     fn as_contract_args(&self) -> Vec<ClarityValue> {
         Vec::new()
     }
-    async fn validate<S>(&self, _db: &S, _ctx: &ReqContext) -> Result<(), Error>
+    async fn validate<C>(&self, _db: &C, _ctx: &ReqContext) -> Result<(), Error>
     where
-        S: DbRead + Send + Sync,
+        C: Context + Send + Sync,
     {
         Ok(())
     }

--- a/signer/tests/integration/withdrawal_accept.rs
+++ b/signer/tests/integration/withdrawal_accept.rs
@@ -248,10 +248,10 @@ async fn accept_withdrawal_validation_happy_path() {
         make_withdrawal_accept(&req, sweep_outpoint, aggregate_key, &chain_tip, bitmap);
 
     // This should not return an Err.
-    let ctx = TestSignerContext::from_db(db);
+    let ctx = TestSignerContext::from_db(db.clone());
     accept_withdrawal_tx.validate(&ctx, &req_ctx).await.unwrap();
 
-    testing::storage::drop_db(ctx.into_db()).await;
+    testing::storage::drop_db(db).await;
 }
 
 /// For this test we check that the `AcceptWithdrawalV1::validate` function
@@ -315,7 +315,7 @@ async fn accept_withdrawal_validation_deployer_mismatch() {
     accept_withdrawal_tx.deployer = StacksAddress::p2pkh(false, &signer_set[0].into());
     req_ctx.deployer = StacksAddress::p2pkh(false, &signer_set[1].into());
 
-    let ctx = TestSignerContext::from_db(db);
+    let ctx = TestSignerContext::from_db(db.clone());
     let validate_future = accept_withdrawal_tx.validate(&ctx, &req_ctx);
     match validate_future.await.unwrap_err() {
         Error::WithdrawalAcceptValidation(ref err) => {
@@ -324,7 +324,7 @@ async fn accept_withdrawal_validation_deployer_mismatch() {
         err => panic!("unexpected error during validation {err}"),
     }
 
-    testing::storage::drop_db(ctx.into_db()).await;
+    testing::storage::drop_db(db).await;
 }
 
 /// For this test we check that the `AcceptWithdrawalV1::validate` function
@@ -384,7 +384,7 @@ async fn accept_withdrawal_validation_missing_withdrawal_request() {
     let (accept_withdrawal_tx, req_ctx) =
         make_withdrawal_accept(&req, sweep_outpoint, aggregate_key, &chain_tip, bitmap);
 
-    let ctx = TestSignerContext::from_db(db);
+    let ctx = TestSignerContext::from_db(db.clone());
     let validation_result = accept_withdrawal_tx.validate(&ctx, &req_ctx).await;
     match validation_result.unwrap_err() {
         Error::WithdrawalAcceptValidation(ref err) => {
@@ -393,7 +393,7 @@ async fn accept_withdrawal_validation_missing_withdrawal_request() {
         err => panic!("unexpected error during validation {err}"),
     }
 
-    testing::storage::drop_db(ctx.into_db()).await;
+    testing::storage::drop_db(db).await;
 }
 
 /// For this test we check that the `AcceptWithdrawalV1::validate` function
@@ -456,7 +456,7 @@ async fn accept_withdrawal_validation_recipient_mismatch() {
     let (accept_withdrawal_tx, req_ctx) =
         make_withdrawal_accept(&req, sweep_outpoint, aggregate_key, &chain_tip, bitmap);
 
-    let ctx = TestSignerContext::from_db(db);
+    let ctx = TestSignerContext::from_db(db.clone());
     let validation_result = accept_withdrawal_tx.validate(&ctx, &req_ctx).await;
     match validation_result.unwrap_err() {
         Error::WithdrawalAcceptValidation(ref err) => {
@@ -465,7 +465,7 @@ async fn accept_withdrawal_validation_recipient_mismatch() {
         err => panic!("unexpected error during validation {err}"),
     }
 
-    testing::storage::drop_db(ctx.into_db()).await;
+    testing::storage::drop_db(db).await;
 }
 
 /// For this test we check that the `AcceptWithdrawalV1::validate` function
@@ -528,7 +528,7 @@ async fn accept_withdrawal_validation_invalid_mint_amount() {
     let (accept_withdrawal_tx, req_ctx) =
         make_withdrawal_accept(&req, sweep_outpoint, aggregate_key, &chain_tip, bitmap);
 
-    let ctx = TestSignerContext::from_db(db);
+    let ctx = TestSignerContext::from_db(db.clone());
     let validation_result = accept_withdrawal_tx.validate(&ctx, &req_ctx).await;
     match validation_result.unwrap_err() {
         Error::WithdrawalAcceptValidation(ref err) => {
@@ -537,7 +537,7 @@ async fn accept_withdrawal_validation_invalid_mint_amount() {
         err => panic!("unexpected error during validation {err}"),
     }
 
-    testing::storage::drop_db(ctx.into_db()).await;
+    testing::storage::drop_db(db).await;
 }
 
 /// For this test we check that the `AcceptWithdrawalV1::validate` function
@@ -605,7 +605,7 @@ async fn accept_withdrawal_validation_invalid_fee() {
     // `req.value - req.max_fee` and thus invalid.
     accept_withdrawal_tx.tx_fee = req.max_fee + 1;
 
-    let ctx = TestSignerContext::from_db(db);
+    let ctx = TestSignerContext::from_db(db.clone());
     let validate_future = accept_withdrawal_tx.validate(&ctx, &req_ctx);
     match validate_future.await.unwrap_err() {
         Error::WithdrawalAcceptValidation(ref err) => {
@@ -614,7 +614,7 @@ async fn accept_withdrawal_validation_invalid_fee() {
         err => panic!("unexpected error during validation {err}"),
     }
 
-    testing::storage::drop_db(ctx.into_db()).await;
+    testing::storage::drop_db(db).await;
 }
 
 /// For this test we check that the `AcceptWithdrawalV1::validate` function
@@ -663,7 +663,7 @@ async fn accept_withdrawal_validation_sweep_tx_missing() {
     let (accept_withdrawal_tx, req_ctx) =
         make_withdrawal_accept(&req, sweep_outpoint, aggregate_key, &chain_tip, bitmap);
 
-    let ctx = TestSignerContext::from_db(db);
+    let ctx = TestSignerContext::from_db(db.clone());
     let validation_result = accept_withdrawal_tx.validate(&ctx, &req_ctx).await;
     match validation_result.unwrap_err() {
         Error::WithdrawalAcceptValidation(ref err) => {
@@ -672,7 +672,7 @@ async fn accept_withdrawal_validation_sweep_tx_missing() {
         err => panic!("unexpected error during validation {err}"),
     }
 
-    testing::storage::drop_db(ctx.into_db()).await;
+    testing::storage::drop_db(db).await;
 }
 
 /// For this test we check that the `AcceptWithdrawalV1::validate` function
@@ -757,7 +757,7 @@ async fn accept_withdrawal_validation_sweep_reorged() {
     // be `chain_tip1`.
     req_ctx.chain_tip = chain_tip.into();
 
-    let ctx = TestSignerContext::from_db(db);
+    let ctx = TestSignerContext::from_db(db.clone());
     let validation_result = accept_withdrawal_tx.validate(&ctx, &req_ctx).await;
     match validation_result.unwrap_err() {
         Error::WithdrawalAcceptValidation(ref err) => {
@@ -766,7 +766,7 @@ async fn accept_withdrawal_validation_sweep_reorged() {
         err => panic!("unexpected error during validation {err}"),
     }
 
-    testing::storage::drop_db(ctx.into_db()).await;
+    testing::storage::drop_db(db).await;
 }
 
 /// For this test we check that the `AcceptWithdrawalV1::validate` function
@@ -834,7 +834,7 @@ async fn accept_withdrawal_validation_withdrawal_not_in_sweep() {
     let (accept_withdrawal_tx, req_ctx) =
         make_withdrawal_accept(&req, sweep_outpoint, aggregate_key, &chain_tip, bitmap);
 
-    let ctx = TestSignerContext::from_db(db);
+    let ctx = TestSignerContext::from_db(db.clone());
     let validation_result = accept_withdrawal_tx.validate(&ctx, &req_ctx).await;
     match validation_result.unwrap_err() {
         Error::WithdrawalAcceptValidation(ref err) => {
@@ -843,7 +843,7 @@ async fn accept_withdrawal_validation_withdrawal_not_in_sweep() {
         err => panic!("unexpected error during validation {err}"),
     }
 
-    testing::storage::drop_db(ctx.into_db()).await;
+    testing::storage::drop_db(db).await;
 }
 
 /// For this test we check that the `AcceptWithdrawalV1::validate` function
@@ -912,7 +912,7 @@ async fn accept_withdrawal_validation_bitmap_mismatch() {
     let (accept_withdrawal_tx, req_ctx) =
         make_withdrawal_accept(&req, sweep_outpoint, aggregate_key, &chain_tip, bitmap);
 
-    let ctx = TestSignerContext::from_db(db);
+    let ctx = TestSignerContext::from_db(db.clone());
     let validation_result = accept_withdrawal_tx.validate(&ctx, &req_ctx).await;
     match validation_result.unwrap_err() {
         Error::WithdrawalAcceptValidation(ref err) => {
@@ -921,5 +921,5 @@ async fn accept_withdrawal_validation_bitmap_mismatch() {
         err => panic!("unexpected error during validation {err}"),
     }
 
-    testing::storage::drop_db(ctx.into_db()).await;
+    testing::storage::drop_db(db).await;
 }

--- a/signer/tests/integration/withdrawal_accept.rs
+++ b/signer/tests/integration/withdrawal_accept.rs
@@ -28,6 +28,7 @@ use signer::testing::storage::model::TestData;
 
 use fake::Fake;
 use rand::SeedableRng;
+use signer::testing::TestSignerContext;
 
 use crate::DATABASE_NUM;
 
@@ -67,7 +68,7 @@ fn make_withdrawal_accept(
     };
 
     // This is what the current signer things of the state of things.
-    let ctx = ReqContext {
+    let req_ctx = ReqContext {
         chain_tip: chain_tip.into(),
         // This value means that the signer will go back 10 blocks when
         // looking for pending and accepted withdrawal requests.
@@ -84,7 +85,7 @@ fn make_withdrawal_accept(
         deployer: StacksAddress::burn_address(false),
     };
 
-    (complete_withdrawal_tx, ctx)
+    (complete_withdrawal_tx, req_ctx)
 }
 
 /// Generate a signer set, withdrawal requests and store them into the
@@ -243,13 +244,14 @@ async fn accept_withdrawal_validation_happy_path() {
     // Normal: get the signer bitmap for how they voted.
     let bitmap = get_withdrawal_request_signer_votes(&db, &req, &aggregate_key).await;
     // Generate the transaction and corresponding request context.
-    let (accept_withdrawal_tx, ctx) =
+    let (accept_withdrawal_tx, req_ctx) =
         make_withdrawal_accept(&req, sweep_outpoint, aggregate_key, &chain_tip, bitmap);
 
     // This should not return an Err.
-    accept_withdrawal_tx.validate(&db, &ctx).await.unwrap();
+    let ctx = TestSignerContext::from_db(db);
+    accept_withdrawal_tx.validate(&ctx, &req_ctx).await.unwrap();
 
-    testing::storage::drop_db(db).await;
+    testing::storage::drop_db(ctx.into_db()).await;
 }
 
 /// For this test we check that the `AcceptWithdrawalV1::validate` function
@@ -307,13 +309,14 @@ async fn accept_withdrawal_validation_deployer_mismatch() {
     // Normal: get the signer bitmap for how they voted.
     let bitmap = get_withdrawal_request_signer_votes(&db, &req, &aggregate_key).await;
     // Generate the transaction and corresponding request context.
-    let (mut accept_withdrawal_tx, mut ctx) =
+    let (mut accept_withdrawal_tx, mut req_ctx) =
         make_withdrawal_accept(&req, sweep_outpoint, aggregate_key, &chain_tip, bitmap);
     // Different: Okay, let's make sure the deployers do not match.
     accept_withdrawal_tx.deployer = StacksAddress::p2pkh(false, &signer_set[0].into());
-    ctx.deployer = StacksAddress::p2pkh(false, &signer_set[1].into());
+    req_ctx.deployer = StacksAddress::p2pkh(false, &signer_set[1].into());
 
-    let validate_future = accept_withdrawal_tx.validate(&db, &ctx);
+    let ctx = TestSignerContext::from_db(db);
+    let validate_future = accept_withdrawal_tx.validate(&ctx, &req_ctx);
     match validate_future.await.unwrap_err() {
         Error::WithdrawalAcceptValidation(ref err) => {
             assert_eq!(err.error, WithdrawalErrorMsg::DeployerMismatch)
@@ -321,7 +324,7 @@ async fn accept_withdrawal_validation_deployer_mismatch() {
         err => panic!("unexpected error during validation {err}"),
     }
 
-    testing::storage::drop_db(db).await;
+    testing::storage::drop_db(ctx.into_db()).await;
 }
 
 /// For this test we check that the `AcceptWithdrawalV1::validate` function
@@ -378,10 +381,11 @@ async fn accept_withdrawal_validation_missing_withdrawal_request() {
     db.write_bitcoin_transaction(&bitcoin_tx_ref).await.unwrap();
 
     let bitmap = get_withdrawal_request_signer_votes(&db, &req, &aggregate_key).await;
-    let (accept_withdrawal_tx, ctx) =
+    let (accept_withdrawal_tx, req_ctx) =
         make_withdrawal_accept(&req, sweep_outpoint, aggregate_key, &chain_tip, bitmap);
 
-    let validation_result = accept_withdrawal_tx.validate(&db, &ctx).await;
+    let ctx = TestSignerContext::from_db(db);
+    let validation_result = accept_withdrawal_tx.validate(&ctx, &req_ctx).await;
     match validation_result.unwrap_err() {
         Error::WithdrawalAcceptValidation(ref err) => {
             assert_eq!(err.error, WithdrawalErrorMsg::RequestMissing)
@@ -389,7 +393,7 @@ async fn accept_withdrawal_validation_missing_withdrawal_request() {
         err => panic!("unexpected error during validation {err}"),
     }
 
-    testing::storage::drop_db(db).await;
+    testing::storage::drop_db(ctx.into_db()).await;
 }
 
 /// For this test we check that the `AcceptWithdrawalV1::validate` function
@@ -449,10 +453,11 @@ async fn accept_withdrawal_validation_recipient_mismatch() {
     // Normal: get the signer bitmap for how they voted.
     let bitmap = get_withdrawal_request_signer_votes(&db, &req, &aggregate_key).await;
     // Generate the transaction and corresponding request context.
-    let (accept_withdrawal_tx, ctx) =
+    let (accept_withdrawal_tx, req_ctx) =
         make_withdrawal_accept(&req, sweep_outpoint, aggregate_key, &chain_tip, bitmap);
 
-    let validation_result = accept_withdrawal_tx.validate(&db, &ctx).await;
+    let ctx = TestSignerContext::from_db(db);
+    let validation_result = accept_withdrawal_tx.validate(&ctx, &req_ctx).await;
     match validation_result.unwrap_err() {
         Error::WithdrawalAcceptValidation(ref err) => {
             assert_eq!(err.error, WithdrawalErrorMsg::RecipientMismatch)
@@ -460,7 +465,7 @@ async fn accept_withdrawal_validation_recipient_mismatch() {
         err => panic!("unexpected error during validation {err}"),
     }
 
-    testing::storage::drop_db(db).await;
+    testing::storage::drop_db(ctx.into_db()).await;
 }
 
 /// For this test we check that the `AcceptWithdrawalV1::validate` function
@@ -520,10 +525,11 @@ async fn accept_withdrawal_validation_invalid_mint_amount() {
     // Normal: get the signer bitmap for how they voted.
     let bitmap = get_withdrawal_request_signer_votes(&db, &req, &aggregate_key).await;
     // Generate the transaction and corresponding request context.
-    let (accept_withdrawal_tx, ctx) =
+    let (accept_withdrawal_tx, req_ctx) =
         make_withdrawal_accept(&req, sweep_outpoint, aggregate_key, &chain_tip, bitmap);
 
-    let validation_result = accept_withdrawal_tx.validate(&db, &ctx).await;
+    let ctx = TestSignerContext::from_db(db);
+    let validation_result = accept_withdrawal_tx.validate(&ctx, &req_ctx).await;
     match validation_result.unwrap_err() {
         Error::WithdrawalAcceptValidation(ref err) => {
             assert_eq!(err.error, WithdrawalErrorMsg::InvalidAmount)
@@ -531,7 +537,7 @@ async fn accept_withdrawal_validation_invalid_mint_amount() {
         err => panic!("unexpected error during validation {err}"),
     }
 
-    testing::storage::drop_db(db).await;
+    testing::storage::drop_db(ctx.into_db()).await;
 }
 
 /// For this test we check that the `AcceptWithdrawalV1::validate` function
@@ -591,7 +597,7 @@ async fn accept_withdrawal_validation_invalid_fee() {
     // Normal: get the signer bitmap for how they voted.
     let bitmap = get_withdrawal_request_signer_votes(&db, &req, &aggregate_key).await;
     // Generate the transaction and corresponding request context.
-    let (mut accept_withdrawal_tx, ctx) =
+    let (mut accept_withdrawal_tx, req_ctx) =
         make_withdrawal_accept(&req, sweep_outpoint, aggregate_key, &chain_tip, bitmap);
     // Different: The fee cannot exceed the max fee. Setting the `tx_fee`
     // to `max_fee + 1` here will result in the validation validating
@@ -599,7 +605,8 @@ async fn accept_withdrawal_validation_invalid_fee() {
     // `req.value - req.max_fee` and thus invalid.
     accept_withdrawal_tx.tx_fee = req.max_fee + 1;
 
-    let validate_future = accept_withdrawal_tx.validate(&db, &ctx);
+    let ctx = TestSignerContext::from_db(db);
+    let validate_future = accept_withdrawal_tx.validate(&ctx, &req_ctx);
     match validate_future.await.unwrap_err() {
         Error::WithdrawalAcceptValidation(ref err) => {
             assert_eq!(err.error, WithdrawalErrorMsg::InvalidFee)
@@ -607,7 +614,7 @@ async fn accept_withdrawal_validation_invalid_fee() {
         err => panic!("unexpected error during validation {err}"),
     }
 
-    testing::storage::drop_db(db).await;
+    testing::storage::drop_db(ctx.into_db()).await;
 }
 
 /// For this test we check that the `AcceptWithdrawalV1::validate` function
@@ -653,10 +660,11 @@ async fn accept_withdrawal_validation_sweep_tx_missing() {
     // Normal: get the signer bitmap for how they voted.
     let bitmap = get_withdrawal_request_signer_votes(&db, &req, &aggregate_key).await;
     // Generate the transaction and corresponding request context.
-    let (accept_withdrawal_tx, ctx) =
+    let (accept_withdrawal_tx, req_ctx) =
         make_withdrawal_accept(&req, sweep_outpoint, aggregate_key, &chain_tip, bitmap);
 
-    let validation_result = accept_withdrawal_tx.validate(&db, &ctx).await;
+    let ctx = TestSignerContext::from_db(db);
+    let validation_result = accept_withdrawal_tx.validate(&ctx, &req_ctx).await;
     match validation_result.unwrap_err() {
         Error::WithdrawalAcceptValidation(ref err) => {
             assert_eq!(err.error, WithdrawalErrorMsg::SweepTransactionMissing)
@@ -664,7 +672,7 @@ async fn accept_withdrawal_validation_sweep_tx_missing() {
         err => panic!("unexpected error during validation {err}"),
     }
 
-    testing::storage::drop_db(db).await;
+    testing::storage::drop_db(ctx.into_db()).await;
 }
 
 /// For this test we check that the `AcceptWithdrawalV1::validate` function
@@ -741,15 +749,16 @@ async fn accept_withdrawal_validation_sweep_reorged() {
     // Normal: get the signer bitmap for how they voted.
     let bitmap = get_withdrawal_request_signer_votes(&db, &req, &aggregate_key).await;
     // Generate the transaction and corresponding request context.
-    let (accept_withdrawal_tx, mut ctx) =
+    let (accept_withdrawal_tx, mut req_ctx) =
         make_withdrawal_accept(&req, sweep_outpoint, aggregate_key, &chain_tip2, bitmap);
     // Different: We already created the BTC transaction that swept out the
     // users funds and confirmed it on a bitcoin blockchain identified by
     // `chain_tip2`. Here we set the canonical chain tip on the context to
     // be `chain_tip1`.
-    ctx.chain_tip = chain_tip.into();
+    req_ctx.chain_tip = chain_tip.into();
 
-    let validation_result = accept_withdrawal_tx.validate(&db, &ctx).await;
+    let ctx = TestSignerContext::from_db(db);
+    let validation_result = accept_withdrawal_tx.validate(&ctx, &req_ctx).await;
     match validation_result.unwrap_err() {
         Error::WithdrawalAcceptValidation(ref err) => {
             assert_eq!(err.error, WithdrawalErrorMsg::SweepTransactionReorged)
@@ -757,7 +766,7 @@ async fn accept_withdrawal_validation_sweep_reorged() {
         err => panic!("unexpected error during validation {err}"),
     }
 
-    testing::storage::drop_db(db).await;
+    testing::storage::drop_db(ctx.into_db()).await;
 }
 
 /// For this test we check that the `AcceptWithdrawalV1::validate` function
@@ -822,10 +831,11 @@ async fn accept_withdrawal_validation_withdrawal_not_in_sweep() {
     let bitmap = get_withdrawal_request_signer_votes(&db, &req, &aggregate_key).await;
     // Generate the transaction and corresponding request context.
     // Different: using the "invalid" `sweep_outpoint` we created above.
-    let (accept_withdrawal_tx, ctx) =
+    let (accept_withdrawal_tx, req_ctx) =
         make_withdrawal_accept(&req, sweep_outpoint, aggregate_key, &chain_tip, bitmap);
 
-    let validation_result = accept_withdrawal_tx.validate(&db, &ctx).await;
+    let ctx = TestSignerContext::from_db(db);
+    let validation_result = accept_withdrawal_tx.validate(&ctx, &req_ctx).await;
     match validation_result.unwrap_err() {
         Error::WithdrawalAcceptValidation(ref err) => {
             assert_eq!(err.error, WithdrawalErrorMsg::UtxoMissingFromSweep)
@@ -833,7 +843,7 @@ async fn accept_withdrawal_validation_withdrawal_not_in_sweep() {
         err => panic!("unexpected error during validation {err}"),
     }
 
-    testing::storage::drop_db(db).await;
+    testing::storage::drop_db(ctx.into_db()).await;
 }
 
 /// For this test we check that the `AcceptWithdrawalV1::validate` function
@@ -899,10 +909,11 @@ async fn accept_withdrawal_validation_bitmap_mismatch() {
     let first_vote = *bitmap.get(0).unwrap();
     bitmap.set(0, !first_vote);
     // Generate the transaction and corresponding request context.
-    let (accept_withdrawal_tx, ctx) =
+    let (accept_withdrawal_tx, req_ctx) =
         make_withdrawal_accept(&req, sweep_outpoint, aggregate_key, &chain_tip, bitmap);
 
-    let validation_result = accept_withdrawal_tx.validate(&db, &ctx).await;
+    let ctx = TestSignerContext::from_db(db);
+    let validation_result = accept_withdrawal_tx.validate(&ctx, &req_ctx).await;
     match validation_result.unwrap_err() {
         Error::WithdrawalAcceptValidation(ref err) => {
             assert_eq!(err.error, WithdrawalErrorMsg::BitmapMismatch)
@@ -910,5 +921,5 @@ async fn accept_withdrawal_validation_bitmap_mismatch() {
         err => panic!("unexpected error during validation {err}"),
     }
 
-    testing::storage::drop_db(db).await;
+    testing::storage::drop_db(ctx.into_db()).await;
 }


### PR DESCRIPTION
## Description

Addresses part of https://github.com/stacks-network/sbtc/issues/175 sorta, and paves the way for https://github.com/stacks-network/sbtc/issues/552.

While working on https://github.com/stacks-network/sbtc/issues/552, I realized that I needed to make quite a few auxiliary changes, so I stopped when it felt like a lot and decided to open this PR.

## Changes

* Have the `AsContractCall::validate` function take something that implements the `Context` trait. This is needed for https://github.com/stacks-network/sbtc/issues/552.
* Allow for the inner context type to be exposed in tests.
* Make sure the `BitcoinCoreClient` and `StacksClient` implement Clone. This is preparation for changes to the `SignerContext` type, and allows for a simplification of the `InnerSignerContext` object.
* Implement `TryFrom<&Url>` for `BitcoinCoreClient` instead of `TryFrom<Url>`.
* Have `NoopSignerContext::init` take an owned `Settings` object rather than cloning it internally.
* Move the `get_block` implementation into the `BitcoinCoreClient`.


## Testing Information

This is just a refactor to make subsequent work possible (and hopefully simpler). So if this tests pass then we're good.

## Checklist:

- [x] I have performed a self-review of my code

