### PR TITLE
check that wsts messages are signed by the specified signer_id

### DIFF
--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -460,6 +460,10 @@ pub enum Error {
     /// The smart contract has already been deployed
     #[error("smart contract already deployed, contract name: {0}")]
     ContractAlreadyDeployed(&'static str),
+
+    /// Received coordinator message wasn't from coordinator for this chain tip
+    #[error("not chain tip coordinator")]
+    NotChainTipCoordinator,
 }
 
 impl From<std::convert::Infallible> for Error {

--- a/signer/src/testing/transaction_signer.rs
+++ b/signer/src/testing/transaction_signer.rs
@@ -562,6 +562,18 @@ where
             .expect("storage error")
             .expect("no chain tip");
 
+        // now that we have a chain tip, get the real coordinator
+        let coordinator_public_key =
+            crate::transaction_coordinator::coordinator_public_key(&bitcoin_chain_tip, &signer_set)
+                .unwrap();
+        let coordinator_signer_info = signer_info
+            .iter()
+            .find(|signer| {
+                PublicKey::from_private_key(&signer.signer_private_key) == coordinator_public_key
+            })
+            .unwrap()
+            .clone();
+
         run_dkg_and_store_results_for_signers(
             &signer_info,
             &bitcoin_chain_tip,


### PR DESCRIPTION
## Description
`sBTC` messages contain a signature and a public key, in addition to the payload.  Verifying the message shows that it has not been tampered with.

`WSTS` message payloads either contain a `signer_id`, or are coordinator messages.  So in addition to verifying the signature, we also need to show that the public key used to sign was the correct public key for that signer (or the coordinator).

Closes: #578 

## Changes
Call `verify` on the `sBTC` message, then check that the message was signed by the correct public key.

## Testing Information
All unit and integration tests still pass.

## Checklist:

- [ x] I have performed a self-review of my code
- [ x] My changes generate no new warnings
- [ x] New and existing unit tests pass locally with my changes
- [ x] Any dependent changes have been merged and published in downstream modules
