### PR TITLE
feat: Retry updates when a version conflict fails update

### DIFF
--- a/emily/handler/src/api/handlers/deposit.rs
+++ b/emily/handler/src/api/handlers/deposit.rs
@@ -340,16 +340,11 @@ pub async fn update_deposits(
 
         // Loop through all updates and execute.
         for (index, update) in validated_request.deposits {
-            // Get original deposit entry.
-            let deposit_entry = accessors::get_deposit_entry(&context, &update.key).await?;
-            // Make the update package.
-            let update_package = DepositUpdatePackage::try_from(&deposit_entry, update)?;
-            let updated_deposit = accessors::update_deposit(&context, &update_package)
-                .await?
-                .try_into()?;
-            // Append the updated deposit to the list.
-            updated_deposits.push((index, updated_deposit));
+            let updated_deposit =
+                accessors::pull_and_update_deposit_with_retry(&context, update, 15).await?;
+            updated_deposits.push((index, updated_deposit.try_into()?));
         }
+
         updated_deposits.sort_by_key(|(index, _)| *index);
         let deposits = updated_deposits
             .into_iter()

--- a/emily/handler/src/api/handlers/deposit.rs
+++ b/emily/handler/src/api/handlers/deposit.rs
@@ -22,7 +22,7 @@ use crate::common::error::Error;
 use crate::context::EmilyContext;
 use crate::database::accessors;
 use crate::database::entries::deposit::{
-    DepositEntry, DepositEntryKey, DepositEvent, DepositParametersEntry, DepositUpdatePackage,
+    DepositEntry, DepositEntryKey, DepositEvent, DepositParametersEntry,
     ValidatedUpdateDepositsRequest,
 };
 

--- a/emily/handler/src/api/handlers/withdrawal.rs
+++ b/emily/handler/src/api/handlers/withdrawal.rs
@@ -12,7 +12,7 @@ use crate::context::EmilyContext;
 use crate::database::accessors;
 use crate::database::entries::withdrawal::{
     ValidatedUpdateWithdrawalRequest, WithdrawalEntry, WithdrawalEntryKey, WithdrawalEvent,
-    WithdrawalParametersEntry, WithdrawalUpdatePackage,
+    WithdrawalParametersEntry,
 };
 use crate::database::entries::StatusEntry;
 use warp::http::StatusCode;

--- a/emily/handler/src/api/handlers/withdrawal.rs
+++ b/emily/handler/src/api/handlers/withdrawal.rs
@@ -235,17 +235,11 @@ pub async fn update_withdrawals(
 
         // Loop through all updates and execute.
         for (index, update) in validated_request.withdrawals {
-            // Get original withdrawal entry.
-            let withdrawal_entry =
-                accessors::get_withdrawal_entry(&context, &update.request_id).await?;
-            // Make the update package.
-            let update_package = WithdrawalUpdatePackage::try_from(&withdrawal_entry, update)?;
-            let updated_withdrawal = accessors::update_withdrawal(&context, &update_package)
-                .await?
-                .try_into()?;
-            // Append the updated withdrawal to the list.
-            updated_withdrawals.push((index, updated_withdrawal));
+            let updated_withdrawal =
+                accessors::pull_and_update_withdrawal_with_retry(&context, update, 15).await?;
+            updated_withdrawals.push((index, updated_withdrawal.try_into()?));
         }
+
         updated_withdrawals.sort_by_key(|(index, _)| *index);
         let withdrawals = updated_withdrawals
             .into_iter()

--- a/emily/handler/src/database/accessors.rs
+++ b/emily/handler/src/database/accessors.rs
@@ -142,6 +142,8 @@ pub async fn get_deposit_entries_for_transaction(
 
 /// Pulls in a deposit entry and then updates it, retrying the specified number
 /// of times when there's a version conflict.
+///
+/// TODO(792): Combine this with the withdrawal version.
 pub async fn pull_and_update_deposit_with_retry(
     context: &EmilyContext,
     update: ValidatedDepositUpdate,
@@ -339,6 +341,8 @@ pub async fn get_all_withdrawal_entries_modified_after_height_with_status(
 
 /// Pulls in a withdrawal entry and then updates it, retrying the specified number
 /// of times when there's a version conflict.
+///
+/// TODO(792): Combine this with the deposit version.
 pub async fn pull_and_update_withdrawal_with_retry(
     context: &EmilyContext,
     update: ValidatedWithdrawalUpdate,

--- a/emily/handler/src/database/accessors.rs
+++ b/emily/handler/src/database/accessors.rs
@@ -4,10 +4,13 @@ use aws_sdk_dynamodb::types::AttributeValue;
 use serde_dynamo::Item;
 use tracing::{info, warn};
 
+use crate::api::models::deposit::Deposit;
 use crate::common::error::{Error, Inconsistency};
 
 use crate::{api::models::common::Status, context::EmilyContext};
 
+use super::entries::deposit::ValidatedDepositUpdate;
+use super::entries::withdrawal::ValidatedWithdrawalUpdate;
 use super::entries::{
     chainstate::{
         ApiStateEntry, ApiStatus, ChainstateEntry, ChainstateTablePrimaryIndex,
@@ -136,6 +139,38 @@ pub async fn get_deposit_entries_for_transaction(
         maybe_page_size,
     )
     .await
+}
+
+/// Pulls in a deposit entry and then updates it, retrying the specified number
+/// of times when there's a version conflict.
+pub async fn pull_and_update_deposit_with_retry(
+    context: &EmilyContext,
+    update: ValidatedDepositUpdate,
+    retries: u16,
+) -> Result<DepositEntry, Error> {
+    for _ in 0..retries {
+        // Get original deposit entry.
+        let deposit_entry = get_deposit_entry(&context, &update.key).await?;
+        // Return the existing entry if no update is necessary.
+        if update.is_unnecessary(&deposit_entry) {
+            return Ok(deposit_entry);
+        }
+        // Make the update package.
+        let update_package: DepositUpdatePackage =
+            DepositUpdatePackage::try_from(&deposit_entry, update.clone())?;
+        // Attempt to update the deposit.
+        match update_deposit(&context, &update_package).await {
+            Err(Error::VersionConflict) => {
+                // Retry.
+                continue;
+            }
+            otherwise => {
+                return otherwise;
+            }
+        }
+    }
+    // Failed to update due to a version conflict
+    return Err(Error::VersionConflict);
 }
 
 /// Updates a deposit.
@@ -301,6 +336,37 @@ pub async fn get_all_withdrawal_entries_modified_after_height_with_status(
         maybe_page_size,
     )
     .await
+}
+
+/// Pulls in a withdrawal entry and then updates it, retrying the specified number
+/// of times when there's a version conflict.
+pub async fn pull_and_update_withdrawal_with_retry(
+    context: &EmilyContext,
+    update: ValidatedWithdrawalUpdate,
+    retries: u16,
+) -> Result<WithdrawalEntry, Error> {
+    for _ in 0..retries {
+        // Get original withdrawal entry.
+        let entry = get_withdrawal_entry(&context, &update.request_id).await?;
+        // Return the existing entry if no update is necessary.
+        if update.is_unnecessary(&entry) {
+            return Ok(entry);
+        }
+        // Make the update package.
+        let update_package = WithdrawalUpdatePackage::try_from(&entry, update.clone())?;
+        // Attempt to update the deposit.
+        match update_withdrawal(&context, &update_package).await {
+            Err(Error::VersionConflict) => {
+                // Retry.
+                continue;
+            }
+            otherwise => {
+                return otherwise;
+            }
+        }
+    }
+    // Failed to update due to a version conflict
+    return Err(Error::VersionConflict);
 }
 
 /// Updates a withdrawal based on the update package.

--- a/emily/handler/src/database/entries/deposit.rs
+++ b/emily/handler/src/database/entries/deposit.rs
@@ -605,6 +605,13 @@ mod tests {
             stacks_block_hash: "".to_string(),
         };
 
+        let accepted = DepositEvent {
+            status: StatusEntry::Accepted,
+            message: "".to_string(),
+            stacks_block_height: 1,
+            stacks_block_hash: "".to_string(),
+        };
+
         let deposit = DepositEntry {
             key: Default::default(),
             version: 0,
@@ -622,7 +629,7 @@ mod tests {
 
         let update = ValidatedDepositUpdate {
             key: Default::default(),
-            event: pending,
+            event: accepted,
         };
 
         assert!(!update.is_unnecessary(&deposit));

--- a/emily/handler/src/database/entries/deposit.rs
+++ b/emily/handler/src/database/entries/deposit.rs
@@ -559,7 +559,14 @@ mod tests {
 
     #[test]
     fn deposit_update_should_be_unnecessary_when_event_is_present() {
-        let event = DepositEvent {
+        let pending = DepositEvent {
+            status: StatusEntry::Pending,
+            message: "".to_string(),
+            stacks_block_height: 0,
+            stacks_block_hash: "".to_string(),
+        };
+
+        let accepted = DepositEvent {
             status: StatusEntry::Accepted,
             message: "".to_string(),
             stacks_block_height: 1,
@@ -578,28 +585,23 @@ mod tests {
             last_update_height: 0,
             last_update_block_hash: "".to_string(),
             fulfillment: None,
-            history: vec![
-                DepositEvent {
-                    status: StatusEntry::Pending,
-                    message: "".to_string(),
-                    stacks_block_height: 0,
-                    stacks_block_hash: "".to_string(),
-                },
-                event.clone(),
-            ],
+            history: vec![pending, accepted.clone()],
         };
 
-        let update = ValidatedDepositUpdate { key: Default::default(), event };
+        let update = ValidatedDepositUpdate {
+            key: Default::default(),
+            event: accepted,
+        };
 
         assert!(update.is_unnecessary(&deposit));
     }
 
     #[test]
     fn deposit_update_should_be_necessary_when_event_is_not_present() {
-        let event = DepositEvent {
-            status: StatusEntry::Accepted,
+        let pending = DepositEvent {
+            status: StatusEntry::Pending,
             message: "".to_string(),
-            stacks_block_height: 1,
+            stacks_block_height: 0,
             stacks_block_hash: "".to_string(),
         };
 
@@ -615,15 +617,13 @@ mod tests {
             last_update_height: 0,
             last_update_block_hash: "".to_string(),
             fulfillment: None,
-            history: vec![DepositEvent {
-                status: StatusEntry::Pending,
-                message: "".to_string(),
-                stacks_block_height: 0,
-                stacks_block_hash: "".to_string(),
-            }],
+            history: vec![pending.clone()],
         };
 
-        let update = ValidatedDepositUpdate { key: Default::default(), event };
+        let update = ValidatedDepositUpdate {
+            key: Default::default(),
+            event: pending,
+        };
 
         assert!(!update.is_unnecessary(&deposit));
     }

--- a/emily/handler/src/database/entries/withdrawal.rs
+++ b/emily/handler/src/database/entries/withdrawal.rs
@@ -493,6 +493,18 @@ impl TryFrom<WithdrawalUpdate> for ValidatedWithdrawalUpdate {
     }
 }
 
+impl ValidatedWithdrawalUpdate {
+    /// Returns true if the update is not necessary.
+    pub fn is_unnecessary(&self, entry: &WithdrawalEntry) -> bool {
+        entry
+            .history
+            .iter()
+            .rev()
+            .take_while(|event| event.stacks_block_height >= self.event.stacks_block_height)
+            .any(|event| event == &self.event)
+    }
+}
+
 /// Packaged withdrawal update.
 pub struct WithdrawalUpdatePackage {
     /// Key.
@@ -526,5 +538,107 @@ impl WithdrawalUpdatePackage {
             version: entry.version,
             event: update.event,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::database::entries::StatusEntry;
+    use crate::{
+        api::models::common::Status,
+        database::entries::withdrawal::{
+            ValidatedWithdrawalUpdate, WithdrawalEntry, WithdrawalEntryKey, WithdrawalEvent,
+            WithdrawalParametersEntry,
+        },
+    };
+
+    #[test]
+    fn withdrawal_update_should_be_unnecessary_when_event_is_present() {
+        // Arrange
+        let withdrawal_event_to_update = WithdrawalEvent {
+            status: StatusEntry::Failed,
+            message: "message".to_string(),
+            stacks_block_height: 2,
+            stacks_block_hash: "hash".to_string(),
+        };
+
+        let withdrawal_entry = WithdrawalEntry {
+            key: WithdrawalEntryKey {
+                request_id: 1,
+                stacks_block_hash: "hash".to_string(),
+            },
+            stacks_block_height: 1,
+            version: 1,
+            recipient: "recipient".to_string(),
+            amount: 1,
+            parameters: WithdrawalParametersEntry { max_fee: 1 },
+            status: Status::Pending,
+            last_update_height: 1,
+            last_update_block_hash: "hash".to_string(),
+            history: vec![
+                WithdrawalEvent {
+                    status: StatusEntry::Pending,
+                    message: "message".to_string(),
+                    stacks_block_height: 1,
+                    stacks_block_hash: "hash".to_string(),
+                },
+                // Place the event that will be in the update.
+                withdrawal_event_to_update.clone(),
+            ],
+        };
+
+        let withdrawal_update = ValidatedWithdrawalUpdate {
+            request_id: 1,
+            event: withdrawal_event_to_update,
+        };
+
+        // Act
+        let is_unnecessary = withdrawal_update.is_unnecessary(&withdrawal_entry);
+
+        // Assert
+        assert!(is_unnecessary);
+    }
+
+    #[test]
+    fn withdrawal_update_should_be_necessary_when_event_is_not_present() {
+        // Arrange
+        let withdrawal_event_to_update = WithdrawalEvent {
+            status: StatusEntry::Failed,
+            message: "message".to_string(),
+            stacks_block_height: 2,
+            stacks_block_hash: "hash".to_string(),
+        };
+
+        let withdrawal_entry = WithdrawalEntry {
+            key: WithdrawalEntryKey {
+                request_id: 1,
+                stacks_block_hash: "hash".to_string(),
+            },
+            stacks_block_height: 1,
+            version: 1,
+            recipient: "recipient".to_string(),
+            amount: 1,
+            parameters: WithdrawalParametersEntry { max_fee: 1 },
+            status: Status::Pending,
+            last_update_height: 1,
+            last_update_block_hash: "hash".to_string(),
+            history: vec![WithdrawalEvent {
+                status: StatusEntry::Pending,
+                message: "message".to_string(),
+                stacks_block_height: 1,
+                stacks_block_hash: "hash".to_string(),
+            }],
+        };
+
+        let withdrawal_update = ValidatedWithdrawalUpdate {
+            request_id: 1,
+            event: withdrawal_event_to_update,
+        };
+
+        // Act
+        let is_unnecessary = withdrawal_update.is_unnecessary(&withdrawal_entry);
+
+        // Assert
+        assert!(!is_unnecessary);
     }
 }

--- a/emily/handler/src/database/entries/withdrawal.rs
+++ b/emily/handler/src/database/entries/withdrawal.rs
@@ -604,6 +604,13 @@ mod tests {
             stacks_block_hash: "hash".to_string(),
         };
 
+        let failed = WithdrawalEvent {
+            status: StatusEntry::Failed,
+            message: "message".to_string(),
+            stacks_block_height: 2,
+            stacks_block_hash: "hash".to_string(),
+        };
+
         let withdrawal_entry = WithdrawalEntry {
             key: WithdrawalEntryKey {
                 request_id: 1,
@@ -620,7 +627,7 @@ mod tests {
             history: vec![pending.clone()],
         };
 
-        let withdrawal_update = ValidatedWithdrawalUpdate { request_id: 1, event: pending };
+        let withdrawal_update = ValidatedWithdrawalUpdate { request_id: 1, event: failed };
 
         // Act
         let is_unnecessary = withdrawal_update.is_unnecessary(&withdrawal_entry);

--- a/emily/handler/src/database/entries/withdrawal.rs
+++ b/emily/handler/src/database/entries/withdrawal.rs
@@ -555,7 +555,14 @@ mod tests {
     #[test]
     fn withdrawal_update_should_be_unnecessary_when_event_is_present() {
         // Arrange
-        let withdrawal_event_to_update = WithdrawalEvent {
+        let pending = WithdrawalEvent {
+            status: StatusEntry::Pending,
+            message: "message".to_string(),
+            stacks_block_height: 1,
+            stacks_block_hash: "hash".to_string(),
+        };
+
+        let failed = WithdrawalEvent {
             status: StatusEntry::Failed,
             message: "message".to_string(),
             stacks_block_height: 2,
@@ -575,22 +582,10 @@ mod tests {
             status: Status::Pending,
             last_update_height: 1,
             last_update_block_hash: "hash".to_string(),
-            history: vec![
-                WithdrawalEvent {
-                    status: StatusEntry::Pending,
-                    message: "message".to_string(),
-                    stacks_block_height: 1,
-                    stacks_block_hash: "hash".to_string(),
-                },
-                // Place the event that will be in the update.
-                withdrawal_event_to_update.clone(),
-            ],
+            history: vec![pending, failed.clone()],
         };
 
-        let withdrawal_update = ValidatedWithdrawalUpdate {
-            request_id: 1,
-            event: withdrawal_event_to_update,
-        };
+        let withdrawal_update = ValidatedWithdrawalUpdate { request_id: 1, event: failed };
 
         // Act
         let is_unnecessary = withdrawal_update.is_unnecessary(&withdrawal_entry);
@@ -602,10 +597,10 @@ mod tests {
     #[test]
     fn withdrawal_update_should_be_necessary_when_event_is_not_present() {
         // Arrange
-        let withdrawal_event_to_update = WithdrawalEvent {
-            status: StatusEntry::Failed,
+        let pending = WithdrawalEvent {
+            status: StatusEntry::Pending,
             message: "message".to_string(),
-            stacks_block_height: 2,
+            stacks_block_height: 1,
             stacks_block_hash: "hash".to_string(),
         };
 
@@ -622,18 +617,10 @@ mod tests {
             status: Status::Pending,
             last_update_height: 1,
             last_update_block_hash: "hash".to_string(),
-            history: vec![WithdrawalEvent {
-                status: StatusEntry::Pending,
-                message: "message".to_string(),
-                stacks_block_height: 1,
-                stacks_block_hash: "hash".to_string(),
-            }],
+            history: vec![pending.clone()],
         };
 
-        let withdrawal_update = ValidatedWithdrawalUpdate {
-            request_id: 1,
-            event: withdrawal_event_to_update,
-        };
+        let withdrawal_update = ValidatedWithdrawalUpdate { request_id: 1, event: pending };
 
         // Act
         let is_unnecessary = withdrawal_update.is_unnecessary(&withdrawal_entry);

--- a/signer/src/api/new_block.rs
+++ b/signer/src/api/new_block.rs
@@ -14,7 +14,6 @@ use emily_client::models::Fulfillment;
 use emily_client::models::Status;
 use emily_client::models::UpdateDepositsResponse;
 use emily_client::models::UpdateWithdrawalsResponse;
-use emily_client::models::Withdrawal;
 use emily_client::models::WithdrawalParameters;
 use emily_client::models::WithdrawalUpdate;
 use futures::FutureExt;
@@ -54,8 +53,6 @@ static SBTC_REGISTRY_IDENTIFIER: OnceLock<QualifiedContractIdentifier> = OnceLoc
 enum UpdateResult {
     Deposit(Result<UpdateDepositsResponse, Error>),
     Withdrawal(Result<UpdateWithdrawalsResponse, Error>),
-    CreatedWithdrawal(Vec<Result<Withdrawal, Error>>),
-    Chainstate(Result<Chainstate, Error>),
 }
 
 /// A handler of `POST /new_block` webhook events.
@@ -179,6 +176,27 @@ pub async fn new_block_handler(state: State<ApiState<impl Context>>, body: Strin
     // Send the updates to Emily.
     let emily_client = api.ctx.get_emily_client();
     let chainstate = Chainstate::new(block_id.to_string(), new_block_event.block_height);
+
+    // Create chainstate first so that we're sure that Emily is viewing the chain state
+    // the same way.
+    if let Err(error) = emily_client.set_chainstate(chainstate).await {
+        tracing::error!(%error, "Failed to set chainstate in Emily");
+    }
+
+    // Create any new withdrawal instances. We do this before performing any updates
+    // because a withdrawal needs to exist in the Emily API database in order for it
+    // to be updated.
+    emily_client
+        .create_withdrawals(created_withdrawals)
+        .await
+        .into_iter()
+        .for_each(|create_withdrawal_result| {
+            if let Err(error) = create_withdrawal_result {
+                tracing::error!(%error, "Failed to create withdrawal in Emily");
+            }
+        });
+
+    // Execute updates in parallel.
     let futures = vec![
         emily_client
             .update_deposits(completed_deposits)
@@ -187,14 +205,6 @@ pub async fn new_block_handler(state: State<ApiState<impl Context>>, body: Strin
         emily_client
             .update_withdrawals(updated_withdrawals)
             .map(UpdateResult::Withdrawal)
-            .boxed(),
-        emily_client
-            .create_withdrawals(created_withdrawals)
-            .map(UpdateResult::CreatedWithdrawal)
-            .boxed(),
-        emily_client
-            .set_chainstate(chainstate)
-            .map(UpdateResult::Chainstate)
             .boxed(),
     ];
 
@@ -206,21 +216,11 @@ pub async fn new_block_handler(state: State<ApiState<impl Context>>, body: Strin
     // is sent to Emily.
     for result in results {
         match result {
-            UpdateResult::Chainstate(Err(error)) => {
-                tracing::warn!(%error, "Failed to set chainstate in Emily");
-            }
             UpdateResult::Deposit(Err(error)) => {
                 tracing::warn!(%error, "Failed to update deposits in Emily");
             }
             UpdateResult::Withdrawal(Err(error)) => {
                 tracing::warn!(%error, "Failed to update withdrawals in Emily");
-            }
-            UpdateResult::CreatedWithdrawal(results) => {
-                for result in results {
-                    if let Err(error) = result {
-                        tracing::warn!(%error, "Failed to create withdrawals in Emily");
-                    }
-                }
             }
             _ => {} // Ignore successful results.
         }

--- a/signer/src/api/new_block.rs
+++ b/signer/src/api/new_block.rs
@@ -197,17 +197,15 @@ pub async fn new_block_handler(state: State<ApiState<impl Context>>, body: Strin
             .map(UpdateResult::Chainstate)
             .boxed(),
     ];
-    // TODO: Ideally, we would use `futures::future::join_all` here, but Emily
-    // randomly returns a `VersionConflict` error when we send multiple
-    // requests that may update the chainstate.
-    // let results = futures::future::join_all(futures).await;
+
+    let results = futures::future::join_all(futures).await;
 
     // Log any errors that occurred while updating Emily.
     // We don't return a non-success status code here because we rely on
     // the redundancy of the other sBTC signers to ensure that the update
     // is sent to Emily.
-    for future in futures {
-        match future.await {
+    for result in results {
+        match result {
             UpdateResult::Chainstate(Err(error)) => {
                 tracing::warn!(%error, "Failed to set chainstate in Emily");
             }

--- a/signer/tests/integration/stacks_events_observer.rs
+++ b/signer/tests/integration/stacks_events_observer.rs
@@ -432,6 +432,7 @@ async fn test_new_blocks_sends_update_deposits_to_emily() {
 
     let resp = new_block_handler(state.clone(), body).await;
     assert_eq!(resp, StatusCode::OK);
+
     // Check that the chain tip is updated
     let resp = get_chain_tip(&emily_context).await.unwrap();
     assert_eq!(resp.stacks_block_height, new_block_event.block_height);
@@ -439,6 +440,7 @@ async fn test_new_blocks_sends_update_deposits_to_emily() {
         resp.stacks_block_hash,
         new_block_event.index_block_hash.to_hex()
     );
+
     // Check that the deposit is confirmed
     let resp = get_deposit(
         &emily_context,
@@ -447,6 +449,7 @@ async fn test_new_blocks_sends_update_deposits_to_emily() {
     )
     .await;
     assert!(resp.is_ok());
+
     let resp = resp.unwrap();
     assert_eq!(resp.bitcoin_txid, bitcoin_txid);
     assert_eq!(resp.status, Status::Confirmed);


### PR DESCRIPTION
## Description

Closes: #752

## Changes

Adds retry on version conflict when updating an entry in a  dynamodb table to Emily. Also adds a function that prevents attempting an update when the entry doesn't need to consume the update.

Additionally, I had to change the order of the concurrent API calls updating Emily; it cannot receive updates to withdrawals that it doesn't know about yet, so the chainstate and create withdrawal calls need to occur first.

## Testing Information

Tested with unit tests and integration tests.

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
