### PR TITLE
Change mandatory fulfillment for confirmed instead of accepted requests

### DIFF
--- a/emily/handler/src/database/entries/deposit.rs
+++ b/emily/handler/src/database/entries/deposit.rs
@@ -222,7 +222,7 @@ impl TryFrom<DepositEntry> for Deposit {
         let status_message = latest_event.message.clone();
         let status: Status = (&latest_event.status).into();
         let fulfillment = match &latest_event.status {
-            StatusEntry::Accepted(fulfillment) => Some(fulfillment.clone()),
+            StatusEntry::Confirmed(fulfillment) => Some(fulfillment.clone()),
             _ => None,
         };
 
@@ -438,11 +438,11 @@ impl TryFrom<DepositUpdate> for ValidatedDepositUpdate {
         };
         // Make status entry.
         let status_entry: StatusEntry = match update.status {
-            Status::Accepted => {
+            Status::Confirmed => {
                 let fulfillment = update.fulfillment.ok_or(Error::InternalServer)?;
-                StatusEntry::Accepted(fulfillment)
+                StatusEntry::Confirmed(fulfillment)
             }
-            Status::Confirmed => StatusEntry::Confirmed,
+            Status::Accepted => StatusEntry::Accepted,
             Status::Pending => StatusEntry::Pending,
             Status::Reprocessing => StatusEntry::Reprocessing,
             Status::Failed => StatusEntry::Failed,

--- a/emily/handler/src/database/entries/mod.rs
+++ b/emily/handler/src/database/entries/mod.rs
@@ -84,14 +84,14 @@ pub enum StatusEntry {
     ///
     /// For example, a deposit or withdrawal that has specified too low of a
     /// BTC fee may fail after being accepted.
-    Accepted(Fulfillment),
+    Accepted,
     /// The articacts that fulill the operation have been observed in a valid fork of
     /// both the Stacks blockchain and the Bitcoin blockchain by at least one signer.
     ///
     /// Note that if the signers detect a conflicting chainstate in which the operation
     /// is not confirmed this status will be reverted to either ACCEPTED or REEVALUATING
     /// depending on whether the conflicting chainstate calls the acceptance into question.
-    Confirmed,
+    Confirmed(Fulfillment),
     /// The operation was not fulfilled.
     Failed,
 }
@@ -101,8 +101,8 @@ impl From<&StatusEntry> for Status {
         match value {
             StatusEntry::Pending => Status::Pending,
             StatusEntry::Reprocessing => Status::Reprocessing,
-            StatusEntry::Accepted(_) => Status::Accepted,
-            StatusEntry::Confirmed => Status::Confirmed,
+            StatusEntry::Accepted => Status::Accepted,
+            StatusEntry::Confirmed(_) => Status::Confirmed,
             StatusEntry::Failed => Status::Failed,
         }
     }

--- a/emily/handler/src/database/entries/withdrawal.rs
+++ b/emily/handler/src/database/entries/withdrawal.rs
@@ -180,7 +180,7 @@ impl TryFrom<WithdrawalEntry> for Withdrawal {
         let status_message = latest_event.message.clone();
         let status: Status = (&latest_event.status).into();
         let fulfillment = match &latest_event.status {
-            StatusEntry::Accepted(fulfillment) => Some(fulfillment.clone()),
+            StatusEntry::Confirmed(fulfillment) => Some(fulfillment.clone()),
             _ => None,
         };
 
@@ -424,11 +424,11 @@ impl TryFrom<WithdrawalUpdate> for ValidatedWithdrawalUpdate {
     fn try_from(update: WithdrawalUpdate) -> Result<Self, Self::Error> {
         // Make status entry.
         let status_entry: StatusEntry = match update.status {
-            Status::Accepted => {
+            Status::Confirmed => {
                 let fulfillment = update.fulfillment.ok_or(Error::InternalServer)?;
-                StatusEntry::Accepted(fulfillment)
+                StatusEntry::Confirmed(fulfillment)
             }
-            Status::Confirmed => StatusEntry::Confirmed,
+            Status::Accepted => StatusEntry::Accepted,
             Status::Pending => StatusEntry::Pending,
             Status::Reprocessing => StatusEntry::Reprocessing,
             Status::Failed => StatusEntry::Failed,

--- a/emily/handler/tests/integration/endpoints/deposit.rs
+++ b/emily/handler/tests/integration/endpoints/deposit.rs
@@ -392,7 +392,7 @@ async fn update_deposit() {
     // Make some parameters.
     let updated_hash = "UPDATED_HASH".to_string();
     let updated_height: u64 = 12345;
-    let updated_status: Status = Status::Accepted;
+    let updated_status: Status = Status::Confirmed;
     let updated_message: String = "UPDATED_MESSAGE".to_string();
     let fulfillment: Fulfillment = Fulfillment {
         bitcoin_txid: "FULFILLMENT_BITCOIN_TXID".to_string(),
@@ -496,7 +496,7 @@ async fn update_deposit() {
             stacks_block_hash: "DUMMY_HASH".to_string(),
         },
         DepositEvent {
-            status: StatusEntry::Accepted(fulfillment.clone()),
+            status: StatusEntry::Confirmed(fulfillment.clone()),
             message: updated_message.clone(),
             stacks_block_height: updated_height,
             stacks_block_hash: updated_hash.clone(),

--- a/emily/handler/tests/integration/endpoints/withdrawal.rs
+++ b/emily/handler/tests/integration/endpoints/withdrawal.rs
@@ -252,7 +252,7 @@ async fn update_withdrawal() {
     // Make some parameters.
     let updated_hash = "UPDATED_HASH".to_string();
     let updated_height: u64 = 12345;
-    let updated_status: Status = Status::Accepted;
+    let updated_status: Status = Status::Confirmed;
     let updated_message: String = "UPDATED_MESSAGE".to_string();
     let fulfillment: Fulfillment = Fulfillment {
         bitcoin_txid: "FULFILLMENT_BITCOIN_TXID".to_string(),
@@ -353,7 +353,7 @@ async fn update_withdrawal() {
             stacks_block_hash: "test_stacks_block_hash_1".to_string(),
         },
         WithdrawalEvent {
-            status: StatusEntry::Accepted(fulfillment.clone()),
+            status: StatusEntry::Confirmed(fulfillment.clone()),
             message: updated_message.clone(),
             stacks_block_height: updated_height,
             stacks_block_hash: updated_hash.clone(),

--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -71,9 +71,9 @@ use wsts::state_machine::coordinator::Coordinator as _;
 ///
 /// [^1]: A deposit or withdraw request is considered pending if it is confirmed
 ///       on chain but hasn't been fulfilled in an sBTC transaction yet.
-/// [^2]: A deposit or withdraw request is considered active if has been 
+/// [^2]: A deposit or withdraw request is considered active if has been
 ///       fulfilled in an sBTC transaction,
-///       but the result hasn't been acknowledged on Stacks as a 
+///       but the result hasn't been acknowledged on Stacks as a
 ///       `deposit-accept`, `withdraw-accept` or `withdraw-reject` transaction.
 ///
 /// The whole flow is illustrated in the following flowchart.


### PR DESCRIPTION
## Description

Make fulfilment required for confirmed requests instead of accepted ones.

## Testing Information

Emily integrations tests are green.

## Checklist:

- [X] I have performed a self-review of my code