### PR TITLE
feat: broadcast withdrawal decision + tests

### DIFF
--- a/signer/src/message.rs
+++ b/signer/src/message.rs
@@ -24,7 +24,7 @@ pub enum Payload {
     /// A decision related to signer deposit
     SignerDepositDecision(SignerDepositDecision),
     /// A decision related to signer withdrawal
-    SignerWithdrawalDecision(SignerWithdrawDecision),
+    SignerWithdrawalDecision(SignerWithdrawalDecision),
     /// A request to sign a Stacks transaction
     StacksTransactionSignRequest(StacksTransactionSignRequest),
     /// A signature of a Stacks transaction
@@ -53,8 +53,8 @@ impl From<SignerDepositDecision> for Payload {
     }
 }
 
-impl From<SignerWithdrawDecision> for Payload {
-    fn from(value: SignerWithdrawDecision) -> Self {
+impl From<SignerWithdrawalDecision> for Payload {
+    fn from(value: SignerWithdrawalDecision) -> Self {
         Self::SignerWithdrawalDecision(value)
     }
 }
@@ -103,7 +103,7 @@ pub struct SignerDepositDecision {
 /// Represents a decision related to signer withdrawal.
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "testing", derive(fake::Dummy))]
-pub struct SignerWithdrawDecision {
+pub struct SignerWithdrawalDecision {
     /// ID of the withdraw request.
     pub request_id: u64,
     /// ID of the Stacks block containing the request.
@@ -199,7 +199,7 @@ impl wsts::net::Signable for SignerDepositDecision {
     }
 }
 
-impl wsts::net::Signable for SignerWithdrawDecision {
+impl wsts::net::Signable for SignerWithdrawalDecision {
     fn hash(&self, hasher: &mut sha2::Sha256) {
         hasher.update("SIGNER_WITHDRAW_DECISION");
         hasher.update(self.request_id.to_be_bytes());
@@ -265,7 +265,7 @@ mod tests {
     #[test]
     fn signer_messages_should_be_signable() {
         assert_signer_messages_should_be_signable_with_type::<SignerDepositDecision>();
-        assert_signer_messages_should_be_signable_with_type::<SignerWithdrawDecision>();
+        assert_signer_messages_should_be_signable_with_type::<SignerWithdrawalDecision>();
         assert_signer_messages_should_be_signable_with_type::<BitcoinTransactionSignRequest>();
         assert_signer_messages_should_be_signable_with_type::<BitcoinTransactionSignAck>();
         assert_signer_messages_should_be_signable_with_type::<StacksTransactionSignRequest>();
@@ -276,7 +276,7 @@ mod tests {
     #[test]
     fn signer_messages_should_be_encodable() {
         assert_signer_messages_should_be_encodable_with_type::<SignerDepositDecision>();
-        assert_signer_messages_should_be_encodable_with_type::<SignerWithdrawDecision>();
+        assert_signer_messages_should_be_encodable_with_type::<SignerWithdrawalDecision>();
         assert_signer_messages_should_be_encodable_with_type::<BitcoinTransactionSignRequest>();
         assert_signer_messages_should_be_encodable_with_type::<BitcoinTransactionSignAck>();
         assert_signer_messages_should_be_encodable_with_type::<StacksTransactionSignRequest>();

--- a/signer/src/message.rs
+++ b/signer/src/message.rs
@@ -24,7 +24,7 @@ pub enum Payload {
     /// A decision related to signer deposit
     SignerDepositDecision(SignerDepositDecision),
     /// A decision related to signer withdrawal
-    SignerWithdrawDecision(SignerWithdrawDecision),
+    SignerWithdrawalDecision(SignerWithdrawDecision),
     /// A request to sign a Stacks transaction
     StacksTransactionSignRequest(StacksTransactionSignRequest),
     /// A signature of a Stacks transaction
@@ -55,7 +55,7 @@ impl From<SignerDepositDecision> for Payload {
 
 impl From<SignerWithdrawDecision> for Payload {
     fn from(value: SignerWithdrawDecision) -> Self {
-        Self::SignerWithdrawDecision(value)
+        Self::SignerWithdrawalDecision(value)
     }
 }
 
@@ -181,7 +181,7 @@ impl wsts::net::Signable for Payload {
         match self {
             Self::WstsMessage(msg) => msg.hash(hasher),
             Self::SignerDepositDecision(msg) => msg.hash(hasher),
-            Self::SignerWithdrawDecision(msg) => msg.hash(hasher),
+            Self::SignerWithdrawalDecision(msg) => msg.hash(hasher),
             Self::BitcoinTransactionSignRequest(msg) => msg.hash(hasher),
             Self::BitcoinTransactionSignAck(msg) => msg.hash(hasher),
             Self::StacksTransactionSignRequest(msg) => msg.hash(hasher),

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -65,7 +65,7 @@ fn contract_transaction_kinds() -> &'static HashMap<&'static str, TransactionTyp
 
 /// This function extracts the signer relevant sBTC related transactions
 /// from the given blocks.
-/// 
+///
 /// Here the deployer is the address that deployed the sBTC smart
 /// contracts.
 pub fn extract_relevant_transactions(

--- a/signer/src/testing/message.rs
+++ b/signer/src/testing/message.rs
@@ -47,7 +47,7 @@ impl fake::Dummy<fake::Faker> for message::Payload {
     fn dummy_with_rng<R: rand::RngCore + ?Sized>(config: &fake::Faker, rng: &mut R) -> Self {
         let variants = [
             dummy_payload::<message::SignerDepositDecision, _>,
-            dummy_payload::<message::SignerWithdrawDecision, _>,
+            dummy_payload::<message::SignerWithdrawalDecision, _>,
             dummy_payload::<message::WstsMessage, _>,
         ];
 

--- a/signer/src/testing/transaction_signer.rs
+++ b/signer/src/testing/transaction_signer.rs
@@ -10,6 +10,7 @@ use crate::keys::PrivateKey;
 use crate::keys::PublicKey;
 use crate::keys::SignerScriptPubKey as _;
 use crate::message;
+use crate::message::Payload;
 use crate::network;
 use crate::storage;
 use crate::storage::model;
@@ -162,6 +163,7 @@ where
         let network = network::in_memory::Network::new();
         let signer_info = testing::wsts::generate_signer_info(&mut rng, self.num_signers);
         let coordinator_signer_info = &signer_info.first().cloned().unwrap();
+        let mut network_rx = network.connect();
 
         let event_loop_harness = EventLoopHarness::create(
             network.connect(),
@@ -192,6 +194,16 @@ where
             1,
         )
         .await;
+
+        tokio::time::timeout(Duration::from_secs(1), async move {
+            while let Ok(msg) = network_rx.receive().await {
+                if matches!(msg.payload, Payload::SignerDepositDecision(_)) {
+                    break;
+                }
+            }
+        })
+        .await
+        .expect("signer deposit decision was not broadcasted");
     }
 
     /// Assert that the transaction signer will make and store decisions
@@ -201,6 +213,7 @@ where
         let network = network::in_memory::Network::new();
         let signer_info = testing::wsts::generate_signer_info(&mut rng, self.num_signers);
         let coordinator_signer_info = signer_info.first().cloned().unwrap();
+        let mut network_rx = network.connect();
 
         let event_loop_harness = EventLoopHarness::create(
             network.connect(),
@@ -231,6 +244,16 @@ where
             1,
         )
         .await;
+
+        tokio::time::timeout(Duration::from_secs(1), async move {
+            while let Ok(msg) = network_rx.receive().await {
+                if matches!(msg.payload, Payload::SignerWithdrawalDecision(_)) {
+                    break;
+                }
+            }
+        })
+        .await
+        .expect("signer withdrawal decision was not broadcasted");
     }
 
     /// Assert that the transaction signer will make and store decisions

--- a/signer/src/testing/wallet.rs
+++ b/signer/src/testing/wallet.rs
@@ -29,7 +29,7 @@ use crate::stacks::wallet::SignerWallet;
 
 /// A static for a test 2-3 multi-sig wallet. This wallet is loaded with
 /// funds in the local devnet environment. It matches the signer.deployer
-/// address in the default config file. 
+/// address in the default config file.
 pub static WALLET: LazyLock<(SignerWallet, [Keypair; 3], u16)> = LazyLock::new(generate_wallet);
 
 /// Helper function for generating a test 2-3 multi-sig wallet

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -208,7 +208,7 @@ where
             .get_pending_withdraw_requests(&bitcoin_chain_tip)
             .await?
         {
-            self.handle_pending_withdraw_request(withdraw_request)
+            self.handle_pending_withdraw_request(withdraw_request, &bitcoin_chain_tip)
                 .await?;
         }
 
@@ -236,7 +236,7 @@ where
                     .await?;
             }
 
-            (message::Payload::SignerWithdrawDecision(decision), _, _) => {
+            (message::Payload::SignerWithdrawalDecision(decision), _, _) => {
                 self.persist_received_withdraw_decision(decision, msg.signer_pub_key)
                     .await?;
             }
@@ -627,25 +627,35 @@ where
     #[tracing::instrument(skip(self))]
     async fn handle_pending_withdraw_request(
         &mut self,
-        withdraw_request: model::WithdrawalRequest,
+        withdrawal_request: model::WithdrawalRequest,
+        bitcoin_chain_tip: &model::BitcoinBlockHash,
     ) -> Result<(), Error> {
         // TODO: Do we want to do this on the sender address or the
         // recipient address?
         let is_accepted = self
-            .can_accept(&withdraw_request.sender_address.to_string())
+            .can_accept(&withdrawal_request.sender_address.to_string())
             .await;
 
+        let msg = message::SignerWithdrawDecision {
+            request_id: withdrawal_request.request_id,
+            block_hash: withdrawal_request.block_hash.0,
+            accepted: is_accepted,
+            txid: withdrawal_request.txid,
+        };
+
         let signer_decision = model::WithdrawalSigner {
-            request_id: withdraw_request.request_id,
-            block_hash: withdraw_request.block_hash,
+            request_id: withdrawal_request.request_id,
+            block_hash: withdrawal_request.block_hash,
             signer_pub_key: self.signer_pub_key(),
             is_accepted,
-            txid: withdraw_request.txid,
+            txid: withdrawal_request.txid,
         };
 
         self.storage
             .write_withdrawal_signer_decision(&signer_decision)
             .await?;
+
+        self.send_message(msg, bitcoin_chain_tip).await?;
 
         Ok(())
     }

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -208,7 +208,7 @@ where
             .get_pending_withdraw_requests(&bitcoin_chain_tip)
             .await?
         {
-            self.handle_pending_withdraw_request(withdraw_request, &bitcoin_chain_tip)
+            self.handle_pending_withdrawal_request(withdraw_request, &bitcoin_chain_tip)
                 .await?;
         }
 
@@ -625,7 +625,7 @@ where
     }
 
     #[tracing::instrument(skip(self))]
-    async fn handle_pending_withdraw_request(
+    async fn handle_pending_withdrawal_request(
         &mut self,
         withdrawal_request: model::WithdrawalRequest,
         bitcoin_chain_tip: &model::BitcoinBlockHash,
@@ -636,7 +636,7 @@ where
             .can_accept(&withdrawal_request.sender_address.to_string())
             .await;
 
-        let msg = message::SignerWithdrawDecision {
+        let msg = message::SignerWithdrawalDecision {
             request_id: withdrawal_request.request_id,
             block_hash: withdrawal_request.block_hash.0,
             accepted: is_accepted,
@@ -698,7 +698,7 @@ where
     #[tracing::instrument(skip(self))]
     async fn persist_received_withdraw_decision(
         &mut self,
-        decision: &message::SignerWithdrawDecision,
+        decision: &message::SignerWithdrawalDecision,
         signer_pub_key: PublicKey,
     ) -> Result<(), Error> {
         let signer_decision = model::WithdrawalSigner {


### PR DESCRIPTION
## Description

The transaction signer wasn't broadcasting its withdrawal decision in `handle_pending_withdraw_request()`; this PR adds it and adjusts both the deposit + withdrawal tests to verify that it's broadcasted.

## Changes

- Broadcasts a `SignerWithdrawalDecision` in `handle_pending_withdrawal_request()`.
- Adds asserts to both deposit and withdrawal tests to ensure that this is done for both.
- Some renames of `withdraw` to `withdrawal`

## Testing Information

Nothing special other than what's noted above.

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
