### PR TITLE
feat: move stacks client into signer context

### DIFF
--- a/signer/src/bitcoin/mod.rs
+++ b/signer/src/bitcoin/mod.rs
@@ -27,14 +27,17 @@ pub trait BitcoinInteract: Sync + Send {
     ) -> impl Future<Output = Result<Option<bitcoin::Block>, Error>> + Send;
 
     /// get tx
-    fn get_tx(&self, txid: &Txid) -> impl Future<Output = Result<Option<GetTxResponse>, Error>>;
+    fn get_tx(
+        &self,
+        txid: &Txid,
+    ) -> impl Future<Output = Result<Option<GetTxResponse>, Error>> + Send;
 
     /// get tx info
     fn get_tx_info(
         &self,
         txid: &Txid,
         block_hash: &BlockHash,
-    ) -> impl Future<Output = Result<Option<BitcoinTxInfo>, Error>>;
+    ) -> impl Future<Output = Result<Option<BitcoinTxInfo>, Error>> + Send;
 
     /// Estimate fee rate
     // This should be implemented with the help of the `fees::EstimateFees` trait

--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -389,6 +389,7 @@ mod tests {
             Settings::new_from_default_config().unwrap(),
             storage.clone(),
             test_harness.clone(),
+            test_harness.clone(),
         );
         // There must be at least one signal receiver alive when the block observer
         // later tries to send a signal, hence this line.
@@ -495,6 +496,7 @@ mod tests {
             Settings::new_from_default_config().unwrap(),
             storage.clone(),
             test_harness.clone(),
+            test_harness.clone(),
         );
 
         let mut block_observer = BlockObserver {
@@ -572,6 +574,7 @@ mod tests {
             Settings::new_from_default_config().unwrap(),
             storage.clone(),
             test_harness.clone(),
+            test_harness.clone(),
         );
 
         let mut block_observer = BlockObserver {
@@ -639,6 +642,7 @@ mod tests {
         let ctx = SignerContext::new(
             Settings::new_from_default_config().unwrap(),
             storage.clone(),
+            test_harness.clone(),
             test_harness.clone(),
         );
 

--- a/signer/src/main.rs
+++ b/signer/src/main.rs
@@ -65,7 +65,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // Initialize the signer context.
-    let context = SignerContext::<_, ApiFallbackClient<BitcoinCoreClient>>::init(settings, db)?;
+    let context = SignerContext::<
+        _,
+        ApiFallbackClient<BitcoinCoreClient>,
+        ApiFallbackClient<StacksClient>,
+    >::init(settings, db)?;
 
     // Run the application components concurrently. We're `join!`ing them
     // here so that every component can shut itself down gracefully when

--- a/signer/src/testing/api_clients.rs
+++ b/signer/src/testing/api_clients.rs
@@ -7,6 +7,7 @@ use crate::bitcoin::rpc::GetTxResponse;
 use crate::bitcoin::BitcoinInteract;
 use crate::bitcoin::MockBitcoinInteract;
 use crate::blocklist_client::BlocklistChecker;
+use crate::config::Settings;
 use crate::emily_client::EmilyInteract;
 use crate::error::Error;
 use crate::stacks::api::StacksInteract;
@@ -19,6 +20,13 @@ pub struct NoopApiClient;
 impl TryFrom<&[Url]> for NoopApiClient {
     type Error = Error;
     fn try_from(_value: &[Url]) -> Result<Self, Self::Error> {
+        Ok(NoopApiClient)
+    }
+}
+
+impl TryFrom<&Settings> for NoopApiClient {
+    type Error = Error;
+    fn try_from(_value: &Settings) -> Result<Self, Self::Error> {
         Ok(NoopApiClient)
     }
 }

--- a/signer/src/testing/context.rs
+++ b/signer/src/testing/context.rs
@@ -10,8 +10,11 @@ use crate::{
     config::Settings,
     context::{Context, SignerContext},
     error::Error,
+    stacks::api::StacksInteract,
     storage::in_memory::{SharedStore, Store},
 };
+
+use super::api_clients::NoopApiClient;
 
 /// A [`Context`] which can be used for testing.
 ///
@@ -24,7 +27,7 @@ use crate::{
 #[derive(Clone)]
 pub struct TestContext<BC> {
     /// The inner [`SignerContext`] which this context wraps.
-    pub inner: SignerContext<SharedStore, BC>,
+    pub inner: SignerContext<SharedStore, BC, NoopApiClient>,
 
     /// The mocked bitcoin client.
     pub bitcoin_client: BC,
@@ -39,7 +42,7 @@ where
         let settings = Settings::new_from_default_config().unwrap();
         let store = Store::new_shared();
 
-        let context = SignerContext::new(settings, store, bitcoin_client.clone());
+        let context = SignerContext::new(settings, store, bitcoin_client.clone(), NoopApiClient);
 
         Self { inner: context, bitcoin_client }
     }
@@ -101,6 +104,10 @@ where
 
     fn get_bitcoin_client(&self) -> impl BitcoinInteract + Clone {
         self.inner.get_bitcoin_client()
+    }
+
+    fn get_stacks_client(&self) -> impl StacksInteract + Clone {
+        NoopApiClient
     }
 }
 

--- a/signer/src/testing/mod.rs
+++ b/signer/src/testing/mod.rs
@@ -29,7 +29,7 @@ use crate::storage::postgres::PgStore;
 pub const DEFAULT_CONFIG_PATH: Option<&str> = Some("./src/config/default");
 
 /// A [`SignerContext`] which uses [`NoopApiClient`]s.
-pub type NoopSignerContext<S> = SignerContext<S, NoopApiClient>;
+pub type NoopSignerContext<S> = SignerContext<S, NoopApiClient, NoopApiClient>;
 
 impl Settings {
     /// Create a new `Settings` instance from the default configuration file.
@@ -42,7 +42,7 @@ impl Settings {
 /// A client that can be used for integration tests. The settings are
 /// loaded from the default config toml, and the PgStore is assumed to
 /// point to a test database.
-pub type TestSignerContext = SignerContext<PgStore, BitcoinCoreClient>;
+pub type TestSignerContext = SignerContext<PgStore, BitcoinCoreClient, NoopApiClient>;
 
 impl TestSignerContext {
     /// Create a new one from the given database connection pool with the
@@ -52,7 +52,7 @@ impl TestSignerContext {
 
         let url = config.bitcoin.rpc_endpoints.first().unwrap();
         let bitcoin_client = BitcoinCoreClient::try_from(url).unwrap();
-        Self::new(config, db, bitcoin_client)
+        Self::new(config, db, bitcoin_client, NoopApiClient)
     }
 }
 


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/597.

## Changes

* Move the stacks client into the signer context
* Make sure the async trait functions implement `Send`

## Testing Information

Moreover nothing uses the new context for the stacks client so all tests should pass.

## Checklist:

- [x] I have performed a self-review of my code
