### PR TITLE
Clarity/Sweep TXID

### DIFF
--- a/contracts/contracts/sbtc-deposit.clar
+++ b/contracts/contracts/sbtc-deposit.clar
@@ -63,7 +63,7 @@
         (try! (contract-call? .sbtc-token protocol-mint amount recipient))
 
         ;; Complete the deposit
-        (ok (contract-call? .sbtc-registry complete-deposit txid vout-index amount recipient burn-hash burn-height))
+        (ok (contract-call? .sbtc-registry complete-deposit txid vout-index amount recipient burn-hash burn-height sweep-txid))
     )
 )
 

--- a/contracts/contracts/sbtc-registry.clar
+++ b/contracts/contracts/sbtc-registry.clar
@@ -172,6 +172,7 @@
     (fee uint)
     (burn-hash (buff 32))
     (burn-height uint)
+    (sweep-txid (buff 32))
   )
   (begin 
     (try! (is-protocol-caller))
@@ -186,6 +187,7 @@
       fee: fee,
       burn-hash: burn-hash,
       burn-height: burn-height,
+      sweep-txid: sweep-txid,
     })
     (ok true)
   )
@@ -229,6 +231,7 @@
     (recipient principal)
     (burn-hash (buff 32))
     (burn-height uint)
+    (sweep-txid (buff 32))
   )
   (begin
     (try! (is-protocol-caller))
@@ -243,6 +246,7 @@
       amount: amount,
       burn-hash: burn-hash,
       burn-height: burn-height,
+      sweep-txid: sweep-txid,
     })
     (ok true)
   )

--- a/contracts/contracts/sbtc-withdrawal.clar
+++ b/contracts/contracts/sbtc-withdrawal.clar
@@ -147,7 +147,8 @@
                                           (output-index uint)
                                           (fee uint)
                                           (burn-hash (buff 32))
-                                          (burn-height uint))
+                                          (burn-height uint)
+                                          (sweep-txid (buff 32)))
   (let 
     (
       (current-signer-data (contract-call? .sbtc-registry get-current-signer-data))   
@@ -220,7 +221,8 @@
                                       output-index: (optional uint), 
                                       fee: (optional uint),
                                       burn-hash: (buff 32),
-                                      burn-height: uint})))
+                                      burn-height: uint,
+                                      sweep-txid: (optional (buff 32))})))
   (let 
       (
           (current-signer-data (contract-call? .sbtc-registry get-current-signer-data))
@@ -242,7 +244,8 @@
                                                         output-index: (optional uint), 
                                                         fee: (optional uint),
                                                         burn-hash: (buff 32),
-                                                        burn-height: uint}) 
+                                                        burn-height: uint,
+                                                        sweep-txid: (optional (buff 32))}) 
                                                        (helper-response (response uint uint)))
   (match helper-response 
     index
@@ -260,7 +263,7 @@
             (asserts! 
               (and (is-some current-bitcoin-txid) (is-some current-output-index) (is-some current-fee)) 
               (err (+ ERR_WITHDRAWAL_INDEX_PREFIX (+ u10 index))))
-            (unwrap! (accept-withdrawal-request (get request-id withdrawal) (unwrap-panic current-bitcoin-txid) current-signer-bitmap (unwrap-panic current-output-index) (unwrap-panic current-fee) (get burn-hash withdrawal) (get burn-height withdrawal)) (err (+ ERR_WITHDRAWAL_INDEX_PREFIX (+ u10 index))))
+            (unwrap! (accept-withdrawal-request (get request-id withdrawal) (unwrap-panic current-bitcoin-txid) current-signer-bitmap (unwrap-panic current-output-index) (unwrap-panic current-fee) (get burn-hash withdrawal) (get burn-height withdrawal) (unwrap-panic (get sweep-txid withdrawal))) (err (+ ERR_WITHDRAWAL_INDEX_PREFIX (+ u10 index))))
           )
           ;; rejected
           (unwrap! (reject-withdrawal-request (get request-id withdrawal) current-signer-bitmap) (err (+ ERR_WITHDRAWAL_INDEX_PREFIX (+ u10 index))))

