### PR TITLE
Add Docker Container Release Workflow

### DIFF
--- a/.github/actions/dockerfiles/Dockerfile.signer.debian
+++ b/.github/actions/dockerfiles/Dockerfile.signer.debian
@@ -2,7 +2,7 @@ FROM rust:1.81.0-slim-bookworm as build
 
 # Install dependencies.
 RUN apt-get update
-RUN apt-get install -y \
+RUN apt-get install -y --no-install-recommends \
     libclang-dev \
     git \
     pkg-config \

--- a/.github/actions/dockerfiles/Dockerfile.signer.debian
+++ b/.github/actions/dockerfiles/Dockerfile.signer.debian
@@ -21,4 +21,4 @@ RUN make install && make build
 # Create Docker image to run the signer.
 FROM debian:bookworm-slim AS signer
 COPY --from=build /code/sbtc/target/debug/signer /usr/local/bin/signer
-ENTRYPOINT ["/usr/local/bin/signer --config /signer-config.toml --migrate-db"]
+CMD ["/usr/local/bin/signer --config /signer-config.toml --migrate-db"]

--- a/.github/actions/dockerfiles/Dockerfile.signer.debian
+++ b/.github/actions/dockerfiles/Dockerfile.signer.debian
@@ -1,0 +1,24 @@
+FROM rust:1.81.0-slim-bookworm as build
+
+# Install dependencies.
+RUN apt-get update
+RUN apt-get install -y \
+    libclang-dev \
+    git \
+    pkg-config \
+    libssl-dev \
+    make \
+    protobuf-compiler \
+    npm \
+    default-jre
+RUN npm install -g pnpm@9
+RUN npm install -g @openapitools/openapi-generator-cli
+
+WORKDIR /code/sbtc
+COPY . .
+RUN make install && make build
+
+# Create Docker image to run the signer.
+FROM debian:bookworm-slim AS signer
+COPY --from=build /code/sbtc/target/debug/signer /usr/local/bin/signer
+ENTRYPOINT ["/usr/local/bin/signer --config /signer-config.toml --migrate-db"]

--- a/.github/workflows/image-build.yaml
+++ b/.github/workflows/image-build.yaml
@@ -3,32 +3,22 @@
 name: Docker Image (Binary)
 
 on:
-  workflow_dispatch:
-    inputs:
-      tag:
-        required: true
-        type: string
-        description: "Version tag for docker images. Requires that a release branch for the tag exists."
-      push-image:
-        required: true
-        type: boolean
-        description: "False if dry running the docker image build"
-      is-latest:
-        required: false
-        type: boolean
-        description: "True if the image is the latest release"
+  push:
+    tags:
+      - '*'
 
 ## Define which docker arch to build for
 env:
   docker_platforms: "linux/amd64"
   docker-org: blockstack
