### PR TITLE
Submit rotate-key tx

### DIFF
--- a/signer/src/stacks/api.rs
+++ b/signer/src/stacks/api.rs
@@ -127,6 +127,16 @@ pub trait StacksInteract: Send + Sync {
         &self,
         contract_principal: &StacksAddress,
     ) -> impl Future<Output = Result<Vec<PublicKey>, Error>> + Send;
+
+    /// Retrieve the current signers' aggregate key from the `sbtc-registry` contract.
+    ///
+    /// This is done by making a `GET /v2/data_var/<contract-principal>/sbtc-registry/current-aggregate-pubkey`
+    /// request.
+    fn get_current_signers_aggregate_key(
+        &self,
+        contract_principal: &StacksAddress,
+    ) -> impl Future<Output = Result<Option<PublicKey>, Error>> + Send;
+
     /// Get the latest account info for the given address.
     fn get_account(
         &self,
@@ -953,6 +963,34 @@ impl StacksInteract for StacksClient {
         }
     }
 
+    async fn get_current_signers_aggregate_key(
+        &self,
+        contract_principal: &StacksAddress,
+    ) -> Result<Option<PublicKey>, Error> {
+        let result = self
+            .get_data_var(
+                contract_principal,
+                &ContractName::from("sbtc-registry"),
+                &ClarityName::from("current-aggregate-pubkey"),
+            )
+            .await?;
+
+        // Check the result and return the aggregate key.
+        match result {
+            Value::Sequence(SequenceData::Buffer(BuffData { data })) => {
+                // The initial value of the data var is all zeros
+                if data.iter().all(|v| *v == 0) {
+                    Ok(None)
+                } else {
+                    PublicKey::from_slice(&data).map(Some)
+                }
+            }
+            _ => Err(Error::InvalidStacksResponse(
+                "expected a buffer but got something else",
+            )),
+        }
+    }
+
     async fn get_account(&self, address: &StacksAddress) -> Result<AccountInfo, Error> {
         self.get_account(address).await
     }