--- a/contracts/contracts/sbtc-withdrawal.clar
+++ b/contracts/contracts/sbtc-withdrawal.clar
@@ -180,7 +180,7 @@
       )
 
       ;; Call into registry to confirm accepted withdrawal
-      (try! (contract-call? .sbtc-registry complete-withdrawal-accept request-id bitcoin-txid output-index signer-bitmap fee burn-hash burn-height))
+      (try! (contract-call? .sbtc-registry complete-withdrawal-accept request-id bitcoin-txid output-index signer-bitmap fee burn-hash burn-height sweep-txid))
 
       (ok true)
   )

--- a/contracts/tests/clarigen-types.ts
+++ b/contracts/tests/clarigen-types.ts
@@ -751,6 +751,7 @@ export const contracts = {
           { name: "recipient", type: "principal" },
           { name: "burn-hash", type: { buffer: { length: 32 } } },
           { name: "burn-height", type: "uint128" },
+          { name: "sweep-txid", type: { buffer: { length: 32 } } },
         ],
         outputs: { type: { response: { ok: "bool", error: "uint128" } } },
       } as TypedAbiFunction<
@@ -761,6 +762,7 @@ export const contracts = {
           recipient: TypedAbiArg<string, "recipient">,
           burnHash: TypedAbiArg<Uint8Array, "burnHash">,
           burnHeight: TypedAbiArg<number | bigint, "burnHeight">,
+          sweepTxid: TypedAbiArg<Uint8Array, "sweepTxid">,
         ],
         Response<boolean, bigint>
       >,
@@ -775,6 +777,7 @@ export const contracts = {
           { name: "fee", type: "uint128" },
           { name: "burn-hash", type: { buffer: { length: 32 } } },
           { name: "burn-height", type: "uint128" },
+          { name: "sweep-txid", type: { buffer: { length: 32 } } },
         ],
         outputs: { type: { response: { ok: "bool", error: "uint128" } } },
       } as TypedAbiFunction<
@@ -786,6 +789,7 @@ export const contracts = {
           fee: TypedAbiArg<number | bigint, "fee">,
           burnHash: TypedAbiArg<Uint8Array, "burnHash">,
           burnHeight: TypedAbiArg<number | bigint, "burnHeight">,
+          sweepTxid: TypedAbiArg<Uint8Array, "sweepTxid">,
         ],
         Response<boolean, bigint>
       >,

--- a/contracts/tests/clarigen-types.ts
+++ b/contracts/tests/clarigen-types.ts
@@ -503,6 +503,7 @@ export const contracts = {
                 { name: "burn-hash", type: { buffer: { length: 32 } } },
                 { name: "burn-height", type: "uint128" },
                 { name: "recipient", type: "principal" },
+                { name: "sweep-txid", type: { buffer: { length: 32 } } },
                 { name: "txid", type: { buffer: { length: 32 } } },
                 { name: "vout-index", type: "uint128" },
               ],
@@ -522,6 +523,7 @@ export const contracts = {
               burnHash: Uint8Array;
               burnHeight: number | bigint;
               recipient: string;
+              sweepTxid: Uint8Array;
               txid: Uint8Array;
               voutIndex: number | bigint;
             },
