### PR TITLE
feat: import libp2p changes from `feat/demo-cli` (related to #669)

### DIFF
--- a/.generated-sources/blocklist-api/Cargo.toml
+++ b/.generated-sources/blocklist-api/Cargo.toml
@@ -10,7 +10,6 @@ edition = "2021"
 serde = { version = "^1.0", features = ["derive"] }
 serde_with = { version = "^3.8", default-features = false, features = ["base64", "std", "macros"] }
 serde_json = "^1.0"
-serde_repr = "^0.1"
 url = "^2.5"
 uuid = { version = "^1.8", features = ["serde", "v4"] }
 reqwest = { version = "^0.12", features = ["json", "multipart"] }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1050,7 +1050,6 @@ dependencies = [
  "reqwest 0.12.4",
  "serde 1.0.203",
  "serde_json",
- "serde_repr",
  "serde_with",
  "url",
  "uuid",

--- a/signer/src/network/libp2p/event_loop.rs
+++ b/signer/src/network/libp2p/event_loop.rs
@@ -1,9 +1,10 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use futures::StreamExt;
 use libp2p::swarm::SwarmEvent;
 use libp2p::{autonat, gossipsub, identify, mdns, Swarm};
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, RwLock};
 
 use crate::codec::{Decode, Encode};
 use crate::context::{Context, P2PEvent, SignerCommand, SignerSignal};
@@ -12,16 +13,13 @@ use crate::network::Msg;
 use super::swarm::{SignerBehavior, SignerBehaviorEvent};
 use super::TOPIC;
 
+#[tracing::instrument(skip_all, name = "p2p")]
 pub async fn run(ctx: &impl Context, swarm: Arc<Mutex<Swarm<SignerBehavior>>>) {
-    // NOTE: We are locking the swarm here for the life of the event loop.
-    // Right now there's nothing else that needs to access the swarm while
-    // it's running, but if that changes we will need to move the lock into
-    // the loop and implement a timeout within the select! so that other
-    // tasks can access the swarm.
-    let mut swarm = swarm.lock().await;
+    // Subscribe to the gossipsub topic.
     let topic = TOPIC.clone();
-
     swarm
+        .lock()
+        .await
         .behaviour_mut()
         .gossipsub
         .subscribe(&TOPIC)
@@ -31,89 +29,83 @@ pub async fn run(ctx: &impl Context, swarm: Arc<Mutex<Swarm<SignerBehavior>>>) {
     let mut signal_rx = ctx.get_signal_receiver();
     let signal_tx = ctx.get_signal_sender();
 
-    loop {
-        tokio::select! {
-            // Handle termination signals from the application
-            _ = term.wait_for_shutdown() => {
-                tracing::info!("libp2p received a termination signal; stopping the libp2p swarm");
-                break;
-            },
-            // Handle signals from the application
-            Ok(SignerSignal::Command(cmd)) = signal_rx.recv() => {
-                match cmd {
-                    // Handle a request to publish a message to the P2P network.
-                    SignerCommand::P2PPublish(payload) => {
-                        let msg_id = payload.id();
+    // Here we create a future that listens for `P2PPublish` commands from the
+    // app signalling channel and pushes them into the outbound message queue.
+    // This queue is then polled by the `poll_swarm` event loop to publish the
+    // messages to the network.
+    let outbox = RwLock::new(Vec::<Msg>::new());
+    let poll_outbound = async {
+        tracing::debug!("P2P outbound message polling started");
+        loop {
+            let Ok(SignerSignal::Command(SignerCommand::P2PPublish(payload))) =
+                signal_rx.recv().await
+            else {
+                continue;
+            };
 
-                        // Attempt to encode the message payload into bytes
-                        // using the signer codec.
-                        let encoded_msg = match payload.encode_to_vec() {
-                            Ok(msg) => msg,
-                            Err(error) => {
-                                // An error occurred while encoding the message.
-                                // Log the error and send a failure signal to the application
-                                // so that it can handle the failure as needed.
-                                tracing::warn!(%error, "Failed to encode message");
-                                let _ = signal_tx.send(P2PEvent::PublishFailure(msg_id).into());
-                                continue;
-                            }
-                        };
+            outbox.write().await.push(payload);
+        }
+    };
 
-                        let _ = swarm.behaviour_mut()
-                            .gossipsub
-                            .publish(topic.clone(), encoded_msg)
-                            .map_err(|error| {
-                                // An error occurred while attempting to publish.
-                                // Log the error and send a failure signal to the application
-                                // so that it can handle the failure as needed.
-                                tracing::warn!(%error, ?msg_id, "Failed to publish message");
-                                let _ = signal_tx.send(P2PEvent::PublishFailure(msg_id).into());
-                            })
-                            .map(|_| {
-                                // The message was published successfully. Log the success
-                                // and send a success signal to the application so that it can
-                                // handle the success as needed.
-                                tracing::trace!(?msg_id, "Message published successfully");
-                                let _ = signal_tx.send(P2PEvent::PublishSuccess(msg_id).into());
-                            });
-                    },
-                }
-            },
-            // Handle events from the libp2p swarm
-            event = swarm.select_next_some() => {
+    // Here we create a future that polls the libp2p swarm for events and also
+    // publishes messages from the outbox to the network.
+    let poll_swarm = async {
+        tracing::debug!("P2P network polling started");
+
+        loop {
+            // Poll the libp2p swarm for events, waiting for a maximum of 5ms
+            // so that we don't starve the outbox.
+            let event =
+                match tokio::time::timeout(Duration::from_millis(5), swarm.lock().await.next())
+                    .await
+                {
+                    Ok(event) => event,
+                    Err(_) => None,
+                };
+
+            // Handle the event if one was received.
+            if let Some(event) = event {
+                //let swarm = &mut *swarm.lock().await;
+                let mut swarm = swarm.lock().await;
+
                 match event {
                     // mDNS autodiscovery events. These are used by the local
                     // peer to discover other peers on the local network.
-                    SwarmEvent::Behaviour(SignerBehaviorEvent::Mdns(event)) =>
-                        handle_mdns_event(&mut swarm, ctx, event),
+                    SwarmEvent::Behaviour(SignerBehaviorEvent::Mdns(event)) => {
+                        handle_mdns_event(&mut swarm, ctx, event)
+                    }
                     // Identify protocol events. These are used by the relay to
                     // help determine/verify its own address.
-                    SwarmEvent::Behaviour(SignerBehaviorEvent::Identify(event)) =>
-                        handle_identify_event(&mut swarm, ctx, event),
+                    SwarmEvent::Behaviour(SignerBehaviorEvent::Identify(event)) => {
+                        handle_identify_event(&mut swarm, ctx, event)
+                    }
                     // Gossipsub protocol events.
-                    SwarmEvent::Behaviour(SignerBehaviorEvent::Gossipsub(event)) =>
-                        handle_gossipsub_event(&mut swarm, ctx, event),
+                    SwarmEvent::Behaviour(SignerBehaviorEvent::Gossipsub(event)) => {
+                        handle_gossipsub_event(&mut swarm, ctx, event)
+                    }
                     // AutoNAT client protocol events.
-                    SwarmEvent::Behaviour(SignerBehaviorEvent::AutonatClient(event)) =>
-                        handle_autonat_client_event(&mut swarm, ctx, event),
+                    SwarmEvent::Behaviour(SignerBehaviorEvent::AutonatClient(event)) => {
+                        handle_autonat_client_event(&mut swarm, ctx, event)
+                    }
                     // AutoNAT server protocol events.
-                    SwarmEvent::Behaviour(SignerBehaviorEvent::AutonatServer(event)) =>
-                        handle_autonat_server_event(&mut swarm, event),
+                    SwarmEvent::Behaviour(SignerBehaviorEvent::AutonatServer(event)) => {
+                        handle_autonat_server_event(&mut swarm, event)
+                    }
                     SwarmEvent::NewListenAddr { address, .. } => {
                         tracing::info!(%address, "Listener started");
-                    },
+                    }
                     SwarmEvent::ExpiredListenAddr { address, .. } => {
                         tracing::debug!(%address, "Listener expired");
-                    },
+                    }
                     SwarmEvent::ListenerClosed { addresses, reason, .. } => {
                         tracing::info!(?addresses, ?reason, "Listener closed");
-                    },
+                    }
                     SwarmEvent::ListenerError { listener_id, error } => {
                         tracing::warn!(%listener_id, %error, "Listener error");
-                    },
+                    }
                     SwarmEvent::Dialing { peer_id, connection_id } => {
                         tracing::info!(peer_id = ?peer_id, %connection_id, "Dialing peer");
-                    },
+                    }
                     SwarmEvent::ConnectionEstablished { endpoint, peer_id, .. } => {
                         if !ctx.state().current_signer_set().is_allowed_peer(&peer_id) {
                             tracing::warn!(%peer_id, ?endpoint, "Connected to peer, however it is not a known signer; disconnecting");
@@ -121,41 +113,98 @@ pub async fn run(ctx: &impl Context, swarm: Arc<Mutex<Swarm<SignerBehavior>>>) {
                             continue;
                         }
                         tracing::info!(%peer_id, ?endpoint, "Connected to peer");
-                    },
+                    }
                     SwarmEvent::ConnectionClosed { peer_id, cause, .. } => {
                         tracing::info!(%peer_id, ?cause, "Connection closed");
-                    },
+                    }
                     SwarmEvent::IncomingConnection { local_addr, send_back_addr, .. } => {
                         tracing::debug!(%local_addr, %send_back_addr, "Incoming connection");
-                    },
+                    }
                     SwarmEvent::Behaviour(SignerBehaviorEvent::Ping(ping)) => {
                         tracing::trace!("ping received: {:?}", ping);
-                    },
+                    }
                     SwarmEvent::OutgoingConnectionError { connection_id, error, .. } => {
                         tracing::warn!(%connection_id, %error, "outgoing connection error");
-                    },
-                    SwarmEvent::IncomingConnectionError { local_addr, send_back_addr, error, .. } => {
+                    }
+                    SwarmEvent::IncomingConnectionError {
+                        local_addr,
+                        send_back_addr,
+                        error,
+                        ..
+                    } => {
                         tracing::warn!(%local_addr, %send_back_addr, %error, "incoming connection error");
-                    },
+                    }
                     SwarmEvent::NewExternalAddrCandidate { address } => {
                         tracing::debug!(%address, "New external address candidate");
-                    },
+                    }
                     SwarmEvent::ExternalAddrConfirmed { address } => {
                         tracing::debug!(%address, "External address confirmed");
-                    },
+                    }
                     SwarmEvent::ExternalAddrExpired { address } => {
                         tracing::debug!(%address, "External address expired");
-                    },
+                    }
                     SwarmEvent::NewExternalAddrOfPeer { peer_id, address } => {
                         tracing::debug!(%peer_id, %address, "New external address of peer");
-                    },
+                    }
                     // The derived `SwarmEvent` is marked as #[non_exhaustive], so we must have a
                     // catch-all.
                     _ => tracing::trace!("unhandled swarm event"),
                 }
             }