@@ -1102,6 +1140,20 @@ impl StacksInteract for ApiFallbackClient<StacksClient> {
     ) -> Result<Vec<PublicKey>, Error> {
         self.exec(|client, retry| async move {
             let result = client.get_current_signer_set(contract_principal).await;
+            retry.abort_if(|| matches!(result, Err(Error::InvalidStacksResponse(_))));
+            result
+        })
+        .await
+    }
+
+    async fn get_current_signers_aggregate_key(
+        &self,
+        contract_principal: &StacksAddress,
+    ) -> Result<Option<PublicKey>, Error> {
+        self.exec(|client, retry| async move {
+            let result = client
+                .get_current_signers_aggregate_key(contract_principal)
+                .await;
             retry.abort_if(|| matches!(result, Err(Error::InvalidStacksResponse(_))));
             result
         })
@@ -1514,6 +1566,62 @@ mod tests {
 
         // Assert that the response is what we expect
         assert_eq!(&resp, &public_keys);
+        mock.assert();
+    }
+
+    #[test_case(|url| StacksClient::new(url, 20).unwrap(), false; "stacks-client-some")]
+    #[test_case(|url| StacksClient::new(url, 20).unwrap(), true; "stacks-client-none")]
+    #[test_case(|url| ApiFallbackClient::new(vec![StacksClient::new(url, 20).unwrap()]).unwrap(), false; "fallback-client-some")]
+    #[test_case(|url| ApiFallbackClient::new(vec![StacksClient::new(url, 20).unwrap()]).unwrap(), true; "fallback-client-none")]
+    #[tokio::test]
+    async fn get_current_signers_aggregate_key_works<F, C>(client: F, return_none: bool)
+    where
+        C: StacksInteract,
+        F: Fn(Url) -> C,
+    {
+        let aggregate_key = generate_pubkeys(1).into_iter().next().unwrap();
+
+        let data;
+        let expected;
+        if return_none {
+            data = [0; 33].to_vec();
+            expected = None;
+        } else {
+            data = aggregate_key.serialize().to_vec();
+            expected = Some(aggregate_key);
+        }
+        let aggregate_key_clarity = Value::Sequence(SequenceData::Buffer(BuffData { data }));
+
+        // The format of the response JSON is `{"data": "0x<serialized-value>"}` (excluding the proof).
+        let raw_json_response = format!(
+            r#"{{"data":"0x{}"}}"#,
+            Value::serialize_to_hex(&aggregate_key_clarity).expect("failed to serialize value")
+        );
+
+        // Setup our mock server
+        let mut stacks_node_server = mockito::Server::new_async().await;
+        let mock = stacks_node_server
+            .mock("GET", "/v2/data_var/ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM/sbtc-registry/current-aggregate-pubkey?proof=0")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(&raw_json_response)
+            .expect(1)
+            .create();
+
+        // Setup our Stacks client
+        let client = client(url::Url::parse(stacks_node_server.url().as_str()).unwrap());
+
+        // Make the request to the mock server
+        let resp = client
+            .get_current_signers_aggregate_key(
+                &StacksAddress::from_string("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM")
+                    .expect("failed to parse stacks address"),
+            )
+            .await
+            .unwrap();
+
+        // Assert that the response is what we expect
+        assert_eq!(resp, expected);
         mock.assert();
     }
 

--- a/signer/src/stacks/contracts.rs
+++ b/signer/src/stacks/contracts.rs
@@ -1008,7 +1008,7 @@ pub struct RotateKeysV1 {
     /// The new set of public keys for all known signers during this
     /// PoX cycle.
     new_keys: BTreeSet<PublicKey>,
-    /// The aggregate key created by combining the above public keys.
+    /// The signers bitcoin aggregate key
     aggregate_key: PublicKey,
     /// The address that deployed the contract.
     deployer: StacksAddress,
@@ -1019,9 +1019,13 @@ pub struct RotateKeysV1 {
 impl RotateKeysV1 {
     /// Create a new instance of a RotateKeysV1 transaction object where
     /// the new keys will match those provided by the input wallet.
-    pub fn new(wallet: &SignerWallet, deployer: StacksAddress) -> Self {
+    pub fn new(
+        wallet: &SignerWallet,
+        deployer: StacksAddress,
+        bitcoin_aggregate_key: &PublicKey,
+    ) -> Self {
         Self {
-            aggregate_key: *wallet.stacks_aggregate_key(),
+            aggregate_key: *bitcoin_aggregate_key,
             new_keys: wallet.public_keys().clone(),
             deployer,
             signatures_required: wallet.signatures_required(),
@@ -1236,6 +1240,7 @@ impl SmartContract {
 
 #[cfg(test)]
 mod tests {
+    use fake::Fake as _;
     use rand::rngs::StdRng;
     use rand::SeedableRng as _;
     use secp256k1::SecretKey;
@@ -1308,8 +1313,9 @@ mod tests {
         let public_keys = secret_keys.map(|sk| sk.public_key(SECP256K1).into());
         let wallet = SignerWallet::new(&public_keys, 2, NetworkKind::Testnet, 0).unwrap();
         let deployer = StacksAddress::burn_address(false);
+        let aggregate_key: PublicKey = fake::Faker.fake_with_rng(&mut rng);
 
-        let call = RotateKeysV1::new(&wallet, deployer);
+        let call = RotateKeysV1::new(&wallet, deployer, &aggregate_key);
 
         // This is to check that this function doesn't implicitly panic. If
         // it doesn't panic now, it can never panic at runtime.

--- a/signer/src/testing/block_observer.rs
+++ b/signer/src/testing/block_observer.rs
@@ -241,6 +241,13 @@ impl StacksInteract for TestHarness {
         // issue #118
         todo!()
     }
+    async fn get_current_signers_aggregate_key(
+        &self,
+        _contract_principal: &StacksAddress,
+    ) -> Result<Option<PublicKey>, Error> {
+        // issue #118
+        todo!()
+    }
     async fn get_account(&self, _address: &StacksAddress) -> Result<AccountInfo, Error> {
         // issue #118
         todo!()

--- a/signer/src/testing/context.rs
+++ b/signer/src/testing/context.rs
@@ -305,6 +305,17 @@ impl StacksInteract for WrappedMock<MockStacksInteract> {
             .await
     }
 
+    async fn get_current_signers_aggregate_key(
+        &self,
+        contract_principal: &StacksAddress,
+    ) -> Result<Option<PublicKey>, Error> {
+        self.inner
+            .lock()
+            .await
+            .get_current_signers_aggregate_key(contract_principal)
+            .await
+    }
+
     async fn get_account(&self, address: &StacksAddress) -> Result<AccountInfo, Error> {
         self.inner.lock().await.get_account(address).await
     }

--- a/signer/src/testing/transaction_coordinator.rs
+++ b/signer/src/testing/transaction_coordinator.rs
@@ -194,6 +194,14 @@ where
             })
             .await;
 
+        self.context
+            .with_stacks_client(|client| {
+                client
+                    .expect_get_current_signers_aggregate_key()
+                    .returning(move |_| Box::pin(std::future::ready(Ok(Some(aggregate_key)))));
+            })
+            .await;
+
         // Create a channel to log all transactions broadcasted by the coordinator.
         // The receiver is created by this method but not used as it is held as a
         // handle to ensure that the channel is alive until the end of the test.
@@ -338,6 +346,14 @@ where
                             Ok(emily_client::models::UpdateDepositsResponse { deposits: vec![] })
                         })
                     });
+            })
+            .await;
+
+        self.context
+            .with_stacks_client(|client| {
+                client
+                    .expect_get_current_signers_aggregate_key()
+                    .returning(move |_| Box::pin(std::future::ready(Ok(Some(aggregate_key)))));
             })
             .await;
 

--- a/signer/tests/integration/contracts.rs
+++ b/signer/tests/integration/contracts.rs
@@ -161,6 +161,7 @@ pub async fn deploy_smart_contracts() -> &'static SignerStxState {
 #[test_case(ContractCallWrapper(RotateKeysV1::new(
     &testing::wallet::WALLET.0,
     *testing::wallet::WALLET.0.address(),
+    &signer::keys::PublicKey::from_slice(&[0x02; 33]).unwrap()
 )); "rotate-keys")]
 #[tokio::test]
 async fn complete_deposit_wrapper_tx_accepted<T: AsContractCall>(contract: ContractCallWrapper<T>) {

--- a/signer/tests/integration/emily.rs
+++ b/signer/tests/integration/emily.rs
@@ -431,6 +431,10 @@ async fn deposit_flow() {
                 });
                 Box::pin(std::future::ready(response))
             });
