### PR TITLE
feat: add optional git hooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,3 +181,13 @@ run-signer:
 	RUST_LOG=info SIGNER_SIGNER__DB_ENDPOINT="postgres://devenv:devenv@localhost:$$POSTGRES_PORT/signer" cargo run --bin signer -- -c ./signer/src/config/default.toml --migrate-db
 
 .PHONY: run-signer
+
+# Git hooks
+# ----------------------------------------------------
+
+install-git-hooks:
+	mkdir -p .git/hooks
+	cp -r ./devenv/hooks/pre-commit-make-lint.sh .git/hooks/
+
+.PHONY: install-git-hooks
+

--- a/Makefile
+++ b/Makefile
@@ -187,7 +187,7 @@ run-signer:
 
 install-git-hooks:
 	mkdir -p .git/hooks
-	cp -r ./devenv/hooks/pre-commit-make-lint.sh .git/hooks/
+	ln -s ../../devenv/hooks/pre-commit-make-lint.sh .git/hooks/
 
 .PHONY: install-git-hooks
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,14 @@ Once running, the following services are available:
 - Stacks explorer at [localhost:3020](http://localhost:3020)
 - Mempool.space Bitcoin explorer at [localhost:8083](http://localhost:8083)
 
+### Git hooks
+
+[`./devenv/hooks`](./devenv/hooks) contains Git hooks you can install to run
+`pre-commit` checks. You can (optionally) run `make install-git-hooks` to
+install them. Be advised: under the hood, the hooks will run `make lint`, which
+relies on `clippy` and `rust fmt` and might need to download and compile
+dependencies.
+
 ### Operating Systems
 
 This project currently supports development on UNIX-based operating systems but

--- a/devenv/hooks/pre-commit-make-lint.sh
+++ b/devenv/hooks/pre-commit-make-lint.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# shellcheck disable=SC2016
+if test "$BASH" = "" || "$BASH" -uc 'a=();true "${a[@]}"' 2>/dev/null; then
+	# Bash 4.4, Zsh
+	set -Eeuo pipefail
+else
+	# Bash 4.3 and older chokes on empty arrays with set -u.
+	set -Eeo pipefail
+fi
+if shopt | grep globstar &>/dev/null; then
+	shopt -s nullglob globstar || true
+fi
+
+if [[ -n ${DEBUG+x} ]]; then
+	set -x
+fi
+
+make lint
+result=$?
+
+if [[ ${result} -ne 0 ]]; then
+	echo '`make lint` has found some code/style issues, fix them first.'
+fi
+
+exit $result


### PR DESCRIPTION
## Description

Add _optional_ Git hooks for those who don't like to push code only to find it rejected by the CI linter.

## Changes

## Testing Information

Read the new `README.md` section. After installing the hooks, try making a modification that `cargo fmt` won't like. Try to commit it, or try running `.git/hooks/pre-commit-make-lint.sh`.

## Checklist:

- [X] I have performed a self-review of my code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
