### PR TITLE
feat: properly parse the reclaim script lock time

### DIFF
--- a/.generated-sources/emily/openapi/emily-openapi-spec.json
+++ b/.generated-sources/emily/openapi/emily-openapi-spec.json
@@ -1413,7 +1413,7 @@
         "properties": {
           "lockTime": {
             "type": "integer",
-            "format": "int64",
+            "format": "int32",
             "description": "Bitcoin block height at which the reclaim script becomes executable.",
             "minimum": 0
           },

--- a/emily/handler/src/api/handlers/deposit.rs
+++ b/emily/handler/src/api/handlers/deposit.rs
@@ -261,7 +261,7 @@ struct ScriptParameters {
     amount: u64,
     max_fee: u64,
     recipient: String,
-    lock_time: u64,
+    lock_time: u32,
 }
 
 /// Convert scripts to resource parameters.
@@ -377,7 +377,7 @@ mod tests {
     #[test_case(15000, 500_000, 150; "All parameters are normal numbers")]
     #[test_case(0, 0, 0; "All parameters are zeros")]
     fn test_scripts_to_resource_parameters(max_fee: u64, amount_sats: u64, lock_time: u32) {
-        let setup: TxSetup = testing::deposits::tx_setup(lock_time as i64, max_fee, amount_sats);
+        let setup: TxSetup = testing::deposits::tx_setup(lock_time, max_fee, amount_sats);
 
         let deposit_script = setup.deposit.deposit_script().to_hex_string();
         let reclaim_script = setup.reclaim.reclaim_script().to_hex_string();
@@ -386,7 +386,7 @@ mod tests {
             scripts_to_resource_parameters(&deposit_script, &reclaim_script).unwrap();
 
         assert_eq!(script_parameters.max_fee, max_fee);
-        assert_eq!(script_parameters.lock_time, lock_time as u64);
+        assert_eq!(script_parameters.lock_time, lock_time);
 
         // TODO: Test the recipient with an input value.
         assert!(script_parameters.recipient.len() > 0);

--- a/emily/handler/src/api/models/deposit/mod.rs
+++ b/emily/handler/src/api/models/deposit/mod.rs
@@ -79,7 +79,7 @@ pub struct DepositParameters {
     /// the transaction.
     pub max_fee: u64,
     /// Bitcoin block height at which the reclaim script becomes executable.
-    pub lock_time: u64,
+    pub lock_time: u32,
 }
 
 /// Reduced version of the Deposit data.

--- a/emily/handler/src/database/entries/deposit.rs
+++ b/emily/handler/src/database/entries/deposit.rs
@@ -257,7 +257,7 @@ pub struct DepositParametersEntry {
     /// the transaction.
     pub max_fee: u64,
     /// Bitcoin block height at which the reclaim script becomes executable.
-    pub lock_time: u64,
+    pub lock_time: u32,
 }
 
 /// Event in the history of a deposit.

--- a/emily/handler/tests/integration/deposit.rs
+++ b/emily/handler/tests/integration/deposit.rs
@@ -15,7 +15,7 @@ const BLOCK_HASH: &'static str = "";
 const BLOCK_HEIGHT: u64 = 0;
 const INITIAL_DEPOSIT_STATUS_MESSAGE: &'static str = "Just received deposit";
 
-const DEPOSIT_LOCK_TIME: u64 = 12345;
+const DEPOSIT_LOCK_TIME: u32 = 12345;
 const DEPOSIT_MAX_FEE: u64 = 30;
 
 // TODO(TBD): This is the only value that will work at the moment because the
@@ -69,9 +69,9 @@ struct DepositTxnData {
 }
 
 impl DepositTxnData {
-    pub fn new(lock_time: u64, max_fee: u64, amount_sats: u64) -> Self {
+    pub fn new(lock_time: u32, max_fee: u64, amount_sats: u64) -> Self {
         let test_deposit_tx: TxSetup =
-            testing::deposits::tx_setup(lock_time as i64, max_fee, amount_sats);
+            testing::deposits::tx_setup(lock_time, max_fee, amount_sats);
         let recipient_hex_string =
             hex::encode(&test_deposit_tx.deposit.recipient.serialize_to_vec());
         Self {

--- a/emily/handler/tests/integration/deposit.rs
+++ b/emily/handler/tests/integration/deposit.rs
@@ -70,8 +70,7 @@ struct DepositTxnData {
 
 impl DepositTxnData {
     pub fn new(lock_time: u32, max_fee: u64, amount_sats: u64) -> Self {
-        let test_deposit_tx: TxSetup =
-            testing::deposits::tx_setup(lock_time, max_fee, amount_sats);
+        let test_deposit_tx: TxSetup = testing::deposits::tx_setup(lock_time, max_fee, amount_sats);
         let recipient_hex_string =
             hex::encode(&test_deposit_tx.deposit.recipient.serialize_to_vec());
         Self {

--- a/sbtc/src/deposits.rs
+++ b/sbtc/src/deposits.rs
@@ -401,9 +401,6 @@ impl ReclaimScriptInputs {
 
     /// Get the lock time in the reclaim script.
     pub fn lock_time(&self) -> u32 {
-        // We know this number is positive because that is one of the
-        // invariants upheld by this struct, and we check for it in
-        // `Self::try_new`, so this will never be a lossy conversion.
         self.lock_time.to_consensus_u32()
     }
 
@@ -468,7 +465,7 @@ impl ReclaimScriptInputs {
             // works in bitcoin-core:
             // https://github.com/bitcoin/bitcoin/blob/v27.1/src/script/interpreter.cpp#L531-L573
             // That said, we only accepts 4-byte unsigned integers, and we
-            // that check below.
+            // check that below.
             [n, rest @ ..] if *n <= 5 && rest.get(*n as usize) == Some(&OP_CSV) => {
                 // We know the error and panic paths cannot happen because
                 // of the above `if` check.

--- a/sbtc/src/deposits.rs
+++ b/sbtc/src/deposits.rs
@@ -354,15 +354,14 @@ impl DepositScriptInputs {
 /// user-supplied script is correct and standard.
 ///
 /// Currently, we only accept locktimes denominated in Bitcoin blocks. This
-/// implies that the 22nd bit in the locktime, counting from the least
-/// significant bit, must be zero.
+/// implies that bit (1 << 22) in the locktime, must be zero.
 ///
 /// Note that locktimes used as `OP_CSV` inputs in the reclaim script only
 /// use the 16 least significant bits for the value of the locktime. All
 /// other bits in the 32-bit locktime must be zero or the deposit
 /// transaction will fail validation. When we support time-based locktimes,
-/// a user may set the 22nd bit to indicate that the locktime value is time
-/// based, as described in BIP-68.
+/// a user may set bit (1 << 22) to indicate that the locktime value is
+/// time based, as described in BIP-68.
 ///
 /// <https://github.com/bitcoin/bips/blob/17c04f9fa1ecae173d6864b65717e13dfc1880af/bip-0068.mediawiki#specification>
 /// <https://github.com/bitcoin/bips/blob/812907c2b00b92ee31e2b638622a4fe14a428aee/bip-0112.mediawiki#summary>

--- a/sbtc/src/deposits.rs
+++ b/sbtc/src/deposits.rs
@@ -800,7 +800,9 @@ mod tests {
     #[test]
     fn lock_time_as_time() {
         // We do not support time based lock times. Check that
-        let lock_time = LockTime::from_seconds_ceil(20000).unwrap().to_consensus_u32();
+        let lock_time = LockTime::from_seconds_ceil(20000)
+            .unwrap()
+            .to_consensus_u32();
         let reclaim = ReclaimScriptInputs::try_new(lock_time, ScriptBuf::new()).unwrap_err();
 
         assert!(matches!(reclaim, Error::UnsupportedLockTimeUnits(_)));

--- a/sbtc/src/deposits.rs
+++ b/sbtc/src/deposits.rs
@@ -46,7 +46,7 @@ const STANDARD_SCRIPT_LENGTH: usize =
 ///   112) [^2]. Note: Transaction inputs have an nSequence field that is
 ///   different from the one referenced in the above bullet point.
 /// * If this flag is set, CTxIn::nSequence is NOT interpreted as a
-///   relative lock-time.
+///   relative locktime.
 /// * It skips SequenceLocks() for any input that has it set (BIP 68).
 ///
 /// The last two bullets were taken from [^3].
@@ -350,26 +350,26 @@ impl DepositScriptInputs {
 /// deposit script address.
 ///
 /// This struct upholds the invariant that the `lock_time` is a valid and
-/// standard `locktime` in bitcoin-core. We do not verify whether the
+/// standard locktime in bitcoin-core. We do not verify whether the
 /// user-supplied script is correct and standard.
 ///
-/// Currently, we only accept lock-times denominated in Bitcoin blocks. This
+/// Currently, we only accept locktimes denominated in Bitcoin blocks. This
 /// implies that the 22nd bit in the locktime, counting from the least
 /// significant bit, must be zero.
 ///
-/// Note that lock-times used as `OP_CSV` inputs in the reclaim script may
+/// Note that locktimes used as `OP_CSV` inputs in the reclaim script may
 /// only use the 16 least significant bits for the value of the locktime.
 /// All other bits in the 32-bit locktime must be zero. When we support
-/// time-based lock-times, a user may set the 22nd bit to indicate that the
+/// time-based locktimes, a user may set the 22nd bit to indicate that the
 /// locktime will be time based, as described in BIP-68.
 ///
 /// <https://github.com/bitcoin/bips/blob/17c04f9fa1ecae173d6864b65717e13dfc1880af/bip-0068.mediawiki#specification>
 /// <https://github.com/bitcoin/bips/blob/812907c2b00b92ee31e2b638622a4fe14a428aee/bip-0112.mediawiki#summary>
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ReclaimScriptInputs {
-    /// This is the lock time used for the `OP_CSV` opcode in the reclaim
+    /// This is the locktime used for the `OP_CSV` opcode in the reclaim
     /// script. It is not allowed to exceed the bounds expected for a
-    /// 4-byte lock-time in bitcoin-core. It is also not allowed to have
+    /// 4-byte locktime in bitcoin-core. It is also not allowed to have
     /// the [`SEQUENCE_LOCKTIME_DISABLE_FLAG`] bit set.
     lock_time: LockTime,
     /// The reclaim script after the `<locked-time> OP_CSV` part of the
@@ -380,14 +380,14 @@ pub struct ReclaimScriptInputs {
 impl ReclaimScriptInputs {
     /// Create a new one
     pub fn try_new(lock_time: u32, script: ScriptBuf) -> Result<Self, Error> {
-        // OP_CSV checks can be disabled if the lock-time has the disabled
-        // lock-time bit set to 1. So we disallow such lock times to ensure
+        // OP_CSV checks can be disabled if the locktime has the disabled
+        // locktime bit set to 1. So we disallow such locktimes to ensure
         // that the OP_CSV check is always enabled.
         //
         // <https://github.com/bitcoin/bitcoin/blob/v27.1/src/script/interpreter.cpp#L560-L592>
         let lock_time = LockTime::from_consensus(lock_time).map_err(Error::DisabledLockTime)?;
 
-        // For now, we only accept lock-times denominated in bitcoin block
+        // For now, we only accept locktimes denominated in bitcoin block
         // units.
         if matches!(lock_time, LockTime::Time(_)) {
             return Err(Error::UnsupportedLockTimeUnits(

--- a/sbtc/src/error.rs
+++ b/sbtc/src/error.rs
@@ -7,7 +7,8 @@ use bitcoin::Txid;
 /// Errors
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    /// This happens when we realize that the lock-time is diabled.
+    /// This happens when we realize that the lock-time in the reclaim
+    /// script disables the OP_CSV check.
     #[error("invalid lock-time: {0}")]
     DisabledLockTime(#[source] bitcoin::locktime::relative::DisabledLockTimeError),
     /// The end of the deposit script has a fixed format that is very
@@ -41,9 +42,9 @@ pub enum Error {
     /// Could not parse the Stacks principal address.
     #[error("could not parse the stacks principal address: {0}")]
     ParseStacksAddress(#[source] stacks_common::codec::Error),
-    /// This happens when the lock time is given in block units instead of
-    /// time units.
-    #[error("Lock-time given in time, only blocks is supported: {0}")]
+    /// This happens when the lock-time is given in time units instead of
+    /// block units.
+    #[error("lock-time given in time units, but only block units are supported: {0}")]
     UnsupportedLockTimeUnits(u32),
     /// Failed to extract the outpoint from the bitcoin::Transaction.
     #[error("could not get outpoint {1} from BTC transaction: {0}")]

--- a/sbtc/src/error.rs
+++ b/sbtc/src/error.rs
@@ -7,6 +7,9 @@ use bitcoin::Txid;
 /// Errors
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
+    /// This happens when we realize that the lock-time is diabled.
+    #[error("invalid lock-time: {0}")]
+    DisabledLockTime(#[source] bitcoin::locktime::relative::DisabledLockTimeError),
     /// The end of the deposit script has a fixed format that is very
     /// similar to a P2PK check_sig script, the script violated that format
     #[error("script is CHECKSIG part of script")]
@@ -38,6 +41,10 @@ pub enum Error {
     /// Could not parse the Stacks principal address.
     #[error("could not parse the stacks principal address: {0}")]
     ParseStacksAddress(#[source] stacks_common::codec::Error),
+    /// This happens when the lock time is given in block units instead of
+    /// time units.
+    #[error("Lock-time given in time, only blocks is supported: {0}")]
+    UnsupportedLockTimeUnits(u32),
     /// Failed to extract the outpoint from the bitcoin::Transaction.
     #[error("could not get outpoint {1} from BTC transaction: {0}")]
     OutpointIndex(

--- a/sbtc/src/testing/deposits.rs
+++ b/sbtc/src/testing/deposits.rs
@@ -30,7 +30,7 @@ pub struct TxSetup {
 
 /// The BTC transaction that is in this TxSetup is consistent with
 /// the deposit and reclaim scripts.
-pub fn tx_setup(lock_time: i64, max_fee: u64, amount: u64) -> TxSetup {
+pub fn tx_setup(lock_time: u32, max_fee: u64, amount: u64) -> TxSetup {
     let secret_key = SecretKey::new(&mut OsRng);
 
     let deposit = DepositScriptInputs {

--- a/sbtc/tests/integration/validation.rs
+++ b/sbtc/tests/integration/validation.rs
@@ -70,8 +70,10 @@ fn tx_validation_from_mempool() {
     assert_eq!(parsed.reclaim_script, request.reclaim_script);
     assert_eq!(parsed.amount, amount_sats);
     assert_eq!(parsed.signers_public_key, setup.deposit.signers_public_key);
-    assert_eq!(parsed.lock_time, bitcoin::relative::LockTime::from_height(lock_time as u16));
     assert_eq!(parsed.recipient, setup.deposit.recipient);
+
+    let lock_time_height = bitcoin::relative::LockTime::from_height(lock_time as u16);
+    assert_eq!(parsed.lock_time, lock_time_height);
 }
 
 /// This validates that we need to reject deposit scripts that do not

--- a/sbtc/tests/integration/validation.rs
+++ b/sbtc/tests/integration/validation.rs
@@ -70,7 +70,7 @@ fn tx_validation_from_mempool() {
     assert_eq!(parsed.reclaim_script, request.reclaim_script);
     assert_eq!(parsed.amount, amount_sats);
     assert_eq!(parsed.signers_public_key, setup.deposit.signers_public_key);
-    assert_eq!(parsed.lock_time, lock_time as u64);
+    assert_eq!(parsed.lock_time, bitcoin::relative::LockTime::from_height(lock_time as u16));
     assert_eq!(parsed.recipient, setup.deposit.recipient);
 }
 
@@ -223,7 +223,7 @@ fn op_csv_disabled() {
     // We're going to create a P2SH UTXO with this script. Anyone can spend
     // this script immediately, since the lock-time disables OP_CSV.
     let script_pubkey = ScriptBuf::builder()
-        .push_int(lock_time)
+        .push_int(lock_time as i64)
         .push_opcode(bitcoin::opcodes::all::OP_CSV)
         .push_opcode(bitcoin::opcodes::all::OP_DROP)
         .push_opcode(bitcoin::opcodes::OP_TRUE)
@@ -310,7 +310,7 @@ fn op_csv_disabled() {
     // The script_pubkey script function above is quite simple, it should
     // produce this:
     let script_pubkey2 = ScriptBuf::builder()
-        .push_int(lock_time)
+        .push_int(lock_time as i64)
         .push_opcode(bitcoin::opcodes::all::OP_CSV)
         .push_opcode(bitcoin::opcodes::all::OP_DROP)
         .push_opcode(bitcoin::opcodes::OP_TRUE)

--- a/signer/src/storage/model.rs
+++ b/signer/src/storage/model.rs
@@ -74,8 +74,8 @@ pub struct DepositRequest {
     pub max_fee: u64,
     /// The relative lock time in the reclaim script.
     #[sqlx(try_from = "i64")]
-    #[cfg_attr(feature = "testing", dummy(faker = "3..u32::MAX as u64"))]
-    pub lock_time: u64,
+    #[cfg_attr(feature = "testing", dummy(faker = "3..u16::MAX as u32"))]
+    pub lock_time: u32,
     /// The public key used in the deposit script. The signers public key
     /// is for Schnorr signatures.
     pub signer_public_key: PublicKeyXOnly,
@@ -104,7 +104,7 @@ impl From<Deposit> for DepositRequest {
             recipient: deposit.info.recipient.into(),
             amount: deposit.info.amount,
             max_fee: deposit.info.max_fee,
-            lock_time: deposit.info.lock_time,
+            lock_time: deposit.info.lock_time.to_consensus_u32(),
             signer_public_key: deposit.info.signers_public_key.into(),
             sender_script_pub_keys: sender_script_pub_keys.into_iter().collect(),
         }

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -1406,7 +1406,7 @@ impl super::DbWrite for PgStore {
         .bind(&deposit_request.recipient)
         .bind(i64::try_from(deposit_request.amount).map_err(Error::ConversionDatabaseInt)?)
         .bind(i64::try_from(deposit_request.max_fee).map_err(Error::ConversionDatabaseInt)?)
-        .bind(i64::try_from(deposit_request.lock_time).map_err(Error::ConversionDatabaseInt)?)
+        .bind(i64::from(deposit_request.lock_time))
         .bind(deposit_request.signer_public_key)
         .bind(&deposit_request.sender_script_pub_keys)
         .execute(&self.0)
@@ -1444,7 +1444,7 @@ impl super::DbWrite for PgStore {
             recipient.push(req.recipient);
             amount.push(i64::try_from(req.amount).map_err(Error::ConversionDatabaseInt)?);
             max_fee.push(i64::try_from(req.max_fee).map_err(Error::ConversionDatabaseInt)?);
-            lock_time.push(i64::try_from(req.lock_time).map_err(Error::ConversionDatabaseInt)?);
+            lock_time.push(i64::from(req.lock_time));
             signer_public_key.push(req.signer_public_key);
             // We need to join the addresses like this (and later split
             // them), because handling of multidimensional arrays in

--- a/signer/src/testing/dummy.rs
+++ b/signer/src/testing/dummy.rs
@@ -445,7 +445,7 @@ pub struct DepositTxConfig {
     /// bit set to 1 or the else the [`ReclaimScriptInputs::try_new`]
     /// function will return an error.
     #[dummy(faker = "2..250")]
-    pub lock_time: i64,
+    pub lock_time: u32,
 }
 
 impl fake::Dummy<DepositTxConfig> for BitcoinTx {


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/516, with proper lock-time handling being done when https://github.com/stacks-network/sbtc/issues/380 gets closed.

After this change, locktimes used as `OP_CSV` inputs in the reclaim script only use the 16 least significant bits for the value of the locktime. All other bits in the 32-bit locktime must be zero or else the deposit transaction will fail validation. When we support time-based locktimes, a user may set bit (1 << 22) to indicate that the locktime value is time based, as described in BIP-68.

## Changes

* Use rust-bitcoin's relative `LockTime` type for representing the lock-time under the hood.
* Reject time-based `locktime`s. We've set ourselves up to support them, but the real work lies in the signer.
* Change the underlying type for a `locktime` to be a `u32`.

## Testing Information



## Checklist:

- [x] I have performed a self-review of my code

