### PR TITLE
638 chore add bridge website docker container to devenv

### DIFF
--- a/devenv/local/docker-compose/Dockerfile.emily
+++ b/devenv/local/docker-compose/Dockerfile.emily
@@ -4,8 +4,10 @@ FROM rust:bookworm as builder
 RUN apt-get update
 RUN apt-get install -y \
     libclang-dev \
-    git pkg-config \
-    libssl-dev make \
+    git \
+    pkg-config \
+    libssl-dev \
+    make \
     protobuf-compiler \
     npm \
     default-jre
@@ -19,9 +21,6 @@ WORKDIR /code
 RUN git clone https://github.com/stacks-network/sbtc.git
 WORKDIR /code/sbtc
 
-# TODO: DELETE THIS LINE BEFORE MERGING vvv
-RUN git checkout chore/run-signer-binary-against-devenv
-# TODO: DELETE THIS LINE BEFORE MERGING ^^^
 
 RUN make install
 RUN make build
@@ -30,6 +29,8 @@ RUN make build
 # ------------------------------------------------------------------------------
 ARG AWS_STAGE=local
 ARG TABLES_ONLY=true
+
+# TODO: Use make command to generat the cdk template.
 RUN pnpm --filter emily-cdk run synth
 
 # NOTE: If you want to synthsize with the lambda and apigateway instance as well

--- a/devenv/local/docker-compose/Dockerfile.sbtc-bridge-website
+++ b/devenv/local/docker-compose/Dockerfile.sbtc-bridge-website
@@ -1,0 +1,14 @@
+FROM debian:bookworm-slim
+
+RUN apt-get update
+RUN apt-get install -y \
+    git \
+    npm
+
+RUN mkdir /code
+WORKDIR /code
+RUN git clone https://github.com/Strata-Labs/sbtc-bridge
+WORKDIR /code/sbtc-bridge
+RUN npm install
+
+CMD [ "npm", "run", "dev" ]

--- a/devenv/local/docker-compose/docker-compose.yml
+++ b/devenv/local/docker-compose/docker-compose.yml
@@ -481,6 +481,18 @@ services:
     ports:
       - "3031:3031"
 
+  sbtc-bridge-website:
+    build:
+      context: .
+      dockerfile: Dockerfile.sbtc-bridge-website
+    depends_on:
+      - stacks
+      - stacks-api
+      - emily-server
+      - bitcoin
+    ports:
+      - "3010:3000"
+
   stacker:
     build:
       context: .


### PR DESCRIPTION
## Description

Closes: #638 

## Changes

1. Adds `sbtc` bridge website container to docker compose.
2. Fixes a bug I introduced where main isn't used when compiling the `emily` sources.

## Testing Information

Tested by running the following:

- `docker compose --file devenv/local/docker-compose/docker-compose.yml --progress=plain up sbtc-bridge-website`

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
