### PR TITLE
Store deposit requests txs when extracted

### DIFF
--- a/signer/src/storage/in_memory.rs
+++ b/signer/src/storage/in_memory.rs
@@ -599,6 +599,7 @@ impl super::DbWrite for SharedStore {
 
     async fn write_bitcoin_transactions(&self, txs: Vec<model::Transaction>) -> Result<(), Error> {
         for tx in txs {
+            self.write_transaction(&tx).await?;
             let bitcoin_transaction = model::BitcoinTxRef {
                 txid: tx.txid.into(),
                 block_hash: tx.block_hash.into(),
@@ -757,6 +758,7 @@ impl super::DbWrite for SharedStore {
         stacks_transactions: Vec<model::Transaction>,
     ) -> Result<(), Error> {
         for tx in stacks_transactions {
+            self.write_transaction(&tx).await?;
             let stacks_transaction = model::StacksTransaction {
                 txid: tx.txid.into(),
                 block_hash: tx.block_hash.into(),


### PR DESCRIPTION
## Description

Closes: https://github.com/stacks-network/sbtc/issues/625

## Changes

In `extract_deposit_requests`, we store the bitcoin tx for deposit requests (both the bitcoin tx and the "raw" `TransactionType::DepositRequest` tx).
Also added the `write_transaction` call in `write_bitcoin_transactions` and `write_stacks_transactions` for in memory storage impl, as done by the pg one.

## Testing Information

Added a check on an existing test, and tested on the integration test in https://github.com/stacks-network/sbtc/pull/609.

## Checklist:

- [X] I have performed a self-review of my code