### PR TITLE
feat: block observer processes confirmed deposit requests

### DIFF
--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -93,6 +93,10 @@ impl DepositRequestValidator for CreateDepositRequest {
             return Ok(None);
         };
 
+        // TODO(515): After the transaction passes validation, we need to
+        // check whether we know about the public key in the deposit
+        // script.
+
         Ok(Some(Deposit {
             info: self.validate_tx(&tx_info.tx)?,
             tx_info,
@@ -209,8 +213,9 @@ where
                 },
                 // This happens when we cannot find the associated
                 // transaction confirmed on a bitcoin block, or when we
-                // encounted some unexpected error when reaching out the
-                // bitcoin-core.
+                // encounted some unexpected error when reaching out to
+                // bitcoin-core or our database. We've already logged the
+                // error above, so there is nothing more to do.
                 Err(_) | Ok(None) => {}
             }
         }

--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -185,7 +185,7 @@ where
     }
 
     /// Fetch deposit requests from Emily and store the validated ones into
-    /// the database. Update Emily about the ones that fail validation.
+    /// the database.
     #[tracing::instrument(skip(self))]
     async fn load_latest_deposit_requests(&mut self) -> Result<(), Error> {
         let mut deposit_requests = Vec::new();
@@ -216,8 +216,6 @@ where
                 Err(_) | Ok(None) => {}
             }
         }
-
-        // TODO: Update emily about the requests that have failed validation.
 
         self.store_deposit_requests(deposit_requests).await?;
 

--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -202,15 +202,15 @@ where
                 // request.
                 Ok(Some(deposit)) => deposit_requests.push(deposit),
                 // This happens when the transaction has failed the first
-                // step of validation or has passed the first step but we
-                // don't recongnize the x-only public key in the deposit
+                // step of validation or has passed the first step, but we
+                // don't recognize the x-only public key in the deposit
                 // script.
                 Err(Error::SbtcLib(_)) | Err(Error::UnknownAggregateKey(_, _)) => {
                     failed_requests.push(request.outpoint);
                 }
                 // This happens when we cannot find the associated
                 // transaction confirmed on a bitcoin block, or when we
-                // encounted some unexpected error when reaching out to
+                // encountered some unexpected error when reaching out to
                 // bitcoin-core or our database. We've already logged the
                 // error above, so there is nothing more to do.
                 Err(_) | Ok(None) => {}
@@ -287,7 +287,7 @@ where
     /// For each of the deposit requests, persist the corresponding
     /// transaction and the parsed deposit info into the database.
     ///
-    /// Since this functions writes to the `bitcoin_transactions` table, we
+    /// Since this function writes to the `bitcoin_transactions` table, we
     /// must make sure that we have the bitcoin block header info in the
     /// database. So, this function must be called after
     /// [`BlockObserver::process_bitcoin_block`]
