### PR TITLE
fix: local fixes linking stacks blocks to bitcoin blocks

### DIFF
--- a/signer/src/stacks/api.rs
+++ b/signer/src/stacks/api.rs
@@ -1162,6 +1162,12 @@ impl StacksInteract for ApiFallbackClient<StacksClient> {
         address: &StacksAddress,
         contract_name: &str,
     ) -> Result<ContractSrcResponse, Error> {
+        // TODO: We need to properly catch catch certain errors and let
+        // them pass. In particular, this error is fine:
+        // ```rust
+        // Error::StacksNodeResponse(error)
+        //      if error.status() == Some(reqwest::StatusCode::NOT_FOUND)
+        // ```
         self.get_client()
             .get_contract_source(address, contract_name)
             .await

--- a/signer/src/stacks/api.rs
+++ b/signer/src/stacks/api.rs
@@ -1162,7 +1162,8 @@ impl StacksInteract for ApiFallbackClient<StacksClient> {
         address: &StacksAddress,
         contract_name: &str,
     ) -> Result<ContractSrcResponse, Error> {
-        self.exec(|client, _| StacksClient::get_contract_source(client, address, contract_name))
+        self.get_client()
+            .get_contract_source(address, contract_name)
             .await
     }
 }

--- a/signer/src/storage/model.rs
+++ b/signer/src/storage/model.rs
@@ -761,13 +761,17 @@ impl From<[u8; 32]> for BitcoinBlockHash {
 
 impl From<BurnchainHeaderHash> for BitcoinBlockHash {
     fn from(value: BurnchainHeaderHash) -> Self {
-        value.into_bytes().into()
+        let mut bytes = value.into_bytes();
+        bytes.reverse();
+        bytes.into()
     }
 }
 
 impl From<BitcoinBlockHash> for BurnchainHeaderHash {
     fn from(value: BitcoinBlockHash) -> Self {
-        BurnchainHeaderHash(value.to_byte_array())
+        let mut bytes = value.to_byte_array();
+        bytes.reverse();
+        BurnchainHeaderHash(bytes)
     }
 }
 


### PR DESCRIPTION
## Description

This was discovered during local testing

## Changes

* Transform stacks blocks to bitcoin block hashes correctly.
* Don't retry on failure for `get_contract_source`.

## Testing Information

I couldn't get the `link_blocks` integration test to pass locally, not sure what the issue was. @matteojug was able to get his local main version to pass though.

## Checklist:

- [x] I have performed a self-review of my code
