### PR TITLE
chore: add `flake.nix` including developer shell

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,13 +9,6 @@ RUN cargo install --locked cargo-lambda
 
 RUN wget -qO- https://get.pnpm.io/install.sh | bash -
 
-RUN mkdir -p /tmp/smithy-install/smithy
-RUN curl -L https://github.com/smithy-lang/smithy/releases/download/1.49.0/smithy-cli-linux-aarch64.zip -o /tmp/smithy-install/smithy-cli-linux-aarch64.zip
-RUN unzip -qo /tmp/smithy-install/smithy-cli-linux-aarch64.zip -d /tmp/smithy-install
-RUN mv /tmp/smithy-install/smithy-cli-linux-aarch64/* /tmp/smithy-install/smithy
-RUN /tmp/smithy-install/smithy/install
-RUN rm -rf /tmp/smithy-install
-
 RUN mkdir -p /tmp/node-install
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x -o /tmp/node-install/nodesource_setup.sh
 RUN bash /tmp/node-install/nodesource_setup.sh

--- a/README.md
+++ b/README.md
@@ -39,6 +39,16 @@ The following are the developer tools that you should install on your local mach
 - **[Docker](https://docs.docker.com/manuals/)** - [Installation Guide](https://docs.docker.com/desktop/). This is used for running integration tests.
 - **[protoc](https://github.com/protocolbuffers/protobuf)** - [Installation Guide](https://grpc.io/docs/protoc-installation/). Compiles protobuf files.
 
+#### Developer shell through `nix`
+
+If you have `nix` and `flakes` installed (e.g. through the [DeterminateSystems
+installer](https://github.com/DeterminateSystems/nix-installer)), running the
+following command will enter a shell with all dependencies installed:
+
+```bash
+$ nix develop
+```
+
 #### Tool Versions
 
 This command should check the version of the dependencies required for the sBTC

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ The following are the developer tools that you should install on your local mach
 - **[Cargo](https://doc.rust-lang.org/cargo/)** - [Installation Guide](https://doc.rust-lang.org/cargo/getting-started/installation.html) - Builds rust packages.
 - **[Cargo-lambda](https://www.cargo-lambda.info/)** - [Installation Guide](https://www.cargo-lambda.info/guide/getting-started.html) - Compile the package for AWS Lambda.
 - **[pnpm](https://pnpm.io)** - [Installation guide](https://pnpm.io/installation) - Manages node packages
-- **[Smithy](https://smithy.io/2.0/index.html)** - [Installation Guide](https://smithy.io/2.0/guides/smithy-cli/cli_installation.html) - Generates OpenAPI templates
 - **[Make](https://www.gnu.org/software/make/)** - Development task runner; natively present on nearly every system.
 - **[Docker](https://docs.docker.com/manuals/)** - [Installation Guide](https://docs.docker.com/desktop/). This is used for running integration tests.
 - **[protoc](https://github.com/protocolbuffers/protobuf)** - [Installation Guide](https://grpc.io/docs/protoc-installation/). Compiles protobuf files.
@@ -59,7 +58,6 @@ echo "\n--- sBTC tool versions ---" \
     && cargo --version \
     && cargo lambda --version \
     && echo "pnpm $(pnpm --version)" \
-    && echo "smithy $(smithy --version)" \
     && make --version | head -n 1
 ```
 
@@ -70,7 +68,6 @@ Below is the output on a machine that is able to build and run all the sources a
 cargo 1.77.2 (e52e36006 2024-03-26)
 cargo-lambda 1.2.1 (12f9b61 2024-04-05Z)
 pnpm 8.15.4
-smithy 1.47.0
 GNU Make 3.81
 ```
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,82 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1728241625,
+        "narHash": "sha256-yumd4fBc/hi8a9QgA9IT8vlQuLZ2oqhkJXHPKxH/tRw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c31898adf5a8ed202ce5bea9f347b1c6871f32d1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1728461096,
+        "narHash": "sha256-cd0cXB85B3kGpm+iumP9xCnqFErspXL9Z/2X59kQ6c4=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "e310b9bd71fa6c6a9fec0a8cf5af43ce798a0ad6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -18,27 +18,6 @@
             inherit system overlays;
           };
           toolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
-
-          smithy-cli = pkgs.stdenv.mkDerivation rec {
-            smithy-system-hash = {
-              "aarch64-darwin" = [ "darwin-aarch64" "sha256-s/y8turEQfvGwJ2xz70SwAIlg1fk4miOPZ5SapO6tJU=" ];
-              "x86_64-darwin" = [ "darwin-x86_64" "sha256-iTJ4PbFfxG+sU2B4Viu5fG0K44zqcU/I3Y7sTlFPAuQ=" ];
-              "aarch64-linux" = [ "linux-aarch64" "sha256-3SSmT1t5ctgVa3lXnjGRDb2OJ3j272RTUm1aQ1Itjlo=" ];
-              "x86_64-linux" = [ "linux-x86_64" "sha256-TleL3pvFg/LemPFktzUDVI1YYzh78yKtHwuc0l33x1I=" ];
-            }.${system};
-
-            pname = "smithy-cli";
-            version = "1.51.0";
-            base_url = "https://github.com/smithy-lang/smithy/releases/download/";
-            src = pkgs.fetchzip {
-              url = "${base_url}/${version}/smithy-cli-${builtins.elemAt smithy-system-hash 0}.zip";
-              hash = builtins.elemAt smithy-system-hash 1;
-            };
-            buildPhase = ''
-              mkdir $out
-              mv * $out
-            '';
-          };
         in
         with pkgs;
         {
@@ -51,7 +30,6 @@
 
             buildInputs = [
               toolchain
-              smithy-cli
 
               cargo-lambda
               gnumake

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,46 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+      };
+    };
+  };
+  outputs = { self, nixpkgs, flake-utils, rust-overlay }:
+    flake-utils.lib.eachDefaultSystem
+      (system:
+        let
+          overlays = [ (import rust-overlay) ];
+          pkgs = import nixpkgs {
+            inherit system overlays;
+          };
+          toolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+        in
+        with pkgs;
+        {
+          devShells.default = mkShell {
+            RUSTFMT = "${toolchain}/bin/rustfmt";
+            GREETING = "Welcome, sBTC developer!";
+            shellHook = ''
+              echo $GREETING
+            '';
+
+            buildInputs = [
+              toolchain
+              cargo-lambda
+              gnumake
+              jdk21_headless
+              nodejs
+              pnpm
+              protobuf
+            ] ++ lib.optionals pkgs.stdenv.isDarwin [
+              pkgs.darwin.apple_sdk.frameworks.SystemConfiguration
+            ];
+          };
+        }
+      );
+}
+

--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,8 @@
 
             buildInputs = [
               toolchain
+
+              # TODO: `Smithy` is currently missing.
               cargo-lambda
               gnumake
               jdk21_headless

--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,27 @@
             inherit system overlays;
           };
           toolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+
+          smithy-cli = pkgs.stdenv.mkDerivation rec {
+            smithy-system-hash = {
+              "aarch64-darwin" = [ "darwin-aarch64" "sha256-s/y8turEQfvGwJ2xz70SwAIlg1fk4miOPZ5SapO6tJU=" ];
+              "x86_64-darwin" = [ "darwin-x86_64" "sha256-iTJ4PbFfxG+sU2B4Viu5fG0K44zqcU/I3Y7sTlFPAuQ=" ];
+              "aarch64-linux" = [ "linux-aarch64" "sha256-3SSmT1t5ctgVa3lXnjGRDb2OJ3j272RTUm1aQ1Itjlo=" ];
+              "x86_64-linux" = [ "linux-x86_64" "sha256-TleL3pvFg/LemPFktzUDVI1YYzh78yKtHwuc0l33x1I=" ];
+            }.${system};
+
+            pname = "smithy-cli";
+            version = "1.51.0";
+            base_url = "https://github.com/smithy-lang/smithy/releases/download/";
+            src = pkgs.fetchzip {
+              url = "${base_url}/${version}/smithy-cli-${builtins.elemAt smithy-system-hash 0}.zip";
+              hash = builtins.elemAt smithy-system-hash 1;
+            };
+            buildPhase = ''
+              mkdir $out
+              mv * $out
+            '';
+          };
         in
         with pkgs;
         {
@@ -30,8 +51,8 @@
 
             buildInputs = [
               toolchain
+              smithy-cli
 
-              # TODO: `Smithy` is currently missing.
               cargo-lambda
               gnumake
               jdk21_headless


### PR DESCRIPTION
## Description

As someone who was configuring how to build this project for the first time, I thought it would be useful to have an easy way to install all build dependencies at once. I gave this a shot with `nix`. 

The result is that if you have `nix` installed and configured, you can run `nix develop` to enter a shell having all dependencies installed. Well, all except Smithy, who doesn't have a nix package yet.

Closes: ~NA~

## Changes

- Add `flake.nix` for development shells.

## Testing Information

- Install [`nix`](https://determinate.systems/posts/determinate-nix-installer/)
- Make sure you have flakes enabled (the installer linked above takes care of it, else see [here](https://nixos.wiki/wiki/Flakes))
- Run `nix develop`

## Checklist:

- [X] I have performed a self-review of my code
- [X] My changes generate no new warnings
- [ ] ~New and existing unit tests pass locally with my changes~
- [ ] ~Any dependent changes have been merged and published in downstream modules~
