### PR TITLE
fix: reuse wallet when deploying contracts

### DIFF
--- a/signer/src/main.rs
+++ b/signer/src/main.rs
@@ -342,7 +342,7 @@ async fn run_block_observer(ctx: impl Context) -> Result<(), Error> {
         bitcoin_blocks: stream.to_block_hash_stream(),
         stacks_client,
         emily_client,
-        horizon: 1,
+        horizon: 20,
     };
 
     block_observer.run().await


### PR DESCRIPTION
## Description

Followup for https://github.com/stacks-network/sbtc/issues/688

## Changes

Reuse the same wallet object when deploying the different contracts to avoid conflicting nonces in mempool.
Also bump the block observer horizon to a reasonable value.

## Testing Information

Tested on devenv: all the contracts were deployed in the same stacks block.

## Checklist:

- [X] I have performed a self-review of my code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes