### PR TITLE
feat: emily event observer sidecar

### DIFF
--- a/signer/src/api/mod.rs
+++ b/signer/src/api/mod.rs
@@ -4,8 +4,14 @@
 pub mod new_block;
 pub mod status;
 
+use emily_client::models::Chainstate;
+use emily_client::models::UpdateDepositsResponse;
+use emily_client::models::UpdateWithdrawalsResponse;
+use emily_client::models::Withdrawal;
 pub use new_block::new_block_handler;
 pub use status::status_handler;
+
+use crate::error::Error;
 
 /// A struct with state data necessary for runtime operation.
 #[derive(Debug, Clone)]
@@ -16,3 +22,10 @@ pub struct ApiState<C> {
 
 /// The name of the sbtc registry smart contract.
 const SBTC_REGISTRY_CONTRACT_NAME: &str = "sbtc-registry";
+
+enum UpdateResult {
+    Deposit(Result<UpdateDepositsResponse, Error>),
+    Withdrawal(Result<UpdateWithdrawalsResponse, Error>),
+    CreatedWithdrawal(Vec<Result<Withdrawal, Error>>),
+    Chainstate(Result<Chainstate, Error>),
+}

--- a/signer/src/api/new_block.rs
+++ b/signer/src/api/new_block.rs
@@ -226,7 +226,7 @@ async fn fetch_btc_block_from_txid(db: &impl DbRead, txid: Txid) -> Option<Bitco
         .ok()?;
 
     let block_hash = blocks_hashes.last()?;
-    db.get_bitcoin_block(&block_hash).await.ok()?
+    db.get_bitcoin_block(block_hash).await.ok()?
 }
 
 /// Processes a completed deposit event by updating relevant deposit records

--- a/signer/src/emily_client.rs
+++ b/signer/src/emily_client.rs
@@ -292,7 +292,7 @@ impl EmilyInteract for ApiFallbackClient<EmilyClient> {
             Ok::<Vec<Result<Withdrawal, Error>>, Error>(withdrawals) // Wrap the Vec in Ok to satisfy exec's type constraints
         })
         .await
