### PR TITLE
Feat/Emily can populate chainstate table with the height and hash inferred from deposit and withdrawal updates.

### DIFF
--- a/emily/handler/src/api/handlers/chainstate.rs
+++ b/emily/handler/src/api/handlers/chainstate.rs
@@ -153,7 +153,9 @@ pub async fn update_chainstate(
 /// Adds the chainstate to the table, and reorganizes the API if there's a
 /// conflict that suggests it needs a reorg in order for this entry to be
 /// consistent.
-async fn add_chainstate_entry_or_reorg(
+///
+/// TODO(TBD): Consider moving this logic into database accessor structures.
+pub async fn add_chainstate_entry_or_reorg(
     context: &EmilyContext,
     chainstate: &Chainstate,
 ) -> Result<(), Error> {

--- a/emily/handler/src/api/handlers/deposit.rs
+++ b/emily/handler/src/api/handlers/deposit.rs
@@ -323,9 +323,21 @@ pub async fn update_deposits(
         api_state.error_if_reorganizing()?;
         // Validate request.
         let validated_request: ValidatedUpdateDepositsRequest = body.try_into()?;
+
+        // Infer the new chainstates that would come from these deposit updates and then
+        // attempt to update the chainstates.
+        let inferred_chainstates = validated_request.inferred_chainstates()?;
+        for chainstate in inferred_chainstates {
+            // TODO(TBD): Determine what happens if this occurs in multiple lambda
+            // instances at once.
+            crate::api::handlers::chainstate::add_chainstate_entry_or_reorg(&context, &chainstate)
+                .await?;
+        }
+
         // Create aggregator.
         let mut updated_deposits: Vec<Deposit> =
             Vec::with_capacity(validated_request.deposits.len());
+
         // Loop through all updates and execute.
         for update in validated_request.deposits {
             // Get original deposit entry.

--- a/emily/handler/src/api/handlers/deposit.rs
+++ b/emily/handler/src/api/handlers/deposit.rs
@@ -335,11 +335,11 @@ pub async fn update_deposits(
         }
 
         // Create aggregator.
-        let mut updated_deposits: Vec<Deposit> =
+        let mut updated_deposits: Vec<(usize, Deposit)> =
             Vec::with_capacity(validated_request.deposits.len());
 
         // Loop through all updates and execute.
-        for update in validated_request.deposits {
+        for (index, update) in validated_request.deposits {
             // Get original deposit entry.
             let deposit_entry = accessors::get_deposit_entry(&context, &update.key).await?;
             // Make the update package.
@@ -348,9 +348,14 @@ pub async fn update_deposits(
                 .await?
                 .try_into()?;
             // Append the updated deposit to the list.
-            updated_deposits.push(updated_deposit);
+            updated_deposits.push((index, updated_deposit));
         }
-        let response = UpdateDepositsResponse { deposits: updated_deposits };
+        updated_deposits.sort_by_key(|(index, _)| *index);
+        let deposits = updated_deposits
+            .into_iter()
+            .map(|(_, deposit)| deposit)
+            .collect();
+        let response = UpdateDepositsResponse { deposits };
         Ok(with_status(json(&response), StatusCode::CREATED))
     }
     // Handle and respond.

--- a/emily/handler/src/database/entries/deposit.rs
+++ b/emily/handler/src/database/entries/deposit.rs
@@ -1,5 +1,7 @@
 //! Entries into the deposit table.
 
+use std::collections::HashSet;
+
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -279,17 +281,21 @@ impl DepositEvent {
     pub fn ensure_following_event_is_valid(&self, next_event: &DepositEvent) -> Result<(), Error> {
         // Determine if event is valid.
         if self.stacks_block_height > next_event.stacks_block_height {
-            return Err(Error::InconsistentState(Inconsistency::ItemUpdate(
-                "Attempting to update a deposit with a block height earlier than it should be."
-                    .into(),
-            )));
+            let err_msg = format!(
+                "Attempting to update a deposit with a block height earlier than it should be..\n
+                latest_existing_event:\n{self:?}\n
+                newest_event:\n{next_event:?}"
+            );
+            return Err(Error::InconsistentState(Inconsistency::ItemUpdate(err_msg)));
         } else if self.stacks_block_height == next_event.stacks_block_height
             && self.stacks_block_hash != next_event.stacks_block_hash
         {
-            return Err(Error::InconsistentState(Inconsistency::ItemUpdate(
-                "Attempting to update a deposit with a block height and hash that conflicts with the current history."
-                    .into(),
-            )));
+            let err_msg = format!(
+                "Attempting to update a deposit with a block height and hash that conflicts with its current history.\n
+                latest_existing_event:\n{self:?}\n
+                newest_event:\n{next_event:?}"
+            );
+            return Err(Error::InconsistentState(Inconsistency::ItemUpdate(err_msg)));
         }
 
         Ok(())
@@ -401,6 +407,7 @@ impl From<DepositInfoEntry> for DepositInfo {
 }
 
 /// Validated version of the update deposit request.
+#[derive(Clone, Default, Debug, Eq, PartialEq, Hash)]
 pub struct ValidatedUpdateDepositsRequest {
     /// Validated deposit update requests.
     pub deposits: Vec<ValidatedDepositUpdate>,
@@ -411,16 +418,48 @@ impl TryFrom<UpdateDepositsRequestBody> for ValidatedUpdateDepositsRequest {
     type Error = Error;
     fn try_from(update_request: UpdateDepositsRequestBody) -> Result<Self, Self::Error> {
         // Validate all the depoit updates.
-        let deposits = update_request
+        let mut deposits: Vec<_> = update_request
             .deposits
             .into_iter()
             .map(|i| i.try_into())
             .collect::<Result<_, Error>>()?;
+
+        // Order the updates by order of when they occur so that it's
+        // as though we got them in chronological order.
+        deposits.sort_by_key(|update: &ValidatedDepositUpdate| update.event.stacks_block_height);
+
         Ok(ValidatedUpdateDepositsRequest { deposits })
     }
 }
 
+impl ValidatedUpdateDepositsRequest {
+    /// Infers all chainstates that need to be present in the API for the
+    /// deposit updates to be valid.
+    pub fn inferred_chainstates(&self) -> Result<Vec<Chainstate>, Error> {
+        // TODO(TBD): Error if the inferred chainstates have conflicting block hashes
+        // for a the same block height.
+        let mut inferred_chainstates = self
+            .deposits
+            .clone()
+            .into_iter()
+            .map(|update| Chainstate {
+                stacks_block_hash: update.event.stacks_block_hash,
+                stacks_block_height: update.event.stacks_block_height,
+            })
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+
+        // Sort the chainsates in the order that they should come in.
+        inferred_chainstates.sort_by_key(|chainstate| chainstate.stacks_block_height);
+
+        // Return.
+        Ok(inferred_chainstates)
+    }
+}
+
 /// Validated deposit update.
+#[derive(Clone, Default, Debug, Eq, PartialEq, Hash)]
 pub struct ValidatedDepositUpdate {
     /// Key.
     pub key: DepositEntryKey,

--- a/emily/handler/tests/integration/deposit.rs
+++ b/emily/handler/tests/integration/deposit.rs
@@ -505,7 +505,7 @@ async fn update_deposits_updates_chainstate() {
 
     // Order the, pecularily so that they are not in order.
     deposit_updates.sort_by_key(|update|
-        (update.last_update_height as i64 - (max_height - min_height) / 2).abs());
+        (update.last_update_height as i64 - (min_height + (max_height - min_height) / 2)).abs());
 
     let expected_last_update_height_at_output_index: Vec<(usize, u64)> = deposit_updates
         .iter()

--- a/emily/handler/tests/integration/deposit.rs
+++ b/emily/handler/tests/integration/deposit.rs
@@ -484,7 +484,10 @@ async fn update_deposits_updates_chainstate() {
     // It's okay to say it's accepted over and over.
     let update_status: Status = Status::Accepted;
     let update_status_message: &str = "test_status_message";
-    let range = 20..30;
+
+    let min_height: i64 = 20;
+    let max_height: i64 = 30;
+    let range = min_height..max_height;
 
     let mut deposit_updates = Vec::new();
     for update_block_height in range.clone() {
@@ -493,12 +496,22 @@ async fn update_deposits_updates_chainstate() {
             bitcoin_txid: bitcoin_txid.into(),
             fulfillment: None,
             last_update_block_hash: format!("hash_{}", update_block_height),
-            last_update_height: update_block_height,
+            last_update_height: update_block_height as u64,
             status: update_status.clone(),
             status_message: update_status_message.into(),
         };
         deposit_updates.push(deposit_update);
     }
+
+    // Order the, pecularily so that they are not in order.
+    deposit_updates.sort_by_key(|update|
+        (update.last_update_height as i64 - (max_height - min_height) / 2).abs());
+
+    let expected_last_update_height_at_output_index: Vec<(usize, u64)> = deposit_updates
+        .iter()
+        .enumerate()
+        .map(|(index, update)| (index, update.last_update_height))
+        .collect();
 
     // Create the deposits here.
     let update_request = UpdateDepositsRequestBody { deposits: deposit_updates };
@@ -512,15 +525,19 @@ async fn update_deposits_updates_chainstate() {
         .expect("Received an error after making a valid create deposit request api call.");
 
     // Send it a bunch of updates.
-    apis::deposit_api::update_deposits(&configuration, update_request.clone())
+    let update_deposits_response= apis::deposit_api::update_deposits(&configuration, update_request.clone())
         .await
         .expect("Received an error after making a valid update deposits api call.");
 
     for height in range {
-        let chainstate = apis::chainstate_api::get_chainstate_at_height(&configuration, height)
+        let chainstate = apis::chainstate_api::get_chainstate_at_height(&configuration, height as u64)
             .await
             .expect("Received an error after making a valid get chainstate at height api call.");
-        assert_eq!(chainstate.stacks_block_height, height);
+        assert_eq!(chainstate.stacks_block_height, height as u64);
         assert_eq!(chainstate.stacks_block_hash, format!("hash_{}", height));
+    }
+
+    for (index, last_update_height) in expected_last_update_height_at_output_index {
+        assert_eq!(update_deposits_response.deposits[index].last_update_height, last_update_height);
     }
 }

--- a/emily/handler/tests/integration/withdrawal.rs
+++ b/emily/handler/tests/integration/withdrawal.rs
@@ -162,7 +162,7 @@ async fn get_withdrawals() {
             Some(chunksize),
         )
         .await
-        .expect("Received an error after making a valid get deposits api call.");
+        .expect("Received an error after making a valid get withdrawal api call.");
         gotten_withdrawal_info_chunks.push(response.withdrawals);
         // If there's no next token then break.
         next_token = response.next_token;
@@ -193,7 +193,7 @@ async fn get_withdrawals() {
 
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
-async fn update_deposits() {
+async fn update_withdrawals() {
     let configuration = clean_setup().await;
 
     // Arrange.
@@ -260,7 +260,6 @@ async fn update_deposits() {
         expected_withdrawals.push(expected);
     }
 
-    // Create the deposits here.
     let update_request = UpdateWithdrawalsRequestBody {
         withdrawals: withdrawal_updates,
     };
@@ -271,7 +270,7 @@ async fn update_deposits() {
     let update_withdrawals_response =
         apis::withdrawal_api::update_withdrawals(&configuration, update_request)
             .await
-            .expect("Received an error after making a valid update deposits api call.");
+            .expect("Received an error after making a valid update withdrawals api call.");
 
     // Assert.
     // -------
@@ -279,4 +278,68 @@ async fn update_deposits() {
     updated_withdrawals.sort_by(arbitrary_withdrawal_partial_cmp);
     expected_withdrawals.sort_by(arbitrary_withdrawal_partial_cmp);
     assert_eq!(expected_withdrawals, updated_withdrawals);
+}
+
+#[cfg_attr(not(feature = "integration-tests"), ignore)]
+#[tokio::test]
+async fn update_withdrawals_updates_chainstate() {
+    let configuration = clean_setup().await;
+
+    // Arrange.
+    // --------
+    let request_id = 123;
+    let amount = 0;
+    let parameters = WithdrawalParameters { max_fee: 123 };
+
+    let create_request = CreateWithdrawalRequestBody {
+        amount,
+        parameters: Box::new(parameters.clone()),
+        recipient: RECIPIENT.into(),
+        request_id,
+        stacks_block_hash: BLOCK_HASH.into(),
+        stacks_block_height: BLOCK_HEIGHT,
+    };
+
+    // It's okay to say it's accepted over and over.
+    let update_status: Status = Status::Accepted;
+    let update_status_message: &str = "test_status_message";
+    let range = 20..30;
+
+    let mut withdrawal_updates = Vec::new();
+    for update_block_height in range.clone() {
+        let withdrawal_update = WithdrawalUpdate {
+            request_id,
+            fulfillment: None,
+            last_update_block_hash: format!("hash_{}", update_block_height),
+            last_update_height: update_block_height,
+            status: update_status.clone(),
+            status_message: update_status_message.into(),
+        };
+        withdrawal_updates.push(withdrawal_update);
+    }
+
+    let update_request = UpdateWithdrawalsRequestBody {
+        withdrawals: withdrawal_updates,
+    };
+
+    // Act.
+    // ----
+
+    // Create a withdrawal.
+    apis::withdrawal_api::create_withdrawal(&configuration, create_request)
+        .await
+        .expect("Received an error after making a valid create withdrawal request api call.");
+
+    // Send it a bunch of updates.
+    apis::withdrawal_api::update_withdrawals(&configuration, update_request)
+        .await
+        .expect("Received an error after making a valid update withdrawals api call.");
+
+    for height in range {
+        let chainstate = apis::chainstate_api::get_chainstate_at_height(&configuration, height)
+            .await
+            .expect("Received an error after making a valid get chainstate at height api call.");
+        assert_eq!(chainstate.stacks_block_height, height);
+        assert_eq!(chainstate.stacks_block_hash, format!("hash_{}", height));
+    }
 }

--- a/emily/handler/tests/integration/withdrawal.rs
+++ b/emily/handler/tests/integration/withdrawal.rs
@@ -323,7 +323,7 @@ async fn update_withdrawals_updates_chainstate() {
 
     // Order the, pecularily so that they are not in order.
     withdrawal_updates.sort_by_key(|update|
-        (update.last_update_height as i64 - (max_height - min_height) / 2).abs());
+        (update.last_update_height as i64 - (min_height + (max_height - min_height) / 2)).abs());
 
     let expected_last_update_height_at_output_index: Vec<(usize, u64)> = withdrawal_updates
         .iter()


### PR DESCRIPTION
## Description

Changes Emily to accept deposit / withdrawal updates that have unknown chainstate entries, and updates the chainstate
entries to match the chainstates that can be inferred from the deposit / withdrawal updates.

Closes: #?

## Changes

- Deposit update flow will update chainstate
- Withdrawal update flow will update chainstate

## Testing Information

Tested with integration tests.

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