@@ -610,7 +610,7 @@ mod tests {
 
         block_observer.load_latest_deposit_requests().await.unwrap();
         // Only the transaction from tx_setup0 was valid. Note that, since
-        // we are not using a real block hash stored in the database. Out
+        // we are not using a real block hash stored in the database. Our
         // DbRead function won't actually find it. And in prod we won't
         // actually store the deposit request transaction.
         let deposit = {

--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -206,7 +206,7 @@ where
                 // don't recongnize the x-only public key in the deposit
                 // script.
                 Err(Error::SbtcLib(_)) | Err(Error::UnknownAggregateKey(_, _)) => {
-                    failed_requests.push(request);
+                    failed_requests.push(request.outpoint);
                 }
                 // This happens when we cannot find the associated
                 // transaction confirmed on a bitcoin block, or when we

--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -54,8 +54,6 @@ pub struct BlockObserver<Context, StacksClient, EmilyClient, BlockHashStream> {
     pub bitcoin_blocks: BlockHashStream,
     /// How far back in time the observer should look
     pub horizon: usize,
-    /// The bitcoin network
-    pub network: bitcoin::Network,
 }
 
 /// A full "deposit", containing the bitcoin transaction and a fully
@@ -491,7 +489,6 @@ mod tests {
             emily_client: test_harness.clone(),
             bitcoin_blocks: block_hash_stream,
             horizon: 1,
-            network: bitcoin::Network::Regtest,
         };
 
         block_observer.run().await.expect("block observer failed");
@@ -610,7 +607,6 @@ mod tests {
             emily_client: test_harness.clone(),
             bitcoin_blocks: block_hash_stream,
             horizon: 1,
-            network: bitcoin::Network::Regtest,
         };
 
         block_observer.load_latest_deposit_requests().await.unwrap();
@@ -680,7 +676,6 @@ mod tests {
             emily_client: test_harness.clone(),
             bitcoin_blocks: block_hash_stream,
             horizon: 1,
-            network: bitcoin::Network::Regtest,
         };
 
         block_observer.load_latest_deposit_requests().await.unwrap();
@@ -768,7 +763,6 @@ mod tests {
             emily_client: test_harness.clone(),
             bitcoin_blocks: test_harness.spawn_block_hash_stream(),
             horizon: 1,
-            network: bitcoin::Network::Regtest,
         };
 
         // First we try extracting the transactions from a block that does

--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -17,7 +17,6 @@
 //! - Update signer set transactions
 //! - Set aggregate key transactions
 
-use std::collections::HashMap;
 use std::future::Future;
 
 use crate::bitcoin::rpc::BitcoinTxInfo;
@@ -36,7 +35,6 @@ use bitcoin::hashes::Hash as _;
 use bitcoin::BlockHash;
 use bitcoin::ScriptBuf;
 use bitcoin::Transaction;
-use bitcoin::Txid;
 use blockstack_lib::chainstate::nakamoto;
 use futures::stream::StreamExt;
 use sbtc::deposits::CreateDepositRequest;
@@ -56,9 +54,6 @@ pub struct BlockObserver<Context, StacksClient, EmilyClient, BlockHashStream> {
     pub bitcoin_blocks: BlockHashStream,
     /// How far back in time the observer should look
     pub horizon: usize,
-    /// An in memory map of deposit requests that haven't been confirmed
-    /// on bitcoin yet.
-    pub deposit_requests: HashMap<Txid, Vec<Deposit>>,
     /// The bitcoin network
     pub network: bitcoin::Network,
 }
@@ -136,10 +131,6 @@ where
                     ?new_block_hash,
                     "new bitcoin block observed on bitcoin core block hash stream"
                 );
-                tracing::info!("loading latest deposit requests from Emily");
-                if let Err(error) = self.load_latest_deposit_requests().await {
-                    tracing::warn!(%error, "could not load latest deposit requests from Emily");
-                }
 
                 let new_block_hash = match new_block_hash {
                     Ok(hash) => hash,
@@ -166,6 +157,11 @@ where
                     }
                 }
 
+                tracing::info!("loading latest deposit requests from Emily");
+                if let Err(error) = self.load_latest_deposit_requests().await {
+                    tracing::warn!(%error, "could not load latest deposit requests from Emily");
+                }
+
                 self.context
                     .signal(SignerEvent::BitcoinBlockObserved.into())?;
             }
@@ -187,23 +183,41 @@ where
         Ok(())
     }
 