@@ -544,6 +546,7 @@ export const contracts = {
           { name: "recipient", type: "principal" },
           { name: "burn-hash", type: { buffer: { length: 32 } } },
           { name: "burn-height", type: "uint128" },
+          { name: "sweep-txid", type: { buffer: { length: 32 } } },
         ],
         outputs: {
           type: {
@@ -561,6 +564,7 @@ export const contracts = {
           recipient: TypedAbiArg<string, "recipient">,
           burnHash: TypedAbiArg<Uint8Array, "burnHash">,
           burnHeight: TypedAbiArg<number | bigint, "burnHeight">,
+          sweepTxid: TypedAbiArg<Uint8Array, "sweepTxid">,
         ],
         Response<Response<boolean, bigint>, bigint>
       >,
@@ -578,6 +582,7 @@ export const contracts = {
                     { name: "burn-hash", type: { buffer: { length: 32 } } },
                     { name: "burn-height", type: "uint128" },
                     { name: "recipient", type: "principal" },
+                    { name: "sweep-txid", type: { buffer: { length: 32 } } },
                     { name: "txid", type: { buffer: { length: 32 } } },
                     { name: "vout-index", type: "uint128" },
                   ],
@@ -596,6 +601,7 @@ export const contracts = {
               burnHash: Uint8Array;
               burnHeight: number | bigint;
               recipient: string;
+              sweepTxid: Uint8Array;
               txid: Uint8Array;
               voutIndex: number | bigint;
             }[],
@@ -1569,6 +1575,10 @@ export const contracts = {
                 { name: "request-id", type: "uint128" },
                 { name: "signer-bitmap", type: "uint128" },
                 { name: "status", type: "bool" },
+                {
+                  name: "sweep-txid",
+                  type: { optional: { buffer: { length: 32 } } },
+                },
               ],
             },
           },
@@ -1590,6 +1600,7 @@ export const contracts = {
               requestId: number | bigint;
               signerBitmap: number | bigint;
               status: boolean;
+              sweepTxid: Uint8Array | null;
             },
             "withdrawal"
           >,
@@ -1611,6 +1622,7 @@ export const contracts = {
           { name: "fee", type: "uint128" },
           { name: "burn-hash", type: { buffer: { length: 32 } } },
           { name: "burn-height", type: "uint128" },
+          { name: "sweep-txid", type: { buffer: { length: 32 } } },
         ],
         outputs: { type: { response: { ok: "bool", error: "uint128" } } },
       } as TypedAbiFunction<
@@ -1622,6 +1634,7 @@ export const contracts = {
           fee: TypedAbiArg<number | bigint, "fee">,
           burnHash: TypedAbiArg<Uint8Array, "burnHash">,
           burnHeight: TypedAbiArg<number | bigint, "burnHeight">,
+          sweepTxid: TypedAbiArg<Uint8Array, "sweepTxid">,
         ],
         Response<boolean, bigint>
       >,
@@ -1646,6 +1659,10 @@ export const contracts = {
                     { name: "request-id", type: "uint128" },
                     { name: "signer-bitmap", type: "uint128" },
                     { name: "status", type: "bool" },
+                    {
+                      name: "sweep-txid",
+                      type: { optional: { buffer: { length: 32 } } },
+                    },
                   ],
                 },
                 length: 600,
@@ -1666,6 +1683,7 @@ export const contracts = {
               requestId: number | bigint;
               signerBitmap: number | bigint;
               status: boolean;
+              sweepTxid: Uint8Array | null;
             }[],
             "withdrawals"
           >,

--- a/contracts/tests/sbtc-deposit.test.ts
+++ b/contracts/tests/sbtc-deposit.test.ts
@@ -147,6 +147,7 @@ describe("sBTC deposit contract", () => {
         amount: 1000n,
         burnHash,
         burnHeight: BigInt(burnHeight),
+        sweepTxid: new Uint8Array(32).fill(1),
       });
     });
 

--- a/contracts/tests/sbtc-deposit.test.ts
+++ b/contracts/tests/sbtc-deposit.test.ts
@@ -24,6 +24,7 @@ describe("sBTC deposit contract", () => {
           recipient: deployer,
           burnHash,
           burnHeight,
+          sweepTxid: new Uint8Array(32).fill(1),
         }),
         deployer
       );
@@ -41,6 +42,7 @@ describe("sBTC deposit contract", () => {
           recipient: deployer,
           burnHash,
           burnHeight,
+          sweepTxid: new Uint8Array(32).fill(1),
         }),
         deployer
       );
@@ -60,6 +62,7 @@ describe("sBTC deposit contract", () => {
           recipient: deployer,
           burnHash,
           burnHeight,
+          sweepTxid: new Uint8Array(32).fill(1),
         }),
         deployer
       );
