### PR TITLE
feat: run block observer

### DIFF
--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -21,6 +21,7 @@ use std::collections::HashMap;
 
 use crate::bitcoin::BitcoinInteract;
 use crate::context::Context;
+use crate::context::SignerEvent;
 use crate::error::Error;
 use crate::stacks::api::StacksInteract;
 use crate::storage;
@@ -41,7 +42,7 @@ use std::collections::HashSet;
 
 /// Block observer
 #[derive(Debug)]
-pub struct BlockObserver<Context, StacksClient, EmilyClient, BlockHashStream, Storage> {
+pub struct BlockObserver<Context, StacksClient, EmilyClient, BlockHashStream> {
     /// Signer context
     pub context: Context,
     /// Stacks client
@@ -50,10 +51,6 @@ pub struct BlockObserver<Context, StacksClient, EmilyClient, BlockHashStream, St
     pub emily_client: EmilyClient,
     /// Stream of blocks from the block notifier
     pub bitcoin_blocks: BlockHashStream,
-    /// Database connection
-    pub storage: Storage,
-    /// Used to notify any other system that the database has been updated
-    pub subscribers: tokio::sync::watch::Sender<()>,
     /// How far back in time the observer should look
     pub horizon: usize,
     /// An in memory map of deposit requests that haven't been confirmed
@@ -105,27 +102,40 @@ pub trait DepositRequestValidator {
         C: BitcoinInteract;
 }
 
-impl<C, SC, EC, BHS, S> BlockObserver<C, SC, EC, BHS, S>
+impl<C, SC, EC, BHS> BlockObserver<C, SC, EC, BHS>
 where
     C: Context,
     SC: StacksInteract,
     EC: EmilyInteract,
-    S: DbWrite + DbRead + Send + Sync,
-    BHS: futures::stream::Stream<Item = bitcoin::BlockHash> + Unpin,
+    BHS: futures::stream::Stream<Item = Result<bitcoin::BlockHash, Error>> + Unpin,
 {
     /// Run the block observer
     #[tracing::instrument(skip(self))]
     pub async fn run(mut self) -> Result<(), Error> {
-        while let Some(new_block_hash) = self.bitcoin_blocks.next().await {
-            self.load_latest_deposit_requests().await;
+        let mut term = self.context.get_termination_handle();
 
-            for block in self.next_blocks_to_process(new_block_hash).await? {
-                self.process_bitcoin_block(block).await?;
+        let run = async {
+            while let Some(new_block_hash) = self.bitcoin_blocks.next().await {
+                self.load_latest_deposit_requests().await;
+
+                // TODO: What to do when `new_block_hash?` errors?
+                for block in self.next_blocks_to_process(new_block_hash?).await? {
+                    self.process_bitcoin_block(block).await?;
+                }
+
+                self.context
+                    .signal(SignerEvent::BlockObserverUpdated.into())?;
             }
 
-            if self.subscribers.send(()).is_err() {
-                tracing::info!("block observer has no subscribers");
-                break;
+            Ok::<_, Error>(())
+        };
+
+        tokio::select! {
+            _ = term.wait_for_shutdown() => {
+                tracing::info!("block observer received shutdown signal");
+            },
+            result = run => {
+                result?;
             }
         }
 
@@ -186,7 +196,8 @@ where
         block_hash: bitcoin::BlockHash,
     ) -> Result<bool, Error> {
         Ok(self
-            .storage
+            .context
+            .get_storage()
             .get_bitcoin_block(&block_hash.to_byte_array().into())
             .await?
             .is_some())
@@ -197,7 +208,7 @@ where
         let info = self.stacks_client.get_tenure_info().await?;
         let stacks_blocks = crate::stacks::api::fetch_unknown_ancestors(
             &mut self.stacks_client,
-            &self.storage,
+            &self.context.get_storage(),
             info.tip_block_id,
         )
         .await?;
@@ -218,7 +229,11 @@ where
             .map(model::DepositRequest::from)
             .collect();
 
-        self.storage.write_deposit_requests(deposit_request).await?;
+        self.context
+            .get_storage_mut()
+            .write_deposit_requests(deposit_request)
+            .await?;
+
         Ok(())
     }
 
@@ -238,7 +253,8 @@ where
         // We store all the scriptPubKeys associated with the signers'
         // aggregate public key. Let's get the last years worth of them.
         let signer_script_pubkeys: HashSet<ScriptBuf> = self
-            .storage
+            .context
+            .get_storage()
             .get_signers_script_pubkeys()
             .await?
             .into_iter()
@@ -272,7 +288,10 @@ where
             .map_err(Error::BitcoinEncodeTransaction)?;
 
         // Write these transactions into storage.
-        self.storage.write_bitcoin_transactions(sbtc_txs).await?;
+        self.context
+            .get_storage_mut()
+            .write_bitcoin_transactions(sbtc_txs)
+            .await?;
         Ok(())
     }
 
@@ -286,8 +305,9 @@ where
             .map(model::StacksBlock::try_from)
             .collect::<Result<_, _>>()?;
 
-        self.storage.write_stacks_block_headers(headers).await?;
-        self.storage.write_stacks_transactions(txs).await?;
+        let storage = self.context.get_storage_mut();
+        storage.write_stacks_block_headers(headers).await?;
+        storage.write_stacks_transactions(txs).await?;
         Ok(())
     }
 
@@ -303,7 +323,10 @@ where
             confirms: Vec::new(),
         };
 
-        self.storage.write_bitcoin_block(&db_block).await?;
+        self.context
+            .get_storage_mut()
+            .write_bitcoin_block(&db_block)
+            .await?;
         self.extract_sbtc_transactions(block.block_hash(), &block.txdata)
             .await?;
 
@@ -372,25 +395,20 @@ mod tests {
             storage.clone(),
             test_harness.clone(),
         );
+        let _signal_rx = ctx.get_signal_receiver();
         let block_hash_stream = test_harness.spawn_block_hash_stream();
-        let (subscribers, subscriber_rx) = tokio::sync::watch::channel(());
 
         let block_observer = BlockObserver {
             context: ctx,
             stacks_client: test_harness.clone(),
             emily_client: (),
             bitcoin_blocks: block_hash_stream,
-            storage: storage.clone(),
-            subscribers,
             horizon: 1,
             deposit_requests: HashMap::new(),
             network: bitcoin::Network::Regtest,
         };
 
-        block_observer
-            .run()
-            .await
-            .expect("block observer failed");
+        block_observer.run().await.expect("block observer failed");
 
         for block in test_harness.bitcoin_blocks {
             let persisted = storage
@@ -401,8 +419,6 @@ mod tests {
 
             assert_eq!(persisted.block_hash, block.block_hash().into())
         }
-
-        std::mem::drop(subscriber_rx);
     }
 
     /// Test that `BlockObserver::load_latest_deposit_requests` takes
@@ -473,7 +489,6 @@ mod tests {
         // Now we finish setting up the block observer.
         let storage = storage::in_memory::Store::new_shared();
         let block_hash_stream = test_harness.spawn_block_hash_stream();
-        let (subscribers, _subscriber_rx) = tokio::sync::watch::channel(());
         let ctx = SignerContext::new(
             Settings::new_from_default_config().unwrap(),
             storage.clone(),
@@ -485,8 +500,6 @@ mod tests {
             stacks_client: test_harness.clone(),
             emily_client: DummyEmily(vec![deposit_request0, deposit_request1]),
             bitcoin_blocks: block_hash_stream,
-            storage: storage.clone(),
-            subscribers,
             horizon: 1,
             deposit_requests: HashMap::new(),
             network: bitcoin::Network::Regtest,
@@ -550,7 +563,6 @@ mod tests {
         // Now we finish setting up the block observer.
         let storage = storage::in_memory::Store::new_shared();
         let block_hash_stream = test_harness.spawn_block_hash_stream();
-        let (subscribers, _subscriber_rx) = tokio::sync::watch::channel(());
         let ctx = SignerContext::new(
             Settings::new_from_default_config().unwrap(),
             storage.clone(),
@@ -562,8 +574,6 @@ mod tests {
             stacks_client: test_harness.clone(),
             emily_client: DummyEmily(vec![deposit_request0]),
             bitcoin_blocks: block_hash_stream,
-            storage: storage.clone(),
-            subscribers,
             horizon: 1,
             deposit_requests: HashMap::new(),
             network: bitcoin::Network::Regtest,
@@ -577,7 +587,7 @@ mod tests {
             .extract_deposit_requests(&[tx_setup0.tx.clone()])
             .await
             .unwrap();
-        let storage = block_observer.storage.lock().await;
+        let storage = storage.lock().await;
         assert_eq!(storage.deposit_requests.len(), 1);
         let db_outpoint: (BitcoinTxId, u32) = (tx_setup0.tx.compute_txid().into(), 0);
         assert!(storage.deposit_requests.get(&db_outpoint).is_some());
@@ -641,16 +651,11 @@ mod tests {
         // This one does not spend to the signers :(
         let tx_setup1 = sbtc::testing::deposits::tx_setup(1, 10, 2000);
 
-        // Now we finish setting up the block observer.
-        let (subscribers, _) = tokio::sync::watch::channel(());
-
         let block_observer = BlockObserver {
             context: ctx,
             stacks_client: test_harness.clone(),
             emily_client: (),
             bitcoin_blocks: test_harness.spawn_block_hash_stream(),
-            storage: storage.clone(),
-            subscribers,
             horizon: 1,
             deposit_requests: HashMap::new(),
             network: bitcoin::Network::Regtest,
@@ -666,7 +671,7 @@ mod tests {
 
         // We need to change the scope so that the mutex guard is dropped.
         {
-            let store = block_observer.storage.lock().await;
+            let store = storage.lock().await;
             // Under the hood, bitcoin transactions get stored in the
             // `bitcoin_block_to_transactions` field, so lets check there
             let stored_transactions = store.bitcoin_block_to_transactions.get(&block_hash.into());
@@ -684,7 +689,7 @@ mod tests {
             .await
             .unwrap();
 
-        let store = block_observer.storage.lock().await;
+        let store = storage.lock().await;
         let stored_transactions = store.bitcoin_block_to_transactions.get(&block_hash.into());
 
         // Is our one transaction stored? This block hash should now have
@@ -760,11 +765,11 @@ mod tests {
 
         fn spawn_block_hash_stream(
             &self,
-        ) -> tokio_stream::wrappers::ReceiverStream<bitcoin::BlockHash> {
+        ) -> tokio_stream::wrappers::ReceiverStream<Result<bitcoin::BlockHash, Error>> {
             let headers: Vec<_> = self
                 .bitcoin_blocks
                 .iter()
-                .map(|block| block.block_hash())
+                .map(|block| Ok(block.block_hash()))
                 .collect();
 
             let (tx, rx) = tokio::sync::mpsc::channel(128);

--- a/signer/src/config/default.toml
+++ b/signer/src/config/default.toml
@@ -19,10 +19,25 @@ port = 8080
 # Format: ["http://<user>:<pass>@<host>:<port>", ..]
 # Default: <none>
 # Required: true
-# Environment: SIGNER_BITCOIN__ENDPOINTS
+# Environment: SIGNER_BITCOIN__RPC_ENDPOINTS
 # Environment Example: http://user:pass@seed-1:4122,http://foo:bar@seed-2:4122
-endpoints = [
+rpc_endpoints = [
     "http://user:pass@localhost:18443",
+]
+
+# The URI(s) of the Bitcoin Core ZMQ block hash stream(s) to connect to.
+#
+# You may optionally specify multiple endpoints if you have them. They will be
+# tried in order until one succeeds, and it will attempt failover to the next
+# endpoint if the connection is lost.
+#
+# Format: ["tcp://<host>:<port>", ..]
+# Default: <none>
+# Required: true
+# Environment: SIGNER_BITCOIN__BLOCK_HASH_STREAM_ENDPOINTS
+# Environment Example: tcp://10.0.0.1:28332,tcp://10.0.0.2:28332
+block_hash_stream_endpoints = [
+    "tcp://localhost:28332"
 ]
 
 # !! ==============================================================================

--- a/signer/src/context/messaging.rs
+++ b/signer/src/context/messaging.rs
@@ -22,6 +22,8 @@ pub enum SignerCommand {
 pub enum SignerEvent {
     /// Signals that a P2P event has occurred.
     P2P(P2PEvent),
+    /// Signals that a block observer event has occurred.
+    BlockObserverUpdated,
 }
 
 /// Events that can be triggered from the P2P network.

--- a/signer/src/context/messaging.rs
+++ b/signer/src/context/messaging.rs
@@ -23,7 +23,7 @@ pub enum SignerEvent {
     /// Signals that a P2P event has occurred.
     P2P(P2PEvent),
     /// Signals that a block observer event has occurred.
-    BlockObserverUpdated,
+    BitcoinBlockObserved,
 }
 
 /// Events that can be triggered from the P2P network.

--- a/signer/src/context/mod.rs
+++ b/signer/src/context/mod.rs
@@ -72,7 +72,7 @@ where
     /// Initializes a new [`SignerContext`], automatically creating clients
     /// based on the provided types.
     pub fn init(config: Settings, db: S) -> Result<Self, Error> {
-        let bc = BC::try_from(&config.bitcoin.endpoints)?;
+        let bc = BC::try_from(&config.bitcoin.rpc_endpoints)?;
 
         Ok(Self::new(config, db, bc))
     }

--- a/signer/src/testing/mod.rs
+++ b/signer/src/testing/mod.rs
@@ -49,7 +49,7 @@ impl TestSignerContext {
     pub fn from_db(db: PgStore) -> Self {
         let config = Settings::new_from_default_config().unwrap();
 
-        let url = config.bitcoin.endpoints.first().unwrap();
+        let url = config.bitcoin.rpc_endpoints.first().unwrap();
         let bitcoin_client = BitcoinCoreClient::try_from(url).unwrap();
         Self::new(config, db, bitcoin_client)
     }


### PR DESCRIPTION
## Description

Closes: #548 

## Changes

- Adds the block observer to the main entry-point
- Changes the block observer db-update notification to use the app signalling channel (and updated tests)
- Removes `Storage` from the `BlockObserver` and adds `Context` (storage is retrieved from the context)
- Fixed an issue in block observer tests where the test harness returned a stream of non-result items
- Added configuration for bitcoin zmq block hash stream endpoints
- Updated the run-loop for the block observer

TODO: Add validation for block stream config

## Testing Information

Same test suite as before.

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
