### PR TITLE
feat: update contract calls with burn block check inputs

### DIFF
--- a/signer/src/stacks/contracts.rs
+++ b/signer/src/stacks/contracts.rs
@@ -582,6 +582,8 @@ impl AsContractCall for AcceptWithdrawalV1 {
     fn as_contract_args(&self) -> Vec<ClarityValue> {
         let txid_data = self.outpoint.txid.to_byte_array().to_vec();
         let txid = BuffData { data: txid_data };
+        let burn_hash_data = self.sweep_block_hash.to_byte_array().to_vec();
+        let burn_hash = BuffData { data: burn_hash_data };
 
         vec![
             ClarityValue::UInt(self.request_id as u128),
@@ -589,6 +591,8 @@ impl AsContractCall for AcceptWithdrawalV1 {
             ClarityValue::UInt(self.signer_bitmap.load_le()),
             ClarityValue::UInt(self.outpoint.vout as u128),
             ClarityValue::UInt(self.tx_fee as u128),
+            ClarityValue::Sequence(SequenceData::Buffer(burn_hash)),
+            ClarityValue::UInt(self.sweep_block_height as u128),
         ]
     }
     /// Validates that the accept-withdrawal-request satisfies the

--- a/signer/src/stacks/contracts.rs
+++ b/signer/src/stacks/contracts.rs
@@ -258,12 +258,16 @@ impl AsContractCall for CompleteDepositV1 {
     fn as_contract_args(&self) -> Vec<ClarityValue> {
         let txid_data = self.outpoint.txid.to_byte_array().to_vec();
         let txid = BuffData { data: txid_data };
+        let burn_hash_data = self.sweep_block_hash.to_byte_array().to_vec();
+        let burn_hash = BuffData { data: burn_hash_data };
 
         vec![
             ClarityValue::Sequence(SequenceData::Buffer(txid)),
             ClarityValue::UInt(self.outpoint.vout as u128),
             ClarityValue::UInt(self.amount as u128),
             ClarityValue::Principal(self.recipient.clone()),
+            ClarityValue::Sequence(SequenceData::Buffer(burn_hash)),
+            ClarityValue::UInt(self.sweep_block_height as u128),
         ]
     }
     /// Validates that the Complete deposit request satisfies the following


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/734.

## Changes

* Update the `complete-deposit-wrapper` and `accept-withdrawal-request` contract call with the new parameter.

## Testing Information

This is untested (I'm running it now to make sure the stacks-node accepts it). There will be quite some setup to do to properly test this, so I created https://github.com/stacks-network/sbtc/issues/735 for that work.

## Checklist:

- [x] I have performed a self-review of my code
