### PR TITLE
feat: Add time_mined to bitcoin blocks in database

### DIFF
--- a/signer/migrations/0003__create_tables.sql
+++ b/signer/migrations/0003__create_tables.sql
@@ -14,6 +14,7 @@ CREATE TABLE sbtc_signer.bitcoin_blocks (
     block_height BIGINT NOT NULL,
     parent_hash BYTEA NOT NULL,
     confirms BYTEA[] NOT NULL,
+    time_mined INTEGER NOT NULL,
     created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL
 );
 

--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -425,6 +425,7 @@ where
                 .expect("Failed to get block height"),
             parent_hash: block.header.prev_blockhash.into(),
             confirms: Vec::new(),
+            time_mined: block.header.time,
         };
 
         self.context

--- a/signer/src/storage/model.rs
+++ b/signer/src/storage/model.rs
@@ -30,6 +30,10 @@ pub struct BitcoinBlock {
     /// Stacks block confirmed by this block.
     #[cfg_attr(feature = "testing", dummy(default))]
     pub confirms: Vec<StacksBlockHash>,
+    /// Time the block was mined.
+    #[sqlx(try_from = "i32")]
+    #[cfg_attr(feature = "testing", dummy(faker = "0..u16::MAX as u32"))]
+    pub time_mined: u32,
 }
 
 /// Stacks block.

--- a/signer/src/testing/storage/model.rs
+++ b/signer/src/testing/storage/model.rs
@@ -282,6 +282,9 @@ impl TestData {
 
         block.parent_hash = parent_block_summary.block_hash;
         block.block_height = parent_block_summary.block_height + 1;
+        if let Some(parent_block) = self.get_bitcoin_block(&block.parent_hash) {
+            block.time_mined = parent_block.time_mined + 600;
+        }
 
         block
     }

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -707,6 +707,7 @@ async fn writing_transactions_postgres() {
         block_height: 15,
         parent_hash: parent_hash.into(),
         confirms: Vec::new(),
+        time_mined: 0,
     };
 
     // We start by writing the bitcoin block because of the foreign key
@@ -1207,7 +1208,7 @@ async fn block_in_canonical_bitcoin_blockchain_in_other_block_chain() {
 async fn should_be_able_to_query_canonical_bitcoin_blocks() {
     let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
     let mut store = testing::storage::new_test_database(db_num, true).await;
-    let mut rng = rand::rngs::StdRng::seed_from_u64(31415);
+    let mut rng = rand::rngs::StdRng::seed_from_u64(314159);
 
     let test_model_params = testing::storage::model::Params {
         num_bitcoin_blocks: 20,

--- a/signer/tests/integration/setup.rs
+++ b/signer/tests/integration/setup.rs
@@ -369,6 +369,7 @@ pub async fn backfill_bitcoin_blocks(db: &PgStore, rpc: &Client, chain_tip: &bit
             block_height: block_header.height as u64,
             parent_hash: parent_header_hash.into(),
             confirms: Vec::new(),
+            time_mined: block_header.time as u32,
         };
 
         db.write_bitcoin_block(&bitcoin_block).await.unwrap();

--- a/signer/tests/integration/transaction_signer.rs
+++ b/signer/tests/integration/transaction_signer.rs
@@ -251,7 +251,7 @@ async fn get_signer_public_keys_and_aggregate_key_falls_back() {
     // tables...
     let stacks_chain_tip = db.get_stacks_chain_tip(&chain_tip).await.unwrap().unwrap();
 
-    let rotate_keys: RotateKeysTransaction = Faker.fake_with_rng(&mut rng);
+    let mut rotate_keys: RotateKeysTransaction = Faker.fake_with_rng(&mut rng);
     let transaction = model::Transaction {
         txid: rotate_keys.txid.into_bytes(),
         tx: Vec::new(),
@@ -271,13 +271,16 @@ async fn get_signer_public_keys_and_aggregate_key_falls_back() {
 
     // Alright, now that we have a rotate-keys transaction, we can check if
     // it is preferred over the config.
-    let signer_set: Vec<PublicKey> = coord
+    let mut signer_set: Vec<PublicKey> = coord
         .get_signer_public_keys(&chain_tip)
         .await
         .unwrap()
         .into_iter()
         .collect();
 
+    // Sort the two lists so the comparison is easier.
+    signer_set.sort_by_key(|k| k.to_string());
+    rotate_keys.signer_set.sort_by_key(|k| k.to_string());
     assert_eq!(rotate_keys.signer_set, signer_set);
 
     testing::storage::drop_db(db).await;


### PR DESCRIPTION
## Description

Part 2/3 of addressing: #380

## Changes

1. Adds the `time_mined` field to the signer database.
2. Fixes an integration test that relies on the order of an unordered set.

## Testing Information

Tested with existing integration tests

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
