### PR TITLE
595 feature provide raw transaction data for emily api deposit operations

### DIFF
--- a/.generated-sources/emily/openapi/emily-openapi-spec.json
+++ b/.generated-sources/emily/openapi/emily-openapi-spec.json
@@ -1305,7 +1305,7 @@
           },
           "depositScript": {
             "type": "string",
-            "description": "Raw deposit script binary."
+            "description": "Raw deposit script binary in hex."
           },
           "fulfillment": {
             "allOf": [
@@ -1334,7 +1334,7 @@
           },
           "reclaimScript": {
             "type": "string",
-            "description": "Raw reclaim script binary."
+            "description": "Raw reclaim script binary in hex."
           },
           "status": {
             "$ref": "#/components/schemas/Status"
@@ -1378,7 +1378,7 @@
           },
           "depositScript": {
             "type": "string",
-            "description": "Raw deposit script binary."
+            "description": "Raw deposit script binary in hex."
           },
           "lastUpdateBlockHash": {
             "type": "string",
@@ -1396,7 +1396,7 @@
           },
           "reclaimScript": {
             "type": "string",
-            "description": "Raw reclaim script binary."
+            "description": "Raw reclaim script binary in hex."
           },
           "status": {
             "$ref": "#/components/schemas/Status"

--- a/.generated-sources/emily/openapi/emily-openapi-spec.json
+++ b/.generated-sources/emily/openapi/emily-openapi-spec.json
@@ -1203,8 +1203,8 @@
         "required": [
           "bitcoinTxid",
           "bitcoinTxOutputIndex",
-          "reclaim",
-          "deposit"
+          "reclaimScript",
+          "depositScript"
         ],
         "properties": {
           "bitcoinTxOutputIndex": {
@@ -1217,11 +1217,11 @@
             "type": "string",
             "description": "Bitcoin transaction id."
           },
-          "deposit": {
+          "depositScript": {
             "type": "string",
             "description": "Deposit script."
           },
-          "reclaim": {
+          "reclaimScript": {
             "type": "string",
             "description": "Reclaim script."
           }

--- a/.generated-sources/emily/openapi/emily-openapi-spec.json
+++ b/.generated-sources/emily/openapi/emily-openapi-spec.json
@@ -1282,7 +1282,9 @@
           "lastUpdateBlockHash",
           "status",
           "statusMessage",
-          "parameters"
+          "parameters",
+          "reclaimScript",
+          "depositScript"
         ],
         "properties": {
           "amount": {
@@ -1300,6 +1302,10 @@
           "bitcoinTxid": {
             "type": "string",
             "description": "Bitcoin transaction id."
+          },
+          "depositScript": {
+            "type": "string",
+            "description": "Raw deposit script binary."
           },
           "fulfillment": {
             "allOf": [
@@ -1326,6 +1332,10 @@
             "type": "string",
             "description": "Stacks address to received the deposited sBTC."
           },
+          "reclaimScript": {
+            "type": "string",
+            "description": "Raw reclaim script binary."
+          },
           "status": {
             "$ref": "#/components/schemas/Status"
           },
@@ -1345,7 +1355,9 @@
           "amount",
           "lastUpdateHeight",
           "lastUpdateBlockHash",
-          "status"
+          "status",
+          "reclaimScript",
+          "depositScript"
         ],
         "properties": {
           "amount": {
@@ -1364,6 +1376,10 @@
             "type": "string",
             "description": "Bitcoin transaction id."
           },
+          "depositScript": {
+            "type": "string",
+            "description": "Raw deposit script binary."
+          },
           "lastUpdateBlockHash": {
             "type": "string",
             "description": "The most recent Stacks block hash the API was aware of when the deposit was last\nupdated. If the most recent update is tied to an artifact on the Stacks blockchain\nthen this hash is the Stacks block hash that contains that artifact."
@@ -1378,6 +1394,10 @@
             "type": "string",
             "description": "Stacks address to received the deposited sBTC."
           },
+          "reclaimScript": {
+            "type": "string",
+            "description": "Raw reclaim script binary."
+          },
           "status": {
             "$ref": "#/components/schemas/Status"
           }
@@ -1388,8 +1408,7 @@
         "description": "Deposit parameters.",
         "required": [
           "maxFee",
-          "lockTime",
-          "reclaimScript"
+          "lockTime"
         ],
         "properties": {
           "lockTime": {
@@ -1403,10 +1422,6 @@
             "format": "int64",
             "description": "Maximum fee the signers are allowed to take from the deposit to facilitate\nthe transaction.",
             "minimum": 0
-          },
-          "reclaimScript": {
-            "type": "string",
-            "description": "Raw reclaim script."
           }
         }
       },

--- a/Makefile
+++ b/Makefile
@@ -161,6 +161,7 @@ EMILY_CDK_SOURCE_FILES := $(wildcard $(subst dir, emily/bin/lib, $(FIVE_DIRS_DEE
 
 $(EMILY_CDK_TEMPLATE): $(INSTALL_TARGET) $(EMILY_OPENAPI_SPEC) $(EMILY_CDK_SOURCE_FILES)
 	AWS_STAGE=local \
+	TABLES_ONLY=true \
 	pnpm --filter $(EMILY_CDK_PROJECT_NAME) run synth
 
 # Emily Handler --------------------------------------
@@ -234,4 +235,3 @@ run-signer:
 	done; \
 	echo $$POSTGRES_PORT; \
 	RUST_LOG=debug SIGNER_SIGNER__DB_ENDPOINT="postgres://postgres:postgres@localhost:$$POSTGRES_PORT/signer" cargo run --bin signer -- -c ./signer/src/config/default.toml --migrate-db
-	

--- a/devenv/aws-setup/initialize.py
+++ b/devenv/aws-setup/initialize.py
@@ -117,8 +117,12 @@ def replace_local_lambda_path(template, local_lambda_path):
         modified_template, "AWS::Lambda::Function")
 
     # Ensure there's exactly one lambda function in the template.
+    if len(lambda_template_resource_ids) == 0:
+        print(f"Not making any lambda changes because no Lambda functions were found.")
+        return
     if len(lambda_template_resource_ids) != 1:
-        print(f"{len(lambda_template_resource_ids)} Lambda functions found, but there must be exactly 1.")
+        print(f"{len(lambda_template_resource_ids)} Lambda functions found, but this script supports at most 1. Failing...")
+        print(f"Lambda resource ids: {lambda_template_resource_ids}")
         exit(1)
 
     # Update lambda local code path.

--- a/emily/cdk/lib/emily-stack-utils.ts
+++ b/emily/cdk/lib/emily-stack-utils.ts
@@ -26,6 +26,11 @@ export class EmilyStackUtils {
     private static awsRegion?: string;
 
     /*
+     * Whether only tables should be deployed.
+     */
+    private static tablesOnly?: boolean;
+
+    /*
      * Returns the current stage name.
      */
     public static getStageName(): string {
@@ -62,6 +67,14 @@ export class EmilyStackUtils {
         // standard beta region: us-west-2.
         this.awsRegion ??= "us-west-2";
         return this.awsRegion;
+    }
+
+    /*
+     * Returns whether only tables should be deployed.
+     */
+    public static isTablesOnly(): boolean {
+        this.tablesOnly ??= (process.env.TABLES_ONLY ?? "false").toLowerCase() === "true";
+        return this.tablesOnly;
     }
 
     /*

--- a/emily/cdk/lib/emily-stack.ts
+++ b/emily/cdk/lib/emily-stack.ts
@@ -103,6 +103,8 @@ export class EmilyStack extends cdk.Stack {
                 "Recipient",
                 "Amount",
                 "LastUpdateBlockHash",
+                "ReclaimScript",
+                "DepositScript",
             ]
         });
 

--- a/emily/cdk/lib/emily-stack.ts
+++ b/emily/cdk/lib/emily-stack.ts
@@ -45,19 +45,21 @@ export class EmilyStack extends cdk.Stack {
             chainstateTableName,
         );
 
-        const operationLambda: lambda.Function = this.createOrUpdateOperationLambda(
-            depositTableName,
-            withdrawalTableName,
-            chainstateTableName,
-            props
-        );
+        if (!EmilyStackUtils.isTablesOnly()) {
+            const operationLambda: lambda.Function = this.createOrUpdateOperationLambda(
+                depositTableName,
+                withdrawalTableName,
+                chainstateTableName,
+                props
+            );
 
-        // Give the operation lambda full access to the DynamoDB tables.
-        depositTable.grantReadWriteData(operationLambda);
-        withdrawalTable.grantReadWriteData(operationLambda);
-        chainstateTable.grantReadWriteData(operationLambda);
+            // Give the operation lambda full access to the DynamoDB tables.
+            depositTable.grantReadWriteData(operationLambda);
+            withdrawalTable.grantReadWriteData(operationLambda);
+            chainstateTable.grantReadWriteData(operationLambda);
 
-        const emilyApi: apig.SpecRestApi = this.createOrUpdateApi(operationLambda, props);
+            const emilyApi: apig.SpecRestApi = this.createOrUpdateApi(operationLambda, props);
+        }
     }
 
     /**

--- a/emily/handler/src/api/handlers/deposit.rs
+++ b/emily/handler/src/api/handlers/deposit.rs
@@ -215,7 +215,6 @@ pub async fn create_deposit(
                 bitcoin_tx_output_index: body.bitcoin_tx_output_index,
             },
             parameters: DepositParametersEntry {
-                reclaim_script: body.reclaim,
                 ..Default::default()
             },
             history: vec![DepositEvent {
@@ -227,6 +226,8 @@ pub async fn create_deposit(
             status,
             last_update_block_hash: stacks_block_hash,
             last_update_height: stacks_block_height,
+            reclaim_script: body.reclaim,
+            deposit_script: body.deposit,
             ..Default::default()
         };
         // Validate deposit entry.

--- a/emily/handler/src/api/handlers/deposit.rs
+++ b/emily/handler/src/api/handlers/deposit.rs
@@ -214,9 +214,7 @@ pub async fn create_deposit(
                 bitcoin_txid: body.bitcoin_txid,
                 bitcoin_tx_output_index: body.bitcoin_tx_output_index,
             },
-            parameters: DepositParametersEntry {
-                ..Default::default()
-            },
+            parameters: DepositParametersEntry { ..Default::default() },
             history: vec![DepositEvent {
                 status: StatusEntry::Pending,
                 message: "Just received deposit".to_string(),

--- a/emily/handler/src/api/handlers/deposit.rs
+++ b/emily/handler/src/api/handlers/deposit.rs
@@ -226,8 +226,8 @@ pub async fn create_deposit(
             status,
             last_update_block_hash: stacks_block_hash,
             last_update_height: stacks_block_height,
-            reclaim_script: body.reclaim,
-            deposit_script: body.deposit,
+            reclaim_script: body.reclaim_script,
+            deposit_script: body.deposit_script,
             ..Default::default()
         };
         // Validate deposit entry.

--- a/emily/handler/src/api/models/deposit/mod.rs
+++ b/emily/handler/src/api/models/deposit/mod.rs
@@ -49,9 +49,9 @@ pub struct Deposit {
     pub status_message: String,
     /// Deposit parameters
     pub parameters: DepositParameters,
-    /// Raw reclaim script binary.
+    /// Raw reclaim script binary in hex.
     pub reclaim_script: String,
-    /// Raw deposit script binary.
+    /// Raw deposit script binary in hex.
     pub deposit_script: String,
     /// Details about the on chain artifacts that fulfilled the deposit.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -80,8 +80,6 @@ pub struct DepositParameters {
     pub max_fee: u64,
     /// Bitcoin block height at which the reclaim script becomes executable.
     pub lock_time: u64,
-    // /// Raw reclaim script.
-    // pub reclaim_script: String,
 }
 
 /// Reduced version of the Deposit data.
@@ -119,9 +117,9 @@ pub struct DepositInfo {
     pub last_update_block_hash: String,
     /// The status of the deposit.
     pub status: Status,
-    /// Raw reclaim script binary.
+    /// Raw reclaim script binary in hex.
     pub reclaim_script: String,
-    /// Raw deposit script binary.
+    /// Raw deposit script binary in hex.
     pub deposit_script: String,
 }
 

--- a/emily/handler/src/api/models/deposit/mod.rs
+++ b/emily/handler/src/api/models/deposit/mod.rs
@@ -49,6 +49,10 @@ pub struct Deposit {
     pub status_message: String,
     /// Deposit parameters
     pub parameters: DepositParameters,
+    /// Raw reclaim script binary.
+    pub reclaim_script: String,
+    /// Raw deposit script binary.
+    pub deposit_script: String,
     /// Details about the on chain artifacts that fulfilled the deposit.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fulfillment: Option<Fulfillment>,
@@ -76,8 +80,8 @@ pub struct DepositParameters {
     pub max_fee: u64,
     /// Bitcoin block height at which the reclaim script becomes executable.
     pub lock_time: u64,
-    /// Raw reclaim script.
-    pub reclaim_script: String,
+    // /// Raw reclaim script.
+    // pub reclaim_script: String,
 }
 
 /// Reduced version of the Deposit data.
@@ -115,6 +119,10 @@ pub struct DepositInfo {
     pub last_update_block_hash: String,
     /// The status of the deposit.
     pub status: Status,
+    /// Raw reclaim script binary.
+    pub reclaim_script: String,
+    /// Raw deposit script binary.
+    pub deposit_script: String,
 }
 
 /// Create a DepositInfo, which has a subset of the data within a Deposit, from a Deposit.
@@ -128,6 +136,8 @@ impl From<Deposit> for DepositInfo {
             last_update_height: deposit.last_update_height,
             last_update_block_hash: deposit.last_update_block_hash,
             status: deposit.status,
+            reclaim_script: deposit.reclaim_script,
+            deposit_script: deposit.deposit_script,
         }
     }
 }

--- a/emily/handler/src/api/models/deposit/requests.rs
+++ b/emily/handler/src/api/models/deposit/requests.rs
@@ -40,9 +40,9 @@ pub struct CreateDepositRequestBody {
     /// Output index on the bitcoin transaction associated with this specific deposit.
     pub bitcoin_tx_output_index: u32,
     /// Reclaim script.
-    pub reclaim: String,
+    pub reclaim_script: String,
     /// Deposit script.
-    pub deposit: String,
+    pub deposit_script: String,
 }
 
 /// A singlular Deposit update that contains only the fields pertinent

--- a/emily/handler/src/database/entries/deposit.rs
+++ b/emily/handler/src/database/entries/deposit.rs
@@ -50,6 +50,10 @@ pub struct DepositEntry {
     /// The status of the deposit.
     #[serde(rename = "OpStatus")]
     pub status: Status,
+    /// The raw reclaim script.
+    pub reclaim_script: String,
+    /// The raw deposit script.
+    pub deposit_script: String,
     /// The most recent Stacks block height the API was aware of when the deposit was last
     /// updated. If the most recent update is tied to an artifact on the Stacks blockchain
     /// then this height is the Stacks block height that contains that artifact.
@@ -235,8 +239,9 @@ impl TryFrom<DepositEntry> for Deposit {
             parameters: DepositParameters {
                 max_fee: deposit_entry.parameters.max_fee,
                 lock_time: deposit_entry.parameters.lock_time,
-                reclaim_script: deposit_entry.parameters.reclaim_script,
             },
+            reclaim_script: deposit_entry.reclaim_script,
+            deposit_script: deposit_entry.deposit_script,
             fulfillment,
         })
     }
@@ -251,8 +256,6 @@ pub struct DepositParametersEntry {
     pub max_fee: u64,
     /// Bitcoin block height at which the reclaim script becomes executable.
     pub lock_time: u64,
-    /// Raw reclaim script.
-    pub reclaim_script: String,
 }
 
 /// Event in the history of a deposit.
@@ -334,6 +337,10 @@ pub struct DepositInfoEntry {
     pub recipient: String,
     /// Amount of BTC being deposited in satoshis.
     pub amount: u64,
+    /// The raw reclaim script.
+    pub reclaim_script: String,
+    /// The raw deposit script.
+    pub deposit_script: String,
     /// The most recent Stacks block hash the API was aware of when the deposit was last
     /// updated. If the most recent update is tied to an artifact on the Stacks blockchain
     /// then this hash is the Stacks block hash that contains that artifact.
@@ -387,6 +394,8 @@ impl From<DepositInfoEntry> for DepositInfo {
             last_update_height: deposit_info_entry.key.last_update_height,
             last_update_block_hash: deposit_info_entry.last_update_block_hash,
             status: deposit_info_entry.key.status,
+            reclaim_script: deposit_info_entry.reclaim_script,  
+            deposit_script: deposit_info_entry.deposit_script,
         }
     }
 }

--- a/emily/handler/src/database/entries/deposit.rs
+++ b/emily/handler/src/database/entries/deposit.rs
@@ -394,7 +394,7 @@ impl From<DepositInfoEntry> for DepositInfo {
             last_update_height: deposit_info_entry.key.last_update_height,
             last_update_block_hash: deposit_info_entry.last_update_block_hash,
             status: deposit_info_entry.key.status,
-            reclaim_script: deposit_info_entry.reclaim_script,  
+            reclaim_script: deposit_info_entry.reclaim_script,
             deposit_script: deposit_info_entry.deposit_script,
         }
     }

--- a/emily/handler/tests/integration/complex/reorg.rs
+++ b/emily/handler/tests/integration/complex/reorg.rs
@@ -113,8 +113,8 @@ async fn simple_reorg_test_base(scenario: ReorgScenario) {
         let deposit_request = CreateDepositRequestBody {
             bitcoin_txid: format!("{TEST_BITCOIN_TXID}-{stacks_block_height}"),
             bitcoin_tx_output_index: 1,
-            reclaim: TEST_RECLAIM_SCRIPT.to_string(),
-            deposit: TEST_DEPOSIT_SCRIPT.to_string(),
+            reclaim_script: TEST_RECLAIM_SCRIPT.to_string(),
+            deposit_script: TEST_DEPOSIT_SCRIPT.to_string(),
         };
         let withdrawal_request = CreateWithdrawalRequestBody {
             request_id: stacks_block_height,

--- a/emily/handler/tests/integration/endpoints/deposit.rs
+++ b/emily/handler/tests/integration/endpoints/deposit.rs
@@ -80,8 +80,8 @@ async fn setup_deposit_integration_test() -> TestClient {
         let request: CreateDepositRequestBody = serde_json::from_value(json!({
             "bitcoinTxid": bitcoin_txid.clone(),
             "bitcoinTxOutputIndex": bitcoin_tx_output_index,
-            "reclaim": TEST_RECLAIM_SCRIPT.to_string(),
-            "deposit": TEST_DEPOSIT_SCRIPT.to_string(),
+            "reclaimScript": TEST_RECLAIM_SCRIPT.to_string(),
+            "depositScript": TEST_DEPOSIT_SCRIPT.to_string(),
         }))
         .expect("Failed to deserialize create deposit request body in test setup");
         let response = client.create_deposit(&request).await;

--- a/emily/handler/tests/integration/endpoints/deposit.rs
+++ b/emily/handler/tests/integration/endpoints/deposit.rs
@@ -87,10 +87,7 @@ async fn setup_deposit_integration_test() -> TestClient {
         let response = client.create_deposit(&request).await;
         util::assert_eq_pretty(
             response,
-            just_created_deposit(
-                bitcoin_txid,
-                bitcoin_tx_output_index,
-            ),
+            just_created_deposit(bitcoin_txid, bitcoin_tx_output_index),
         );
     }
     client
@@ -115,10 +112,7 @@ fn all_test_deposit_data() -> impl Iterator<Item = TestDepositData> {
 /// bitcoin txid and bitcoin tx output index. Note that this will
 /// need to be changed as the creation function becomes more
 /// complex and correct.
-fn just_created_deposit(
-    bitcoin_txid: String,
-    bitcoin_tx_output_index: u32,
-) -> Deposit {
+fn just_created_deposit(bitcoin_txid: String, bitcoin_tx_output_index: u32) -> Deposit {
     Deposit {
         bitcoin_txid,
         bitcoin_tx_output_index,

--- a/emily/handler/tests/integration/endpoints/deposit.rs
+++ b/emily/handler/tests/integration/endpoints/deposit.rs
@@ -6,7 +6,7 @@ use emily_handler::{
         deposit::{
             requests::{CreateDepositRequestBody, DepositUpdate, UpdateDepositsRequestBody},
             responses::{GetDepositsForTransactionResponse, GetDepositsResponse},
-            Deposit, DepositInfo, DepositParameters,
+            Deposit, DepositInfo,
         },
     },
     context::EmilyContext,
@@ -23,6 +23,8 @@ use std::sync::LazyLock;
 use tokio;
 
 const TEST_BLOCK_HEIGHT: u64 = 123;
+const TEST_RECLAIM_SCRIPT: &str = "example_reclaim_script";
+const TEST_DEPOSIT_SCRIPT: &str = "example_deposit_script";
 
 /// Contains data about a deposit transaction used for testing so that
 /// all the tests have a common understanding of the deposits in the
@@ -78,14 +80,17 @@ async fn setup_deposit_integration_test() -> TestClient {
         let request: CreateDepositRequestBody = serde_json::from_value(json!({
             "bitcoinTxid": bitcoin_txid.clone(),
             "bitcoinTxOutputIndex": bitcoin_tx_output_index,
-            "reclaim": "example_reclaim_script",
-            "deposit": "example_deposit_script",
+            "reclaim": TEST_RECLAIM_SCRIPT.to_string(),
+            "deposit": TEST_DEPOSIT_SCRIPT.to_string(),
         }))
         .expect("Failed to deserialize create deposit request body in test setup");
         let response = client.create_deposit(&request).await;
         util::assert_eq_pretty(
             response,
-            just_created_deposit(bitcoin_txid, bitcoin_tx_output_index),
+            just_created_deposit(
+                bitcoin_txid,
+                bitcoin_tx_output_index,
+            ),
         );
     }
     client
@@ -110,17 +115,18 @@ fn all_test_deposit_data() -> impl Iterator<Item = TestDepositData> {
 /// bitcoin txid and bitcoin tx output index. Note that this will
 /// need to be changed as the creation function becomes more
 /// complex and correct.
-fn just_created_deposit(bitcoin_txid: String, bitcoin_tx_output_index: u32) -> Deposit {
+fn just_created_deposit(
+    bitcoin_txid: String,
+    bitcoin_tx_output_index: u32,
+) -> Deposit {
     Deposit {
         bitcoin_txid,
         bitcoin_tx_output_index,
         last_update_block_hash: "DUMMY_HASH".to_string(),
         last_update_height: TEST_BLOCK_HEIGHT,
         status_message: "Just received deposit".to_string(),
-        parameters: DepositParameters {
-            reclaim_script: "example_reclaim_script".to_string(),
-            ..Default::default()
-        },
+        reclaim_script: TEST_RECLAIM_SCRIPT.to_string(),
+        deposit_script: TEST_DEPOSIT_SCRIPT.to_string(),
         ..Default::default()
     }
 }

--- a/emily/handler/tests/integration/populate/mod.rs
+++ b/emily/handler/tests/integration/populate/mod.rs
@@ -35,8 +35,8 @@ async fn create_deposits(client: &TestClient) {
             let create_request = CreateDepositRequestBody {
                 bitcoin_txid: format!("txid-{i}"),
                 bitcoin_tx_output_index: j + offset,
-                reclaim: format!("reclaim-script-{i}"),
-                deposit: format!("deposit-script-{i}"),
+                reclaim_script: format!("reclaim-script-{i}"),
+                deposit_script: format!("deposit-script-{i}"),
             };
             client.create_deposit(&create_request).await;
         }

--- a/emily/handler/tests/integration/util/mod.rs
+++ b/emily/handler/tests/integration/util/mod.rs
@@ -63,8 +63,8 @@ pub fn test_create_deposit_request(id_num: u64, output_index: u32) -> CreateDepo
     CreateDepositRequestBody {
         bitcoin_txid: format!("deposit-txid-{id_num}"),
         bitcoin_tx_output_index: output_index,
-        reclaim: format!("deposit-txid-{id_num}:{output_index}-reclaim-script"),
-        deposit: format!("deposit-txid-{id_num}:{output_index}-deposit-script"),
+        reclaim_script: format!("deposit-txid-{id_num}:{output_index}-reclaim-script"),
+        deposit_script: format!("deposit-txid-{id_num}:{output_index}-deposit-script"),
     }
 }
 


### PR DESCRIPTION
## Description

Closes: #595 

## Changes

1. Adds a feature to the Emily API CDK template where the AWS resources can be created without the ApiGateway and the Emily Lambda when an environment variable is set. This is useful for testing when the Emily lambda handler isn't going to be fielding the API requests
2. Adds `deposit_script` and `reclaim_script` to the Emily API `Deposit` and `DepositInfo` resources and updates tests accordingly.

## Testing Information

Tested with integration tests. At the moment this requires three separate commands to run concurrently, and is easiest with three terminals. 

- Terminal 1: `make emily-integration-env-up`
- Terminal 2: `make emily-server-watch`
- Terminal 3: `make emily-integration-test`

> Note: We *won't* be fixing this need for three terminals for integration tests soon so we can focus solely on the core product flows of handling deposits and withdrawals, but the ticket #505 tracks the need to do it.

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