+    /// Fetch deposit requests from Emily and store the validated ones into
+    /// the database. Update Emily about the ones that fail validation.
     #[tracing::instrument(skip(self))]
     async fn load_latest_deposit_requests(&mut self) -> Result<(), Error> {
-        let deposit_requests = self.emily_client.get_deposits().await?;
+        let mut deposit_requests = Vec::new();
+        let mut failed_requests = Vec::new();
 
-        for request in deposit_requests {
+        for request in self.emily_client.get_deposits().await? {
             let deposit = request
                 .validate(&self.context.get_bitcoin_client())
                 .await
                 .inspect_err(|error| tracing::warn!(%error, "could not validate deposit request"));
 
-            if let Ok(Some(deposit)) = deposit {
-                self.deposit_requests
-                    .entry(deposit.info.outpoint.txid)
-                    .or_default()
-                    .push(deposit);
+            match deposit {
+                // Happy path, we've successfully validated the deposit
+                // request.
+                Ok(Some(deposit)) => deposit_requests.push(deposit),
+                // This happens when the transaction has failed the first
+                // step of validation or has passed the first step but we
+                // don't recongnize the x-only public key in the deposit
+                // script.
+                Err(Error::SbtcLib(_)) | Err(Error::UnknownAggregateKey(_, _)) => {
+                    failed_requests.push(request);
+                },
+                // This happens when we cannot find the associated
+                // transaction confirmed on a bitcoin block, or when we
+                // encounted some unexpected error when reaching out the
+                // bitcoin-core.
+                Err(_) | Ok(None) => {}
             }
         }
+
+        // TODO: Update emily about the requests that have failed validation.
+
+        self.store_deposit_requests(deposit_requests).await?;
 
         Ok(())
     }
@@ -266,37 +280,26 @@ where
         self.write_stacks_blocks(&stacks_blocks).await?;
         self.write_bitcoin_block(&block).await?;
 
-        self.extract_deposit_requests(&block.txdata, block.block_hash())
-            .await?;
-
         tracing::debug!("finished processing bitcoin block");
         Ok(())
     }
 
-    async fn extract_deposit_requests(
-        &mut self,
-        txs: &[Transaction],
-        block_hash: BlockHash,
-    ) -> Result<(), Error> {
-        let (deposit_request, deposit_request_txs) = txs
-            .iter()
-            .filter_map(|tx| self.deposit_requests.remove(&tx.compute_txid()))
-            .flatten()
+    /// For each of the deposit requests, persist the corresponding
+    /// transaction and the parsed deposit info into the database.
+    async fn store_deposit_requests(&mut self, requests: Vec<Deposit>) -> Result<(), Error> {
+        let (deposit_requests, deposit_request_txs) = requests
+            .into_iter()
             .map(|deposit| {
-                let mut tx_bytes = Vec::new();
-                deposit.tx_info.tx.consensus_encode(&mut tx_bytes)?;
-
                 let tx = model::Transaction {
                     txid: deposit.tx_info.txid.to_byte_array(),
-                    tx: tx_bytes,
+                    tx: bitcoin::consensus::serialize(&deposit.tx_info.tx),
                     tx_type: model::TransactionType::DepositRequest,
-                    block_hash: block_hash.to_byte_array(),
+                    block_hash: deposit.tx_info.block_hash.to_byte_array(),
                 };
 
-                Ok((model::DepositRequest::from(deposit), tx))
+                (model::DepositRequest::from(deposit), tx)
             })
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(Error::BitcoinEncodeTransaction)?
+            .collect::<Vec<_>>()
             .into_iter()
             .unzip();
 
@@ -306,7 +309,7 @@ where
             .await?;
         self.context
             .get_storage_mut()
-            .write_deposit_requests(deposit_request)
+            .write_deposit_requests(deposit_requests)
             .await?;
 
         Ok(())
@@ -478,7 +481,6 @@ mod tests {
             emily_client: test_harness.clone(),
             bitcoin_blocks: block_hash_stream,
             horizon: 1,
-            deposit_requests: HashMap::new(),
             network: bitcoin::Network::Regtest,
         };
 
@@ -598,21 +600,13 @@ mod tests {
             emily_client: test_harness.clone(),
             bitcoin_blocks: block_hash_stream,
             horizon: 1,
-            deposit_requests: HashMap::new(),
             network: bitcoin::Network::Regtest,
         };
 
         block_observer.load_latest_deposit_requests().await.unwrap();
+        let db = storage.lock().await;
         // Only the transaction from tx_setup0 was valid.
-        assert_eq!(block_observer.deposit_requests.len(), 1);
-
-        let deposit = block_observer
-            .deposit_requests
-            .get(&tx_setup0.tx.compute_txid())
-            .cloned()
-            .unwrap();
-        assert_eq!(deposit.len(), 1);
-        assert_eq!(deposit[0].tx_info.tx, tx_setup0.tx);
+        assert_eq!(db.deposit_requests.len(), 1);
     }
 
     /// Test that `BlockObserver::extract_deposit_requests` after
@@ -676,18 +670,11 @@ mod tests {
             emily_client: test_harness.clone(),
             bitcoin_blocks: block_hash_stream,
             horizon: 1,
-            deposit_requests: HashMap::new(),
             network: bitcoin::Network::Regtest,
         };
 
         block_observer.load_latest_deposit_requests().await.unwrap();
-        // The transaction from tx_setup0 was valid.
-        assert_eq!(block_observer.deposit_requests.len(), 1);
 
-        block_observer
-            .extract_deposit_requests(&[tx_setup0.tx.clone()], block_hash)
-            .await
-            .unwrap();
         let storage = storage.lock().await;
         assert_eq!(storage.deposit_requests.len(), 1);
         let db_outpoint: (BitcoinTxId, u32) = (tx_setup0.tx.compute_txid().into(), 0);
@@ -705,9 +692,6 @@ mod tests {
                 .tx_type,
             model::TransactionType::DepositRequest
         );
-
-        // Now the deposit_requests thing should be empty now, since we stored the things.
-        assert!(block_observer.deposit_requests.is_empty());
     }
 
     /// Test that `BlockObserver::extract_sbtc_transactions` takes the
@@ -774,7 +758,6 @@ mod tests {
             emily_client: test_harness.clone(),
             bitcoin_blocks: test_harness.spawn_block_hash_stream(),
             horizon: 1,
-            deposit_requests: HashMap::new(),
             network: bitcoin::Network::Regtest,
         };
 

--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -30,7 +30,6 @@ use crate::storage;
 use crate::storage::model;
 use crate::storage::DbRead;
 use crate::storage::DbWrite;
-use bitcoin::consensus::Encodable as _;
 use bitcoin::hashes::Hash as _;
 use bitcoin::BlockHash;
 use bitcoin::ScriptBuf;
@@ -364,10 +363,6 @@ where
                 continue;
             }
 