@@ -72,6 +75,7 @@ describe("sBTC deposit contract", () => {
           recipient: deployer,
           burnHash,
           burnHeight,
+          sweepTxid: new Uint8Array(32).fill(1),
         }),
         deployer
       );
@@ -89,6 +93,7 @@ describe("sBTC deposit contract", () => {
           recipient: deployer,
           burnHash,
           burnHeight,
+          sweepTxid: new Uint8Array(32).fill(1),
         }),
         deployer
       );
@@ -102,6 +107,7 @@ describe("sBTC deposit contract", () => {
           recipient: deployer,
           burnHash: new Uint8Array(32).fill(1),
           burnHeight,
+          sweepTxid: new Uint8Array(32).fill(2),
         }),
         deployer
       );
@@ -119,6 +125,7 @@ describe("sBTC deposit contract", () => {
           recipient: deployer,
           burnHash,
           burnHeight,
+          sweepTxid: new Uint8Array(32).fill(1),
         }),
         deployer
       );
@@ -154,6 +161,7 @@ describe("sBTC deposit contract", () => {
           recipient: deployer,
           burnHash,
           burnHeight,
+          sweepTxid: new Uint8Array(32).fill(2),
         }),
         deployer
       );
@@ -184,6 +192,7 @@ describe("sBTC deposit contract", () => {
               recipient: deployer,
               burnHash,
               burnHeight,
+              sweepTxid: new Uint8Array(32).fill(1),
             },
             {
               txid: new Uint8Array(32).fill(1),
@@ -192,6 +201,7 @@ describe("sBTC deposit contract", () => {
               recipient: deployer,
               burnHash,
               burnHeight,
+              sweepTxid: new Uint8Array(32).fill(1),
             },
           ],
           ...getCurrentBurnInfo(),
@@ -214,6 +224,7 @@ describe("sBTC deposit contract", () => {
               recipient: deployer,
               burnHash,
               burnHeight,
+              sweepTxid: new Uint8Array(32).fill(1),
             },
             {
               txid: new Uint8Array(32).fill(1),
@@ -222,6 +233,7 @@ describe("sBTC deposit contract", () => {
               recipient: deployer,
               burnHash,
               burnHeight,
+              sweepTxid: new Uint8Array(32).fill(1),
             },
           ],
           ...getCurrentBurnInfo(),
@@ -244,6 +256,7 @@ describe("sBTC deposit contract", () => {
               recipient: deployer,
               burnHash,
               burnHeight,
+              sweepTxid: new Uint8Array(32).fill(1),
             },
             {
               txid: new Uint8Array(32).fill(1),
@@ -252,6 +265,7 @@ describe("sBTC deposit contract", () => {
               recipient: deployer,
               burnHash,
               burnHeight,
+              sweepTxid: new Uint8Array(32).fill(1),
             },
             {
               txid: new Uint8Array(32).fill(2),
@@ -260,6 +274,7 @@ describe("sBTC deposit contract", () => {
               recipient: alice,
               burnHash,
               burnHeight,
+              sweepTxid: new Uint8Array(32).fill(1),
             },
           ],
           ...getCurrentBurnInfo(),
@@ -282,6 +297,7 @@ describe("sBTC deposit contract", () => {
               recipient: deployer,
               burnHash,
               burnHeight,
+              sweepTxid: new Uint8Array(32).fill(1),
             },
             {
               txid: new Uint8Array(32).fill(1),
@@ -290,6 +306,7 @@ describe("sBTC deposit contract", () => {
               recipient: deployer,
               burnHash,
               burnHeight,
+              sweepTxid: new Uint8Array(32).fill(1),
             },
           ],
           ...getCurrentBurnInfo(),
@@ -317,6 +334,7 @@ describe("optimization tests", () => {
           recipient: deployer,
           burnHash,
           burnHeight,
+          sweepTxid: new Uint8Array(32).fill(1),
         })),
         ...getCurrentBurnInfo(),
       }),

--- a/contracts/tests/sbtc-token.test.ts
+++ b/contracts/tests/sbtc-token.test.ts
@@ -15,6 +15,7 @@ describe("sBTC token contract", () => {
           recipient: alice,
           burnHash,
           burnHeight,
+          sweepTxid: new Uint8Array(32).fill(0),
         }),
         deployer
       );
@@ -56,6 +57,7 @@ describe("sBTC token contract", () => {
           recipient: alice,
           burnHash,
           burnHeight,
+          sweepTxid: new Uint8Array(32).fill(1),
         }),
         deployer
       );

--- a/contracts/tests/sbtc-token.test.ts
+++ b/contracts/tests/sbtc-token.test.ts
@@ -15,7 +15,7 @@ describe("sBTC token contract", () => {
           recipient: alice,
           burnHash,
           burnHeight,
-          sweepTxid: new Uint8Array(32).fill(0),
+          sweepTxid: new Uint8Array(32).fill(1),
         }),
         deployer
       );
@@ -37,6 +37,7 @@ describe("sBTC token contract", () => {
         amount: 1000n,
         burnHash,
         burnHeight: BigInt(burnHeight),
+        sweepTxid: new Uint8Array(32).fill(1),
       });
       const receipt1 = rov(
         token.getBalance({
@@ -78,7 +79,8 @@ describe("sBTC token contract", () => {
         outputIndex: 0n,
         amount: 1000n,
         burnHash,
-        burnHeight: BigInt(burnHeight)
+        burnHeight: BigInt(burnHeight),
+        sweepTxid: new Uint8Array(32).fill(1),
       });
       const receipt1 = txOk(
         token.transfer({

--- a/contracts/tests/sbtc-withdrawal.test.ts
+++ b/contracts/tests/sbtc-withdrawal.test.ts
@@ -85,6 +85,7 @@ describe("initiating a withdrawal request", () => {
         recipient: alice,
         burnHash,
         burnHeight,
+        sweepTxid: new Uint8Array(32).fill(1),
       }),
       deployer
     );
@@ -151,6 +152,7 @@ describe("initiating a withdrawal request", () => {
         recipient: alice,
         burnHash,
         burnHeight,
+        sweepTxid: new Uint8Array(32).fill(1),
       }),
       deployer
     );
@@ -190,6 +192,7 @@ describe("initiating a withdrawal request", () => {
         recipient: alice,
         burnHash,
         burnHeight,
+        sweepTxid: new Uint8Array(32).fill(1),
       }),
       deployer
     );
@@ -237,6 +240,7 @@ describe("initiating a withdrawal request", () => {
         recipient: alice,
         burnHash,
         burnHeight,
+        sweepTxid: new Uint8Array(32).fill(1),
       }),
       deployer
     );
@@ -262,6 +266,7 @@ test("max-fee must be accounted for", () => {
       recipient: alice,
       burnHash,
       burnHeight,
+      sweepTxid: new Uint8Array(32).fill(1),
     }),
     deployer
   );
@@ -296,6 +301,7 @@ describe("Accepting a withdrawal request", () => {
         recipient: alice,
         burnHash,
         burnHeight,
+        sweepTxid: new Uint8Array(32).fill(1),
       }),
       deployer
     );
@@ -316,6 +322,7 @@ describe("Accepting a withdrawal request", () => {
         fee: 1n,
         burnHash,
         burnHeight,
+        sweepTxid: new Uint8Array(32).fill(1),
       }),
       deployer
     );
@@ -332,6 +339,7 @@ describe("Accepting a withdrawal request", () => {
         recipient: alice,
         burnHash,
         burnHeight,
+        sweepTxid: new Uint8Array(32).fill(1),
       }),
       deployer
     );
@@ -352,6 +360,7 @@ describe("Accepting a withdrawal request", () => {
         fee: 1n,
         burnHash,
         burnHeight,
+        sweepTxid: new Uint8Array(32).fill(1),
       }),
       alice
     );
@@ -368,6 +377,7 @@ describe("Accepting a withdrawal request", () => {
         recipient: alice,
         burnHash,
         burnHeight,
+        sweepTxid: new Uint8Array(32).fill(1),
       }),
       deployer
     );
