### PR TITLE
feat: db stacks transactions validated incorrectly

### DIFF
--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -310,7 +310,8 @@ where
         &mut self,
         blocks: &[nakamoto::NakamotoBlock],
     ) -> Result<(), Error> {
-        let txs = storage::postgres::extract_relevant_transactions(blocks);
+        let deployer = &self.context.config().signer.deployer;
+        let txs = storage::postgres::extract_relevant_transactions(blocks, deployer);
         let headers = blocks
             .iter()
             .map(model::StacksBlock::try_from)

--- a/signer/src/testing/wallet.rs
+++ b/signer/src/testing/wallet.rs
@@ -25,7 +25,8 @@ use crate::stacks::contracts::StacksTxPostConditions;
 use crate::stacks::wallet::SignerWallet;
 
 /// A static for a test 2-3 multi-sig wallet. This wallet is loaded with
-/// funds in the local devnet environment.
+/// funds in the local devnet environment. It matches the signer.deployer
+/// address in the default config file. 
 pub static WALLET: LazyLock<(SignerWallet, [Keypair; 3], u16)> = LazyLock::new(generate_wallet);
 
 /// Helper function for generating a test 2-3 multi-sig wallet

--- a/signer/tests/integration/contracts.rs
+++ b/signer/tests/integration/contracts.rs
@@ -284,7 +284,7 @@ async fn complete_deposit_wrapper_tx_accepted<T: AsContractCall>(contract: Contr
         .await
         .unwrap();
 
-    let transactions = postgres::extract_relevant_transactions(&blocks);
+    let transactions = postgres::extract_relevant_transactions(&blocks, &signer.wallet.address());
     assert!(!transactions.is_empty());
 
     let txids = transactions

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -97,14 +97,16 @@ async fn should_be_able_to_query_bitcoin_blocks() {
     signer::testing::storage::drop_db(store).await;
 }
 
-struct InitiateWithdrawalRequest;
+struct InitiateWithdrawalRequest {
+    deployer: StacksAddress,
+}
 
 impl AsContractCall for InitiateWithdrawalRequest {
     const CONTRACT_NAME: &'static str = "sbtc-withdrawal";
     const FUNCTION_NAME: &'static str = "initiate-withdrawal-request";
     /// The stacks address that deployed the contract.
     fn deployer_address(&self) -> StacksAddress {
-        StacksAddress::burn_address(false)
+        self.deployer
     }
     /// The arguments to the clarity function.
     fn as_contract_args(&self) -> Vec<ClarityValue> {
@@ -122,7 +124,9 @@ impl AsContractCall for InitiateWithdrawalRequest {
 /// do, which is store all stacks blocks and store the transactions that we
 /// care about, which, naturally, are sBTC related transactions.
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
-#[test_case(ContractCallWrapper(InitiateWithdrawalRequest); "initiate-withdrawal")]
+#[test_case(ContractCallWrapper(InitiateWithdrawalRequest {
+    deployer: testing::wallet::WALLET.0.address(),
+}); "initiate-withdrawal")]
 #[test_case(ContractCallWrapper(CompleteDepositV1 {
     outpoint: bitcoin::OutPoint::null(),
     amount: 123654,

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -188,7 +188,8 @@ async fn writing_stacks_blocks_works<T: AsContractCall>(contract: ContractCallWr
 
     // Okay now to save these blocks. We check that all of these blocks are
     // saved and that the transaction that we care about is saved as well.
-    let txs = storage::postgres::extract_relevant_transactions(&blocks);
+    let settings = Settings::new_from_default_config().unwrap();
+    let txs = storage::postgres::extract_relevant_transactions(&blocks, &settings.signer.deployer);
     let headers = blocks
         .iter()
         .map(model::StacksBlock::try_from)


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/523.

## Changes

* This change makes sure that we only extract stacks transactions that were deployed by the appropriate entity.

## Testing Information

There was a test for extracting relevant stacks transactions and it was updated to check that contract calls to smart contracts with the incorrect stacks addresses are ignored.

## Checklist:

- [x] I have performed a self-review of my code