-        .unwrap_or_else(|err| vec![Err(err.into())])
+        .unwrap_or_else(|err| vec![Err(err)])
     }
 
     async fn update_withdrawals(

--- a/signer/src/emily_client.rs
+++ b/signer/src/emily_client.rs
@@ -8,12 +8,18 @@ use bitcoin::Txid;
 use emily_client::apis::chainstate_api;
 use emily_client::apis::configuration::Configuration as EmilyApiConfig;
 use emily_client::apis::deposit_api;
+use emily_client::apis::withdrawal_api;
 use emily_client::apis::Error as EmilyError;
 use emily_client::models::Chainstate;
+use emily_client::models::CreateWithdrawalRequestBody;
 use emily_client::models::DepositUpdate;
 use emily_client::models::Status;
 use emily_client::models::UpdateDepositsRequestBody;
 use emily_client::models::UpdateDepositsResponse;
+use emily_client::models::UpdateWithdrawalsRequestBody;
+use emily_client::models::UpdateWithdrawalsResponse;
+use emily_client::models::Withdrawal;
+use emily_client::models::WithdrawalUpdate;
 use sbtc::deposits::CreateDepositRequest;
 use url::Url;
 
@@ -42,6 +48,14 @@ pub enum EmilyClientError {
     #[error("error updating deposits: {0}")]
     UpdateDeposits(EmilyError<deposit_api::UpdateDepositsError>),
 
+    /// An error occurred while creating withdrawals
+    #[error("error creating withdrawals: {0}")]
+    CreateWithdrawal(EmilyError<withdrawal_api::CreateWithdrawalError>),
+
+    /// An error occurred while updating withdrawals
+    #[error("error updating withdrawals: {0}")]
+    UpdateWithdrawals(EmilyError<withdrawal_api::UpdateWithdrawalsError>),
+
     /// An error occurred while adding a chainstate entry
     #[error("error adding chainstate entry: {0}")]
     AddChainstateEntry(EmilyError<chainstate_api::SetChainstateError>),
@@ -63,6 +77,24 @@ pub trait EmilyInteract: Sync + Send {
         transaction: &'a UnsignedTransaction<'a>,
         stacks_chain_tip: &'a StacksBlock,
     ) -> impl std::future::Future<Output = Result<UpdateDepositsResponse, Error>> + Send;
+
+    /// Update the status of deposits in Emily.
+    fn update_deposits(
+        &self,
+        update_deposits: Vec<DepositUpdate>,
+    ) -> impl std::future::Future<Output = Result<UpdateDepositsResponse, Error>> + Send;
+
+    /// Create withdrawals in Emily.
+    fn create_withdrawals(
+        &self,
+        create_withdrawals: Vec<CreateWithdrawalRequestBody>,
+    ) -> impl std::future::Future<Output = Vec<Result<Withdrawal, Error>>> + Send;
+
+    /// Update the status of withdrawals in Emily.
+    fn update_withdrawals(
+        &self,
+        update_withdrawals: Vec<WithdrawalUpdate>,
+    ) -> impl std::future::Future<Output = Result<UpdateWithdrawalsResponse, Error>> + Send;
 
     /// Set the chainstate in Emily. This could trigger a reorg.
     fn set_chainstate(
@@ -138,10 +170,18 @@ impl EmilyInteract for EmilyClient {
             .collect()
     }
 
-    async fn set_chainstate(&self, chainstate: Chainstate) -> Result<Chainstate, Error> {
-        chainstate_api::set_chainstate(&self.config, chainstate)
+    async fn update_deposits(
+        &self,
+        update_deposits: Vec<DepositUpdate>,
+    ) -> Result<UpdateDepositsResponse, Error> {
+        if update_deposits.is_empty() {
+            return Ok(UpdateDepositsResponse { deposits: vec![] });
+        }
+
+        let update_request = UpdateDepositsRequestBody { deposits: update_deposits };
+        deposit_api::update_deposits(&self.config, update_request)
             .await
-            .map_err(EmilyClientError::AddChainstateEntry)
+            .map_err(EmilyClientError::UpdateDeposits)
             .map_err(Error::EmilyApi)
     }
 
@@ -167,15 +207,54 @@ impl EmilyInteract for EmilyClient {
             })
             .collect();
 
-        if update_request.is_empty() {
-            return Ok(UpdateDepositsResponse { deposits: vec![] });
+        self.update_deposits(update_request).await
+    }
+
+    async fn create_withdrawals(
+        &self,
+        create_withdrawals: Vec<CreateWithdrawalRequestBody>,
+    ) -> Vec<Result<Withdrawal, Error>> {
+        if create_withdrawals.is_empty() {
+            return vec![];
         }
 
-        let update_request = UpdateDepositsRequestBody { deposits: update_request };
+        let futures = create_withdrawals
+            .into_iter()
+            .map(|withdrawal| withdrawal_api::create_withdrawal(&self.config, withdrawal));
 
-        deposit_api::update_deposits(&self.config, update_request)
+        let results = futures::future::join_all(futures).await;
+
+        results
+            .into_iter()
+            .map(|result| {
+                result
+                    .map_err(EmilyClientError::CreateWithdrawal)
+                    .map_err(Error::EmilyApi)
+            })
+            .collect()
+    }
+
+    async fn update_withdrawals(
+        &self,
+        update_withdrawals: Vec<WithdrawalUpdate>,
+    ) -> Result<UpdateWithdrawalsResponse, Error> {
+        if update_withdrawals.is_empty() {
+            return Ok(UpdateWithdrawalsResponse { withdrawals: vec![] });
+        }
+
+        let update_request = UpdateWithdrawalsRequestBody {
+            withdrawals: update_withdrawals,
+        };
+        withdrawal_api::update_withdrawals(&self.config, update_request)
             .await
-            .map_err(EmilyClientError::UpdateDeposits)
+            .map_err(EmilyClientError::UpdateWithdrawals)
+            .map_err(Error::EmilyApi)
+    }
+
+    async fn set_chainstate(&self, chainstate: Chainstate) -> Result<Chainstate, Error> {
+        chainstate_api::set_chainstate(&self.config, chainstate)
+            .await
+            .map_err(EmilyClientError::AddChainstateEntry)
             .map_err(Error::EmilyApi)
     }
 }
@@ -187,12 +266,40 @@ impl EmilyInteract for ApiFallbackClient<EmilyClient> {
         self.exec(|client, _| client.get_deposits())
     }
 
+    async fn update_deposits(
+        &self,
+        update_deposits: Vec<DepositUpdate>,
+    ) -> Result<UpdateDepositsResponse, Error> {
+        self.exec(|client, _| client.update_deposits(update_deposits.clone()))
+            .await
+    }
+
     async fn accept_deposits<'a>(
         &'a self,
         transaction: &'a UnsignedTransaction<'a>,
         stacks_chain_tip: &'a StacksBlock,
     ) -> Result<UpdateDepositsResponse, Error> {
         self.exec(|client, _| client.accept_deposits(transaction, stacks_chain_tip))
+            .await
+    }
+
+    async fn create_withdrawals(
+        &self,
+        create_withdrawals: Vec<CreateWithdrawalRequestBody>,
+    ) -> Vec<Result<Withdrawal, Error>> {
+        self.exec(|client, _| async {
+            let withdrawals = client.create_withdrawals(create_withdrawals.clone()).await;
+            Ok::<Vec<Result<Withdrawal, Error>>, Error>(withdrawals) // Wrap the Vec in Ok to satisfy exec's type constraints
+        })
+        .await
+        .unwrap_or_else(|err| vec![Err(err.into())])
+    }
+
+    async fn update_withdrawals(
+        &self,
+        update_withdrawals: Vec<WithdrawalUpdate>,
+    ) -> Result<UpdateWithdrawalsResponse, Error> {
+        self.exec(|client, _| client.update_withdrawals(update_withdrawals.clone()))
             .await
     }
 

--- a/signer/src/testing/block_observer.rs
+++ b/signer/src/testing/block_observer.rs
@@ -2,9 +2,6 @@
 
 use std::collections::HashMap;
 
-use crate::bitcoin::BitcoinInteract;
-use crate::stacks::api::StacksInteract;
-use crate::storage::model::StacksBlock;
 use bitcoin::hashes::Hash;
 use bitcoin::BlockHash;
 use bitcoin::Txid;
@@ -20,18 +17,23 @@ use blockstack_lib::types::chainstate::StacksAddress;
 use blockstack_lib::types::chainstate::StacksBlockId;
 use clarity::vm::costs::ExecutionCost;
 use emily_client::models::Chainstate;
+use emily_client::models::CreateWithdrawalRequestBody;
+use emily_client::models::Withdrawal;
 use rand::seq::IteratorRandom;
 use sbtc::deposits::CreateDepositRequest;
 
 use crate::bitcoin::rpc::BitcoinTxInfo;
 use crate::bitcoin::rpc::GetTxResponse;
 use crate::bitcoin::utxo;
+use crate::bitcoin::BitcoinInteract;
 use crate::emily_client::EmilyInteract;
 use crate::error::Error;
 use crate::keys::PublicKey;
 use crate::stacks::api::AccountInfo;
 use crate::stacks::api::FeePriority;
+use crate::stacks::api::StacksInteract;
 use crate::stacks::api::SubmitTxResponse;
+use crate::storage::model::StacksBlock;
 use crate::testing::dummy;
 use crate::util::ApiFallbackClient;
 
@@ -348,11 +350,32 @@ impl EmilyInteract for TestHarness {
         Ok(self.pending_deposits.clone())
     }
 
+    async fn update_deposits(
+        &self,
+        _update_deposits: Vec<emily_client::models::DepositUpdate>,
+    ) -> Result<emily_client::models::UpdateDepositsResponse, Error> {
+        unimplemented!()
+    }
+
     async fn accept_deposits<'a>(
         &'a self,
         _transaction: &'a utxo::UnsignedTransaction<'a>,
         _stacks_chain_tip: &'a StacksBlock,
     ) -> Result<emily_client::models::UpdateDepositsResponse, Error> {
+        unimplemented!()
+    }
+
+    async fn create_withdrawals(
+        &self,
+        _create_withdrawals: Vec<CreateWithdrawalRequestBody>,
+    ) -> Vec<Result<Withdrawal, Error>> {
+        unimplemented!()
+    }
+
+    async fn update_withdrawals(
+        &self,
+        _update_withdrawals: Vec<emily_client::models::WithdrawalUpdate>,
+    ) -> Result<emily_client::models::UpdateWithdrawalsResponse, Error> {
         unimplemented!()
     }
 