@@ -388,6 +398,7 @@ describe("Accepting a withdrawal request", () => {
         fee: 1n,
         burnHash,
         burnHeight,
+        sweepTxid: new Uint8Array(32).fill(1),
       }),
       deployer
     );
@@ -400,6 +411,7 @@ describe("Accepting a withdrawal request", () => {
         fee: 1n,
         burnHash,
         burnHeight,
+        sweepTxid: new Uint8Array(32).fill(1),
       }),
       deployer
     );
@@ -416,6 +428,7 @@ describe("Accepting a withdrawal request", () => {
         recipient: alice,
         burnHash,
         burnHeight,
+        sweepTxid: new Uint8Array(32).fill(1),
       }),
       deployer
     );
@@ -436,6 +449,7 @@ describe("Accepting a withdrawal request", () => {
         fee: 11n,
         burnHash,
         burnHeight,
+        sweepTxid: new Uint8Array(32).fill(1),
       }),
       deployer
     );
@@ -452,6 +466,7 @@ describe("Accepting a withdrawal request", () => {
         recipient: alice,
         burnHash,
         burnHeight,
+        sweepTxid: new Uint8Array(32).fill(1),
       }),
       deployer
     );
@@ -472,6 +487,7 @@ describe("Accepting a withdrawal request", () => {
         fee: defaultMaxFee + 10n,
         burnHash,
         burnHeight,
+        sweepTxid: new Uint8Array(32).fill(1),
       }),
       deployer
     );
