### PR TITLE
check that wsts messages are signed by the specified signer_id

### DIFF
--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -460,6 +460,10 @@ pub enum Error {
     /// The smart contract has already been deployed
     #[error("smart contract already deployed, contract name: {0}")]
     ContractAlreadyDeployed(&'static str),
+
+    /// Received coordinator message wasn't from coordinator for this chain tip
+    #[error("not chain tip coordinator")]
+    NotChainTipCoordinator,
 }
 
 impl From<std::convert::Infallible> for Error {

--- a/signer/src/testing/transaction_signer.rs
+++ b/signer/src/testing/transaction_signer.rs
@@ -562,6 +562,18 @@ where
             .expect("storage error")
             .expect("no chain tip");
 
+        // now that we have a chain tip, get the real coordinator
+        let coordinator_public_key =
+            crate::transaction_coordinator::coordinator_public_key(&bitcoin_chain_tip, &signer_set)
+                .unwrap();
+        let coordinator_signer_info = signer_info
+            .iter()
+            .find(|signer| {
+                PublicKey::from_private_key(&signer.signer_private_key) == coordinator_public_key
+            })
+            .unwrap()
+            .clone();
+
         run_dkg_and_store_results_for_signers(
             &signer_info,
             &bitcoin_chain_tip,

--- a/signer/src/testing/transaction_signer.rs
+++ b/signer/src/testing/transaction_signer.rs
@@ -564,7 +564,7 @@ where
 
         // now that we have a chain tip, get the real coordinator
         let coordinator_public_key =
-            crate::transaction_coordinator::coordinator_public_key(&bitcoin_chain_tip, &signer_set)
+            crate::transaction_coordinator::coordinator_public_key(&bitcoin_chain_tip, signer_set)
                 .unwrap();
         let coordinator_signer_info = signer_info
             .iter()

--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -876,11 +876,11 @@ where
             }
             None => {
                 tracing::warn!(
-                            ?packet.msg,
-                            reason = "no public key for signer",
-                signer_id = %signer_id,
-                            "ignoring packet"
-                        );
+                    ?packet.msg,
+                    reason = "no public key for signer",
+                    %signer_id,
+                    "ignoring packet"
+                );
                 false
             }
             _ => true,

--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -865,8 +865,8 @@ where
         public_key_point: p256k1::point::Point,
         sender_is_coordinator: bool,
     ) -> bool {
-        let check_signer_public_key = |signer_id| match &public_keys.get(&signer_id) {
-            Some(signer_public_key) if &public_key_point != *signer_public_key => {
+        let check_signer_public_key = |signer_id| match public_keys.get(&signer_id) {
+            Some(signer_public_key) if public_key_point != *signer_public_key => {
                 tracing::warn!(
                     ?packet.msg,
                     reason = "message was signed by the wrong signer",

--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -818,7 +818,7 @@ where
                 sig: Vec::new(),
             };
 
-            let msg_public_key = msg.signer_pub_key.clone();
+            let msg_public_key = msg.signer_pub_key;
 
             let sender_is_coordinator =
                 given_key_is_coordinator(msg_public_key, bitcoin_chain_tip, &signer_set);
@@ -829,7 +829,7 @@ where
             // check that messages were signed by correct key
             if !Self::authenticate_message(
                 &packet,
-                &public_keys,
+                public_keys,
                 public_key_point,
                 sender_is_coordinator,
             ) {

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -349,8 +349,13 @@ where
             }
 
             (message::Payload::WstsMessage(wsts_msg), _, _) => {
-                self.handle_wsts_message(wsts_msg, &msg.bitcoin_chain_tip, msg.signer_pub_key)
-                    .await?;
+                self.handle_wsts_message(
+                    wsts_msg,
+                    &msg.bitcoin_chain_tip,
+                    msg.signer_pub_key,
+                    &chain_tip_report,
+                )
+                .await?;
             }
 
             (
@@ -580,11 +585,9 @@ where
         msg: &message::WstsMessage,
         bitcoin_chain_tip: &model::BitcoinBlockHash,
         msg_public_key: PublicKey,
+        chain_tip_report: &MsgChainTipReport,
     ) -> Result<(), Error> {
         tracing::info!("handling message");
-        let chain_tip_report = self
-            .inspect_msg_chain_tip(msg_public_key, bitcoin_chain_tip)
-            .await?;
 
         match &msg.inner {
             wsts::net::Message::DkgBegin(_) => {

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -592,7 +592,8 @@ where
         match &msg.inner {
             wsts::net::Message::DkgBegin(_) => {
                 if !chain_tip_report.sender_is_coordinator {
-                    return Err(Error::NotChainTipCoordinator);
+                    warn!("Got coordinator message from wrong signer");
+                    return Ok(());
                 }
 
                 let signer_public_keys = self.get_signer_public_keys(bitcoin_chain_tip).await?;
@@ -608,7 +609,8 @@ where
             }
             wsts::net::Message::DkgPrivateBegin(_) => {
                 if !chain_tip_report.sender_is_coordinator {
-                    return Err(Error::NotChainTipCoordinator);
+                    warn!("Got coordinator message from wrong signer");
+                    return Ok(());
                 }
 
                 self.relay_message(msg.txid, &msg.inner, bitcoin_chain_tip)
@@ -650,7 +652,8 @@ where
             }
             wsts::net::Message::DkgEndBegin(_) => {
                 if !chain_tip_report.sender_is_coordinator {
-                    return Err(Error::NotChainTipCoordinator);
+                    warn!("Got coordinator message from wrong signer");
+                    return Ok(());
                 }
                 self.relay_message(msg.txid, &msg.inner, bitcoin_chain_tip)
                     .await?;
@@ -666,7 +669,8 @@ where
             #[allow(clippy::map_entry)]
             wsts::net::Message::NonceRequest(_) => {
                 if !chain_tip_report.sender_is_coordinator {
-                    return Err(Error::NotChainTipCoordinator);
+                    warn!("Got coordinator message from wrong signer");
+                    return Ok(());
                 }
                 // TODO(296): Validate that message is the appropriate sighash
                 if !self.wsts_state_machines.contains_key(&msg.txid) {
@@ -689,7 +693,8 @@ where
             }
             wsts::net::Message::SignatureShareRequest(_) => {
                 if !chain_tip_report.sender_is_coordinator {
-                    return Err(Error::NotChainTipCoordinator);
+                    warn!("Got coordinator message from wrong signer");
+                    return Ok(());
                 }
 
                 // TODO(296): Validate that message is the appropriate sighash

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -615,9 +615,16 @@ where
                     .await?;
             }
             wsts::net::Message::DkgPublicShares(dkg_public_shares) => {
-                let public_keys = &self.wsts_state_machines[&msg.txid].public_keys;
-                let signer_public_key =
-                    PublicKey::from(&public_keys.signers[&dkg_public_shares.signer_id]);
+                let public_keys = match self.wsts_state_machines.get(&msg.txid) {
+                    Some(state_machine) => &state_machine.public_keys,
+                    None => return Err(Error::MissingStateMachine),
+                };
+                let signer_public_key = match public_keys.signers.get(&dkg_public_shares.signer_id)
+                {
+                    Some(key) => PublicKey::from(key),
+                    None => return Err(Error::MissingPublicKey),
+                };
+
                 if signer_public_key != msg_public_key {
                     return Err(Error::InvalidSignature);
                 }
@@ -625,9 +632,16 @@ where
                     .await?;
             }
             wsts::net::Message::DkgPrivateShares(dkg_private_shares) => {
-                let public_keys = &self.wsts_state_machines[&msg.txid].public_keys;
-                let signer_public_key =
-                    PublicKey::from(&public_keys.signers[&dkg_private_shares.signer_id]);
+                let public_keys = match self.wsts_state_machines.get(&msg.txid) {
+                    Some(state_machine) => &state_machine.public_keys,
+                    None => return Err(Error::MissingStateMachine),
+                };
+                let signer_public_key = match public_keys.signers.get(&dkg_private_shares.signer_id)
+                {
+                    Some(key) => PublicKey::from(key),
+                    None => return Err(Error::MissingPublicKey),
+                };
+
                 if signer_public_key != msg_public_key {
                     return Err(Error::InvalidSignature);
                 }

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -592,7 +592,7 @@ where
         match &msg.inner {
             wsts::net::Message::DkgBegin(_) => {
                 if !chain_tip_report.sender_is_coordinator {
-                    warn!("Got coordinator message from wrong signer");
+                    tracing::warn!("Got coordinator message from wrong signer");
                     return Ok(());
                 }
 
@@ -609,7 +609,7 @@ where
             }
             wsts::net::Message::DkgPrivateBegin(_) => {
                 if !chain_tip_report.sender_is_coordinator {
-                    warn!("Got coordinator message from wrong signer");
+                    tracing::warn!("Got coordinator message from wrong signer");
                     return Ok(());
                 }
 
@@ -652,7 +652,7 @@ where
             }
             wsts::net::Message::DkgEndBegin(_) => {
                 if !chain_tip_report.sender_is_coordinator {
-                    warn!("Got coordinator message from wrong signer");
+                    tracing::warn!("Got coordinator message from wrong signer");
                     return Ok(());
                 }
                 self.relay_message(msg.txid, &msg.inner, bitcoin_chain_tip)
@@ -669,7 +669,7 @@ where
             #[allow(clippy::map_entry)]
             wsts::net::Message::NonceRequest(_) => {
                 if !chain_tip_report.sender_is_coordinator {
-                    warn!("Got coordinator message from wrong signer");
+                    tracing::warn!("Got coordinator message from wrong signer");
                     return Ok(());
                 }
                 // TODO(296): Validate that message is the appropriate sighash
@@ -693,7 +693,7 @@ where
             }
             wsts::net::Message::SignatureShareRequest(_) => {
                 if !chain_tip_report.sender_is_coordinator {
-                    warn!("Got coordinator message from wrong signer");
+                    tracing::warn!("Got coordinator message from wrong signer");
                     return Ok(());
                 }
 


### PR DESCRIPTION
## Description
`sBTC` messages contain a signature and a public key, in addition to the payload.  Verifying the message shows that it has not been tampered with.

`WSTS` message payloads either contain a `signer_id`, or are coordinator messages.  So in addition to verifying the signature, we also need to show that the public key used to sign was the correct public key for that signer (or the coordinator).

Closes: #578 

## Changes
Call `verify` on the `sBTC` message, then check that the message was signed by the correct public key.

## Testing Information
All unit and integration tests still pass.

## Checklist:

- [ x] I have performed a self-review of my code
- [ x] My changes generate no new warnings
- [ x] New and existing unit tests pass locally with my changes
- [ x] Any dependent changes have been merged and published in downstream modules
