### PR TITLE
feat: include all variables in deposit request table

### DIFF
--- a/signer/migrations/0003__create_tables.sql
+++ b/signer/migrations/0003__create_tables.sql
@@ -32,6 +32,9 @@ CREATE TABLE sbtc_signer.deposit_requests (
     recipient TEXT NOT NULL,
     amount BIGINT NOT NULL,
     max_fee BIGINT NOT NULL,
+    lock_time BIGINT NOT NULL,
+    -- this is an x-only public key, we need column comments
+    signer_public_key BYTEA NOT NULL,
     sender_script_pub_keys BYTEA[] NOT NULL,
     created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
     PRIMARY KEY (txid, output_index)

--- a/signer/src/bitcoin/utxo.rs
+++ b/signer/src/bitcoin/utxo.rs
@@ -340,14 +340,7 @@ impl DepositRequest {
     }
 
     /// Try convert from a model::DepositRequest with some additional info.
-    ///
-    /// TODO(511): derive the signer public key from the public keys in the
-    /// votes.
-    pub fn from_model(
-        request: model::DepositRequest,
-        signers_public_key: XOnlyPublicKey,
-        votes: SignerVotes,
-    ) -> Self {
+    pub fn from_model(request: model::DepositRequest, votes: SignerVotes) -> Self {
         Self {
             outpoint: request.outpoint(),
             max_fee: request.max_fee,
@@ -355,7 +348,7 @@ impl DepositRequest {
             amount: request.amount,
             deposit_script: ScriptBuf::from_bytes(request.spend_script),
             reclaim_script: ScriptBuf::from_bytes(request.reclaim_script),
-            signers_public_key,
+            signers_public_key: request.signer_public_key.into(),
         }
     }
 }
@@ -1067,7 +1060,6 @@ mod tests {
     use stacks_common::types::chainstate::StacksAddress;
     use test_case::test_case;
 
-    use crate::keys::PublicKey;
     use crate::testing;
 
     const X_ONLY_PUBLIC_KEY1: &'static str =
@@ -2196,9 +2188,7 @@ mod tests {
         ];
         let votes = SignerVotes::from(signer_votes.to_vec());
         let request: model::DepositRequest = fake::Faker.fake_with_rng(&mut OsRng);
-        let signers_public_key: PublicKey = fake::Faker.fake_with_rng(&mut OsRng);
-        let deposit_request =
-            DepositRequest::from_model(request, signers_public_key.into(), votes.clone());
+        let deposit_request = DepositRequest::from_model(request, votes.clone());
 
         // One explicit vote against and one implicit vote against.
         assert_eq!(deposit_request.votes_against(), 2);

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -159,6 +159,12 @@ pub enum Error {
     #[error("invalid public key: {0}")]
     InvalidPublicKey(#[source] secp256k1::Error),
 
+    /// This occurs when converting a byte slice to our internal x-only
+    /// public key type, which is a thin wrapper around the
+    /// secp256k1::XOnlyPublicKey.
+    #[error("invalid x-only public key: {0}")]
+    InvalidXOnlyPublicKey(#[source] secp256k1::Error),
+
     /// This happens when we tweak our public key by a scalar, and the
     /// result is an invalid public key. I think It is very unlikely that
     /// we will see this one by chance, since the probability that this

--- a/signer/src/keys.rs
+++ b/signer/src/keys.rs
@@ -235,6 +235,52 @@ impl std::fmt::Display for PublicKey {
     }
 }
 
+/// The x-coordinate of a public key for the secp256k1 elliptic curve. It
+/// is used for verification of Taproot signatures and serialized according
+/// to BIP-340.
+#[derive(Copy, Clone, Debug, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct PublicKeyXOnly(secp256k1::XOnlyPublicKey);
+
+impl From<&PublicKeyXOnly> for secp256k1::XOnlyPublicKey {
+    fn from(value: &PublicKeyXOnly) -> Self {
+        value.0
+    }
+}
+
+impl From<PublicKeyXOnly> for secp256k1::XOnlyPublicKey {
+    fn from(value: PublicKeyXOnly) -> Self {
+        value.0
+    }
+}
+
+impl From<&secp256k1::XOnlyPublicKey> for PublicKeyXOnly {
+    fn from(value: &secp256k1::XOnlyPublicKey) -> Self {
+        Self(*value)
+    }
+}
+
+impl From<secp256k1::XOnlyPublicKey> for PublicKeyXOnly {
+    fn from(value: secp256k1::XOnlyPublicKey) -> Self {
+        Self(value)
+    }
+}
+
+impl PublicKeyXOnly {
+    /// Creates a public key directly from a slice.
+    pub fn from_slice(data: &[u8]) -> Result<Self, Error> {
+        secp256k1::XOnlyPublicKey::from_slice(data)
+            .map(Self)
+            .map_err(Error::InvalidXOnlyPublicKey)
+    }
+
+    /// Serializes the key as a byte-encoded pair of values in compressed
+    /// form.
+    pub fn serialize(&self) -> [u8; 32] {
+        self.0.serialize()
+    }
+}
+
 /// A private key type for the secp256k1 elliptic curve.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Deserialize)]
 #[serde(transparent)]

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -526,6 +526,8 @@ impl super::DbRead for PgStore {
               , deposit_requests.recipient
               , deposit_requests.amount
               , deposit_requests.max_fee
+              , deposit_requests.lock_time
+              , deposit_requests.signer_public_key
               , deposit_requests.sender_script_pub_keys
             FROM transactions_in_window transactions
             JOIN sbtc_signer.deposit_requests deposit_requests ON
@@ -583,6 +585,8 @@ impl super::DbRead for PgStore {
               , deposit_requests.recipient
               , deposit_requests.amount
               , deposit_requests.max_fee
+              , deposit_requests.lock_time
+              , deposit_requests.signer_public_key
               , deposit_requests.sender_script_pub_keys
             FROM transactions_in_window transactions
             JOIN sbtc_signer.deposit_requests deposit_requests USING(txid)
@@ -692,6 +696,8 @@ impl super::DbRead for PgStore {
               , requests.recipient
               , requests.amount
               , requests.max_fee
+              , requests.lock_time
+              , requests.signer_public_key
               , requests.sender_script_pub_keys
             FROM sbtc_signer.deposit_requests requests
                  JOIN sbtc_signer.deposit_signers signers
@@ -1384,9 +1390,11 @@ impl super::DbWrite for PgStore {
               , recipient
               , amount
               , max_fee
+              , lock_time
+              , signer_public_key
               , sender_script_pub_keys
               )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
             ON CONFLICT DO NOTHING",
         )
         .bind(deposit_request.txid)
@@ -1396,6 +1404,8 @@ impl super::DbWrite for PgStore {
         .bind(&deposit_request.recipient)
         .bind(i64::try_from(deposit_request.amount).map_err(Error::ConversionDatabaseInt)?)
         .bind(i64::try_from(deposit_request.max_fee).map_err(Error::ConversionDatabaseInt)?)
+        .bind(i64::try_from(deposit_request.lock_time).map_err(Error::ConversionDatabaseInt)?)
+        .bind(&deposit_request.signer_public_key)
         .bind(&deposit_request.sender_script_pub_keys)
         .execute(&self.0)
         .await

--- a/signer/src/testing/dummy.rs
+++ b/signer/src/testing/dummy.rs
@@ -24,6 +24,7 @@ use stacks_common::types::chainstate::StacksAddress;
 
 use crate::keys::PrivateKey;
 use crate::keys::PublicKey;
+use crate::keys::PublicKeyXOnly;
 use crate::keys::SignerScriptPubKey as _;
 use crate::stacks::events::CompletedDepositEvent;
 use crate::stacks::events::WithdrawalAcceptEvent;
@@ -258,6 +259,14 @@ impl fake::Dummy<fake::Faker> for PublicKey {
     fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &fake::Faker, rng: &mut R) -> Self {
         let sk = secp256k1::SecretKey::new(rng);
         Self::from(secp256k1::PublicKey::from_secret_key_global(&sk))
+    }
+}
+
+
+impl fake::Dummy<fake::Faker> for PublicKeyXOnly {
+    fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &fake::Faker, rng: &mut R) -> Self {
+        let pk: PublicKey = fake::Faker.fake_with_rng(rng);
+        Self::from(secp256k1::XOnlyPublicKey::from(pk))
     }
 }
 

--- a/signer/src/testing/dummy.rs
+++ b/signer/src/testing/dummy.rs
@@ -262,7 +262,6 @@ impl fake::Dummy<fake::Faker> for PublicKey {
     }
 }
 
-
 impl fake::Dummy<fake::Faker> for PublicKeyXOnly {
     fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &fake::Faker, rng: &mut R) -> Self {
         let pk: PublicKey = fake::Faker.fake_with_rng(rng);

--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -833,8 +833,6 @@ where
             .get_pending_accepted_withdrawal_requests(bitcoin_chain_tip, context_window, threshold)
             .await?;
 
-        let signers_public_key = bitcoin::XOnlyPublicKey::from(aggregate_key);
-
         let mut deposits: Vec<utxo::DepositRequest> = Vec::new();
 
         for req in pending_deposit_requests {
@@ -844,7 +842,7 @@ where
                 .get_deposit_request_signer_votes(&req.txid, req.output_index, aggregate_key)
                 .await?;
 
-            let deposit = utxo::DepositRequest::from_model(req, signers_public_key, votes);
+            let deposit = utxo::DepositRequest::from_model(req, votes);
             deposits.push(deposit);
         }
 


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/697.

## Changes

* Add `lock_time` and `signer_public_key` columns to the `deposit_requests` table.
* Add a new `PublicKeyXOnly` type. Maybe we should rename it.

## Testing Information

This is a minor refactor. If tests pass then we should be okay.

## Checklist:

- [ ] I have performed a self-review of my code
