### PR TITLE
Chore/run signer binary against devenv emily as server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ devenv: $(wildcard $(subst dir, devenv, $(TWO_DIRS_DEEP)))
 EMILY_CDK_SOURCE_FILES := $(wildcard $(subst dir, emily/cdk/lib, $(FIVE_DIRS_DEEP)))
 EMILY_CDK_SOURCE_FILES := $(wildcard $(subst dir, emily/bin/lib, $(FIVE_DIRS_DEEP))) $(EMILY_CDK_SOURCE_FILES)
 
-$(EMILY_CDK_TEMPLATE): $(INSTALL_TARGET) $(EMILY_OPENAPI_SPEC) $(EMILY_CDK_SOURCE_FILES)
+$(EMILY_CDK_TEMPLATE): $(INSTALL_TARGET) $(EMILY_CDK_SOURCE_FILES)
 	AWS_STAGE=local \
 	TABLES_ONLY=true \
 	pnpm --filter $(EMILY_CDK_PROJECT_NAME) run synth

--- a/devenv/local/docker-compose/Dockerfile.emily
+++ b/devenv/local/docker-compose/Dockerfile.emily
@@ -20,7 +20,7 @@ RUN git clone https://github.com/stacks-network/sbtc.git
 WORKDIR /code/sbtc
 
 # TODO: DELETE THIS LINE BEFORE MERGING vvv
-RUN git checkout chore/run-signer-binary-against-devenv-emily-as-server
+RUN git checkout chore/run-signer-binary-against-devenv
 # TODO: DELETE THIS LINE BEFORE MERGING ^^^
 
 RUN make install

--- a/devenv/local/docker-compose/Dockerfile.emily
+++ b/devenv/local/docker-compose/Dockerfile.emily
@@ -38,12 +38,11 @@ RUN pnpm --filter emily-cdk run synth
 
 # Compile emily handler as a warp server.
 # ------------------------------------------------------------------------------
-RUN cargo build --release --bin emily-server
-RUN ls -l ./target/release/emily-server
+RUN cargo build --bin emily-server
 
 # Create Docker image to setup AWS resources.
 # ------------------------------------------------------------------------------
-FROM python:3.12-slim AS aws-setup
+FROM python:3.12-slim AS emily-aws-setup
 WORKDIR /code
 COPY --from=builder /code/sbtc/devenv/aws-setup/initialize.py /code/initialize.py
 COPY --from=builder /code/sbtc/emily/cdk/cdk.out /code/cdk.out
@@ -62,7 +61,7 @@ ENTRYPOINT ["python3", "/code/initialize.py"]
 FROM debian:bookworm-slim AS emily-server
 WORKDIR /code
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=builder /code/sbtc/target/release/emily-server /usr/local/bin/emily-server
+COPY --from=builder /code/sbtc/target/debug/emily-server /usr/local/bin/emily-server
 ENV HOST=0.0.0.0
 ENV PORT=3031
 ENV DYNAMODB_ENDPOINT=http://dynamodb:8000

--- a/devenv/local/docker-compose/Dockerfile.emily
+++ b/devenv/local/docker-compose/Dockerfile.emily
@@ -1,0 +1,72 @@
+FROM rust:bookworm as builder
+
+# Install dependencies.
+RUN apt-get update
+RUN apt-get install -y \
+    libclang-dev \
+    git pkg-config \
+    libssl-dev make \
+    protobuf-compiler \
+    npm \
+    default-jre
+RUN npm install -g pnpm@9
+RUN npm install -g @openapitools/openapi-generator-cli
+RUN rustup toolchain install stable
+RUN rustup component add rustfmt --toolchain stable
+# Setup the code.
+RUN mkdir /code
+WORKDIR /code
+RUN git clone https://github.com/stacks-network/sbtc.git
+WORKDIR /code/sbtc
+
+# TODO: DELETE THIS LINE BEFORE MERGING vvv
+RUN git checkout chore/run-signer-binary-against-devenv-emily-as-server
+# TODO: DELETE THIS LINE BEFORE MERGING ^^^
+
+RUN make install
+RUN make build
+
+# Generate CDK template
+# ------------------------------------------------------------------------------
+ARG AWS_STAGE=local
+ARG TABLES_ONLY=true
+RUN pnpm --filter emily-cdk run synth
+
+# NOTE: If you want to synthsize with the lambda and apigateway instance as well
+# you need to also compile the emily handler as a lambda and generate the openapi
+# spec before attempting to synthesize the cdk template.
+
+# Compile emily handler as a warp server.
+# ------------------------------------------------------------------------------
+RUN cargo build --release --bin emily-server
+RUN ls -l ./target/release/emily-server
+
+# Create Docker image to setup AWS resources.
+# ------------------------------------------------------------------------------
+FROM python:3.12-slim AS aws-setup
+WORKDIR /code
+COPY --from=builder /code/sbtc/devenv/aws-setup/initialize.py /code/initialize.py
+COPY --from=builder /code/sbtc/emily/cdk/cdk.out /code/cdk.out
+RUN pip3 install boto3
+# The local lambda path is not used here because we're only deploying with the
+# dynamodb tables. This will need to point to the local lambda zip file
+# that was compiled to be deployed.
+ENV LOCAL_LAMBDA_PATH=/code/your-compiled-aws-lambda-here.zip
+ENV DYNAMODB_ENDPOINT=http://dynamodb:8000
+ENV INPUT_CDK_TEMPLATE=/code/cdk.out/EmilyStack.template.json
+ENV OUTPUT_CDK_TEMPLATE=/code/cdk.out/EmilyStack.devenv.template.json
+ENTRYPOINT ["python3", "/code/initialize.py"]
+
+# Create Docker image to run the emily server.
+# ------------------------------------------------------------------------------
+FROM debian:bookworm-slim AS emily-server
+WORKDIR /code
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /code/sbtc/target/release/emily-server /usr/local/bin/emily-server
+ENV HOST=0.0.0.0
+ENV PORT=3031
+ENV DYNAMODB_ENDPOINT=http://dynamodb:8000
+ENTRYPOINT ["/bin/sh", "-c", "/usr/local/bin/emily-server --host $HOST --port $PORT --dynamodb-endpoint $DYNAMODB_ENDPOINT"]
+
+# TODO(TBD): Create the docker image for the sBTC Signer here.
+# TODO(TBD): Create the docker image for the blocklist client here.

