### PR TITLE
feat: Add latest canonical bitcoin blocks db call

### DIFF
--- a/signer/src/storage/mod.rs
+++ b/signer/src/storage/mod.rs
@@ -43,6 +43,19 @@ pub trait DbRead {
         &self,
     ) -> impl Future<Output = Result<Option<model::BitcoinBlockHash>, Error>> + Send;
 
+    /// Get the latest canonical bitcoin blocks.
+    fn get_latest_canonical_bitcoin_blocks(
+        &self,
+        limit: u16,
+    ) -> impl Future<Output = Result<Vec<model::BitcoinBlock>, Error>> + Send;
+
+    /// Get the ancestral bitcoin blocks of the given block hash.
+    fn get_ancestral_bitcoin_blocks(
+        &self,
+        block_hash: &model::BitcoinBlockHash,
+        limit: u16,
+    ) -> impl Future<Output = Result<Vec<model::BitcoinBlock>, Error>> + Send;
+
     /// Get the stacks chain tip, defined as the highest stacks block
     /// confirmed by the bitcoin chain tip.
     fn get_stacks_chain_tip(


### PR DESCRIPTION
## Description

Part 1/3: #380 

This adds two database access functions that let you get the the ancestors of the given bitcoin block hash, and separately one that gives you the latest canonical bitcoin blocks.

## Changes

1. Adds database access function
2. Adds relevant integration tests

## Testing Information

Integration tests and unit tests.

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