+
+            // Drain the outbox and publish the messages to the network.
+            let outbox = outbox.write().await.drain(..).collect::<Vec<_>>();
+            for payload in outbox {
+                tracing::info!("publishing message");
+                let msg_id = payload.id();
+
+                // Attempt to encode the message payload into bytes
+                // using the signer codec.
+                let encoded_msg = match payload.encode_to_vec() {
+                    Ok(msg) => msg,
+                    Err(error) => {
+                        // An error occurred while encoding the message.
+                        // Log the error and send a failure signal to the application
+                        // so that it can handle the failure as needed.
+                        tracing::warn!(%error, "Failed to encode message");
+                        let _ = signal_tx.send(P2PEvent::PublishFailure(msg_id).into());
+                        continue;
+                    }
+                };
+
+                let _ = swarm
+                    .lock()
+                    .await
+                    .behaviour_mut()
+                    .gossipsub
+                    .publish(topic.clone(), encoded_msg)
+                    .map_err(|error| {
+                        // An error occurred while attempting to publish.
+                        // Log the error and send a failure signal to the application
+                        // so that it can handle the failure as needed.
+                        tracing::warn!(%error, ?msg_id, "Failed to publish message");
+                        let _ = signal_tx.send(P2PEvent::PublishFailure(msg_id).into());
+                    })
+                    .map(|_| {
+                        // The message was published successfully. Log the success
+                        // and send a success signal to the application so that it can
+                        // handle the success as needed.
+                        tracing::trace!(?msg_id, "Message published successfully");
+                        let _ = signal_tx.send(P2PEvent::PublishSuccess(msg_id).into());
+                    });
+            }
         }
+    };
+
+    tokio::select! {
+        _ = term.wait_for_shutdown() => {
+            tracing::info!("libp2p received a termination signal; stopping the libp2p swarm");
+        },
+        _ = poll_outbound => {},
+        _ = poll_swarm => {},
     }
+
+    tracing::info!("libp2p event loop terminated");
 }
 
 fn handle_autonat_client_event(


### PR DESCRIPTION
## Description

This resolves part of #669 and is otherwise just pulling in the **unreviewed** libp2p-related changes that were already made in `feat/demo-cli` into main.

## Changes

This changes how the libp2p swarm is polled, ensuring that it is done at a constant interval "driving it" and also ensuring that `tokio::select!` can't abort a p2p publish or the processing of an incoming message if those two events occur at the same time.

In short, what can happen (before this change) is that if both a network message is received (via the `swarm.select_next_some()`) AND a publish command is being processed (via the `signal_rx.recv()`), then these two will race to finish. When one of them finishes, `tokio::select!` will abort the competing tasks which can result in either a message not being published to the network or a received message not being propagated into the app for processing.

This is likely not a real issue in production, but when running tests these events can much more easily coincide.

## Testing Information

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