--- a/devenv/local/docker-compose/docker-compose.yml
+++ b/devenv/local/docker-compose/docker-compose.yml
@@ -27,10 +27,6 @@ x-common-vars:
   - &REWARD_RECIPIENT ${REWARD_RECIPIENT:-STQM73RQC4EX0A07KWG1J5ECZJYBZS4SJ4ERC6WN} # priv: 6ad9cadb42d4edbfbe0c5bfb3b8a4125ddced021c4174f829b714ccbf527f02001
   - &EXIT_FROM_MONITOR 1 # set to "1" to automatically shut down via monitor.ts
 
-networks:
-  aws-local-vpc:
-    name: aws-local-vpc
-
 services:
   bitcoin:
     build:
@@ -455,22 +451,18 @@ services:
     user: root
     volumes:
       - "../../dynamodb/data:/home/dynamodblocal/data"
-    networks:
-      - aws-local-vpc
 
   # Modifies the CDK template and creates DynamoDB Tables if necessary.
-  aws-setup:
+  emily-aws-setup:
     build:
       context: .
       dockerfile: ./Dockerfile.emily
-      target: aws-setup
+      target: emily-aws-setup
     depends_on:
       dynamodb:
         condition: service_started
     environment:
       - DYNAMODB_ENDPOINT=http://dynamodb:8000
-    networks:
-      - aws-local-vpc
 
   # Hosts the SAM CLI
   emily-server:
@@ -479,7 +471,7 @@ services:
       dockerfile: ./Dockerfile.emily
       target: emily-server
     depends_on:
-      aws-setup:
+      emily-aws-setup:
         condition: service_completed_successfully
     environment:
       - AWS_ACCESS_KEY_ID=xxxxxxxxxxxx
@@ -489,8 +481,6 @@ services:
       - PORT=3031
     ports:
       - "3031:3031"
-    networks:
-      - aws-local-vpc
 
   stacker:
     build:

--- a/devenv/local/docker-compose/docker-compose.yml
+++ b/devenv/local/docker-compose/docker-compose.yml
@@ -460,73 +460,37 @@ services:
 
   # Modifies the CDK template and creates DynamoDB Tables if necessary.
   aws-setup:
-    build: ../../aws-setup
+    build:
+      context: .
+      dockerfile: ./Dockerfile.emily
+      target: aws-setup
     depends_on:
       dynamodb:
         condition: service_started
-    volumes:
-      - "../../aws-setup/initialize.py:/initialize.py"
-      - "../../../emily/cdk/cdk.out:/cdk.out"
     environment:
       - DYNAMODB_ENDPOINT=http://dynamodb:8000
-      - LOCAL_LAMBDA_PATH=/code/emily-handler/bootstrap.zip
-      - INPUT_CDK_TEMPLATE=/cdk.out/EmilyStack.template.json
-      - OUTPUT_CDK_TEMPLATE=/cdk.out/EmilyStack.devenv.template.json
-    command: python3 ./initialize.py
     networks:
       - aws-local-vpc
 
   # Hosts the SAM CLI
