### PR TITLE
feat: refactor tx-coordinator runloop

### DIFF
--- a/signer/src/context/termination.rs
+++ b/signer/src/context/termination.rs
@@ -25,6 +25,11 @@ impl TerminationHandle {
         Self(tx, rx)
     }
 
+    /// Check if a shutdown signal has been signalled.
+    pub fn shutdown_signalled(&self) -> bool {
+        *self.1.borrow()
+    }
+
     /// Signal the application to shutdown.
     pub fn signal_shutdown(&self) {
         // We ignore the result here, as if all receivers have been dropped,


### PR DESCRIPTION
## Description

Partially closes: #669

## Changes

Removes the tokio::select! from the transaction coordinator runloop which will ensure that if the signer receives a shutdown signal (other than -9) that it will complete its current run, writing any data, before shutting down.

## Testing Information

Nothing special, all tests pass

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
