### PR TITLE
feat: make block observer + signer + coordinator more robust

### DIFF
--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -121,18 +121,38 @@ where
         // early.
         let run = async {
             while let Some(new_block_hash) = self.bitcoin_blocks.next().await {
-                self.load_latest_deposit_requests().await?;
+                if let Err(error) = self.load_latest_deposit_requests().await {
+                    tracing::warn!(%error, "could not load latest deposit requests from Emily");
+                }
 
                 // TODO: What to do when `new_block_hash?` errors? Perhaps we can
                 // handle this within a failover-stream if this indicates a problem
                 // with the stream, and then we change this back to a plain `BlockHash`
                 // instead of a `Result<>`.
-                for block in self.next_blocks_to_process(new_block_hash?).await? {
-                    self.process_bitcoin_block(block).await?;
-                }
+                match new_block_hash {
+                    Ok(new_block_hash) => {
+                        tracing::info!(%new_block_hash, "observed new bitcoin block from stream");
 
-                self.context
-                    .signal(SignerEvent::BitcoinBlockObserved.into())?;
+                        match self.next_blocks_to_process(new_block_hash).await {
+                            Ok(next_blocks_to_process) => {
+                                for block in next_blocks_to_process {
+                                    if let Err(error) = self.process_bitcoin_block(block).await {
+                                        tracing::warn!(%error, "could not process bitcoin block");
+                                    }
+                                }
+
+                                self.context
+                                    .signal(SignerEvent::BitcoinBlockObserved.into())?;
+                            }
+                            Err(error) => {
+                                tracing::warn!(%error, "could not get next blocks to process");
+                            }
+                        }
+                    }
+                    Err(error) => {
+                        tracing::warn!(%error, "error decoding new bitcoin block hash from stream");
+                    }
+                }
             }
 
             Ok::<_, Error>(())

--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -116,43 +116,39 @@ where
     pub async fn run(mut self) -> Result<(), Error> {
         let mut term = self.context.get_termination_handle();
 
-        // TODO: We need to revisit all of the `?`'s in this function to ensure
-        // that we don't accidentally kill the signer by exiting this function
-        // early.
         let run = async {
             while let Some(new_block_hash) = self.bitcoin_blocks.next().await {
                 if let Err(error) = self.load_latest_deposit_requests().await {
                     tracing::warn!(%error, "could not load latest deposit requests from Emily");
                 }
 
-                // TODO: What to do when `new_block_hash?` errors? Perhaps we can
-                // handle this within a failover-stream if this indicates a problem
-                // with the stream, and then we change this back to a plain `BlockHash`
-                // instead of a `Result<>`.
-                match new_block_hash {
-                    Ok(new_block_hash) => {
-                        tracing::info!(%new_block_hash, "observed new bitcoin block from stream");
-
-                        match self.next_blocks_to_process(new_block_hash).await {
-                            Ok(next_blocks_to_process) => {
-                                for block in next_blocks_to_process {
-                                    if let Err(error) = self.process_bitcoin_block(block).await {
-                                        tracing::warn!(%error, "could not process bitcoin block");
-                                    }
-                                }
-
-                                self.context
-                                    .signal(SignerEvent::BitcoinBlockObserved.into())?;
-                            }
-                            Err(error) => {
-                                tracing::warn!(%error, "could not get next blocks to process");
-                            }
-                        }
-                    }
+                let new_block_hash = match new_block_hash {
+                    Ok(hash) => hash,
                     Err(error) => {
                         tracing::warn!(%error, "error decoding new bitcoin block hash from stream");
+                        continue;
+                    }
+                };
+
+                tracing::info!(%new_block_hash, "observed new bitcoin block from stream");
+
+                let next_blocks_to_process = match self.next_blocks_to_process(new_block_hash).await
+                {
+                    Ok(blocks) => blocks,
+                    Err(error) => {
+                        tracing::warn!(%error, block_hash = %new_block_hash, "could not get next blocks to process");
+                        continue;
+                    }
+                };
+
+                for block in next_blocks_to_process {
+                    if let Err(error) = self.process_bitcoin_block(block).await {
+                        tracing::warn!(%error, "could not process bitcoin block");
                     }
                 }
+
+                self.context
+                    .signal(SignerEvent::BitcoinBlockObserved.into())?;
             }
 
             Ok::<_, Error>(())

--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -138,7 +138,12 @@ where
                     // signer indicating that it has handled new requests.
                     Ok(SignerSignal::Event(SignerEvent::TxSigner(TxSignerEvent::NewRequestsHandled))) => {
                         tracing::debug!("received block observer notification");
-                        self.process_new_blocks().await?;
+                        match self.process_new_blocks().await {
+                            Ok(_) => continue,
+                            Err(error) => {
+                                tracing::error!(?error, "error processing new blocks; skipping this round");
+                            },
+                        };
                     },
                     // If we get an error receiving,
                     Err(error) => {

--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -138,12 +138,8 @@ where
                     // signer indicating that it has handled new requests.
                     Ok(SignerSignal::Event(SignerEvent::TxSigner(TxSignerEvent::NewRequestsHandled))) => {
                         tracing::debug!("received block observer notification");
-                        match self.process_new_blocks().await {
-                            Ok(_) => continue,
-                            Err(error) => {
-                                tracing::error!(?error, "error processing new blocks; skipping this round");
-                            },
-                        };
+                        let _ = self.process_new_blocks().await
+                            .inspect_err(|error| tracing::error!(?error, "error processing new blocks; skipping this round"));
                     },
                     // If we get an error receiving,
                     Err(error) => {
@@ -154,7 +150,6 @@ where
                     // in, so we just continue.
                     _ => {
                         tracing::warn!("ignoring signal");
-                        continue;
                     }
                 },
             }

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -189,8 +189,7 @@ where
                         // Handle the received message.
                         let res = self.handle_signer_message(&msg).await;
                         match res {
-                            Ok(()) => (),
-                            Err(Error::InvalidSignature) => (),
+                            Ok(()) | Err(Error::InvalidSignature) => (),
                             Err(error) => {
                                 tracing::error!(%error, "error handling signer message");
                             }

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -169,7 +169,9 @@ where
 
                 // If we've observed a new block, we need to handle any new requests.
                 if new_block_observed {
-                    self.handle_new_requests().await?;
+                    if let Err(error) = self.handle_new_requests().await {
+                        tracing::warn!(%error, "error handling new requests; skipping this round");
+                    }
                 }
 
                 // Next, we define a future that polls the network for new messages
@@ -180,15 +182,17 @@ where
                 let future = tokio::time::timeout(Duration::from_millis(5), self.network.receive());
 
                 match future.await {
-                    Ok(msg) => {
+                    Ok(Err(error)) => {
+                        tracing::warn!(%error, "message error; skipping");
+                    }
+                    Ok(Ok(msg)) => {
                         // Handle the received message.
-                        let res = self.handle_signer_message(&msg?).await;
+                        let res = self.handle_signer_message(&msg).await;
                         match res {
                             Ok(()) => (),
                             Err(Error::InvalidSignature) => (),
                             Err(error) => {
-                                tracing::error!(%error, "fatal signer error");
-                                return Err::<(), Error>(error);
+                                tracing::error!(%error, "error handling signer message");
                             }
                         }
                     }


### PR DESCRIPTION
## Description

Removes error propagation in the block observer, transaction signer & coordinator event loops, logging the error and waiting for the next run (as these errors can be temporary) instead of causing the signer to shutdown.

This is primarily a problem when bootstrapping because DKG hasn't yet been run, and then we hit an error regarding this and the signer immediately shuts down (which in turn makes it impossible to run DKG).

## Changes

As described in description; error propagation for these event loops are largely removed (we may want to match on some specific truly-fatal errors later, but now it will just keep retrying).

## Testing Information

Nothing special, has been run against devenv.

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