-  apigateway:
-    build: ../../apigateway
+  emily-server:
+    build:
+      context: .
+      dockerfile: ./Dockerfile.emily
+      target: emily-server
     depends_on:
       aws-setup:
         condition: service_completed_successfully
-    ports:
-      - "3000:3000"
-    volumes:
-      - "../../../target/lambda:/code"
-      - "../../../emily/cdk/cdk.out:/cdk.out"
-      - "../../lambda:/lambda"
-      # Give this container access to the host docker socket so it makes sibling containers and
-      # not child containers.
-      - "/var/run/docker.sock:/var/run/docker.sock"
-      # When the SAM CLI launches a lambda container it decompresses the sources in folder under
-      # `tmp` and then mounts that folder onto the new container. When two sibling containers
-      # need access to the same directory they need to do that via a directory on the shared host.
-      #
-      # tl;dr: We're running SAM in a docker container and launching the lambda as a sibling container
-      # so we need the `tmp` directory to be shared on the host.
-      - "/tmp:/tmp"
     environment:
-      - SAM_CLI_TELEMETRY=0
-      - SAM_CLI_CONTAINER_CONNECTION_TIMEOUT=10
-    command: |
-      sam local start-api
-        --host 0.0.0.0
-        --container-host ${CONTAINER_HOST}
-        --docker-network aws-local-vpc
-        --warm-containers LAZY
-        --env-vars /lambda/env.json
-        -t /cdk.out/EmilyStack.devenv.template.json
+      - AWS_ACCESS_KEY_ID=xxxxxxxxxxxx
+      - AWS_SECRET_ACCESS_KEY=xxxxxxxxxxxx
+      - AWS_REGION=us-west-2
+      - DYNAMODB_ENDPOINT=http://dynamodb:8000
+      - PORT=3031
+    ports:
+      - "3031:3031"
     networks:
       - aws-local-vpc
-
-  service-test:
-    build: ../../service-test
-    image: "debian:12.5"
-    profiles:
-      - test
-    depends_on:
-      apigateway:
-        condition: service_started
-    volumes:
-      - "../../service-test:/service-test:ro"
-    command: bash /service-test/curl-test.sh apigateway 3000 5
-    networks:
-      - aws-local-vpc
-
-  # Auto-stacking scripts
 
   stacker:
     build:

--- a/devenv/service-test/curl-test.sh
+++ b/devenv/service-test/curl-test.sh
@@ -22,8 +22,8 @@ curl -X POST "$ENDPOINT/deposit" \
      -d '{
            "bitcoinTxid": "example_txid",
            "bitcoinTxOutputIndex": 0,
-           "reclaim": "example_reclaim_script",
-           "deposit": "example_deposit_script"
+           "reclaimScript": "example_reclaim_script",
+           "depositScript": "example_deposit_script"
          }' | jq
 
 curl -X POST "$ENDPOINT/deposit" \
@@ -31,8 +31,8 @@ curl -X POST "$ENDPOINT/deposit" \
      -d '{
            "bitcoinTxid": "example_txid",
            "bitcoinTxOutputIndex": 1,
-           "reclaim": "example_reclaim_script",
-           "deposit": "example_deposit_script"
+           "reclaimScript": "example_reclaim_script",
+           "depositScript": "example_deposit_script"
          }' | jq
 
 curl -X POST "$ENDPOINT/deposit" \
@@ -40,8 +40,8 @@ curl -X POST "$ENDPOINT/deposit" \
      -d '{
            "bitcoinTxid": "example_txid",
            "bitcoinTxOutputIndex": 4,
-           "reclaim": "example_reclaim_script",
-           "deposit": "example_deposit_script"
+           "reclaimScript": "example_reclaim_script",
+           "depositScript": "example_deposit_script"
          }' | jq
 
 curl "$ENDPOINT/deposit/example_txid/0" | jq
@@ -67,6 +67,7 @@ curl -X POST "$ENDPOINT/withdrawal" \
      -d '{
            "requestId": 0,
            "stacksBlockHash": "example_hash",
