### PR TITLE
feat: fix race condition described in #588

### DIFF
--- a/signer/src/context/messaging.rs
+++ b/signer/src/context/messaging.rs
@@ -53,6 +53,9 @@ pub enum TxSignerEvent {
     PendingWithdrawalRequestRegistered,
     /// A new pending deposit request has been handled.
     PendingDepositRequestRegistered,
+    /// New pending requests have been handled. This is primarily used as a
+    /// trigger for the transaction coordinator to process the new blocks.
+    NewRequestsHandled,
 }
 
 impl From<TxSignerEvent> for SignerSignal {

--- a/signer/src/testing/transaction_coordinator.rs
+++ b/signer/src/testing/transaction_coordinator.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use crate::bitcoin::utxo::SignerUtxo;
 use crate::bitcoin::MockBitcoinInteract;
 use crate::context::Context;
-use crate::context::SignerEvent;
+use crate::context::TxSignerEvent;
 use crate::emily_client::EmilyInteract;
 use crate::error;
 use crate::keys;
@@ -224,10 +224,10 @@ where
                 .await
         });
 
-        // Signal `BitcoinBlockObserved` to trigger the coordinator.
+        // Signal `TxSignerEvent::NewRequestsHandled` to trigger the coordinator.
         handle
             .context
-            .signal(SignerEvent::BitcoinBlockObserved.into())
+            .signal(TxSignerEvent::NewRequestsHandled.into())
             .expect("failed to signal");
 
         // Await the `wait_for_tx_task` to receive the first transaction broadcasted.

--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -29,55 +29,58 @@ use wsts::state_machine::coordinator::Coordinator as _;
 #[cfg_attr(doc, aquamarine::aquamarine)]
 /// # Transaction coordinator event loop
 ///
-/// This struct contains the implementation of the transaction coordinator logic.
-/// Like the transaction signer, the coordinator event loop also subscribes to storage
-/// update notifications from the block observer and listens to signer messages over
-/// the signer network.
+/// This struct contains the implementation of the transaction coordinator
+/// logic. The coordinator subscribes to [`TxSignerEvent::NewRequestsHandled`]
+/// events (from the transaction signer) and listens to signer messages over the
+/// signer P2P network.
 ///
-/// The transaction coordinator will look up the canonical chain tip from
-/// the database upon receiving a storage update notification from the
-/// block observer. This tip is used to decide whether this particular
-/// signer is selected as the signers' coordinator or if it should be
-/// passive in favor of another signer as the coordinator in the signer
-/// network.
+/// The transaction coordinator will look up the canonical chain tip from the
+/// database upon receiving a [`TxSignerEvent::NewRequestsHandled`] event from
+/// the transaction signer. This tip is used to decide whether this particular
+/// signer is selected as the signers' coordinator or if it should be passive in
+/// favor of another signer as the coordinator in the signer network.
 ///
-/// When the coordinator is selected, that coordinator will begin by looking up the signer UTXO, and
-/// do a fee rate estimation for both Bitcoin and Stacks. With that in place it will
-/// proceed to look up any pending[^1] and active[^2] requests to process.
+/// When the coordinator is selected, that coordinator will begin by looking up
+/// the signer UTXO, and do a fee rate estimation for both Bitcoin and Stacks.
+/// With that in place it will proceed to look up any pending[^1] and active[^2]
+/// requests to process.
 ///
-/// The pending requests are used to construct a transaction package, which is a set of bitcoin
-/// transactions fulfilling a subset of the requests. Which pending requests that end up in the
-/// transaction package depends on the amount of singers deciding to accept the request, and on
-/// the maximum fee allowed in the requests. Once the package has been constructed, the
-/// coordinator proceeds by coordinating WSTS signing rounds for each of the transactions in the
-/// package. The signed transactions are then broadcast to bitcoin.
+/// The pending requests are used to construct a transaction package, which is a
+/// set of bitcoin transactions fulfilling a subset of the requests. Which
+/// pending requests that end up in the transaction package depends on the
+/// amount of singers deciding to accept the request, and on the maximum fee
+/// allowed in the requests. Once the package has been constructed, the
+/// coordinator proceeds by coordinating WSTS signing rounds for each of the
+/// transactions in the package. The signed transactions are then broadcast to
+/// bitcoin.
 
 /// Pending deposit and withdrawal requests are used to construct a Bitcoin
