### PR TITLE
feat: ensure bitcoin block confirming deposit is in database

### DIFF
--- a/docker/docker-compose.ci.yml
+++ b/docker/docker-compose.ci.yml
@@ -1,7 +1,6 @@
 services:
 
   bitcoind:
-    container_name: bitcoind
     image: lncm/bitcoind:v25.0
     volumes:
       - ../signer/tests/service-configs/bitcoin.conf:/data/.bitcoin/bitcoin.conf:ro
@@ -27,7 +26,6 @@ services:
 
   postgres:
     image: postgres:16.3
-    container_name: postgres
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres

--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -291,11 +291,6 @@ where
     ///    to the database.
     /// 3. Write the deposit transaction and the extracted deposit info
     ///    into the database.
-    ///
-    /// Since this function writes to the `bitcoin_transactions` table, we
-    /// must make sure that we have the bitcoin block header info in the
-    /// database. So, this function must be called after
-    /// [`BlockObserver::process_bitcoin_block`]
     async fn store_deposit_requests(&self, requests: Vec<Deposit>) -> Result<(), Error> {
         // We need to check to see if we have a record of the bitcoin block
         // that contains the deposit request in our database. If we don't

--- a/signer/src/storage/model.rs
+++ b/signer/src/storage/model.rs
@@ -182,6 +182,24 @@ pub struct BitcoinBlock {
     pub parent_hash: BitcoinBlockHash,
 }
 
+impl From<&bitcoin::Block> for BitcoinBlock {
+    fn from(block: &bitcoin::Block) -> Self {
+        BitcoinBlock {
+            block_hash: block.block_hash().into(),
+            block_height: block
+                .bip34_block_height()
+                .expect("Failed to get block height"),
+            parent_hash: block.header.prev_blockhash.into(),
+        }
+    }
+}
+
+impl From<bitcoin::Block> for BitcoinBlock {
+    fn from(block: bitcoin::Block) -> Self {
+        BitcoinBlock::from(&block)
+    }
+}
+
 /// Stacks block.
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, sqlx::FromRow)]
 #[cfg_attr(feature = "testing", derive(fake::Dummy))]

--- a/signer/tests/integration/block_observer.rs
+++ b/signer/tests/integration/block_observer.rs
@@ -45,7 +45,7 @@ pub const GET_POX_INFO_JSON: &str =
 /// The [`BlockObserver::load_latest_deposit_requests`] function is
 /// supposed to fetch all deposit requests from Emily and persist the ones
 /// that pass validation, regardless of when they were confirmed.
-/// 
+///
 /// The "eight blocks ago" version of this test is kind of fragile.
 /// Increasing the `blocks_ago` without increasing the horizon will lead to
 /// a test failure.


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/731.

This work came about while adding a test for https://github.com/stacks-network/sbtc/pull/756.

## Changes

* Clean up some logging in the block observer.
* Use shared references where possible in block observer functions (that I looked at).
* Make sure bitcoin blocks containing deposits are in the database before writing the deposit transaction.

## Testing Information

I created a new test case for an existing integration test that kinda tests this code. If you comment out the new function that writes the blocks to the database, the test fails with the expected error (a foreign key violation) for the "eight blocks ago" test. But it's not a great case, and I'm not sure how best to go about it using bitcoin-core.

I also needed to update two existing tests that execute this code path.

## Checklist:

- [x] I have performed a self-review of my code