-            let mut tx_bytes = Vec::new();
-            tx.consensus_encode(&mut tx_bytes)
-                .map_err(Error::BitcoinEncodeTransaction)?;
-
             // sBTC transactions have as first txin a signers spendable output
             let mut tx_type = model::TransactionType::Donation;
             if let Some(txin) = tx.input.first() {
@@ -391,7 +386,7 @@ where
 
             sbtc_txs.push(model::Transaction {
                 txid: tx.compute_txid().to_byte_array(),
-                tx: tx_bytes,
+                tx: bitcoin::consensus::serialize(&tx),
                 tx_type,
                 block_hash: block_hash.to_byte_array(),
             });

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -90,11 +90,6 @@ pub enum Error {
     #[error("the message topic {0:?} is unsupported")]
     BitcoinCoreZmqUnsupported(Result<String, std::str::Utf8Error>),
 
-    /// This is for when bitcoin::Transaction::consensus_encode fails. It
-    /// should never happen.
-    #[error("could not serialize bitcoin transaction into bytes.")]
-    BitcoinEncodeTransaction(#[source] bitcoin::io::Error),
-
     /// Invalid amount
     #[error("the change amounts for the transaction is negative: {0}")]
     InvalidAmount(i64),

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -367,6 +367,11 @@ pub enum Error {
     #[error("unexpected public key from signature. key {0}; digest: {1}")]
     UnknownPublicKey(crate::keys::PublicKey, secp256k1::Message),
 
+    /// This is thrown when there is a deposit that parses correctly but
+    /// the public key in the deposit script is not known to the signer.
+    #[error("Unknown x-only public key in deposit outpoint: {0}, public key {1}")]
+    UnknownAggregateKey(bitcoin::OutPoint, secp256k1::XOnlyPublicKey),
+
     /// The error for when the request to sign a withdrawal-accept
     /// transaction fails at the validation step.
     #[error("withdrawal accept validation error: {0}")]

--- a/signer/src/main.rs
+++ b/signer/src/main.rs
@@ -334,7 +334,6 @@ async fn run_block_observer(ctx: impl Context) -> Result<(), Error> {
         bitcoin_blocks: stream.to_block_hash_stream(),
         stacks_client,
         emily_client,
-        deposit_requests: HashMap::new(),
         horizon: 1,
         network: config.signer.network.into(),
     };

--- a/signer/src/main.rs
+++ b/signer/src/main.rs
@@ -335,7 +335,6 @@ async fn run_block_observer(ctx: impl Context) -> Result<(), Error> {
         stacks_client,
         emily_client,
         horizon: 1,
-        network: config.signer.network.into(),
     };
 
     block_observer.run().await

--- a/signer/tests/integration/block_observer.rs
+++ b/signer/tests/integration/block_observer.rs
@@ -1,0 +1,205 @@
+use std::collections::HashSet;
+use std::sync::atomic::AtomicU8;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
+
+use bitcoin::OutPoint;
+use bitcoincore_rpc::RpcApi as _;
+use blockstack_lib::chainstate::nakamoto::NakamotoBlock;
+use blockstack_lib::chainstate::nakamoto::NakamotoBlockHeader;
+use blockstack_lib::net::api::getpoxinfo::RPCPoxInfoData;
+use blockstack_lib::net::api::gettenureinfo::RPCGetTenureInfo;
+use futures::StreamExt;
+use rand::SeedableRng as _;
+use sbtc::testing::regtest;
+use signer::error::Error;
+use stacks_common::types::chainstate::ConsensusHash;
+use stacks_common::types::chainstate::StacksBlockId;
+
+use signer::bitcoin::zmq::BitcoinCoreMessageStream;
+use signer::block_observer::BlockObserver;
+use signer::context::Context as _;
+use signer::context::SignerEvent;
+use signer::context::SignerSignal;
+use signer::storage::DbRead as _;
+use signer::testing;
+use signer::testing::context::TestContext;
+use signer::testing::context::*;
+use tokio_stream::wrappers::BroadcastStream;
+use tokio_stream::wrappers::ReceiverStream;
+
+use crate::setup::TestSweepSetup;
+use crate::zmq::BITCOIN_CORE_ZMQ_ENDPOINT;
+use crate::DATABASE_NUM;
+
+pub const GET_POX_INFO_JSON: &str =
+    include_str!("../../tests/fixtures/stacksapi-get-pox-info-test-data.json");
+
+/// The [`BlockObserver::load_latest_deposit_requests`] function is
+/// supposed to fetch all deposit requests from Emily and persist the ones
+/// that pass validation, regardless of when they were confirmed.
+#[cfg_attr(not(feature = "integration-tests"), ignore)]
+#[tokio::test]
+async fn load_latest_deposit_requests_persists_requests_added_long_ago() {
+    // We start with the typical setup with a fresh database and context
+    // with a real bitcoin core client and a real connection to our
+    // database.
+    let mut rng = rand::rngs::StdRng::seed_from_u64(51);
+    let (rpc, faucet) = regtest::initialize_blockchain();
+    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
+    let db = testing::storage::new_test_database(db_num, true).await;
+    let mut ctx = TestContext::builder()
+        .with_storage(db.clone())
+        .with_first_bitcoin_core_client()
+        .with_mocked_emily_client()
+        .with_mocked_stacks_client()
+        .build();
+
+    // We're going to create two confirmed deposits. This also generates
+    // sweep transactions, but this information is not in our database, so
+    // it doesn't matter for this test.
+    let setup0 = TestSweepSetup::new_setup(rpc, faucet, 100_000, &mut rng);
+    let setup1 = TestSweepSetup::new_setup(rpc, faucet, 200_000, &mut rng);
+
+    // Let's prep Emily with information about these deposits.
+    ctx.with_emily_client(|client| {
+        let emily_client_response = vec![
+            setup0.emily_deposit_request(),
+            setup1.emily_deposit_request(),
+        ];
+        client
+            .expect_get_deposits()
+            .once()
+            .returning(move || Box::pin(std::future::ready(Ok(emily_client_response.clone()))));
+    })
+    .await;
+
+    // We need to set up the stacks client as well. We use it to fetch
+    // information about the Stacks blockchain, so we need to prep it, even
+    // though it isn't necessary for our test.
+    ctx.with_stacks_client(|client| {
+        client.expect_get_tenure_info().returning(move || {
+            let response = Ok(RPCGetTenureInfo {
+                consensus_hash: ConsensusHash([0; 20]),
+                tenure_start_block_id: StacksBlockId([0; 32]),
+                parent_consensus_hash: ConsensusHash([0; 20]),
+                parent_tenure_start_block_id: StacksBlockId::first_mined(),
+                tip_block_id: StacksBlockId([0; 32]),
+                tip_height: 0,
+                reward_cycle: 0,
+            });
+            Box::pin(std::future::ready(response))
+        });
+
+        client.expect_get_block().returning(|_| {
+            let response = Ok(NakamotoBlock {
+                header: NakamotoBlockHeader::empty(),
+                txs: Vec::new(),
+            });
+            Box::pin(std::future::ready(response))
+        });
+
+        client.expect_get_tenure().returning(|_| {
+            let response = Ok(Vec::new());
+            Box::pin(std::future::ready(response))
+        });
+
+        client.expect_get_pox_info().returning(|| {
+            let response = serde_json::from_str::<RPCPoxInfoData>(GET_POX_INFO_JSON)
+                .map_err(Error::JsonSerialize);
+            Box::pin(std::future::ready(response))
+        });
+    })
+    .await;
+
+    // We only proceed with the test after the BlockObserver "process" has
+    // started, and we use this counter to notify us when that happens.
+    let start_count = Arc::new(AtomicU8::new(0));
+    let counter = start_count.clone();
+
+    // We jump through all of these hoops to make sure that the block
+    // stream object is Send + Sync.
+    let zmq_stream =
+        BitcoinCoreMessageStream::new_from_endpoint(BITCOIN_CORE_ZMQ_ENDPOINT, &["hashblock"])
+            .await
+            .unwrap();
+    let (sender, receiver) = tokio::sync::mpsc::channel(100);
+
+    tokio::spawn(async move {
+        let mut stream = zmq_stream.to_block_hash_stream();
+        while let Some(block) = stream.next().await {
+            sender.send(block).await.unwrap();
+        }
+    });
+
+    let block_observer = BlockObserver {
+        context: ctx.clone(),
+        stacks_client: ctx.stacks_client.clone(),
+        emily_client: ctx.emily_client.clone(),
+        bitcoin_blocks: ReceiverStream::new(receiver),
+        horizon: 10,
+    };
+
+    tokio::spawn(async move {
+        counter.fetch_add(1, Ordering::Relaxed);
+        block_observer.run().await
+    });
+
+    // Wait for the task to start.
+    while start_count.load(Ordering::SeqCst) < 1 {
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
+    // Our database shouldn't have any deposit requests. In fact, our
+    // database doesn't have any blockchain data at all.
+    let db = &ctx.storage;
+    assert!(db.get_bitcoin_canonical_chain_tip().await.unwrap().is_none());
+
+    let chain_tip_info = rpc.get_chain_tips().unwrap().pop().unwrap();
+    let deposit_requests = db
+        .get_pending_deposit_requests(&chain_tip_info.hash.into(), 20)
+        .await
+        .unwrap();
+
+    assert!(deposit_requests.is_empty());
+
+    // Let's generate a new block and wait for out block observer to send a
+    // BitcoinBlockObserved signal.
+    let chain_tip = faucet.generate_blocks(1).pop().unwrap().into();
+
+    let receiver = ctx.get_signal_receiver();
+
+    let stream = BroadcastStream::new(receiver)
+        .filter_map(|signal| match signal {
+            Ok(SignerSignal::Event(SignerEvent::BitcoinBlockObserved)) => {
+                std::future::ready(Some(()))
+            }
+            _ => std::future::ready(None),
+        })
+        .fuse();
+    // We need it to implement UnPin for StreamExt::select_next_some, same
+    // for StreamExt::next.
+    tokio::pin!(stream);
+
+    tokio::time::timeout(Duration::from_secs(10), stream.select_next_some())
+        .await
+        .unwrap();
+
+    // Okay now lets check if we have these deposit requests in our
+    // database. It should also have bitcoin blockchain data
+
+    assert!(db.get_bitcoin_canonical_chain_tip().await.unwrap().is_some());
+    let deposit_requests = db
+        .get_pending_deposit_requests(&chain_tip, 20)
+        .await
+        .unwrap();
+
+
+    assert_eq!(deposit_requests.len(), 2);
+    let req_outpoints: HashSet<OutPoint> =
+        deposit_requests.iter().map(|req| req.outpoint()).collect();
+
+    assert!(req_outpoints.contains(&setup0.deposit_info.outpoint));
+    assert!(req_outpoints.contains(&setup1.deposit_info.outpoint));
+}

--- a/signer/tests/integration/emily.rs
+++ b/signer/tests/integration/emily.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
 
@@ -385,7 +384,6 @@ async fn deposit_e2e() {
         bitcoin_blocks: block_stream,
         stacks_client: stacks_client,
         emily_client: emily_client.clone(),
-        deposit_requests: HashMap::new(),
         horizon: 1,
         network: bitcoin::Network::Regtest,
     };

--- a/signer/tests/integration/emily.rs
+++ b/signer/tests/integration/emily.rs
@@ -385,7 +385,6 @@ async fn deposit_e2e() {
         stacks_client: stacks_client,
         emily_client: emily_client.clone(),
         horizon: 1,
-        network: bitcoin::Network::Regtest,
     };
 
     let block_observer_handle = tokio::spawn(async move { block_observer.run().await });

--- a/signer/tests/integration/main.rs
+++ b/signer/tests/integration/main.rs
@@ -2,6 +2,7 @@ use std::sync::atomic::AtomicU16;
 
 mod bitcoin_client;
 mod bitcoin_rpc;
+mod block_observer;
 mod complete_deposit;
 mod contracts;
 mod emily;

--- a/signer/tests/integration/setup.rs
+++ b/signer/tests/integration/setup.rs
@@ -1,4 +1,3 @@
-use bitcoin::consensus::Encodable as _;
 use bitcoin::hashes::Hash as _;
 use bitcoin::AddressType;
 use bitcoin::OutPoint;
@@ -182,11 +181,8 @@ impl TestSweepSetup {
 
     /// Store the deposit transaction into the database
     pub async fn store_deposit_tx(&self, db: &PgStore) {
-        let mut tx = Vec::new();
-        self.deposit_tx_info.tx.consensus_encode(&mut tx).unwrap();
-
         let deposit_tx = model::Transaction {
-            tx,
+            tx: bitcoin::consensus::serialize(&self.deposit_tx_info.tx),
             txid: self.deposit_tx_info.txid.to_byte_array(),
             tx_type: model::TransactionType::SbtcTransaction,
             block_hash: self.deposit_block_hash.to_byte_array(),
@@ -203,11 +199,8 @@ impl TestSweepSetup {
     /// Store the transaction that swept the deposit into the signers' UTXO
     /// into the database
     pub async fn store_sweep_tx(&self, db: &PgStore) {
-        let mut tx = Vec::new();
-        self.sweep_tx_info.tx.consensus_encode(&mut tx).unwrap();
-
         let sweep_tx = model::Transaction {
-            tx,
+            tx: bitcoin::consensus::serialize(&self.sweep_tx_info.tx),
             txid: self.sweep_tx_info.txid.to_byte_array(),
             tx_type: model::TransactionType::SbtcTransaction,
             block_hash: self.sweep_block_hash.to_byte_array(),

--- a/signer/tests/integration/setup.rs
+++ b/signer/tests/integration/setup.rs
@@ -9,6 +9,7 @@ use clarity::vm::types::PrincipalData;
 use fake::Fake;
 use fake::Faker;
 use rand::rngs::OsRng;
+use sbtc::deposits::CreateDepositRequest;
 use sbtc::deposits::DepositInfo;
 use sbtc::testing::regtest;
 use sbtc::testing::regtest::Faucet;
@@ -176,6 +177,16 @@ impl TestSweepSetup {
             aggregated_signer: signer,
             withdrawal_request: requests.withdrawals.pop().unwrap(),
             withdrawal_sender: PrincipalData::from(StacksAddress::burn_address(false)),
+        }
+    }
+
+    /// Return the expected deposit request that our internal EmilyClient
+    /// should return for the deposit here.
+    pub fn emily_deposit_request(&self) -> CreateDepositRequest {
+        CreateDepositRequest {
+            outpoint: self.deposit_info.outpoint,
+            reclaim_script: self.deposit_info.reclaim_script.clone(),
+            deposit_script: self.deposit_info.deposit_script.clone(),
         }
     }
 

--- a/signer/tests/integration/zmq.rs
+++ b/signer/tests/integration/zmq.rs
@@ -4,7 +4,7 @@ use futures::StreamExt;
 use sbtc::testing::regtest;
 use signer::bitcoin::zmq::BitcoinCoreMessageStream;
 
-const BITCOIN_CORE_ZMQ_ENDPOINT: &str = "tcp://localhost:28332";
+pub const BITCOIN_CORE_ZMQ_ENDPOINT: &str = "tcp://localhost:28332";
 
 /// This tests that out bitcoin block stream receives new blocks from
 /// bitcoin-core as it receives them. We create the stream, generate


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/522.

This was largely fixed in https://github.com/stacks-network/sbtc/pull/675.

## Changes

* Have the `load_latest_deposit_requests` function fetch and store all validated deposits that have been confirmed.
* Remove unnecessary fields from the `BlockObserver`.
* Load data from Emily after processing the block.

## Testing Information

The tests were modified after two functions were essentially merged.

## Checklist:

- [x] I have performed a self-review of my code