+  latest-release: $(curl -s https://api.github.com/repos/${{ github.repository }}/releases/latest | jq -r .tag_name)
 
 concurrency:
   group: docker-image-${{ github.head_ref || github.ref || github.run_id }}
   ## Always cancel duplicate jobs
   cancel-in-progress: true
 
-run-name: "Build and Release sBTC Signer ${{ inputs.tag }} Docker Image"
+run-name: "Build and Release sBTC Signer ${{ github.ref_name }} Docker Image"
 
 jobs:
   image:
@@ -54,12 +44,18 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
+      # Fetch the latest release tag and put into environment variables under
+      # the key `latest_release`.
+      - name: Get latest release tag
+        id: get_latest_release
+        run: |
+          latest_release=$(curl -s https://api.github.com/repos/${{ github.repository }}/releases/latest | jq -r .tag_name)
+          echo "latest_release=$latest_release" >> $GITHUB_ENV
+
       ## Checkout the branch of the release provided.
       ## This requires that a release branch exists for the tag.
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: "release/${{ inputs.tag }}"
 
       ## if the repo owner is not `stacks-network`, default to a docker-org of the repo owner (i.e. github user id)
       ## this allows forks to run the docker push workflows without having to hardcode a dockerhub org (but it does require docker hub user to match github username)
@@ -80,10 +76,10 @@ jobs:
           images: |
             ${{ env.docker-org }}/sbtc
           tags: |
-            type=raw,value=${{ matrix.docker_target }}-${{ inputs.tag }}-${{ matrix.dist }}
-            type=raw,value=${{ matrix.docker_target }}-${{ inputs.tag }},enable=${{ matrix.dist == 'debian' }}
-            type=raw,value=${{ matrix.docker_target }}-latest,enable=${{ inputs.is-latest == 'true' && matrix.dist == 'debian' }}
-            type=raw,value=${{ matrix.docker_target }}-latest-${{ matrix.dist }},enable=${{ inputs.is-latest == 'true' }}
+            type=raw,value=${{ matrix.docker_target }}-${{ github.ref_name }}-${{ matrix.dist }}
+            type=raw,value=${{ matrix.docker_target }}-${{ github.ref_name }},enable=${{ matrix.dist == 'debian' }}
+            type=raw,value=${{ matrix.docker_target }}-latest,enable=${{ env.latest_release == github.ref_name && matrix.dist == 'debian' }}
+            type=raw,value=${{ matrix.docker_target }}-latest-${{ matrix.dist }},enable=${{ env.latest_release == github.ref_name }}
 
       ## Build docker image for release
       - name: Build and Push ( ${{ matrix.dist }} ${{ matrix.docker_target }} )

--- a/.github/workflows/image-build.yaml
+++ b/.github/workflows/image-build.yaml
@@ -1,0 +1,96 @@
+## Github workflow to build a multiarch docker image from pre-built binaries
+
+name: Docker Image (Binary)
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        required: true
+        type: string
+        description: "Version tag for docker images. Requires that a release branch for the tag exists."
+      push-image:
+        required: true
+        type: boolean
+        description: "False if dry running the docker image build"
+
+## Define which docker arch to build for
+env:
+  docker_platforms: "linux/amd64"
+  docker-org: blockstack
+
+concurrency:
+  group: docker-image-${{ github.head_ref || github.ref || github.run_id }}
+  ## Always cancel duplicate jobs
+  cancel-in-progress: true
+
+run-name: "Build and Release sBTC Signer ${{ inputs.tag }} Docker Image"
+
+jobs:
+  image:
+    name: Build Image
+    strategy:
+      fail-fast: false
+      ## Build a maximum of 2 images for if / when this is extended
+      ## for more distribution types.
+      max-parallel: 2
+      matrix:
+        dist:
+          - debian
+        docker_target:
+          - signer
+
+    runs-on: ubuntu-latest
+    steps:
+      ## Setup Docker for the builds
+      - name: Docker setup
+        id: docker_setup
+        uses: stacks-network/actions/docker@main
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      ## Checkout the branch of the release provided.
+      ## This requires that a release branch exists for the tag.
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: "release/${{ inputs.tag }}"
+
+      ## if the repo owner is not `stacks-network`, default to a docker-org of the repo owner (i.e. github user id)
+      ## this allows forks to run the docker push workflows without having to hardcode a dockerhub org (but it does require docker hub user to match github username)
+      - name: Set Local env vars
+        id: set_env
+        if: |
+          github.repository_owner != 'stacks-network'
+        run: |
+          echo "docker-org=${{ github.repository_owner }}" >> "$GITHUB_ENV"
+
+      ## Set docker metatdata
+      ## - depending on the matrix.dist, different tags will be enabled
+      ## ex. debian will have this tag: `type=ref,event=tag,enable=${{ matrix.dist == 'debian' }}`
+      - name: Docker Metadata ( ${{ matrix.dist }} )
+        id: docker_metadata
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
+        with:
+          images: |
+            ${{ env.docker-org }}/sbtc
+          tags: |
+            type=raw,value=${{ matrix.docker_target }}-latest,enable=${{ matrix.docker_target != '' && (github.ref == format('refs/heads/{0}', github.event.repository.default_branch) ) && matrix.dist == 'debian' }}
+            type=raw,value=${{ matrix.docker_target }}-${{ inputs.tag }}-${{ matrix.dist }},enable=${{ matrix.docker_target != '' && matrix.dist == 'debian'}}
+            type=raw,value=${{ matrix.docker_target }}-${{ inputs.tag }},enable=${{ matrix.docker_target != '' && matrix.dist == 'debian' }}
+            type=ref,event=tag,enable=${{ matrix.dist == 'debian' }}
+            type=raw,value=${{ matrix.docker_target }}-latest-${{ matrix.dist }},enable=${{ matrix.docker_target != '' && (github.ref == format('refs/heads/{0}', github.event.repository.default_branch) ) && matrix.dist == 'alpine' }}
+            type=raw,value=${{ matrix.docker_target }}-${{ inputs.tag }}-${{ matrix.dist }},enable=${{ matrix.docker_target != '' && matrix.dist == 'alpine' }}
+
+      ## Build docker image for release
+      - name: Build and Push ( ${{ matrix.dist }} ${{ matrix.docker_target }} )
+        id: docker_build
+        uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # v5.3.0
+        with:
+          file: ./.github/actions/dockerfiles/Dockerfile.${{ matrix.docker_target }}.${{ matrix.dist }}
+          platforms: ${{ env.docker_platforms }}
+          tags: ${{ steps.docker_metadata.outputs.tags }}
+          labels: ${{ steps.docker_metadata.outputs.labels }}
+          target: ${{ matrix.docker_target }}
+          push: ${{ inputs.push-image }}

--- a/.github/workflows/image-build.yaml
+++ b/.github/workflows/image-build.yaml
@@ -13,6 +13,10 @@ on:
         required: true
         type: boolean
         description: "False if dry running the docker image build"
+      is-latest:
+        required: false
+        type: boolean
+        description: "True if the image is the latest release"
 
 ## Define which docker arch to build for
 env:
@@ -76,12 +80,10 @@ jobs:
           images: |
             ${{ env.docker-org }}/sbtc
           tags: |
-            type=raw,value=${{ matrix.docker_target }}-latest,enable=${{ matrix.docker_target != '' && (github.ref == format('refs/heads/{0}', github.event.repository.default_branch) ) && matrix.dist == 'debian' }}
-            type=raw,value=${{ matrix.docker_target }}-${{ inputs.tag }}-${{ matrix.dist }},enable=${{ matrix.docker_target != '' && matrix.dist == 'debian'}}
-            type=raw,value=${{ matrix.docker_target }}-${{ inputs.tag }},enable=${{ matrix.docker_target != '' && matrix.dist == 'debian' }}
-            type=ref,event=tag,enable=${{ matrix.dist == 'debian' }}
-            type=raw,value=${{ matrix.docker_target }}-latest-${{ matrix.dist }},enable=${{ matrix.docker_target != '' && (github.ref == format('refs/heads/{0}', github.event.repository.default_branch) ) && matrix.dist == 'alpine' }}
-            type=raw,value=${{ matrix.docker_target }}-${{ inputs.tag }}-${{ matrix.dist }},enable=${{ matrix.docker_target != '' && matrix.dist == 'alpine' }}
+            type=raw,value=${{ matrix.docker_target }}-${{ inputs.tag }}-${{ matrix.dist }}
+            type=raw,value=${{ matrix.docker_target }}-${{ inputs.tag }},enable=${{ matrix.dist == 'debian' }}
+            type=raw,value=${{ matrix.docker_target }}-latest,enable=${{ inputs.is-latest == 'true' && matrix.dist == 'debian' }}
+            type=raw,value=${{ matrix.docker_target }}-latest-${{ matrix.dist }},enable=${{ inputs.is-latest == 'true' }}
 
       ## Build docker image for release
       - name: Build and Push ( ${{ matrix.dist }} ${{ matrix.docker_target }} )


### PR DESCRIPTION
## Description

Closes: #693 

This PR adds a docker container publishing CI action that will build release a docker container for the signer. It uses a similar workflow to the one used in `stacks-core`, but it appears that the one in stacks-core has never been run. This workflow step can only be run manually with a release tag that corresponds to a release branch. This is to avoid accidentally releasing the wrong thing.

This means to release docker images for version `a.b.c` you'll need to do the following:
1. Push to the branch `release/a.b.c`
1. Go to workflows and manually trigger this workflow with the following info:
    1.  `tag = a.b.c`
    1. `push-image = true`
    1. and then if you want the latest tag to be this version, you'd do `is-latest = true`

## Changes

- Creates a GitHub workflow to release the sbtc signer.
- Creates a `Dockerfile.signer.debian` dockerfile to build the container

Releases will be published under [`blockstack/sbtc`](https://hub.docker.com/r/blockstack/sbtc/tags).

The signer will be released under the following:
- `signer-x.x.x`
- `signer-x.x.x-debian`
- `signer-latest` (if latest)
- `signer-latest-debian` (if latest)

Only debian is currently supported but `stacks-core` currently supports alpine as well. This format leaves that open for a future improvement only if we get enough requests for it.

## Testing Information

- Image tested locally
- Deployment tested in CI with the following action: [link](https://github.com/stacks-network/sbtc/actions/runs/11503910306/job/32022240494)


## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
