### PR TITLE
fix: stop at nakamoto block height

### DIFF
--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -17,7 +17,6 @@
 //! - Update signer set transactions
 //! - Set aggregate key transactions
 
-use std::collections::HashMap;
 use std::future::Future;
 
 use crate::bitcoin::rpc::BitcoinTxInfo;
@@ -27,16 +26,15 @@ use crate::context::SignerEvent;
 use crate::emily_client::EmilyInteract;
 use crate::error::Error;
 use crate::stacks::api::StacksInteract;
+use crate::stacks::api::TenureBlocks;
 use crate::storage;
 use crate::storage::model;
-use crate::storage::model::BitcoinBlockHash;
 use crate::storage::DbRead;
 use crate::storage::DbWrite;
 use bitcoin::hashes::Hash as _;
 use bitcoin::BlockHash;
 use bitcoin::ScriptBuf;
 use bitcoin::Transaction;
-use blockstack_lib::chainstate::nakamoto;
 use futures::stream::StreamExt;
 use sbtc::deposits::CreateDepositRequest;
 use sbtc::deposits::DepositInfo;
@@ -431,36 +429,19 @@ where
         Ok(())
     }
 
-    async fn write_stacks_blocks(&self, blocks: &[nakamoto::NakamotoBlock]) -> Result<(), Error> {
+    async fn write_stacks_blocks(&self, tenures: &[TenureBlocks]) -> Result<(), Error> {
         let deployer = &self.context.config().signer.deployer;
-        let txs = storage::postgres::extract_relevant_transactions(blocks, deployer);
-
-        let unique_consensus_hashes = blocks
+        let txs = tenures
             .iter()
-            .map(|block| block.header.consensus_hash)
-            .collect::<HashSet<_>>();
-        let mut consensus_hashes = HashMap::new();
-        for consensus_hash in unique_consensus_hashes {
-            let anchor_block: BitcoinBlockHash = self
-                .stacks_client
-                .get_sortition_info(&consensus_hash)
-                .await?
-                .burn_block_hash
-                .into();
-            consensus_hashes.insert(consensus_hash, anchor_block);
-        }
-
-        let headers = blocks
-            .iter()
-            .map(|block| {
-                Ok(model::StacksBlock::from_nakamoto_block(
-                    block,
-                    consensus_hashes
-                        .get(&block.header.consensus_hash)
-                        .ok_or(Error::MissingBlock)?,
-                ))
+            .flat_map(|tenure| {
+                storage::postgres::extract_relevant_transactions(&tenure.blocks, deployer)
             })
-            .collect::<Result<_, Error>>()?;
+            .collect::<Vec<_>>();
+
+        let headers = tenures
+            .iter()
+            .flat_map(TenureBlocks::as_stacks_blocks)
+            .collect::<Vec<_>>();
 
         let storage = self.context.get_storage_mut();
         storage.write_stacks_block_headers(headers).await?;

--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -434,7 +434,7 @@ where
         let txs = tenures
             .iter()
             .flat_map(|tenure| {
-                storage::postgres::extract_relevant_transactions(&tenure.blocks, deployer)
+                storage::postgres::extract_relevant_transactions(tenure.blocks(), deployer)
             })
             .collect::<Vec<_>>();
 

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -44,6 +44,10 @@ pub enum Error {
     #[error("bitcoin validation error: {0}")]
     BitcoinValidation(#[from] Box<crate::bitcoin::validation::BitcoinValidationError>),
 
+    /// This should never happen
+    #[error("observed a tenure identified by a StacksBlockId with with no blocks")]
+    EmptyStacksTenure,
+
     /// Received an error in call to estimatesmartfee RPC call
     #[error("failed to get fee estimate from bitcoin-core for target {1}. {0}")]
     EstimateSmartFee(#[source] bitcoincore_rpc::Error, u16),

--- a/signer/src/stacks/api.rs
+++ b/signer/src/stacks/api.rs
@@ -1377,6 +1377,20 @@ mod tests {
             .expect(1)
             .create();
 
+        let path = format!("/Users/dan/repos/sbtc/signer/tests/fixtures/stacksapi-v3-sortitions.json");
+        let mut file = std::fs::File::open(path).unwrap();
+        let mut buf = Vec::new();
+        file.read_to_end(&mut buf).unwrap();
+
+        stacks_node_server
+            .mock("GET", "/v3/sortitions/consensus/f9fff2c4c5e5f55788bbd62f6b41aeba99d982fd")
+            .with_status(200)
+            .with_header("content-type", "application/octet-stream")
+            .with_header("transfer-encoding", "chunked")
+            .with_chunked_body(move |w| w.write_all(&buf))
+            .expect(1)
+            .create();
+
         // The StacksClient::get_blocks call should make at least two
         // requests to the stacks node if there are two or more Nakamoto
         // blocks within the same tenure. Our test setup has 23 blocks

--- a/signer/src/stacks/api.rs
+++ b/signer/src/stacks/api.rs
@@ -1377,13 +1377,14 @@ mod tests {
             .expect(1)
             .create();
 
-        let path = format!("/Users/dan/repos/sbtc/signer/tests/fixtures/stacksapi-v3-sortitions.json");
+        let path = format!("tests/fixtures/stacksapi-v3-sortitions.json");
         let mut file = std::fs::File::open(path).unwrap();
         let mut buf = Vec::new();
         file.read_to_end(&mut buf).unwrap();
 
+        let called_endpoint = "/v3/sortitions/consensus/f9fff2c4c5e5f55788bbd62f6b41aeba99d982fd";
         stacks_node_server
-            .mock("GET", "/v3/sortitions/consensus/f9fff2c4c5e5f55788bbd62f6b41aeba99d982fd")
+            .mock("GET", called_endpoint)
             .with_status(200)
             .with_header("content-type", "application/octet-stream")
             .with_header("transfer-encoding", "chunked")

--- a/signer/src/stacks/api.rs
+++ b/signer/src/stacks/api.rs
@@ -192,7 +192,7 @@ pub trait StacksInteract: Send + Sync {
     /// Get information about the current node.
     fn get_node_info(&self) -> impl Future<Output = Result<RPCPeerInfoData, Error>> + Send;
 
-    /// Get the source of the a deployed smart contract.
+    /// Get the source of a deployed smart contract.
     ///
     /// # Notes
     ///
@@ -253,25 +253,25 @@ impl TenureBlocks {
         })
     }
 
-    /// Get all of the blocks contained in this object.
+    /// Get all the blocks contained in this object.
     ///
     /// # Note
     ///
-    /// The struct need not contain all of the blocks in a tenure.
+    /// The struct need not contain all the blocks in a tenure.
     pub fn blocks(&self) -> &[NakamotoBlock] {
         &self.blocks
     }
 
-    /// Return all of the blocks contained in this object.
+    /// Return all the blocks contained in this object.
     ///
     /// # Note
     ///
-    /// The struct need not contain all of the blocks in a tenure.
+    /// The struct need not contain all the blocks in a tenure.
     pub fn into_blocks(self) -> Vec<NakamotoBlock> {
         self.blocks
     }
 
-    /// Return an iterator of Stacks blocks from the this tenure.
+    /// Return an iterator of Stacks blocks included in this object.
     pub fn as_stacks_blocks(&self) -> impl Iterator<Item = StacksBlock> + '_ {
         let bitcoin_anchor = &self.anchor_block_hash;
         self.blocks
@@ -532,7 +532,7 @@ impl StacksClient {
             .and_then(AccountInfo::try_from)
     }
 
-    /// Get the source of the a deployed smart contract.
+    /// Get the source of a deployed smart contract.
     ///
     /// # Notes
     ///
@@ -734,7 +734,7 @@ impl StacksClient {
 
         // If Self::get_tenure_raw returns with Ok(_) then the Vec will
         // include at least 1 Nakamoto block. Since we bail if there is an
-        // error, this vector has a last element.
+        // error, this vector has at least one element.
         let Some(block) = tenure_blocks.last() else {
             return Err(Error::EmptyStacksTenure);
         };
@@ -1146,7 +1146,7 @@ impl StacksInteract for StacksClient {
         self.get_node_info().await
     }
 
-    /// Get the source of the a deployed smart contract.
+    /// Get the source of a deployed smart contract.
     ///
     /// # Notes
     ///

--- a/signer/src/stacks/api.rs
+++ b/signer/src/stacks/api.rs
@@ -257,7 +257,7 @@ impl TenureBlocks {
     ///
     /// # Note
     ///
-    /// The struct need not contain all the blocks in a tenure.
+    /// The struct doesn't need to contain all the blocks in a tenure.
     pub fn blocks(&self) -> &[NakamotoBlock] {
         &self.blocks
     }
@@ -266,7 +266,7 @@ impl TenureBlocks {
     ///
     /// # Note
     ///
-    /// The struct need not contain all the blocks in a tenure.
+    /// The struct doesn't need to contain all the blocks in a tenure.
     pub fn into_blocks(self) -> Vec<NakamotoBlock> {
         self.blocks
     }

--- a/signer/src/stacks/api.rs
+++ b/signer/src/stacks/api.rs
@@ -915,11 +915,6 @@ where
     while let Some(tenure) = blocks.last() {
         // We won't get anymore Nakamoto blocks before this point, so
         // time to stop.
-        //
-        // TODO: This check is technically incorrect. The nakamoto start height
-        // is the _bitcoin block height_ at which Stacks epoch 3.0 activates.
-        // stacks.get_block() will fail if it's requested a pre-nakamoto block,
-        // but I'm not sure about the stacks.get_tenure() down below.
         if tenure.anchor_block_height <= nakamoto_start_height {
             tracing::info!(
                 %nakamoto_start_height,

--- a/signer/src/stacks/api.rs
+++ b/signer/src/stacks/api.rs
@@ -226,12 +226,12 @@ impl GetNakamotoStartHeight for RPCPoxInfoData {
     }
 }
 
-/// This struct represents a subset of the Stacks blocks that were created
-/// during a tenure.
+/// This struct represents a non-empty subset of the Stacks blocks that
+/// were created during a tenure.
 #[derive(Debug)]
 pub struct TenureBlocks {
-    /// The Stacks blocks that were created during a tenure. This is always
-    /// non-empty.
+    /// The subset of Stacks blocks that were created during a tenure. This
+    /// is always non-empty.
     blocks: Vec<NakamotoBlock>,
     /// The bitcoin block that this tenure builds off of.
     pub anchor_block_hash: BitcoinBlockHash,
@@ -262,7 +262,7 @@ impl TenureBlocks {
         &self.blocks
     }
 
-    /// Get all of the blocks contained in this object.
+    /// Return all of the blocks contained in this object.
     ///
     /// # Note
     ///
@@ -271,7 +271,7 @@ impl TenureBlocks {
         self.blocks
     }
 
-    /// Return a vector of Stacks blocks from the this tenure.
+    /// Return an iterator of Stacks blocks from the this tenure.
     pub fn as_stacks_blocks(&self) -> impl Iterator<Item = StacksBlock> + '_ {
         let bitcoin_anchor = &self.anchor_block_hash;
         self.blocks

--- a/signer/src/testing/block_observer.rs
+++ b/signer/src/testing/block_observer.rs
@@ -40,7 +40,6 @@ use crate::stacks::api::SubmitTxResponse;
 use crate::stacks::api::TenureBlocks;
 use crate::stacks::wallet::SignerWallet;
 use crate::storage::model;
-use crate::storage::model::BitcoinBlockHash;
 use crate::testing::dummy;
 use crate::util::ApiFallbackClient;
 
@@ -279,11 +278,7 @@ impl StacksInteract for TestHarness {
             .cloned()
             .collect();
 
-        Ok(TenureBlocks {
-            blocks,
-            anchor_block_hash: BitcoinBlockHash::from(block_id.0),
-            anchor_block_height: stx_block.header.chain_length,
-        })
+        TenureBlocks::from_blocks(blocks)
     }
     async fn get_tenure_info(&self) -> Result<RPCGetTenureInfo, Error> {
         let (_, _, btc_block_id) = self.stacks_blocks.last().unwrap();

--- a/signer/src/testing/block_observer.rs
+++ b/signer/src/testing/block_observer.rs
@@ -37,8 +37,10 @@ use crate::stacks::api::AccountInfo;
 use crate::stacks::api::FeePriority;
 use crate::stacks::api::StacksInteract;
 use crate::stacks::api::SubmitTxResponse;
+use crate::stacks::api::TenureBlocks;
 use crate::stacks::wallet::SignerWallet;
 use crate::storage::model;
+use crate::storage::model::BitcoinBlockHash;
 use crate::testing::dummy;
 use crate::util::ApiFallbackClient;
 
@@ -260,7 +262,7 @@ impl StacksInteract for TestHarness {
             .cloned()
             .ok_or(Error::MissingBlock)
     }
-    async fn get_tenure(&self, block_id: StacksBlockId) -> Result<Vec<NakamotoBlock>, Error> {
+    async fn get_tenure(&self, block_id: StacksBlockId) -> Result<TenureBlocks, Error> {
         let (stx_block_id, stx_block, btc_block_id) = self
             .stacks_blocks
             .iter()
@@ -277,7 +279,11 @@ impl StacksInteract for TestHarness {
             .cloned()
             .collect();
 
-        Ok(blocks)
+        Ok(TenureBlocks {
+            blocks,
+            anchor_block_hash: BitcoinBlockHash::from(block_id.0),
+            anchor_block_height: stx_block.header.chain_length,
+        })
     }
     async fn get_tenure_info(&self) -> Result<RPCGetTenureInfo, Error> {
         let (_, _, btc_block_id) = self.stacks_blocks.last().unwrap();

--- a/signer/src/testing/context.rs
+++ b/signer/src/testing/context.rs
@@ -14,6 +14,7 @@ use blockstack_lib::{
 use clarity::types::chainstate::{StacksAddress, StacksBlockId};
 use tokio::sync::{broadcast, Mutex};
 
+use crate::stacks::api::TenureBlocks;
 use crate::stacks::wallet::SignerWallet;
 use crate::{
     bitcoin::{
@@ -317,7 +318,7 @@ impl StacksInteract for WrappedMock<MockStacksInteract> {
         self.inner.lock().await.get_block(block_id).await
     }
 
-    async fn get_tenure(&self, block_id: StacksBlockId) -> Result<Vec<NakamotoBlock>, Error> {
+    async fn get_tenure(&self, block_id: StacksBlockId) -> Result<TenureBlocks, Error> {
         self.inner.lock().await.get_tenure(block_id).await
     }
 

--- a/signer/src/testing/mod.rs
+++ b/signer/src/testing/mod.rs
@@ -8,6 +8,7 @@ pub mod context;
 pub mod dummy;
 pub mod message;
 pub mod network;
+pub mod stacks;
 pub mod storage;
 pub mod transaction_coordinator;
 pub mod transaction_signer;

--- a/signer/src/testing/stacks.rs
+++ b/signer/src/testing/stacks.rs
@@ -11,7 +11,8 @@ use stacks_common::types::chainstate::SortitionId;
 use crate::error::Error;
 use crate::stacks::api::TenureBlocks;
 
-const DUMMY_SORTITION_INFO: SortitionInfo = SortitionInfo {
+/// Some dummy sortition info
+pub const DUMMY_SORTITION_INFO: SortitionInfo = SortitionInfo {
     burn_block_hash: BurnchainHeaderHash([0; 32]),
     burn_block_height: 0,
     burn_header_timestamp: 0,
@@ -27,12 +28,12 @@ const DUMMY_SORTITION_INFO: SortitionInfo = SortitionInfo {
 
 impl TenureBlocks {
     /// Create a TenureBlocks struct that is basically empty.
-    pub fn nearly_empty() -> Self {
+    pub fn nearly_empty() -> Result<Self, Error> {
         let block = NakamotoBlock {
             header: NakamotoBlockHeader::empty(),
             txs: Vec::new(),
         };
-        Self::try_new(vec![block], DUMMY_SORTITION_INFO).unwrap()
+        Self::try_new(vec![block], DUMMY_SORTITION_INFO)
     }
 
     /// Create TenureBlocks with some dummy sortition info.

--- a/signer/src/testing/stacks.rs
+++ b/signer/src/testing/stacks.rs
@@ -1,0 +1,42 @@
+//! Test utilities from the stacks module
+//!
+
+use blockstack_lib::chainstate::nakamoto::NakamotoBlock;
+use blockstack_lib::chainstate::nakamoto::NakamotoBlockHeader;
+use blockstack_lib::net::api::getsortition::SortitionInfo;
+use stacks_common::types::chainstate::BurnchainHeaderHash;
+use stacks_common::types::chainstate::ConsensusHash;
+use stacks_common::types::chainstate::SortitionId;
+
+use crate::error::Error;
+use crate::stacks::api::TenureBlocks;
+
+const DUMMY_SORTITION_INFO: SortitionInfo = SortitionInfo {
+    burn_block_hash: BurnchainHeaderHash([0; 32]),
+    burn_block_height: 0,
+    burn_header_timestamp: 0,
+    sortition_id: SortitionId([0; 32]),
+    parent_sortition_id: SortitionId([0; 32]),
+    consensus_hash: ConsensusHash([0; 20]),
+    was_sortition: false,
+    miner_pk_hash160: None,
+    stacks_parent_ch: None,
+    last_sortition_ch: None,
+    committed_block_hash: None,
+};
+
+impl TenureBlocks {
+    /// Create a TenureBlocks struct that is basically empty.
+    pub fn nearly_empty() -> Self {
+        let block = NakamotoBlock {
+            header: NakamotoBlockHeader::empty(),
+            txs: Vec::new(),
+        };
+        Self::try_new(vec![block], DUMMY_SORTITION_INFO).unwrap()
+    }
+
+    /// Create TenureBlocks with some dummy sortition info.
+    pub fn from_blocks(blocks: Vec<NakamotoBlock>) -> Result<Self, Error> {
+        Self::try_new(blocks, DUMMY_SORTITION_INFO)
+    }
+}

--- a/signer/tests/fixtures/stacksapi-v3-sortitions.json
+++ b/signer/tests/fixtures/stacksapi-v3-sortitions.json
@@ -1,0 +1,15 @@
+[
+    {
+        "burn_block_hash": "0x31b0f8c03daab94ffbd49fef21de4db3e8ad9c79a49481eb50debcbc146301ba",
+        "burn_block_height": 245,
+        "burn_header_timestamp": 1730916467,
+        "sortition_id": "0x54aeb326b22bf7be52fa908af4f3eae3ac0be378522d14d497275c42abef53ff",
+        "parent_sortition_id": "0xcbff5b55f39f0d735a0122c972ca9cc47922191ec897d47c766ed96da928ec21",
+        "consensus_hash": "0xc6baa8978455ef2ba7459356645798c209e3263a",
+        "was_sortition": true,
+        "miner_pk_hash160": "0xb6c8b1779e32f9468ff4ed56d0669a5943313ca2",
+        "stacks_parent_ch": "0xd8ac51c935a4ab9fdcfaf121d6e25ab89620b262",
+        "last_sortition_ch": "0xd8ac51c935a4ab9fdcfaf121d6e25ab89620b262",
+        "committed_block_hash": "0x8080e1b66c199d9bf5b9058b9cd99923c8031d3ccc8bdb19fac135e05bf5e4a9"
+    }
+]

--- a/signer/tests/integration/block_observer.rs
+++ b/signer/tests/integration/block_observer.rs
@@ -17,7 +17,6 @@ use sbtc::testing::regtest;
 use signer::error::Error;
 use signer::logging::setup_logging;
 use signer::stacks::api::TenureBlocks;
-use signer::storage::model::BitcoinBlockHash;
 use stacks_common::types::chainstate::BurnchainHeaderHash;
 use stacks_common::types::chainstate::ConsensusHash;
 use stacks_common::types::chainstate::SortitionId;
@@ -110,11 +109,7 @@ async fn load_latest_deposit_requests_persists_requests_from_past(blocks_ago: u6
         });
 
         client.expect_get_tenure().returning(|_| {
-            let response = Ok(TenureBlocks {
-                blocks: Vec::new(),
-                anchor_block_hash: BitcoinBlockHash::from([0; 32]),
-                anchor_block_height: 0,
-            });
+            let response = Ok(TenureBlocks::nearly_empty());
             Box::pin(std::future::ready(response))
         });
 

--- a/signer/tests/integration/block_observer.rs
+++ b/signer/tests/integration/block_observer.rs
@@ -108,10 +108,9 @@ async fn load_latest_deposit_requests_persists_requests_from_past(blocks_ago: u6
             Box::pin(std::future::ready(response))
         });
 
-        client.expect_get_tenure().returning(|_| {
-            let response = Ok(TenureBlocks::nearly_empty());
-            Box::pin(std::future::ready(response))
-        });
+        client
+            .expect_get_tenure()
+            .returning(|_| Box::pin(std::future::ready(TenureBlocks::nearly_empty())));
 
         client.expect_get_pox_info().returning(|| {
             let response = serde_json::from_str::<RPCPoxInfoData>(GET_POX_INFO_JSON)

--- a/signer/tests/integration/block_observer.rs
+++ b/signer/tests/integration/block_observer.rs
@@ -16,6 +16,8 @@ use rand::SeedableRng as _;
 use sbtc::testing::regtest;
 use signer::error::Error;
 use signer::logging::setup_logging;
+use signer::stacks::api::TenureBlocks;
+use signer::storage::model::BitcoinBlockHash;
 use stacks_common::types::chainstate::BurnchainHeaderHash;
 use stacks_common::types::chainstate::ConsensusHash;
 use stacks_common::types::chainstate::SortitionId;
@@ -108,7 +110,11 @@ async fn load_latest_deposit_requests_persists_requests_from_past(blocks_ago: u6
         });
 
         client.expect_get_tenure().returning(|_| {
-            let response = Ok(Vec::new());
+            let response = Ok(TenureBlocks {
+                blocks: Vec::new(),
+                anchor_block_hash: BitcoinBlockHash::from([0; 32]),
+                anchor_block_height: 0,
+            });
             Box::pin(std::future::ready(response))
         });
 

--- a/signer/tests/integration/contracts.rs
+++ b/signer/tests/integration/contracts.rs
@@ -201,7 +201,7 @@ async fn complete_deposit_wrapper_tx_accepted<T: AsContractCall>(contract: Contr
 
     let blocks = tenures
         .into_iter()
-        .flat_map(|tenure| tenure.blocks)
+        .flat_map(|tenure| tenure.into_blocks())
         .collect::<Vec<_>>();
 
     let transactions = postgres::extract_relevant_transactions(&blocks, &signer.wallet.address());

--- a/signer/tests/integration/contracts.rs
+++ b/signer/tests/integration/contracts.rs
@@ -195,9 +195,14 @@ async fn complete_deposit_wrapper_tx_accepted<T: AsContractCall>(contract: Contr
     let info = client.get_tenure_info().await.unwrap();
     let storage = Store::new_shared();
 
-    let blocks = stacks::api::fetch_unknown_ancestors(&client, &storage, info.tip_block_id)
+    let tenures = stacks::api::fetch_unknown_ancestors(&client, &storage, info.tip_block_id)
         .await
         .unwrap();
+
+    let blocks = tenures
+        .into_iter()
+        .flat_map(|tenure| tenure.blocks)
+        .collect::<Vec<_>>();
 
     let transactions = postgres::extract_relevant_transactions(&blocks, &signer.wallet.address());
     assert!(!transactions.is_empty());

--- a/signer/tests/integration/transaction_coordinator.rs
+++ b/signer/tests/integration/transaction_coordinator.rs
@@ -34,7 +34,9 @@ use sbtc::testing::regtest::Recipient;
 use secp256k1::Keypair;
 use sha2::Digest as _;
 use signer::network::in_memory2::WanNetwork;
+use signer::stacks::api::TenureBlocks;
 use signer::stacks::contracts::SmartContract;
+use signer::storage::model::BitcoinBlockHash;
 use signer::storage::model::BitcoinTx;
 use stacks_common::types::chainstate::BurnchainHeaderHash;
 use stacks_common::types::chainstate::ConsensusHash;
@@ -1135,7 +1137,11 @@ async fn sign_bitcoin_transaction() {
             });
 
             client.expect_get_tenure().returning(|_| {
-                let response = Ok(Vec::new());
+                let response = Ok(TenureBlocks {
+                    blocks: Vec::new(),
+                    anchor_block_hash: BitcoinBlockHash::from([0; 32]),
+                    anchor_block_height: 0,
+                });
                 Box::pin(std::future::ready(response))
             });
 

--- a/signer/tests/integration/transaction_coordinator.rs
+++ b/signer/tests/integration/transaction_coordinator.rs
@@ -1111,8 +1111,14 @@ async fn sign_bitcoin_transaction() {
         signers.push((ctx, db, kp, network));
     }
 
+    let (broadcast_stacks_tx, _rx) = tokio::sync::broadcast::channel(1);
+
+    let mut stacks_tx_receiver = broadcast_stacks_tx.subscribe();
+    let stacks_tx_receiver_task = tokio::spawn(async move { stacks_tx_receiver.recv().await });
+
     // 3. Check that there are no DKG shares in the database.
     for (ctx, _, _, _) in signers.iter_mut() {
+        let broadcast_stacks_tx = broadcast_stacks_tx.clone();
         ctx.with_stacks_client(|client| {
             client.expect_get_tenure_info().returning(move || {
                 let response = Ok(RPCGetTenureInfo {
@@ -1135,9 +1141,12 @@ async fn sign_bitcoin_transaction() {
                 Box::pin(std::future::ready(response))
             });
 
-            client
-                .expect_get_tenure()
-                .returning(|_| Box::pin(std::future::ready(TenureBlocks::nearly_empty())));
+            let chain_tip = model::BitcoinBlockHash::from(chain_tip_info.hash);
+            client.expect_get_tenure().returning(move |_| {
+                let mut tenure = TenureBlocks::nearly_empty().unwrap();
+                tenure.anchor_block_hash = chain_tip;
+                Box::pin(std::future::ready(Ok(tenure)))
+            });
 
             client.expect_get_pox_info().returning(|| {
                 let response = serde_json::from_str::<RPCPoxInfoData>(GET_POX_INFO_JSON)
@@ -1161,7 +1170,6 @@ async fn sign_bitcoin_transaction() {
                 });
                 Box::pin(std::future::ready(response))
             });
-            let chain_tip = model::BitcoinBlockHash::from(chain_tip_info.hash);
             client.expect_get_sortition_info().returning(move |_| {
                 let response = Ok(SortitionInfo {
                     burn_block_hash: BurnchainHeaderHash::from(chain_tip),
@@ -1177,6 +1185,19 @@ async fn sign_bitcoin_transaction() {
                     committed_block_hash: None,
                 });
                 Box::pin(std::future::ready(response))
+            });
+
+            // Only the client that corresponds to the coordinator will
+            // submit a transaction so we don't make explicit the
+            // expectation here.
+            client.expect_submit_tx().returning(move |tx| {
+                let tx = tx.clone();
+                let txid = tx.txid();
+                let broadcast_stacks_tx = broadcast_stacks_tx.clone();
+                Box::pin(async move {
+                    broadcast_stacks_tx.send(tx).unwrap();
+                    Ok(SubmitTxResponse::Acceptance(txid))
+                })
             });
         })
         .await;
@@ -1319,6 +1340,28 @@ async fn sign_bitcoin_transaction() {
 
     tokio::time::sleep(Duration::from_secs(2)).await;
 
+    // Let's check that the contract call transaction was made.
+    let broadcast_stacks_txs =
+        tokio::time::timeout(Duration::from_secs(10), stacks_tx_receiver_task)
+            .await
+            .unwrap()
+            .expect("failed to receive message")
+            .unwrap();
+
+    let TransactionPayload::ContractCall(contract_call) = broadcast_stacks_txs.payload else {
+        panic!("expected a contract call, got something else");
+    };
+
+    assert_eq!(
+        contract_call.contract_name.as_str(),
+        CompleteDepositV1::CONTRACT_NAME
+    );
+    assert_eq!(
+        contract_call.function_name.as_str(),
+        CompleteDepositV1::FUNCTION_NAME
+    );
+
+    // Now lets check the bitcoin transaction
     let txid = txids.pop().unwrap();
     let tx_info = ctx
         .bitcoin_client

--- a/signer/tests/integration/transaction_coordinator.rs
+++ b/signer/tests/integration/transaction_coordinator.rs
@@ -1135,10 +1135,9 @@ async fn sign_bitcoin_transaction() {
                 Box::pin(std::future::ready(response))
             });
 
-            client.expect_get_tenure().returning(|_| {
-                let response = Ok(TenureBlocks::nearly_empty());
-                Box::pin(std::future::ready(response))
-            });
+            client
+                .expect_get_tenure()
+                .returning(|_| Box::pin(std::future::ready(TenureBlocks::nearly_empty())));
 
             client.expect_get_pox_info().returning(|| {
                 let response = serde_json::from_str::<RPCPoxInfoData>(GET_POX_INFO_JSON)

--- a/signer/tests/integration/transaction_coordinator.rs
+++ b/signer/tests/integration/transaction_coordinator.rs
@@ -1116,7 +1116,6 @@ async fn sign_bitcoin_transaction() {
     let mut stacks_tx_receiver = broadcast_stacks_tx.subscribe();
     let stacks_tx_receiver_task = tokio::spawn(async move { stacks_tx_receiver.recv().await });
 
-    // 3. Check that there are no DKG shares in the database.
     for (ctx, _, _, _) in signers.iter_mut() {
         let broadcast_stacks_tx = broadcast_stacks_tx.clone();
         ctx.with_stacks_client(|client| {

--- a/signer/tests/integration/transaction_coordinator.rs
+++ b/signer/tests/integration/transaction_coordinator.rs
@@ -36,7 +36,6 @@ use sha2::Digest as _;
 use signer::network::in_memory2::WanNetwork;
 use signer::stacks::api::TenureBlocks;
 use signer::stacks::contracts::SmartContract;
-use signer::storage::model::BitcoinBlockHash;
 use signer::storage::model::BitcoinTx;
 use stacks_common::types::chainstate::BurnchainHeaderHash;
 use stacks_common::types::chainstate::ConsensusHash;
@@ -1137,11 +1136,7 @@ async fn sign_bitcoin_transaction() {
             });
 
             client.expect_get_tenure().returning(|_| {
-                let response = Ok(TenureBlocks {
-                    blocks: Vec::new(),
-                    anchor_block_hash: BitcoinBlockHash::from([0; 32]),
-                    anchor_block_height: 0,
-                });
+                let response = Ok(TenureBlocks::nearly_empty());
                 Box::pin(std::future::ready(response))
             });
 


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/778 and addresses part of https://github.com/stacks-network/sbtc/issues/685. 

## Changes

* Change the `get_tenure` return type to include the anchor block hash and anchor block height.
* Make sure `fetch_unknown_ancestors` stops at the nakamoto start height.

## Testing Information

I haven't updated the tests, so this will fail.

## Checklist:

- [x] I have performed a self-review of my code

