### PR TITLE
refactor: minor logging fixes

### DIFF
--- a/signer/src/bitcoin/client.rs
+++ b/signer/src/bitcoin/client.rs
@@ -63,11 +63,17 @@ impl BitcoinInteract for ApiFallbackClient<BitcoinCoreClient> {
     }
 
     async fn estimate_fee_rate(&self) -> Result<f64, Error> {
-        todo!() // TODO(542)
+        // TODO(542): This function is supposed to incorporate other fee
+        // estimation methods, in particular the ones in the
+        // src/bitcoin/fees.rs module.
+        self.exec(|client, _| async { client.estimate_fee_rate(1) })
+            .await
+            .map(|feerate| feerate.sats_per_vbyte)
     }
 
-    async fn get_last_fee(&self, _utxo: bitcoin::OutPoint) -> Result<Option<utxo::Fees>, Error> {
-        todo!() // TODO(541)
+    async fn get_last_fee(&self, utxo: bitcoin::OutPoint) -> Result<Option<utxo::Fees>, Error> {
+        // TODO(541)
+        self.exec(|client, _| client.get_last_fee(utxo)).await
     }
 
     async fn broadcast_transaction(&self, tx: &bitcoin::Transaction) -> Result<(), Error> {

--- a/signer/src/config/default.toml
+++ b/signer/src/config/default.toml
@@ -27,7 +27,7 @@
 # Required: true
 # Environment: SIGNER_EMILY__ENDPOINTS
 endpoints = [
-    "http://localhost:3000"
+    "http://localhost:3031"
 ]
 
 # !! ==============================================================================

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -384,6 +384,10 @@ pub enum Error {
     #[error("no bitcoin chain tip")]
     NoChainTip,
 
+    /// No stacks chain tip found.
+    #[error("no stacks chain tip")]
+    NoStacksChainTip,
+
     /// Bitcoin error when attempting to construct an address from a
     /// scriptPubKey.
     #[error("bitcoin address parse error")]

--- a/signer/src/main.rs
+++ b/signer/src/main.rs
@@ -45,6 +45,7 @@ struct SignerArgs {
 }
 
 #[tokio::main]
+#[tracing::instrument(name = "signer")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Initialize logging
     // TODO(497): The whole logging thing should be revisited. We should support
@@ -198,7 +199,7 @@ where
 
 /// Runs the shutdown-signal watcher. On Unix systems, this listens for SIGHUP,
 /// SIGTERM, and SIGINT. On other systems, it listens for Ctrl-C.
-#[tracing::instrument(skip(ctx))]
+#[tracing::instrument(skip(ctx), name = "shutdown-watcher")]
 async fn run_shutdown_signal_watcher(ctx: impl Context) -> Result<(), Error> {
     let mut term = ctx.get_termination_handle();
 
@@ -273,7 +274,7 @@ async fn run_libp2p_swarm(ctx: impl Context) -> Result<(), Error> {
 }
 
 /// Runs the Stacks event observer server.
-#[tracing::instrument(skip(ctx))]
+#[tracing::instrument(skip(ctx), name = "stacks-event-observer")]
 async fn run_stacks_event_observer(ctx: impl Context + 'static) -> Result<(), Error> {
     tracing::info!("initializing the Stacks event observer server");
 
@@ -310,7 +311,6 @@ async fn run_stacks_event_observer(ctx: impl Context + 'static) -> Result<(), Er
 }
 
 /// Run the block observer event-loop.
-#[tracing::instrument(skip(ctx))]
 async fn run_block_observer(ctx: impl Context) -> Result<(), Error> {
     let config = ctx.config().clone();
 
@@ -343,7 +343,6 @@ async fn run_block_observer(ctx: impl Context) -> Result<(), Error> {
 }
 
 /// Run the transaction signer event-loop.
-#[tracing::instrument(skip(ctx))]
 async fn run_transaction_signer(ctx: impl Context) -> Result<(), Error> {
     let config = ctx.config().clone();
     let network = P2PNetwork::new(&ctx);
@@ -363,7 +362,6 @@ async fn run_transaction_signer(ctx: impl Context) -> Result<(), Error> {
 }
 
 /// Run the transaction coordinator event-loop.
-#[tracing::instrument(skip(ctx))]
 async fn run_transaction_coordinator(ctx: impl Context) -> Result<(), Error> {
     let config = ctx.config().clone();
     let network = P2PNetwork::new(&ctx);

--- a/signer/src/network/libp2p/event_loop.rs
+++ b/signer/src/network/libp2p/event_loop.rs
@@ -192,11 +192,12 @@ fn handle_autonat_server_event(_: &mut Swarm<SignerBehavior>, event: autonat::v2
             result: Ok(()),
         } => {
             tracing::trace!(
-                ?all_addrs, 
-                %client, 
-                %tested_addr, 
-                %data_amount, 
-                "AutoNAT (server) test successful");
+                ?all_addrs,
+                %client,
+                %tested_addr,
+                %data_amount,
+                "AutoNAT (server) test successful"
+            );
         }
         Event {
             all_addrs,
@@ -206,12 +207,13 @@ fn handle_autonat_server_event(_: &mut Swarm<SignerBehavior>, event: autonat::v2
             result: Err(error),
         } => {
             tracing::warn!(
-                ?all_addrs, 
-                %client, 
-                %tested_addr, 
-                %data_amount, 
-                %error, 
-                "AutoNAT (server) test failed");
+                ?all_addrs,
+                %client,
+                %tested_addr,
+                %data_amount,
+                %error,
+                "AutoNAT (server) test failed"
+            );
         }
     }
 }

--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -147,7 +147,7 @@ where
     N: network::MessageTransfer,
 {
     /// Run the coordinator event loop
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip(self), name = "tx-coordinator")]
     pub async fn run(mut self) -> Result<(), Error> {
         tracing::info!("starting transaction coordinator event loop");
         let mut term = self.context.get_termination_handle();

--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -784,18 +784,11 @@ where
     #[tracing::instrument(skip(self))]
     async fn get_btc_state(
         &mut self,
+        chain_tip: &model::BitcoinBlockHash,
         aggregate_key: &PublicKey,
     ) -> Result<utxo::SignerBtcState, Error> {
         let bitcoin_client = self.context.get_bitcoin_client();
         let fee_rate = bitcoin_client.estimate_fee_rate().await?;
-        let Some(chain_tip) = self
-            .context
-            .get_storage()
-            .get_bitcoin_canonical_chain_tip()
-            .await?
-        else {
-            return Err(Error::NoChainTip);
-        };
 
         let utxo = self
             .context
@@ -880,7 +873,7 @@ where
         Ok(Some(utxo::SbtcRequests {
             deposits,
             withdrawals,
-            signer_state: self.get_btc_state(aggregate_key).await?,
+            signer_state: self.get_btc_state(bitcoin_chain_tip, aggregate_key).await?,
             accept_threshold: threshold,
             num_signers,
         }))

--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -278,7 +278,7 @@ where
             .get_storage()
             .get_stacks_chain_tip(bitcoin_chain_tip)
             .await?
-            .ok_or(Error::NoChainTip)?;
+            .ok_or(Error::NoStacksChainTip)?;
 
         let pending_requests_fut =
             self.get_pending_requests(bitcoin_chain_tip, aggregate_key, signer_public_keys);

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -143,7 +143,7 @@ where
     Rng: rand::RngCore + rand::CryptoRng,
 {
     /// Run the signer event loop
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip(self), name = "tx-signer")]
     pub async fn run(mut self) -> Result<(), Error> {
         let mut signal_rx = self.context.get_signal_receiver();
         let mut term = self.context.get_termination_handle();


### PR DESCRIPTION
## Description

This PR contains some of the simple changes that we've had from the demo branch.

## Changes

* A few more logs, better span names and such.
* Use the right emily port by default.
* Implement more `BitcoinInteract` methods for the fallback client.
* Use the existing bitcoin block hash at the time of that `get_btc_state` is called.

## Testing Information

This is a refactor, so if tests pass then everything should be fine.

## Checklist:

- [x] I have performed a self-review of my code