@@ -518,6 +534,7 @@ describe("Accepting a withdrawal request", () => {
         recipient: alice,
         burnHash,
         burnHeight: BigInt(burnHeight),
+        sweepTxid: new Uint8Array(32).fill(1),
       }),
       deployer
     );
@@ -538,6 +555,7 @@ describe("Accepting a withdrawal request", () => {
         fee: defaultMaxFee,
         burnHash,
         burnHeight,
+        sweepTxid: new Uint8Array(32).fill(1),
       }),
       deployer
     );
@@ -573,6 +591,7 @@ describe("Accepting a withdrawal request", () => {
         recipient: alice,
         burnHash,
         burnHeight,
+        sweepTxid: new Uint8Array(32).fill(1),
       }),
       deployer
     );
@@ -663,6 +682,7 @@ describe("Accepting a withdrawal request", () => {
         recipient: alice,
         burnHash,
         burnHeight,
+        sweepTxid: new Uint8Array(32).fill(1),
       }),
       deployer
     );
@@ -683,6 +703,7 @@ describe("Accepting a withdrawal request", () => {
         fee: 9n,
         burnHash,
         burnHeight,
+        sweepTxid: new Uint8Array(32).fill(1),
       }),
       deployer
     );
@@ -702,6 +723,7 @@ describe("Reject a withdrawal request", () => {
         recipient: alice,
         burnHash,
         burnHeight,
+        sweepTxid: new Uint8Array(32).fill(1),
       }),
       deployer
     );
@@ -733,6 +755,7 @@ describe("Reject a withdrawal request", () => {
         recipient: alice,
         burnHash,
         burnHeight,
+        sweepTxid: new Uint8Array(32).fill(1),
       }),
       deployer
     );
@@ -764,6 +787,7 @@ describe("Reject a withdrawal request", () => {
         recipient: alice,
         burnHash,
         burnHeight,
+        sweepTxid: new Uint8Array(32).fill(1),
       }),
       deployer
     );
@@ -784,6 +808,7 @@ describe("Reject a withdrawal request", () => {
         fee: 10n,
         burnHash,
         burnHeight,
+        sweepTxid: new Uint8Array(32).fill(1),
       }),
       deployer
     );