+           "stacksBlockHeight": 11,
            "recipient": "example_recipient",
            "amount": 0,
            "parameters": {
@@ -79,6 +80,7 @@ curl -X POST "$ENDPOINT/withdrawal" \
      -d '{
            "requestId": 2,
            "stacksBlockHash": "example_hash",
+           "stacksBlockHeight": 12,
            "recipient": "example_recipient",
            "amount": 0,
            "parameters": {
@@ -91,6 +93,7 @@ curl -X POST "$ENDPOINT/withdrawal" \
      -d '{
            "requestId": 3,
            "stacksBlockHash": "example_hash",
+           "stacksBlockHeight": 13,
            "recipient": "example_recipient",
            "amount": 0,
            "parameters": {

--- a/emily/handler/src/bin/emily-server.rs
+++ b/emily/handler/src/bin/emily-server.rs
@@ -35,6 +35,9 @@ pub struct GeneralArgs {
     /// Log directives.
     #[arg(long, default_value = "info,emily-handler=debug")]
     pub log_directives: String,
+    /// DynamoDB endpoint.
+    #[arg(long, default_value = "http://localhost:8000")]
+    pub dynamodb_endpoint: String,
 }
 
 /// Server related arguments.
@@ -54,7 +57,7 @@ async fn main() {
     // Get command line arguments.
     let Cli {
         server: ServerArgs { host, port },
-        general: GeneralArgs { pretty_logs, log_directives },
+        general: GeneralArgs { pretty_logs, log_directives, dynamodb_endpoint },
     } = Cli::parse();
 
     // Setup logging.
@@ -62,7 +65,7 @@ async fn main() {
 
     // Setup context.
     // TODO(389 + 358): Handle config pickup in a way that will only fail for the relevant call.
-    let context: EmilyContext = EmilyContext::local_test_instance()
+    let context: EmilyContext = EmilyContext::local_instance(&dynamodb_endpoint)
         .await
         .unwrap_or_else(|e| panic!("{e}"));
     info!("Lambda Context:\n{context:?}");

--- a/emily/handler/src/context.rs
+++ b/emily/handler/src/context.rs
@@ -88,7 +88,9 @@ impl EmilyContext {
     }
     /// Create a local testing instance.
     #[cfg(feature = "testing")]
-    pub async fn local_test_instance() -> Result<Self, Error> {
+    pub async fn local_instance(
+        dynamodb_endpoint: &str,
+    ) -> Result<Self, Error> {
         use std::collections::HashMap;
 
         // Get config that always points to the dynamodb table directly
@@ -96,7 +98,7 @@ impl EmilyContext {
         let sdk_config = aws_config::load_defaults(BehaviorVersion::latest())
             .await
             .into_builder()
-            .endpoint_url("http://localhost:8000")
+            .endpoint_url(dynamodb_endpoint)
             .build();
         let dynamodb_client = Client::new(&sdk_config);
 

--- a/emily/handler/tests/integration/endpoints/deposit.rs
+++ b/emily/handler/tests/integration/endpoints/deposit.rs
@@ -474,7 +474,7 @@ async fn update_deposit() {
     assert_eq!(updated_deposit.fulfillment, None);
 
     // Now try getting the raw internal entry.
-    let context: EmilyContext = EmilyContext::local_test_instance()
+    let context: EmilyContext = EmilyContext::local_instance("http://localhost:8000")
         .await
         .expect("Making emily context must succeed in integration test.");
     let deposit_entry = accessors::get_deposit_entry(

--- a/emily/handler/tests/integration/endpoints/withdrawal.rs
+++ b/emily/handler/tests/integration/endpoints/withdrawal.rs
@@ -337,7 +337,7 @@ async fn update_withdrawal() {
     assert_eq!(updated_withdrawal.fulfillment, None);
 
     // Now try getting the raw internal entry and ensure that the history is good.
-    let context: EmilyContext = EmilyContext::local_test_instance()
+    let context: EmilyContext = EmilyContext::local_instance("http://localhost:8000")
         .await
         .expect("Making emily context must succeed in integration test.");
     let withdrawal_entry = accessors::get_withdrawal_entry(&context, &request_id_1)

--- a/emily/handler/tests/integration/util/mod.rs
+++ b/emily/handler/tests/integration/util/mod.rs
@@ -70,7 +70,7 @@ pub fn test_create_deposit_request(id_num: u64, output_index: u32) -> CreateDepo
 
 /// Make a test context for Emily.
 pub async fn test_context() -> EmilyContext {
-    EmilyContext::local_test_instance()
+    EmilyContext::local_instance("http://localhost:8000")
         .await
         .expect("Failed to setup local test context for Emily integration test.")
 }


### PR DESCRIPTION
## Description

Closes: NA

## Changes

1. Adds a configuration option to the emily-server binary so that the local dynamodb endpoint can be set to a custom endpoint url. Before it was locked into being `http://localhost:8000`
2. Creates a dockerfile for compiling emily and setting up the aws resources
3. Adds the build script to the docker-compose
4. Fixes the curl test so that it uses the most recent version of the API interfaces

Note that before this is merged the part of the Dockerfile that switches to the branch with these changes needs to be changed to point to the destination branch, and then further to the main branch when the devenv PR is to be merged in.

## Testing Information

Tested by running the infrastructure locally with the following commands:

```bash
docker compose --file devenv/local/docker-compose/docker-compose.yml up emily-server --detach && \
make emily-curl-test && \
docker compose --file devenv/local/docker-compose/docker-compose.yml down emily-server 
```

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
