### PR TITLE
fix: add a consolidated receiver

### DIFF
--- a/signer/src/context/messaging.rs
+++ b/signer/src/context/messaging.rs
@@ -10,6 +10,17 @@ pub enum SignerSignal {
     Event(SignerEvent),
 }
 
+impl SignerSignal {
+    /// Return the message that was generated from a [`TxSignerEventLoop`]
+    /// task and None otherwise.
+    pub fn tx_signer_generated(self) -> Option<crate::network::Msg> {
+        match self {
+            Self::Event(SignerEvent::TxSigner(TxSignerEvent::MessageGenerated(msg))) => Some(msg),
+            _ => None,
+        }
+    }
+}
+
 /// Commands that can be sent on the signalling channel.
 #[derive(Debug, Clone, PartialEq)]
 pub enum SignerCommand {

--- a/signer/src/stacks/wallet.rs
+++ b/signer/src/stacks/wallet.rs
@@ -335,6 +335,15 @@ impl MultisigTx {
         &self.tx
     }
 
+    /// Return the total number of signatures that have been received so
+    /// far for this transaction.
+    pub fn num_signatures(&self) -> u16 {
+        self.signatures
+            .values()
+            .map(|maybe_sig| maybe_sig.is_some() as u16)
+            .sum()
+    }
+
     /// Add the given signature to the signature list
     ///
     /// # Notes

--- a/signer/src/stacks/wallet.rs
+++ b/signer/src/stacks/wallet.rs
@@ -490,8 +490,12 @@ mod tests {
             .collect();
 
         // Now add the signatures to the signing object.
+        let mut count = 0;
+        assert_eq!(count, tx_signer.num_signatures());
         for signature in signatures {
             tx_signer.add_signature(signature).unwrap();
+            count += 1;
+            assert_eq!(count, tx_signer.num_signatures());
         }
 
         // Okay, now finalize the transaction. Afterward, it should be

--- a/signer/tests/integration/transaction_coordinator.rs
+++ b/signer/tests/integration/transaction_coordinator.rs
@@ -302,7 +302,7 @@ async fn process_complete_deposit() {
     tx_coordinator_handle.abort();
     event_loop_handles.iter().for_each(|h| h.abort());
 
-    assert!(broadcasted_tx.verify().is_ok());
+    broadcasted_tx.verify().unwrap();
 
     assert_eq!(broadcasted_tx.get_origin_nonce(), nonce);
 


### PR DESCRIPTION
## Description

Fixes an issue that we were seeing on main.

## Changes

* Add a method to retrieve the number of signatures received by a transaction locked with a multi-sig "script" on Stacks.
* Add a consolidated receive function to the transaction coordinator object.

## Testing Information

## Checklist:

- [ ] I have performed a self-review of my code