+
+            client
+                .expect_get_current_signers_aggregate_key()
+                .returning(move |_| Box::pin(std::future::ready(Ok(Some(aggregate_key)))));
         })
         .await;
 
@@ -559,8 +563,9 @@ async fn deposit_flow() {
         .expect("failed to signal");
 
     // Await the `wait_for_tx_task` to receive the first transaction broadcasted.
-    let broadcasted_tx = wait_for_transaction_task
+    let broadcasted_tx = tokio::time::timeout(Duration::from_secs(10), wait_for_transaction_task)
         .await
+        .unwrap()
         .expect("failed to receive message")
         .expect("no message received");
 

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -172,6 +172,7 @@ impl AsContractCall for InitiateWithdrawalRequest {
 #[test_case(ContractCallWrapper(RotateKeysV1::new(
     &testing::wallet::WALLET.0,
     *testing::wallet::WALLET.0.address(),
+    &signer::keys::PublicKey::from_slice(&[0x02; 33]).unwrap()
 )); "rotate-keys")]
 #[tokio::test]
 async fn writing_stacks_blocks_works<T: AsContractCall>(contract: ContractCallWrapper<T>) {

--- a/signer/tests/integration/transaction_coordinator.rs
+++ b/signer/tests/integration/transaction_coordinator.rs
@@ -34,6 +34,7 @@ use sbtc::testing::regtest::Recipient;
 use secp256k1::Keypair;
 use sha2::Digest as _;
 use signer::network::in_memory2::WanNetwork;
+use signer::stacks::contracts::RotateKeysV1;
 use signer::stacks::contracts::SmartContract;
 use signer::storage::model::BitcoinTx;
 use stacks_common::types::chainstate::BurnchainHeaderHash;
@@ -893,6 +894,7 @@ async fn get_signer_public_keys_and_aggregate_key_falls_back() {
 /// 6. Check that we have exactly one row in the `dkg_shares` table.
 /// 7. Check that they all have the same aggregate key in the `dkg_shares`
 ///    table.
+/// 8. Check that the coordinator broadcast a rotate key tx
 ///
 /// Some of the preconditions for this test to run successfully includes
 /// having bootstrap public keys that align with the [`Keypair`] returned
@@ -901,7 +903,8 @@ async fn get_signer_public_keys_and_aggregate_key_falls_back() {
 #[tokio::test]
 async fn run_dkg_from_scratch() {
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
-    let (_, signer_key_pairs): (_, [Keypair; 3]) = testing::wallet::regtest_bootstrap_wallet();
+    let (signer_wallet, signer_key_pairs): (_, [Keypair; 3]) =
+        testing::wallet::regtest_bootstrap_wallet();
 
     // We need to populate our databases, so let's generate some data.
     let test_params = testing::storage::model::Params {
@@ -913,6 +916,13 @@ async fn run_dkg_from_scratch() {
     };
     let test_data = TestData::generate(&mut rng, &[], &test_params);
 
+    let (broadcasted_transaction_tx, _) = tokio::sync::broadcast::channel(1);
+
+    // This task logs all transactions broadcasted by the coordinator.
+    let mut wait_for_transaction_rx = broadcasted_transaction_tx.subscribe();
+    let wait_for_transaction_task =
+        tokio::spawn(async move { wait_for_transaction_rx.recv().await });
+
     let iter: Vec<(Keypair, TestData)> = signer_key_pairs
         .iter()
         .copied()
@@ -922,20 +932,52 @@ async fn run_dkg_from_scratch() {
     // 1. Create a database, an associated context, and a Keypair for each of
     //    the signers in the signing set.
     let signers: Vec<(_, PgStore, Keypair)> = futures::stream::iter(iter)
-        .then(|(kp, data)| async move {
-            let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-            let db = testing::storage::new_test_database(db_num, true).await;
-            let ctx = TestContext::builder()
-                .with_storage(db.clone())
-                .with_mocked_clients()
-                .build();
+        .then(|(kp, data)| {
+            let broadcasted_transaction_tx = broadcasted_transaction_tx.clone();
+            async move {
+                let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
+                let db = testing::storage::new_test_database(db_num, true).await;
+                let mut ctx = TestContext::builder()
+                    .with_storage(db.clone())
+                    .with_mocked_clients()
+                    .build();
 
-            // 2. Populate each database with the same data, so that they
-            //    have the same view of the canonical bitcoin blockchain.
-            //    This ensures that they participate in DKG.
-            data.write_to(&db).await;
+                ctx.with_stacks_client(|client| {
+                    client
+                        .expect_estimate_fees()
+                        .returning(|_, _, _| Box::pin(async { Ok(123000) }));
 
-            (ctx, db, kp)
+                    client.expect_get_account().returning(|_| {
+                        Box::pin(async {
+                            Ok(AccountInfo {
+                                balance: 1_000_000,
+                                locked: 0,
+                                unlock_height: 0,
+                                nonce: 1,
+                            })
+                        })
+                    });
+                    client.expect_submit_tx().returning(move |tx| {
+                        let tx = tx.clone();
+                        let txid = tx.txid();
+                        let broadcasted_transaction_tx = broadcasted_transaction_tx.clone();
+                        Box::pin(async move {
+                            broadcasted_transaction_tx
+                                .send(tx)
+                                .expect("Failed to send result");
+                            Ok(SubmitTxResponse::Acceptance(txid))
+                        })
+                    });
+                })
+                .await;
+
+                // 2. Populate each database with the same data, so that they
+                //    have the same view of the canonical bitcoin blockchain.
+                //    This ensures that they participate in DKG.
+                data.write_to(&db).await;
+
+                (ctx, db, kp)
+            }
         })
         .collect::<Vec<_>>()
         .await;
@@ -1006,7 +1048,12 @@ async fn run_dkg_from_scratch() {
             .unwrap();
     });
 
-    tokio::time::sleep(Duration::from_secs(2)).await;
+    // Await the `wait_for_tx_task` to receive the first transaction broadcasted.
+    let broadcasted_tx = tokio::time::timeout(Duration::from_secs(10), wait_for_transaction_task)
+        .await
+        .unwrap()
+        .expect("failed to receive message")
+        .expect("no message received");
 
     let mut aggregate_keys = BTreeSet::new();
 
@@ -1033,7 +1080,29 @@ async fn run_dkg_from_scratch() {
     //    `dkg_shares` table.
     assert_eq!(aggregate_keys.len(), 1);
 
-    for (_, db, _) in signers {
+    // 8. Check that the coordinator broadcast a rotate key tx
+    broadcasted_tx.verify().unwrap();
+
+    let TransactionPayload::ContractCall(contract_call) = broadcasted_tx.payload else {
+        panic!("unexpected tx payload")
+    };
+    assert_eq!(
+        contract_call.contract_name.to_string(),
+        RotateKeysV1::CONTRACT_NAME
+    );
+    assert_eq!(
+        contract_call.function_name.to_string(),
+        RotateKeysV1::FUNCTION_NAME
+    );
+    let rotate_keys = RotateKeysV1::new(
+        &signer_wallet,
+        signers.first().unwrap().0.config().signer.deployer,
+        aggregate_keys.iter().next().unwrap(),
+    );
+    assert_eq!(contract_call.function_args, rotate_keys.as_contract_args());
+
+    for (ctx, db, _) in signers {
+        ctx.get_termination_handle().signal_shutdown();
         testing::storage::drop_db(db).await;
     }
 }


### PR DESCRIPTION
## Description

First part of: https://github.com/stacks-network/sbtc/issues/653
The second part is related to emily sidecar picking up the event and populating `rotate_keys_transactions` table; ~currently the coordinator keeps broadcasting rotate keys tx (that fails, after the first one) because it doesn't find any rotation in db~ (changed implementation, no longer true).

## Changes

Submit rotate key if the latest DKG differs from chain registry data.

## Testing Information

Tested in devenv and changed an integration test to check for the tx.

## Checklist:

- [X] I have performed a self-review of my code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