@@ -807,6 +832,7 @@ describe("Reject a withdrawal request", () => {
         recipient: alice,
         burnHash,
         burnHeight,
+        sweepTxid: new Uint8Array(32).fill(1),
       }),
       deployer
     );
@@ -830,6 +856,7 @@ describe("Reject a withdrawal request", () => {
             fee: 10n,
             burnHeight: 10n,
             burnHash: new Uint8Array(32).fill(0),
+            sweepTxid: new Uint8Array(32).fill(1),
           },
         ],
       }),
@@ -850,6 +877,7 @@ describe("Reject a withdrawal request", () => {
         recipient: alice,
         burnHash,
         burnHeight,
+        sweepTxid: new Uint8Array(32).fill(1),
       }),
       deployer
     );
@@ -870,6 +898,7 @@ describe("Reject a withdrawal request", () => {
           fee: 10n,
           burnHash: new Uint8Array(32).fill(2),
           burnHeight,
+          sweepTxid: new Uint8Array(32).fill(1),
       }),
       deployer
     );
@@ -887,6 +916,7 @@ describe("Reject a withdrawal request", () => {
         recipient: alice,
         burnHash,
         burnHeight,
+        sweepTxid: new Uint8Array(32).fill(1),
       }),
       deployer
     );
@@ -907,6 +937,7 @@ describe("Reject a withdrawal request", () => {
         fee: defaultMaxFee,
         burnHash,
         burnHeight,
+        sweepTxid: new Uint8Array(32).fill(1),
       }),
       deployer
     );
@@ -926,6 +957,7 @@ describe("Complete multiple withdrawals", () => {
         recipient: alice,
         burnHash,
         burnHeight,
+        sweepTxid: new Uint8Array(32).fill(1),
       }),
       deployer
     );
@@ -946,6 +978,7 @@ describe("Complete multiple withdrawals", () => {
         recipient: bob,
         burnHash,
         burnHeight,
+        sweepTxid: new Uint8Array(32).fill(1),
       }),
       deployer
     );
@@ -970,6 +1003,7 @@ describe("Complete multiple withdrawals", () => {
             fee: defaultMaxFee,
             burnHeight: 10n,
             burnHash: new Uint8Array(32).fill(0),
+            sweepTxid: new Uint8Array(32).fill(1),
           },
           {
             requestId: 2n,
@@ -980,6 +1014,7 @@ describe("Complete multiple withdrawals", () => {
             fee: null,
             burnHeight: 10n,
             burnHash: new Uint8Array(32).fill(0),
+            sweepTxid: null,
           },
         ],
       }),
@@ -1009,6 +1044,7 @@ describe("optimization tests for completing withdrawals", () => {
           recipient: alice,
           burnHash,
           burnHeight,
+          sweepTxid: new Uint8Array(32).fill(1),
         }),
         deployer
       );
@@ -1034,6 +1070,7 @@ describe("optimization tests for completing withdrawals", () => {
             fee: 10n,
             burnHeight,
             burnHash: burnHash!,
+            sweepTxid: new Uint8Array(32).fill(1),
           };
         }),
       }),

--- a/contracts/tests/sbtc-withdrawal.test.ts
+++ b/contracts/tests/sbtc-withdrawal.test.ts
@@ -521,6 +521,7 @@ describe("Accepting a withdrawal request", () => {
       fee: defaultMaxFee + 10n,
       burnHash,
       burnHeight: BigInt(burnHeight),
+      sweepTxid: new Uint8Array(32).fill(1),
     });
   });
   test("accept withdrawal sets withdrawal-status to true", () => {


### PR DESCRIPTION
## Description
This PR adds a 'sweep-txid' parameter to both 'completed-deposits' & 'accepted-withdrawals' that is then emitted from the registry contract, if successful. 

Closes: #583 

## Changes
This contains an update to the withdrawal contract, deposit contract, registry contract, & corresponding test files.

## Testing Information
This is successfully tested by extending existing unit tests that already cover emitted events.

## Checklist:
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
