### PR TITLE
fix: have docker build always push the image

### DIFF
--- a/.github/workflows/image-build.yaml
+++ b/.github/workflows/image-build.yaml
@@ -91,4 +91,4 @@ jobs:
           tags: ${{ steps.docker_metadata.outputs.tags }}
           labels: ${{ steps.docker_metadata.outputs.labels }}
           target: ${{ matrix.docker_target }}
-          push: ${{ inputs.push-image }}
+          push: true


### PR DESCRIPTION
## Description

Fixes bug.

I forgot to remove the `input` variables when I switched to making it trigger on a tag update.
