### PR TITLE
fix: update burn hash check in contract calls

### DIFF
--- a/contracts/contracts/sbtc-deposit.clar
+++ b/contracts/contracts/sbtc-deposit.clar
@@ -28,8 +28,12 @@
 ;; bootstrap signer set address - it cannot be called by users directly.
 ;; This function handles the validation & minting of sBTC, it then calls
 ;; into the sbtc-registry contract to update the state of the protocol
-(define-public (complete-deposit-wrapper (txid (buff 32)) (vout-index uint) (amount uint) (recipient principal) (burn-hash (buff 32)) (burn-height uint) 
-    )
+(define-public (complete-deposit-wrapper (txid (buff 32))
+                                         (vout-index uint)
+                                         (amount uint)
+                                         (recipient principal)
+                                         (burn-hash (buff 32))
+                                         (burn-height uint))
     (let 
         (
             (current-signer-data (contract-call? .sbtc-registry get-current-signer-data))

--- a/contracts/contracts/sbtc-deposit.clar
+++ b/contracts/contracts/sbtc-deposit.clar
@@ -59,9 +59,9 @@
     )
 )
 
+;; Return the bitcoin header hash of the bitcoin block at the given height.
 (define-read-only (get-burn-header (height uint))
-    ;; (get-burn-block-info? header-hash height)
-    (get-tenure-info? burnchain-header-hash height)
+    (get-burn-block-info? header-hash height)
 )
 
 ;; Accept multiple new deposit requests

--- a/contracts/contracts/sbtc-withdrawal.clar
+++ b/contracts/contracts/sbtc-withdrawal.clar
@@ -125,10 +125,6 @@
 ;;
 ;; To specify this address type in the recipient, the `version` is 0x06 and
 ;; the `hashbytes` is the "tweaked" public key.
-(define-read-only (get-burn-header (height uint))
-    ;; (get-burn-block-info? header-hash height)
-    (get-tenure-info? burnchain-header-hash height)
-)
 (define-public (initiate-withdrawal-request (amount uint)
                                             (recipient { version: (buff 1), hashbytes: (buff 32) })
                                             (max-fee uint)
@@ -302,4 +298,9 @@
       ERR_INVALID_ADDR_HASHBYTES)
     (ok true)
   )
+)
+
+;; Return the bitcoin header hash of the bitcoin block at the given height.
+(define-read-only (get-burn-header (height uint))
+    (get-burn-block-info? header-hash height)
 )

--- a/contracts/tests/sbtc-deposit.test.ts
+++ b/contracts/tests/sbtc-deposit.test.ts
@@ -14,14 +14,16 @@ import { CoreNodeEventType, cvToValue } from "@clarigen/core";
 describe("sBTC deposit contract", () => {
   describe("complete deposit contract setup (err 300)", () => {
     test("Fail complete-deposit-wrapper invalid txid length", () => {
+      const { burnHeight, burnHash } = getCurrentBurnInfo();
+
       const receipt = txErr(
         deposit.completeDepositWrapper({
           txid: new Uint8Array(31).fill(0),
           voutIndex: 0,
           amount: 1000n,
           recipient: deployer,
-          burnHash: new Uint8Array(32).fill(0),
-          burnHeight: 0n,
+          burnHash,
+          burnHeight,
         }),
         deployer
       );
@@ -29,14 +31,16 @@ describe("sBTC deposit contract", () => {
     });
 
     test("Fail complete-deposit-wrapper invalid low amount", () => {
+      const { burnHeight, burnHash } = getCurrentBurnInfo();
+
       const receipt = txErr(
         deposit.completeDepositWrapper({
           txid: new Uint8Array(32).fill(0),
           voutIndex: 0,
           amount: 10n,
           recipient: deployer,
-          burnHash: new Uint8Array(32).fill(0),
-          burnHeight: 0n,
+          burnHash,
+          burnHeight,
         }),
         deployer
       );
@@ -46,14 +50,16 @@ describe("sBTC deposit contract", () => {
     });
 
     test("Fail complete-deposit-wrapper replay deposit (err 301)", () => {
+      const { burnHeight, burnHash } = getCurrentBurnInfo();
+
       const receipt0 = txOk(
         deposit.completeDepositWrapper({
           txid: new Uint8Array(32).fill(0),
           voutIndex: 0,
           amount: 1000n,
           recipient: deployer,
-          burnHash: new Uint8Array(32).fill(0),
-          burnHeight: 0n,
+          burnHash,
+          burnHeight,
         }),
         deployer
       );
@@ -64,8 +70,8 @@ describe("sBTC deposit contract", () => {
           voutIndex: 0,
           amount: 1000n,
           recipient: deployer,
-          burnHash: new Uint8Array(32).fill(0),
-          burnHeight: 0n,
+          burnHash,
+          burnHeight,
         }),
         deployer
       );
@@ -73,14 +79,16 @@ describe("sBTC deposit contract", () => {
     });
 
     test("Fail complete-deposit-wrapper Bitcoin forked", () => {
+      const { burnHeight, burnHash } = getCurrentBurnInfo();
+
       const receipt0 = txOk(
         deposit.completeDepositWrapper({
           txid: new Uint8Array(32).fill(0),
           voutIndex: 0,
           amount: 1000n,
           recipient: deployer,
-          burnHash: new Uint8Array(32).fill(0),
-          burnHeight: 0n,
+          burnHash,
+          burnHeight,
         }),
         deployer
       );
@@ -93,7 +101,7 @@ describe("sBTC deposit contract", () => {
           amount: 1000n,
           recipient: deployer,
           burnHash: new Uint8Array(32).fill(1),
-          burnHeight: 0n,
+          burnHeight,
         }),
         deployer
       );
@@ -101,14 +109,16 @@ describe("sBTC deposit contract", () => {
     });
 
     test("Call complete-deposit-wrapper placeholder, check print", () => {
+      const { burnHeight, burnHash } = getCurrentBurnInfo();
+
       const receipt = txOk(
         deposit.completeDepositWrapper({
           txid: new Uint8Array(32).fill(0),
           voutIndex: 0,
           amount: 1000n,
           recipient: deployer,
-          burnHash: new Uint8Array(32).fill(0),
-          burnHeight: 0n,
+          burnHash,
+          burnHeight,
         }),
         deployer
       );
@@ -128,20 +138,22 @@ describe("sBTC deposit contract", () => {
         bitcoinTxid: new Uint8Array(32).fill(0),
         outputIndex: 0n,
         amount: 1000n,
-        burnHash: new Uint8Array(32).fill(0),
-        burnHeight: 0n,
+        burnHash,
+        burnHeight: BigInt(burnHeight),
       });
     });
 
     test("Call get-complete-deposit placeholder", () => {
+      const { burnHeight, burnHash } = getCurrentBurnInfo();
+
       txOk(
         deposit.completeDepositWrapper({
           txid: new Uint8Array(32).fill(0),
           voutIndex: 0,
           amount: 1000n,
           recipient: deployer,
-          burnHash: new Uint8Array(32).fill(0),
-          burnHeight: 0n,
+          burnHash,
+          burnHeight,
         }),
         deployer
       );
@@ -160,6 +172,8 @@ describe("sBTC deposit contract", () => {
   });
   describe("complete many deposits", () => {
     test("fail multiple deposits, first one fails due to txid length", () => {
+      const { burnHeight, burnHash } = getCurrentBurnInfo();
+
       const receipt = txErr(
         deposit.completeDepositsWrapper({
           deposits: [
@@ -168,16 +182,16 @@ describe("sBTC deposit contract", () => {
               voutIndex: 0,
               amount: 1000n,
               recipient: deployer,
-              burnHash: new Uint8Array(32).fill(0),
-              burnHeight: 0n,
+              burnHash,
+              burnHeight,
             },
             {
               txid: new Uint8Array(32).fill(1),
               voutIndex: 0,
               amount: 1000n,
               recipient: deployer,
-              burnHash: new Uint8Array(32).fill(0),
-              burnHeight: 0n,
+              burnHash,
+              burnHeight,
             },
           ],
           ...getCurrentBurnInfo(),
@@ -188,6 +202,8 @@ describe("sBTC deposit contract", () => {
       expect(receipt.value).toEqual(313n);
     });
     test("fail multiple deposits, second one fails due to low amount", () => {
+      const { burnHeight, burnHash } = getCurrentBurnInfo();
+
       const receipt = txErr(
         deposit.completeDepositsWrapper({
           deposits: [
@@ -196,16 +212,16 @@ describe("sBTC deposit contract", () => {
               voutIndex: 0,
               amount: 1000n,
               recipient: deployer,
-              burnHash: new Uint8Array(32).fill(0),
-              burnHeight: 0n,
+              burnHash,
+              burnHeight,
             },
             {
               txid: new Uint8Array(32).fill(1),
               voutIndex: 0,
               amount: 100n,
               recipient: deployer,
-              burnHash: new Uint8Array(32).fill(0),
-              burnHeight: 0n,
+              burnHash,
+              burnHeight,
             },
           ],
           ...getCurrentBurnInfo(),
@@ -216,6 +232,8 @@ describe("sBTC deposit contract", () => {
       expect(receipt.value).toEqual(314n);
     });
     test("fail multiple deposits, third one fails due to invalid caller", () => {
+      const { burnHeight, burnHash } = getCurrentBurnInfo();
+
       const receipt = txErr(
         deposit.completeDepositsWrapper({
           deposits: [
@@ -224,24 +242,24 @@ describe("sBTC deposit contract", () => {
               voutIndex: 0,
               amount: 1000n,
               recipient: deployer,
-              burnHash: new Uint8Array(32).fill(0),
-              burnHeight: 0n,
+              burnHash,
+              burnHeight,
             },
             {
               txid: new Uint8Array(32).fill(1),
               voutIndex: 0,
               amount: 1000n,
               recipient: deployer,
-              burnHash: new Uint8Array(32).fill(0),
-              burnHeight: 0n,
+              burnHash,
+              burnHeight,
             },
             {
               txid: new Uint8Array(32).fill(2),
               voutIndex: 0,
               amount: 100n,
               recipient: alice,
-              burnHash: new Uint8Array(32).fill(0),
-              burnHeight: 0n,
+              burnHash,
+              burnHeight,
             },
           ],
           ...getCurrentBurnInfo(),
@@ -252,6 +270,8 @@ describe("sBTC deposit contract", () => {
       expect(receipt.value).toEqual(315n);
     });
     test("complete multiple deposits successfully", () => {
+      const { burnHeight, burnHash } = getCurrentBurnInfo();
+
       const receipt = txOk(
         deposit.completeDepositsWrapper({
           deposits: [
@@ -260,16 +280,16 @@ describe("sBTC deposit contract", () => {
               voutIndex: 0,
               amount: 1000n,
               recipient: deployer,
-              burnHash: new Uint8Array(32).fill(0),
-              burnHeight: 0n,
+              burnHash,
+              burnHeight,
             },
             {
               txid: new Uint8Array(32).fill(1),
               voutIndex: 0,
               amount: 1000n,
               recipient: deployer,
-              burnHash: new Uint8Array(32).fill(0),
-              burnHeight: 0n,
+              burnHash,
+              burnHeight,
             },
           ],
           ...getCurrentBurnInfo(),
@@ -283,6 +303,8 @@ describe("sBTC deposit contract", () => {
 
 describe("optimization tests", () => {
   test("test maximum deposts that can be processed", () => {
+    const { burnHeight, burnHash } = getCurrentBurnInfo();
+
     const totalAmount = 1000000n;
     const runs = 650;
     const txids = randomPublicKeys(runs).map((pk) => pk.slice(0, 32));
@@ -293,8 +315,8 @@ describe("optimization tests", () => {
           voutIndex: 0,
           amount: totalAmount / BigInt(runs),
           recipient: deployer,
-          burnHash: new Uint8Array(32).fill(0),
-          burnHeight: 0n,
+          burnHash,
+          burnHeight,
         })),
         ...getCurrentBurnInfo(),
       }),

--- a/contracts/tests/sbtc-token.test.ts
+++ b/contracts/tests/sbtc-token.test.ts
@@ -1,4 +1,4 @@
-import { alice, bob, deployer, deposit, errors, token } from "./helpers";
+import { alice, bob, deployer, deposit, errors, getCurrentBurnInfo, token } from "./helpers";
 import { test, expect, describe } from "vitest";
 import { txOk, filterEvents, rov, txErr } from "@clarigen/test";
 import { CoreNodeEventType, cvToValue } from "@clarigen/core";
@@ -6,14 +6,15 @@ import { CoreNodeEventType, cvToValue } from "@clarigen/core";
 describe("sBTC token contract", () => {
   describe("token basics", () => {
     test("Mint sbtc token, check Alice balance", () => {
+      const { burnHeight, burnHash } = getCurrentBurnInfo();
       const receipt = txOk(
         deposit.completeDepositWrapper({
           txid: new Uint8Array(32).fill(0),
           voutIndex: 0,
           amount: 1000n,
           recipient: alice,
-          burnHash: new Uint8Array(32).fill(0),
-          burnHeight: 0n,
+          burnHash,
+          burnHeight,
         }),
         deployer
       );
@@ -33,8 +34,8 @@ describe("sBTC token contract", () => {
         bitcoinTxid: new Uint8Array(32).fill(0),
         outputIndex: 0n,
         amount: 1000n,
-        burnHash: new Uint8Array(32).fill(0),
-        burnHeight: 0n,
+        burnHash,
+        burnHeight: BigInt(burnHeight),
       });
       const receipt1 = rov(
         token.getBalance({
@@ -46,14 +47,15 @@ describe("sBTC token contract", () => {
     });
 
     test("Mint & transfer sbtc token, check Bob balance", () => {
+      const { burnHeight, burnHash } = getCurrentBurnInfo();
       const receipt = txOk(
         deposit.completeDepositWrapper({
           txid: new Uint8Array(32).fill(0),
           voutIndex: 0,
           amount: 1000n,
           recipient: alice,
-          burnHash: new Uint8Array(32).fill(0),
-          burnHeight: 0n,
+          burnHash,
+          burnHeight,
         }),
         deployer
       );
@@ -73,8 +75,8 @@ describe("sBTC token contract", () => {
         bitcoinTxid: new Uint8Array(32).fill(0),
         outputIndex: 0n,
         amount: 1000n,
-        burnHash: new Uint8Array(32).fill(0),
-        burnHeight: 0n,
+        burnHash,
+        burnHeight: BigInt(burnHeight)
       });
       const receipt1 = txOk(
         token.transfer({

--- a/contracts/tests/sbtc-withdrawal.test.ts
+++ b/contracts/tests/sbtc-withdrawal.test.ts
@@ -76,14 +76,15 @@ describe("Validating recipient address", () => {
 
 describe("initiating a withdrawal request", () => {
   test("alice can initiate a request", () => {
+    const { burnHeight, burnHash } = getCurrentBurnInfo();
     txOk(
       deposit.completeDepositWrapper({
         txid: new Uint8Array(32).fill(0),
         voutIndex: 0,
         amount: defaultAmount + (defaultMaxFee + 1n),
         recipient: alice,
-        burnHash: new Uint8Array(32).fill(0),
-        burnHeight: 0n,
+        burnHash,
+        burnHeight,
       }),
       deployer
     );
@@ -141,14 +142,15 @@ describe("initiating a withdrawal request", () => {
   });
 
   test("Tokens are converted to locked sBTC", () => {
+    const { burnHeight, burnHash } = getCurrentBurnInfo();
     txOk(
       deposit.completeDepositWrapper({
         txid: new Uint8Array(32).fill(0),
         voutIndex: 0,
         amount: defaultAmount + defaultMaxFee,
         recipient: alice,
-        burnHash: new Uint8Array(32).fill(0),
-        burnHeight: 0n,
+        burnHash,
+        burnHeight,
       }),
       deployer
     );
@@ -179,14 +181,15 @@ describe("initiating a withdrawal request", () => {
   });
 
   test("Recipient is validated when initiating an address", () => {
+    const { burnHeight, burnHash } = getCurrentBurnInfo();
     txOk(
       deposit.completeDepositWrapper({
         txid: new Uint8Array(32).fill(0),
         voutIndex: 0,
         amount: 4000n,
         recipient: alice,
-        burnHash: new Uint8Array(32).fill(0),
-        burnHeight: 0n,
+        burnHash,
+        burnHeight,
       }),
       deployer
     );
@@ -225,14 +228,15 @@ describe("initiating a withdrawal request", () => {
   });
 
   test("withdrawal amount of less than or equal to dust limit is rejected", () => {
+    const { burnHeight, burnHash } = getCurrentBurnInfo();
     txOk(
       deposit.completeDepositWrapper({
         txid: new Uint8Array(32).fill(0),
         voutIndex: 0,
         amount: 4000n,
         recipient: alice,
-        burnHash: new Uint8Array(32).fill(0),
-        burnHeight: 0n,
+        burnHash,
+        burnHeight,
       }),
       deployer
     );
@@ -249,14 +253,15 @@ describe("initiating a withdrawal request", () => {
 });
 
 test("max-fee must be accounted for", () => {
+  const { burnHeight, burnHash } = getCurrentBurnInfo();
   txOk(
     deposit.completeDepositWrapper({
       txid: new Uint8Array(32).fill(0),
       voutIndex: 0,
       amount: 4000n,
       recipient: alice,
-      burnHash: new Uint8Array(32).fill(0),
-      burnHeight: 0n,
+      burnHash,
+      burnHeight,
     }),
     deployer
   );
@@ -282,14 +287,15 @@ test("max-fee must be accounted for", () => {
 describe("Accepting a withdrawal request", () => {
   test("Fails with non-existant request-id", () => {
     // Alice initiates withdrawalrequest
+    const { burnHeight, burnHash } = getCurrentBurnInfo();
     txOk(
       deposit.completeDepositWrapper({
         txid: new Uint8Array(32).fill(0),
         voutIndex: 0,
         amount: defaultAmount + defaultMaxFee,
         recipient: alice,
-        burnHash: new Uint8Array(32).fill(0),
-        burnHeight: 0n,
+        burnHash,
+        burnHeight,
       }),
       deployer
     );
@@ -308,8 +314,8 @@ describe("Accepting a withdrawal request", () => {
         signerBitmap: 0n,
         outputIndex: 10n,
         fee: 1n,
-        burnHash: new Uint8Array(32).fill(0),
-        burnHeight: 0n,
+        burnHash,
+        burnHeight,
       }),
       deployer
     );
@@ -317,14 +323,15 @@ describe("Accepting a withdrawal request", () => {
   });
   test("Fails when called by non-signer", () => {
     // Alice initiates withdrawalrequest
+    const { burnHeight, burnHash } = getCurrentBurnInfo();
     txOk(
       deposit.completeDepositWrapper({
         txid: new Uint8Array(32).fill(0),
         voutIndex: 0,
         amount: defaultAmount + defaultMaxFee,
         recipient: alice,
-        burnHash: new Uint8Array(32).fill(0),
-        burnHeight: 0n,
+        burnHash,
+        burnHeight,
       }),
       deployer
     );
@@ -343,8 +350,8 @@ describe("Accepting a withdrawal request", () => {
         signerBitmap: 0n,
         outputIndex: 10n,
         fee: 1n,
-        burnHash: new Uint8Array(32).fill(0),
-        burnHeight: 0n,
+        burnHash,
+        burnHeight,
       }),
       alice
     );
@@ -352,14 +359,15 @@ describe("Accepting a withdrawal request", () => {
   });
   test("Fails when replay is attempted", () => {
     // Alice initiates withdrawalrequest
+    const { burnHeight, burnHash } = getCurrentBurnInfo();
     txOk(
       deposit.completeDepositWrapper({
         txid: new Uint8Array(32).fill(0),
         voutIndex: 0,
         amount: defaultAmount + defaultMaxFee,
         recipient: alice,
-        burnHash: new Uint8Array(32).fill(0),
-        burnHeight: 0n,
+        burnHash,
+        burnHeight,
       }),
       deployer
     );
@@ -378,8 +386,8 @@ describe("Accepting a withdrawal request", () => {
         signerBitmap: 0n,
         outputIndex: 10n,
         fee: 1n,
-        burnHash: new Uint8Array(32).fill(0),
-        burnHeight: 0n,
+        burnHash,
+        burnHeight,
       }),
       deployer
     );
@@ -390,8 +398,8 @@ describe("Accepting a withdrawal request", () => {
         signerBitmap: 0n,
         outputIndex: 10n,
         fee: 1n,
-        burnHash: new Uint8Array(32).fill(0),
-        burnHeight: 0n,
+        burnHash,
+        burnHeight,
       }),
       deployer
     );
@@ -399,14 +407,15 @@ describe("Accepting a withdrawal request", () => {
   });
   test("Fails when fee is too high", () => {
     // Alice initiates withdrawalrequest
+    const { burnHeight, burnHash } = getCurrentBurnInfo();
     txOk(
       deposit.completeDepositWrapper({
         txid: new Uint8Array(32).fill(0),
         voutIndex: 0,
         amount: defaultAmount + defaultMaxFee,
         recipient: alice,
-        burnHash: new Uint8Array(32).fill(0),
-        burnHeight: 0n,
+        burnHash,
+        burnHeight,
       }),
       deployer
     );
@@ -425,8 +434,8 @@ describe("Accepting a withdrawal request", () => {
         signerBitmap: 0n,
         outputIndex: 10n,
         fee: 11n,
-        burnHash: new Uint8Array(32).fill(0),
-        burnHeight: 0n,
+        burnHash,
+        burnHeight,
       }),
       deployer
     );
@@ -434,14 +443,15 @@ describe("Accepting a withdrawal request", () => {
   });
   test("Request is successfully accepted with max fee", () => {
     // Alice initiates withdrawalrequest
+    const { burnHeight, burnHash } = getCurrentBurnInfo();
     txOk(
       deposit.completeDepositWrapper({
         txid: new Uint8Array(32).fill(0),
         voutIndex: 0,
         amount: defaultAmount + (defaultMaxFee + 10n),
         recipient: alice,
-        burnHash: new Uint8Array(32).fill(0),
-        burnHeight: 0n,
+        burnHash,
+        burnHeight,
       }),
       deployer
     );
@@ -460,8 +470,8 @@ describe("Accepting a withdrawal request", () => {
         signerBitmap: 2n,
         outputIndex: 10n,
         fee: defaultMaxFee + 10n,
-        burnHash: new Uint8Array(32).fill(0),
-        burnHeight: 0n,
+        burnHash,
+        burnHeight,
       }),
       deployer
     );
@@ -493,20 +503,21 @@ describe("Accepting a withdrawal request", () => {
       outputIndex: 10n,
       topic: "withdrawal-accept",
       fee: defaultMaxFee + 10n,
-      burnHash: new Uint8Array(32).fill(0),
-      burnHeight: 0n,
+      burnHash,
+      burnHeight: BigInt(burnHeight),
     });
   });
   test("accept withdrawal sets withdrawal-status to true", () => {
     // Alice initiates withdrawalrequest
+    const { burnHeight, burnHash } = getCurrentBurnInfo();
     txOk(
       deposit.completeDepositWrapper({
         txid: new Uint8Array(32).fill(0),
         voutIndex: 0,
         amount: defaultAmount + defaultMaxFee,
         recipient: alice,
-        burnHash: new Uint8Array(32).fill(0),
-        burnHeight: 0n,
+        burnHash,
+        burnHeight: BigInt(burnHeight),
       }),
       deployer
     );
@@ -525,8 +536,8 @@ describe("Accepting a withdrawal request", () => {
         signerBitmap: 0n,
         outputIndex: 10n,
         fee: defaultMaxFee,
-        burnHash: new Uint8Array(32).fill(0),
-        burnHeight: 0n,
+        burnHash,
+        burnHeight,
       }),
       deployer
     );
@@ -553,14 +564,15 @@ describe("Accepting a withdrawal request", () => {
     expect(rovOk(token.getBalanceAvailable(alice))).toEqual(0n);
     expect(rovOk(token.getBalanceLocked(alice))).toEqual(0n);
     // Alice initiates withdrawalrequest
+    const { burnHeight, burnHash } = getCurrentBurnInfo();
     txOk(
       deposit.completeDepositWrapper({
         txid: new Uint8Array(32).fill(0),
         voutIndex: 0,
         amount: defaultAmount + defaultMaxFee,
         recipient: alice,
-        burnHash: new Uint8Array(32).fill(0),
-        burnHeight: 0n,
+        burnHash,
+        burnHeight,
       }),
       deployer
     );
@@ -641,6 +653,7 @@ describe("Accepting a withdrawal request", () => {
     });
   });
   test("Request is successfully accepted with fee less than max", () => {
+    const { burnHeight, burnHash } = getCurrentBurnInfo();
     // Alice initiates withdrawalrequest
     txOk(
       deposit.completeDepositWrapper({
@@ -648,8 +661,8 @@ describe("Accepting a withdrawal request", () => {
         voutIndex: 0,
         amount: defaultAmount + defaultMaxFee,
         recipient: alice,
-        burnHash: new Uint8Array(32).fill(0),
-        burnHeight: 0n,
+        burnHash,
+        burnHeight,
       }),
       deployer
     );
@@ -668,8 +681,8 @@ describe("Accepting a withdrawal request", () => {
         signerBitmap: 0n,
         outputIndex: 10n,
         fee: 9n,
-        burnHash: new Uint8Array(32).fill(0),
-        burnHeight: 0n,
+        burnHash,
+        burnHeight,
       }),
       deployer
     );
@@ -679,6 +692,7 @@ describe("Accepting a withdrawal request", () => {
 
 describe("Reject a withdrawal request", () => {
   test("Fails with non-existant request-id", () => {
+    const { burnHeight, burnHash } = getCurrentBurnInfo();
     // Alice initiates withdrawalrequest
     txOk(
       deposit.completeDepositWrapper({
@@ -686,8 +700,8 @@ describe("Reject a withdrawal request", () => {
         voutIndex: 0,
         amount: defaultAmount + defaultMaxFee,
         recipient: alice,
-        burnHash: new Uint8Array(32).fill(0),
-        burnHeight: 0n,
+        burnHash,
+        burnHeight,
       }),
       deployer
     );
@@ -709,6 +723,7 @@ describe("Reject a withdrawal request", () => {
     expect(receipt.value).toEqual(errors.withdrawal.ERR_INVALID_REQUEST);
   });
   test("Fails when called by a non-signer", () => {
+    const { burnHeight, burnHash } = getCurrentBurnInfo();
     // Alice initiates withdrawalrequest
     txOk(
       deposit.completeDepositWrapper({
@@ -716,8 +731,8 @@ describe("Reject a withdrawal request", () => {
         voutIndex: 0,
         amount: defaultAmount + defaultMaxFee,
         recipient: alice,
-        burnHash: new Uint8Array(32).fill(0),
-        burnHeight: 0n,
+        burnHash,
+        burnHeight,
       }),
       deployer
     );
@@ -739,6 +754,7 @@ describe("Reject a withdrawal request", () => {
     expect(receipt.value).toEqual(errors.withdrawal.ERR_INVALID_CALLER);
   });
   test("Fails when request id is replayed", () => {
+    const { burnHeight, burnHash } = getCurrentBurnInfo();
     // Alice initiates withdrawalrequest
     txOk(
       deposit.completeDepositWrapper({
@@ -746,8 +762,8 @@ describe("Reject a withdrawal request", () => {
         voutIndex: 0,
         amount: defaultAmount + defaultMaxFee,
         recipient: alice,
-        burnHash: new Uint8Array(32).fill(0),
-        burnHeight: 0n,
+        burnHash,
+        burnHeight,
       }),
       deployer
     );
@@ -766,8 +782,8 @@ describe("Reject a withdrawal request", () => {
         signerBitmap: 0n,
         outputIndex: 10n,
         fee: 10n,
-        burnHash: new Uint8Array(32).fill(0),
-        burnHeight: 0n,
+        burnHash,
+        burnHeight,
       }),
       deployer
     );
@@ -781,6 +797,7 @@ describe("Reject a withdrawal request", () => {
     expect(receipt.value).toEqual(errors.withdrawal.ERR_ALREADY_PROCESSED);
   });
   test("Fails when Bitcoin forks", () => {
+    const { burnHeight, burnHash } = getCurrentBurnInfo();
     // Alice initiates withdrawalrequest
     txOk(
       deposit.completeDepositWrapper({
@@ -788,8 +805,8 @@ describe("Reject a withdrawal request", () => {
         voutIndex: 0,
         amount: defaultAmount + defaultMaxFee,
         recipient: alice,
-        burnHash: new Uint8Array(32).fill(0),
-        burnHeight: 0n,
+        burnHash,
+        burnHeight,
       }),
       deployer
     );
@@ -822,7 +839,8 @@ describe("Reject a withdrawal request", () => {
     // Where index is 1 in this case & ERR_WITHDRAWAL_INDEX_PREFIX is 507
     expect(receipt.value).toEqual(517n);
   });
-  test("Successfully reject a requested withdrawal", () => {
+  test("accept-withdrawal fails when Bitcoin forks", () => {
+    const { burnHeight, burnHash } = getCurrentBurnInfo();
     // Alice initiates withdrawalrequest
     txOk(
       deposit.completeDepositWrapper({
@@ -830,8 +848,45 @@ describe("Reject a withdrawal request", () => {
         voutIndex: 0,
         amount: defaultAmount + defaultMaxFee,
         recipient: alice,
-        burnHash: new Uint8Array(32).fill(0),
-        burnHeight: 0n,
+        burnHash,
+        burnHeight,
+      }),
+      deployer
+    );
+    txOk(
+      withdrawal.initiateWithdrawalRequest({
+        amount: 1000n,
+        recipient: alicePoxAddr,
+        maxFee: defaultMaxFee,
+      }),
+      alice
+    );
+    const receipt = txErr(
+      withdrawal.acceptWithdrawalRequest({
+          requestId: 1n,
+          signerBitmap: 1n,
+          bitcoinTxid: new Uint8Array(32).fill(1),
+          outputIndex: 10n,
+          fee: 10n,
+          burnHash: new Uint8Array(32).fill(2),
+          burnHeight,
+      }),
+      deployer
+    );
+
+    expect(receipt.value).toEqual(errors.withdrawal.ERR_INVALID_BURN_HASH);
+  });
+  test("Successfully reject a requested withdrawal", () => {
+    const { burnHeight, burnHash } = getCurrentBurnInfo();
+    // Alice initiates withdrawalrequest
+    txOk(
+      deposit.completeDepositWrapper({
+        txid: new Uint8Array(32).fill(0),
+        voutIndex: 0,
+        amount: defaultAmount + defaultMaxFee,
+        recipient: alice,
+        burnHash,
+        burnHeight,
       }),
       deployer
     );
@@ -850,8 +905,8 @@ describe("Reject a withdrawal request", () => {
         signerBitmap: 0n,
         outputIndex: 10n,
         fee: defaultMaxFee,
-        burnHash: new Uint8Array(32).fill(0),
-        burnHeight: 0n,
+        burnHash,
+        burnHeight,
       }),
       deployer
     );
@@ -861,6 +916,7 @@ describe("Reject a withdrawal request", () => {
 
 describe("Complete multiple withdrawals", () => {
   test("Successfully pass in two withdrawals, one accept, one reject", () => {
+    const { burnHeight, burnHash } = getCurrentBurnInfo();
     // Alice setup
     txOk(
       deposit.completeDepositWrapper({
@@ -868,8 +924,8 @@ describe("Complete multiple withdrawals", () => {
         voutIndex: 0,
         amount: defaultAmount + defaultMaxFee,
         recipient: alice,
-        burnHash: new Uint8Array(32).fill(0),
-        burnHeight: 0n,
+        burnHash,
+        burnHeight,
       }),
       deployer
     );
@@ -888,8 +944,8 @@ describe("Complete multiple withdrawals", () => {
         voutIndex: 1,
         amount: defaultAmount + defaultMaxFee,
         recipient: bob,
-        burnHash: new Uint8Array(32).fill(0),
-        burnHeight: 0n,
+        burnHash,
+        burnHeight,
       }),
       deployer
     );
@@ -937,6 +993,7 @@ describe("Complete multiple withdrawals", () => {
 
 describe("optimization tests for completing withdrawals", () => {
   test("maximizing the number of withdrawal completions in one tx", () => {
+    const { burnHeight, burnHash } = getCurrentBurnInfo();
     const totalAmount = 1000000n;
     const runs = 300;
     const perAmount = totalAmount / BigInt(runs);
@@ -950,8 +1007,8 @@ describe("optimization tests for completing withdrawals", () => {
           voutIndex: 0,
           amount: perAmount + maxFee,
           recipient: alice,
-          burnHash: new Uint8Array(32).fill(0),
-          burnHeight: 0n,
+          burnHash,
+          burnHeight,
         }),
         deployer
       );
@@ -964,7 +1021,7 @@ describe("optimization tests for completing withdrawals", () => {
         alice
       );
     }
-    const { burnHeight, burnHash } = getCurrentBurnInfo();
+
     txOk(
       withdrawal.completeWithdrawals({
         withdrawals: txids.map((txid, index) => {


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/779.

## Changes

* Use `get-burn-block-info?` instead of `get-tenure-info?`.
* Update all of our tests, add one more.

## Testing Information

I tested this locally in our local devnet and things worked as expected.

## Checklist:

- [x] I have performed a self-review of my code