-/// transaction package consisting of a set of inputs and outputs that
-/// fulfill these requests. The fulfillment of pending requests in the
-/// transaction package depends on the number of signers agreeing to accept
-/// each request and the maximum fee stipulated in the request. Once the
-/// package is assembled, the coordinator coordinates WSTS signing rounds for
-/// each transaction within the package. The successfully signed
-/// transactions are then broadcast to the Bitcoin network.
+/// transaction package consisting of a set of inputs and outputs that fulfill
+/// these requests. The fulfillment of pending requests in the transaction
+/// package depends on the number of signers agreeing to accept each request and
+/// the maximum fee stipulated in the request. Once the package is assembled,
+/// the coordinator coordinates WSTS signing rounds for each transaction within
+/// the package. The successfully signed transactions are then broadcast to the
+/// Bitcoin network.
 ///
-/// For the active requests, the coordinator will go over each one and create appropriate
-/// stacks response transactions (which are the `withdrawal-accept`, `withdrawal-reject`
-/// and `deposit-accept` contract calls). These transactions are sent through the
-/// signers for signatures, and once enough signatures has been gathered,
-/// the coordinator broadcasts them to the Stacks blockchain.
+/// For the active requests, the coordinator will go over each one and create
+/// appropriate stacks response transactions (which are the `withdrawal-accept`,
+/// `withdrawal-reject` and `deposit-accept` contract calls). These transactions
+/// are sent through the signers for signatures, and once enough signatures has
+/// been gathered, the coordinator broadcasts them to the Stacks blockchain.
 ///
 /// [^1]: A deposit or withdraw request is considered pending if it is confirmed
 ///       on chain but hasn't been fulfilled in an sBTC transaction yet.
-/// [^2]: A deposit or withdraw request is considered active if has been fulfilled in an sBTC transaction,
-///       but the result hasn't been acknowledged on Stacks as a `deposit-accept`,
-///       `withdraw-accept` or `withdraw-reject` transaction.
+/// [^2]: A deposit or withdraw request is considered active if has been 
+///       fulfilled in an sBTC transaction,
+///       but the result hasn't been acknowledged on Stacks as a 
+///       `deposit-accept`, `withdraw-accept` or `withdraw-reject` transaction.
 ///
 /// The whole flow is illustrated in the following flowchart.
 ///
 /// ```mermaid
 /// flowchart TD
-///     SM[Block observer notification] --> GCT(Get canonical chain tip)
+///     SM[New requests handled notification] --> GCT(Get canonical chain tip)
 ///     GCT --> ISC{Is selected?}
 ///     ISC --> |No| DONE[Done]
 ///     ISC --> |Yes| GSU(Get signer UTXO)

--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -11,6 +11,7 @@ use sha2::Digest;
 
 use crate::bitcoin::utxo;
 use crate::bitcoin::BitcoinInteract;
+use crate::context::TxSignerEvent;
 use crate::context::{messaging::SignerEvent, messaging::SignerSignal, Context};
 use crate::error::Error;
 use crate::keys::PrivateKey;
@@ -130,9 +131,9 @@ where
                     break;
                 },
                 signal = signal_rx.recv() => match signal {
-                    // We're only interested in block observer notifications, which
-                    // is our trigger to do some work.
-                    Ok(SignerSignal::Event(SignerEvent::BitcoinBlockObserved)) => {
+                    // We're only interested in notifications from the transaction
+                    // signer indicating that it has handled new requests.
+                    Ok(SignerSignal::Event(SignerEvent::TxSigner(TxSignerEvent::NewRequestsHandled))) => {
                         tracing::debug!("received block observer notification");
                         self.process_new_blocks().await?;
                     },

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -234,6 +234,9 @@ where
                 .await?;
         }
 
+        self.context
+            .signal(TxSignerEvent::NewRequestsHandled.into())?;
+
         Ok(())
     }
 


### PR DESCRIPTION
## Description

Closes: #588

## Changes

This adds a new `TxSignerEvent` variant `NewRequestsHandled`, which is emitted at the end of the tx-signer's `handle_new_requests()` successful completion and used as the trigger for the transaction coordinator. So the new flow is:

Block Observer: `BitcoinBlockObserved` -> Transaction Signer: `NewRequestsHandled` -> Transaction Coordinator runs

## Testing Information

Coordinator tests have been updated to use this new trigger.

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