--- a/signer/src/testing/context.rs
+++ b/signer/src/testing/context.rs
@@ -347,6 +347,17 @@ impl EmilyInteract for WrappedMock<MockEmilyInteract> {
         self.inner.lock().await.get_deposits().await
     }
 
+    async fn update_deposits(
+        &self,
+        update_deposits: Vec<emily_client::models::DepositUpdate>,
+    ) -> Result<emily_client::models::UpdateDepositsResponse, Error> {
+        self.inner
+            .lock()
+            .await
+            .update_deposits(update_deposits)
+            .await
+    }
+
     async fn accept_deposits<'a>(
         &'a self,
         transaction: &'a UnsignedTransaction<'a>,
@@ -356,6 +367,28 @@ impl EmilyInteract for WrappedMock<MockEmilyInteract> {
             .lock()
             .await
             .accept_deposits(transaction, stacks_chain_tip)
+            .await
+    }
+
+    async fn create_withdrawals(
+        &self,
+        create_withdrawals: Vec<emily_client::models::CreateWithdrawalRequestBody>,
+    ) -> Vec<Result<emily_client::models::Withdrawal, Error>> {
+        self.inner
+            .lock()
+            .await
+            .create_withdrawals(create_withdrawals)
+            .await
+    }
+
+    async fn update_withdrawals(
+        &self,
+        update_withdrawals: Vec<emily_client::models::WithdrawalUpdate>,
+    ) -> Result<emily_client::models::UpdateWithdrawalsResponse, Error> {
+        self.inner
+            .lock()
+            .await
+            .update_withdrawals(update_withdrawals)
             .await
     }
 


### PR DESCRIPTION
## Description

Closes: #340 

## Changes
- Extends EmilyClient to expose `create_withdrawals`, `update_withdrawals` and `update_deposits`.
- Extends `new_block_handler` to parse the `NewBlockEvent` for sBTC contracts events, construct the corresponding requests, and concurrently send the updates to Emily. 
    - The data required for creating the Emily requests, not contained in the event itself, is read from the database.
    - In case the required data is not in the database or communication with Emily fails, we just log a warning. We rely on the redundancy of all sBTC signers to guarantee that messages are received from Emily.

### Notes: 
- Confirmed `DepositUpdate` and `WithdrawalUpdate` requests to Emily require to fill out the `btc_fee` spent for the tx. The print event for `WithdrawalAcceptEvent` already contains this information, while the `CompletedDepositEvent` doesn't. At the moment I hardcoded it to a value of 1.

## Testing Information

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
