### PR TITLE
refactor: small fixes comment updates

### DIFF
--- a/emily/handler/src/bin/emily-server.rs
+++ b/emily/handler/src/bin/emily-server.rs
@@ -57,7 +57,12 @@ async fn main() {
     // Get command line arguments.
     let Cli {
         server: ServerArgs { host, port },
-        general: GeneralArgs { pretty_logs, log_directives, dynamodb_endpoint },
+        general:
+            GeneralArgs {
+                pretty_logs,
+                log_directives,
+                dynamodb_endpoint,
+            },
     } = Cli::parse();
 
     // Setup logging.

--- a/emily/handler/src/context.rs
+++ b/emily/handler/src/context.rs
@@ -88,9 +88,7 @@ impl EmilyContext {
     }
     /// Create a local testing instance.
     #[cfg(feature = "testing")]
-    pub async fn local_instance(
-        dynamodb_endpoint: &str,
-    ) -> Result<Self, Error> {
+    pub async fn local_instance(dynamodb_endpoint: &str) -> Result<Self, Error> {
         use std::collections::HashMap;
 
         // Get config that always points to the dynamodb table directly

--- a/sbtc/Cargo.toml
+++ b/sbtc/Cargo.toml
@@ -26,4 +26,6 @@ version = "0.29.0"
 features = ["rand-std", "global-context"]
 
 [dev-dependencies]
+bitcoincore-rpc = { workspace = true }
+bitcoincore-rpc-json = { workspace = true }
 test-case = "3.1"

--- a/sbtc/src/deposits.rs
+++ b/sbtc/src/deposits.rs
@@ -348,9 +348,10 @@ impl DepositScriptInputs {
 /// This struct contains the key variable inputs when constructing a
 /// deposit script address.
 ///
-/// This struct upholds the invariant that the `lock_time` is a valid,
-/// standard `locktime` in bitcoin-core, so it is positive and less than or
-/// equal to the maximum acceptable value of `2**39 - 1`.
+/// This struct upholds the invariant that the `lock_time` is a valid and
+/// standard `locktime` in bitcoin-core. So it is positive and less than or
+/// equal to the maximum acceptable value of `2**39 - 1`. We do not check
+/// whether the user supplied script is correct and standard.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ReclaimScriptInputs {
     /// This is the lock time used for the OP_CSV opcode in the reclaim
@@ -396,7 +397,7 @@ impl ReclaimScriptInputs {
     }
 
     /// Return the user supplied part of the script.
-    /// 
+    ///
     /// The full reclaim script has the form:
     ///```text
     ///  <locked-time> OP_CHECKSEQUENCEVERIFY <rest-of-reclaim-script>
@@ -592,7 +593,7 @@ mod tests {
         assert_eq!(extracts.deposit_script(), script);
     }
 
-    /// Construct a parsable deposit stript that is non-standard and check
+    /// Construct a parsable deposit script that is non-standard and check
     /// that it errors.
     #[test]
     fn non_standard_deposit_scripts() {

--- a/sbtc/src/deposits.rs
+++ b/sbtc/src/deposits.rs
@@ -390,10 +390,8 @@ impl ReclaimScriptInputs {
     pub fn lock_time(&self) -> u64 {
         // We know this number is positive because that is one of the
         // invariants upheld by this struct, and we check for it in
-        // `Self::try_new`, so this will never fail.
-        self.lock_time
-            .try_into()
-            .expect("BUG: We've decided not to uphold the lock_time invariant")
+        // `Self::try_new`, so this will never be a lossy conversion.
+        self.lock_time as u64
     }
 
     /// Return the user supplied part of the script.
@@ -692,7 +690,7 @@ mod tests {
 
         let extracts = ReclaimScriptInputs::parse(&reclaim_script).unwrap();
         assert_eq!(extracts.lock_time, lock_time);
-        assert_eq!(extracts.lock_time(), lock_time as u64);
+        assert_eq!(extracts.lock_time(), u64::try_from(lock_time).unwrap());
         assert_eq!(extracts.reclaim_script(), reclaim_script);
 
         // Let's check that ReclaimScriptInputs::reclaim_script and

--- a/sbtc/src/deposits.rs
+++ b/sbtc/src/deposits.rs
@@ -459,7 +459,7 @@ impl ReclaimScriptInputs {
                 // We know the error and panic paths cannot happen because
                 // of the above `if` check.
                 let (script_num, [OP_CSV, script @ ..]) = rest.split_at(*n as usize) else {
-                    return Err(Error::InvalidDepositScript);
+                    return Err(Error::InvalidReclaimScript);
                 };
                 (read_scriptint(script_num, 5)?, script)
             }

--- a/sbtc/src/deposits.rs
+++ b/sbtc/src/deposits.rs
@@ -692,6 +692,7 @@ mod tests {
 
         let extracts = ReclaimScriptInputs::parse(&reclaim_script).unwrap();
         assert_eq!(extracts.lock_time, lock_time);
+        assert_eq!(extracts.lock_time(), lock_time as u64);
         assert_eq!(extracts.reclaim_script(), reclaim_script);
 
         // Let's check that ReclaimScriptInputs::reclaim_script and
@@ -702,8 +703,9 @@ mod tests {
             .push_opcode(opcodes::OP_CHECKSIG)
             .into_script();
 
-        let inputs = ReclaimScriptInputs::try_new(lock_time, script).unwrap();
+        let inputs = ReclaimScriptInputs::try_new(lock_time, script.clone()).unwrap();
         let reclaim_script = inputs.reclaim_script();
+        assert_eq!(inputs.user_script(), script.as_script());
         assert_eq!(ReclaimScriptInputs::parse(&reclaim_script).unwrap(), inputs);
     }
 

--- a/sbtc/src/lib.rs
+++ b/sbtc/src/lib.rs
@@ -32,14 +32,14 @@ pub const NUMS_X_COORDINATE: [u8; 32] = [
     0x47, 0xbf, 0xee, 0x9a, 0xce, 0x80, 0x3a, 0xc0,
 ];
 
-/// Returns an address with no known private key, since it has no known
+/// Returns a public key with no known private key, since it has no known
 /// discrete logarithm.
 ///
 /// # Notes
 ///
 /// This function returns the public key to used in the key-spend path of
-/// the taproot address. Since we do not want a key-spend path for sBTC
-/// deposit transactions, this address is such that it does not have a
-/// known private key.
+/// the taproot `scriptPubKey`. Since we do not want a key-spend path for
+/// sBTC deposit transactions, this public key is such that it does not
+/// have a known private key.
 pub static UNSPENDABLE_TAPROOT_KEY: LazyLock<XOnlyPublicKey> =
     LazyLock::new(|| XOnlyPublicKey::from_slice(&NUMS_X_COORDINATE).unwrap());

--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -290,7 +290,9 @@ where
 
         // Generate
         let _sign_requests = futures::stream::iter(deposit_requests)
-            .then(|req| self.construct_deposit_stacks_sign_request(req, bitcoin_aggregate_key, &wallet))
+            .then(|req| {
+                self.construct_deposit_stacks_sign_request(req, bitcoin_aggregate_key, &wallet)
+            })
             .try_collect::<Vec<StacksTransactionSignRequest>>()
             .await?;
 


### PR DESCRIPTION
## Description

There were a couple of things I noticed needed a spit-shine:
1. Tests from the crate don't run from VS Code. This is a "bug" that wasn't caught in CI because CI probably compiles tests with all features enabled by default, while not all features are enabled when running tests in my IDE.
2. We do not expose the `lock_time` and the `user-supplied-lock-script` from the reclaim script. The changes here are to help out with some of the work in https://github.com/stacks-network/sbtc/pull/635.

## Changes

1. Make sure the necessary dependencies were added as dev dependencies.
2. Expose the lock time and the user supplied lock script from in the reclaim script.

I'm torn on whether I should add getters and such for `DepositInfo`, since it is supposed to represent a correctly parsed deposit request, and thus invariants to uphold. Maybe, I'll add it if I have enough energy for it but not enough energy for something more complex.

## Testing Information

This doesn't add much functionality, but exposes existing stuff.

## Checklist:

- [x] I have performed a self-review of my code
