### PR TITLE
Update wsts dependency to 9.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7605,9 +7605,9 @@ dependencies = [
 
 [[package]]
 name = "wsts"
-version = "9.1.0"
+version = "9.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f38f50568ce9a30f2d041c26b1286fd453a166aec0059eb63aa51a15c46d776"
+checksum = "538ed71c766b41946e7a663e9d9ab317fd45c3c9b61090edc1d202a281ca195c"
 dependencies = [
  "aes-gcm",
  "bs58 0.5.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ tracing = { version = "0.1", default-features = false }
 tracing-attributes = "0.1"
 url = "2.5"
 warp_lambda = "0.1.4"
-wsts = "9.1.0"
+wsts = "9.2.0"
 zeromq = { version = "0.4.0", default-features = false, features = ["tokio-runtime", "all-transport"] }
 hex = "0.4.3"
 libp2p = { version = "0.54.1", features = [


### PR DESCRIPTION
## Description
There is a DoS vulnerability in `wsts` `9.1.0` and earlier.  This change updates `sbtc` to use the newly published `9.2.0` crate which fixes the vulnerability.

Closes: #?

## Changes

## Testing Information

## Checklist:

- [ x] I have performed a self-review of my code
- [ x] My changes generate no new warnings
- [ x] New and existing unit tests pass locally with my changes
- [ x] Any dependent changes have been merged and published in downstream modules
