### PR TITLE
add parsing and handling of rotate-keys events

### DIFF
--- a/signer/src/api/new_block.rs
+++ b/signer/src/api/new_block.rs
@@ -23,6 +23,7 @@ use crate::context::Context;
 use crate::emily_client::EmilyInteract;
 use crate::error::Error;
 use crate::stacks::events::CompletedDepositEvent;
+use crate::stacks::events::KeyRotationEvent;
 use crate::stacks::events::RegistryEvent;
 use crate::stacks::events::TxInfo;
 use crate::stacks::events::WithdrawalAcceptEvent;
@@ -30,8 +31,10 @@ use crate::stacks::events::WithdrawalCreateEvent;
 use crate::stacks::events::WithdrawalRejectEvent;
 use crate::stacks::webhooks::NewBlockEvent;
 use crate::storage::model::BitcoinBlockHash;
+use crate::storage::model::RotateKeysTransaction;
 use crate::storage::model::StacksBlock;
 use crate::storage::model::StacksBlockHash;
+use crate::storage::model::StacksTxId;
 use crate::storage::DbWrite;
 
 use super::ApiState;
@@ -151,6 +154,9 @@ pub async fn new_block_handler(state: State<ApiState<impl Context>>, body: Strin
                 handle_withdrawal_create(&api.ctx, event, stacks_chaintip.block_height)
                     .await
                     .map(|x| created_withdrawals.push(x))
+            }
+            Ok(RegistryEvent::KeyRotation(event)) => {
+                handle_key_rotation(&api.ctx, event, tx_info.txid.into()).await
             }
             Err(error) => {
                 tracing::error!(%error, "Got an error when transforming the event ClarityValue");
@@ -388,6 +394,23 @@ async fn handle_withdrawal_reject(
     })
 }
 
+async fn handle_key_rotation(
+    ctx: &impl Context,
+    event: KeyRotationEvent,
+    stacks_txid: StacksTxId,
+) -> Result<(), Error> {
+    let key_rotation_tx = RotateKeysTransaction {
+        txid: stacks_txid,
+        aggregate_key: event.new_aggregate_pubkey,
+        signer_set: event.new_keys,
+        signatures_required: event.new_signature_threshold,
+    };
+    ctx.get_storage_mut()
+        .write_rotate_keys_transaction(&key_rotation_tx)
+        .await?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -425,10 +448,13 @@ mod tests {
     const WITHDRAWAL_REJECT_WEBHOOK: &str =
         include_str!("../../tests/fixtures/withdrawal-reject-event.json");
 
+    const ROTATE_KEYS_WEBHOOK: &str = include_str!("../../tests/fixtures/rotate-keys-event.json");
+
     #[test_case(COMPLETED_DEPOSIT_WEBHOOK, |db| db.completed_deposit_events.get(&OutPoint::null()).is_none(); "completed-deposit")]
     #[test_case(WITHDRAWAL_CREATE_WEBHOOK, |db| db.withdrawal_create_events.get(&1).is_none(); "withdrawal-create")]
     #[test_case(WITHDRAWAL_ACCEPT_WEBHOOK, |db| db.withdrawal_accept_events.get(&1).is_none(); "withdrawal-accept")]
     #[test_case(WITHDRAWAL_REJECT_WEBHOOK, |db| db.withdrawal_reject_events.get(&2).is_none(); "withdrawal-reject")]
+    #[test_case(ROTATE_KEYS_WEBHOOK, |db| db.rotate_keys_transactions.is_empty(); "rotate-keys")]
     #[tokio::test]
     async fn test_events<F>(body_str: &str, table_is_empty: F)
     where
@@ -490,6 +516,7 @@ mod tests {
     #[test_case(WITHDRAWAL_CREATE_WEBHOOK, |db| db.withdrawal_create_events.get(&1).is_none(); "withdrawal-create")]
     #[test_case(WITHDRAWAL_ACCEPT_WEBHOOK, |db| db.withdrawal_accept_events.get(&1).is_none(); "withdrawal-accept")]
     #[test_case(WITHDRAWAL_REJECT_WEBHOOK, |db| db.withdrawal_reject_events.get(&2).is_none(); "withdrawal-reject")]
+    #[test_case(ROTATE_KEYS_WEBHOOK, |db| db.rotate_keys_transactions.is_empty(); "rotate-keys")]
     #[tokio::test]
     async fn test_fishy_events<F>(body_str: &str, table_is_empty: F)
     where
@@ -838,5 +865,34 @@ mod tests {
             .withdrawal_reject_events
             .get(&expectation.request_id)
             .is_some());
+    }
+
+    /// Tests handling a key rotation event.
+    /// This function validates that a key rotation event is correctly processed,
+    /// including updating the database with the new key rotation transaction.
+    #[tokio::test]
+    async fn test_handle_key_rotation() {
+        let ctx = TestContext::builder()
+            .with_in_memory_storage()
+            .with_mocked_clients()
+            .build();
+
+        let db = ctx.inner_storage();
+
+        let txid: StacksTxId = fake::Faker.fake_with_rng(&mut OsRng);
+
+        let event = KeyRotationEvent {
+            new_aggregate_pubkey: fake::Faker.fake_with_rng(&mut OsRng),
+            new_keys: vec![fake::Faker.fake_with_rng(&mut OsRng)],
+            new_address: PrincipalData::Standard(StandardPrincipalData::transient()),
+            new_signature_threshold: 3,
+        };
+
+        let res = handle_key_rotation(&ctx, event, txid).await;
+
+        assert!(res.is_ok());
+        let db = db.lock().await;
+        assert_eq!(db.rotate_keys_transactions.len(), 1);
+        assert!(db.rotate_keys_transactions.get(&txid).is_some());
     }
 }

--- a/signer/src/stacks/events.rs
+++ b/signer/src/stacks/events.rs
@@ -23,10 +23,13 @@ use blockstack_lib::burnchains::Txid as StacksTxid;
 use clarity::vm::types::CharType;
 use clarity::vm::types::PrincipalData;
 use clarity::vm::types::SequenceData;
+use clarity::vm::types::SequencedValue;
 use clarity::vm::types::TupleData;
 use clarity::vm::ClarityName;
 use clarity::vm::Value as ClarityValue;
 use stacks_common::types::chainstate::StacksBlockId;
+
+use crate::keys::PublicKey;
 
 /// An error when trying to parse an sBTC event into a concrete type.
 #[derive(Debug, thiserror::Error)]
@@ -48,6 +51,10 @@ pub enum EventError {
     /// is not exactly equal to 32. This should never occur.
     #[error("Could not convert an integer in clarity event into the expected integer {0}")]
     ClarityTxidConversion(#[source] bitcoin::hashes::FromSliceError),
+    /// This error is thrown when trying to convert a public key from a
+    /// Clarity buffer into a proper public key. It should never be thrown.
+    #[error("Could not convert a public key in clarity event into the expected public key {0}")]
+    ClarityPublicKeyConversion(#[source] crate::error::Error),
     /// This should never happen, but happens when one of the given topics
     /// is not on the list of expected topics.
     #[error("Got an unexpected event topic: {0}")]
@@ -79,6 +86,8 @@ pub enum RegistryEvent {
     WithdrawalReject(WithdrawalRejectEvent),
     /// For the `withdrawal-create` topic
     WithdrawalCreate(WithdrawalCreateEvent),
+    /// For the `key-rotation` topic
+    KeyRotation(KeyRotationEvent),
 }
 
 /// A type that points to a transaction in a stacks block.
@@ -114,6 +123,7 @@ impl RegistryEvent {
                     "withdrawal-accept" => event_map.withdrawal_accept(),
                     "withdrawal-create" => event_map.withdrawal_create(),
                     "withdrawal-reject" => event_map.withdrawal_reject(),
+                    "key-rotation" => event_map.key_rotation(),
                     _ => Err(EventError::ClarityUnexpectedEventTopic(topic)),
                 }
             }
@@ -205,6 +215,21 @@ pub struct WithdrawalRejectEvent {
     pub signer_bitmap: BitArray<[u8; 16]>,
 }
 
+/// This is the event that is emitted from the `rotate-keys`
+/// public function in the sbtc-registry smart contract.
+#[derive(Debug, Clone)]
+pub struct KeyRotationEvent {
+    /// The new set of public keys for all known signers during this
+    /// PoX cycle.
+    pub new_keys: Vec<PublicKey>,
+    /// The address that deployed the contract.
+    pub new_address: PrincipalData,
+    /// The new aggregate key created by combining the above public keys.
+    pub new_aggregate_pubkey: PublicKey,
+    /// The number of signatures required for the multi-sig wallet.
+    pub new_signature_threshold: u16,
+}
+
 #[derive(Debug)]
 struct RawTupleData {
     data_map: BTreeMap<ClarityName, ClarityValue>,
@@ -250,6 +275,17 @@ impl RawTupleData {
         match self.data_map.remove(field) {
             Some(ClarityValue::Tuple(TupleData { data_map, .. })) => {
                 Ok(Self::new(data_map, self.tx_info))
+            }
+            _ => Err(EventError::TupleEventField(field, self.tx_info)),
+        }
+    }
+
+    /// Extract the list value from the given field
+    fn remove_list(&mut self, field: &'static str) -> Result<Vec<ClarityValue>, EventError> {
+        match self.data_map.remove(field) {
+            Some(ClarityValue::Sequence(SequenceData::List(mut list))) => {
+                Ok(list.drained_items())
+                // Ok(list)
             }
             _ => Err(EventError::TupleEventField(field, self.tx_info)),
         }
@@ -569,6 +605,51 @@ impl RawTupleData {
             signer_bitmap: BitArray::new(bitmap.to_le_bytes()),
         }))
     }
+
+    /// This function if for transforming the print events of the
+    /// `rotate-keys` function in the sbtc-registry.
+    ///
+    /// # Notes
+    ///
+    /// The print events for `rotate-keys` calls are structured like so:
+    ///
+    /// ```clarity
+    /// (print {
+    ///   topic: "key-rotation",
+    ///   new-keys: (list 128 (buff 33))
+    ///   new-address: principal
+    ///   new-aggregate-pubkey: (buff 33)
+    ///   new-signature-threshold: uint
+    /// })
+    /// ```
+    ///
+    /// The above event is emitted after the keys for the multi-sig wallet
+    /// have been rotated.
+    fn key_rotation(mut self) -> Result<RegistryEvent, EventError> {
+        let new_keys = self
+            .remove_list("new-keys")?
+            .into_iter()
+            .map(|val| match val {
+                ClarityValue::Sequence(SequenceData::Buffer(buf)) => {
+                    PublicKey::from_slice(&buf.data).map_err(EventError::ClarityPublicKeyConversion)
+                }
+                _ => Err(EventError::ClarityUnexpectedValue(val, self.tx_info)),
+            })
+            .collect::<Result<Vec<PublicKey>, EventError>>()?;
+
+        let new_address = self.remove_principal("new-address")?;
+        let new_aggregate_pubkey = self.remove_buff("new-aggregate-pubkey")?;
+        let new_signature_threshold = self.remove_u128("new-signature-threshold")?;
+
+        Ok(RegistryEvent::KeyRotation(KeyRotationEvent {
+            new_keys,
+            new_address,
+            new_aggregate_pubkey: PublicKey::from_slice(&new_aggregate_pubkey)
+                .map_err(EventError::ClarityPublicKeyConversion)?,
+            new_signature_threshold: u16::try_from(new_signature_threshold)
+                .map_err(EventError::ClarityIntConversion)?,
+        }))
+    }
 }
 
 #[cfg(test)]
@@ -578,6 +659,10 @@ mod tests {
     use bitcoin::key::CompressedPublicKey;
     use bitcoin::key::TweakedPublicKey;
     use bitvec::field::BitField as _;
+    use clarity::vm::types::ListData;
+    use clarity::vm::types::ListTypeData;
+    use clarity::vm::types::BUFF_33;
+    use fake::Fake;
     use rand::rngs::OsRng;
     use secp256k1::SECP256K1;
 
@@ -778,6 +863,61 @@ mod tests {
                 let expected_bitmap = BitArray::<[u8; 16]>::new(bitmap.to_le_bytes());
                 assert_eq!(event.request_id, request_id as u64);
                 assert_eq!(event.signer_bitmap, expected_bitmap);
+            }
+            e => panic!("Got the wrong event variant: {e:?}"),
+        };
+    }
+
+    #[test]
+    fn test_key_rotation_event() {
+        let new_keys: Vec<PublicKey> = vec![
+            fake::Faker.fake_with_rng(&mut OsRng),
+            fake::Faker.fake_with_rng(&mut OsRng),
+            fake::Faker.fake_with_rng(&mut OsRng),
+        ];
+        let new_address =
+            PrincipalData::parse("ST1RQHF4VE5CZ6EK3MZPZVQBA0JVSMM9H5PMHMS1Y").unwrap();
+        let new_aggregate_pubkey: PublicKey = fake::Faker.fake_with_rng(&mut OsRng);
+        let new_signature_threshold = 2;
+
+        let event = [
+            (
+                ClarityName::from("new-keys"),
+                ClarityValue::Sequence(SequenceData::List(ListData {
+                    data: new_keys
+                        .iter()
+                        .map(|key| ClarityValue::buff_from(key.serialize().into()).unwrap())
+                        .collect(),
+                    type_signature: ListTypeData::new_list(BUFF_33.clone(), 128)
+                        .expect("Expected list"),
+                })),
+            ),
+            (
+                ClarityName::from("new-address"),
+                ClarityValue::Principal(new_address.clone()),
+            ),
+            (
+                ClarityName::from("new-aggregate-pubkey"),
+                ClarityValue::buff_from(new_aggregate_pubkey.serialize().into()).unwrap(),
+            ),
+            (
+                ClarityName::from("new-signature-threshold"),
+                ClarityValue::UInt(new_signature_threshold as u128),
+            ),
+            (
+                ClarityName::from("topic"),
+                ClarityValue::string_ascii_from_bytes("key-rotation".as_bytes().to_vec()).unwrap(),
+            ),
+        ];
+        let tuple_data = TupleData::from_data(event.to_vec()).unwrap();
+        let value = ClarityValue::Tuple(tuple_data);
+
+        match RegistryEvent::try_new(value, TX_INFO).unwrap() {
+            RegistryEvent::KeyRotation(event) => {
+                assert_eq!(event.new_keys, new_keys);
+                assert_eq!(event.new_address, new_address);
+                assert_eq!(event.new_aggregate_pubkey, new_aggregate_pubkey);
+                assert_eq!(event.new_signature_threshold, new_signature_threshold);
             }
             e => panic!("Got the wrong event variant: {e:?}"),
         };

--- a/signer/tests/fixtures/rotate-keys-event.json
+++ b/signer/tests/fixtures/rotate-keys-event.json
@@ -1,0 +1,368 @@
+{
+    "anchored_cost": {
+        "read_count": 20,
+        "read_length": 25282,
+        "runtime": 180360,
+        "write_count": 6,
+        "write_length": 266
+    },
+    "block_hash": "0x628838c7167591943eb6eeb88949b13c0ae6e7a323de6f4217101bd5028ebcca",
+    "block_height": 47,
+    "block_time": 1730980672,
+    "burn_block_hash": "0x094f2504beaff25578ce059dc7a780c205f901f889483ab0b350bfebc1bc48b5",
+    "burn_block_height": 237,
+    "burn_block_time": 1730980669,
+    "confirmed_microblocks_cost": {
+        "read_count": 0,
+        "read_length": 0,
+        "runtime": 0,
+        "write_count": 0,
+        "write_length": 0
+    },
+    "cycle_number": null,
+    "events": [
+        {
+            "committed": true,
+            "contract_event": {
+                "contract_identifier": "SN3R84XZYA63QS28932XQF3G1J8R9PC3W76P9CSQS.sbtc-registry",
+                "raw_value": "0x0c000000050b6e65772d616464726573730515f08277fe51877c890918bb778e0192309b307c39146e65772d6167677265676174652d7075626b6579020000002102e77bbc2ff7d6a0bb53d0a736a1a95032c6251b9e54a2187d7fc9405ce330e943086e65772d6b6579730b00000003020000002102007311430123d4cad97f4f7e86e023b28143130a18099ecf094d36fef0f6135c0200000021031a4d9f4903da97498945a4e01a5023a1d53bc96ad670bfe03adf8a06c52e63800200000021035249137286c077ccee65ecc43e724b9b9e5a588e3d7f51e3b62f9624c2a49e46176e65772d7369676e61747572652d7468726573686f6c64010000000000000000000000000000000205746f7069630d0000000c6b65792d726f746174696f6e",
+                "topic": "print",
+                "value": {
+                    "Tuple": {
+                        "data_map": {
+                            "new-address": {
+                                "Principal": {
+                                    "Standard": [
+                                        21,
+                                        [
+                                            240,
+                                            130,
+                                            119,
+                                            254,
+                                            81,
+                                            135,
+                                            124,
+                                            137,
+                                            9,
+                                            24,
+                                            187,
+                                            119,
+                                            142,
+                                            1,
+                                            146,
+                                            48,
+                                            155,
+                                            48,
+                                            124,
+                                            57
+                                        ]
+                                    ]
+                                }
+                            },
+                            "new-aggregate-pubkey": {
+                                "Sequence": {
+                                    "Buffer": {
+                                        "data": [
+                                            2,
+                                            231,
+                                            123,
+                                            188,
+                                            47,
+                                            247,
+                                            214,
+                                            160,
+                                            187,
+                                            83,
+                                            208,
+                                            167,
+                                            54,
+                                            161,
+                                            169,
+                                            80,
+                                            50,
+                                            198,
+                                            37,
+                                            27,
+                                            158,
+                                            84,
+                                            162,
+                                            24,
+                                            125,
+                                            127,
+                                            201,
+                                            64,
+                                            92,
+                                            227,
+                                            48,
+                                            233,
+                                            67
+                                        ]
+                                    }
+                                }
+                            },
+                            "new-keys": {
+                                "Sequence": {
+                                    "List": {
+                                        "data": [
+                                            {
+                                                "Sequence": {
+                                                    "Buffer": {
+                                                        "data": [
+                                                            2,
+                                                            0,
+                                                            115,
+                                                            17,
+                                                            67,
+                                                            1,
+                                                            35,
+                                                            212,
+                                                            202,
+                                                            217,
+                                                            127,
+                                                            79,
+                                                            126,
+                                                            134,
+                                                            224,
+                                                            35,
+                                                            178,
+                                                            129,
+                                                            67,
+                                                            19,
+                                                            10,
+                                                            24,
+                                                            9,
+                                                            158,
+                                                            207,
+                                                            9,
+                                                            77,
+                                                            54,
+                                                            254,
+                                                            240,
+                                                            246,
+                                                            19,
+                                                            92
+                                                        ]
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "Sequence": {
+                                                    "Buffer": {
+                                                        "data": [
+                                                            3,
+                                                            26,
+                                                            77,
+                                                            159,
+                                                            73,
+                                                            3,
+                                                            218,
+                                                            151,
+                                                            73,
+                                                            137,
+                                                            69,
+                                                            164,
+                                                            224,
+                                                            26,
+                                                            80,
+                                                            35,
+                                                            161,
+                                                            213,
+                                                            59,
+                                                            201,
+                                                            106,
+                                                            214,
+                                                            112,
+                                                            191,
+                                                            224,
+                                                            58,
+                                                            223,
+                                                            138,
+                                                            6,
+                                                            197,
+                                                            46,
+                                                            99,
+                                                            128
+                                                        ]
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "Sequence": {
+                                                    "Buffer": {
+                                                        "data": [
+                                                            3,
+                                                            82,
+                                                            73,
+                                                            19,
+                                                            114,
+                                                            134,
+                                                            192,
+                                                            119,
+                                                            204,
+                                                            238,
+                                                            101,
+                                                            236,
+                                                            196,
+                                                            62,
+                                                            114,
+                                                            75,
+                                                            155,
+                                                            158,
+                                                            90,
+                                                            88,
+                                                            142,
+                                                            61,
+                                                            127,
+                                                            81,
+                                                            227,
+                                                            182,
+                                                            47,
+                                                            150,
+                                                            36,
+                                                            194,
+                                                            164,
+                                                            158,
+                                                            70
+                                                        ]
+                                                    }
+                                                }
+                                            }
+                                        ],
+                                        "type_signature": {
+                                            "entry_type": {
+                                                "SequenceType": {
+                                                    "BufferType": 33
+                                                }
+                                            },
+                                            "max_len": 3
+                                        }
+                                    }
+                                }
+                            },
+                            "new-signature-threshold": {
+                                "UInt": 2
+                            },
+                            "topic": {
+                                "Sequence": {
+                                    "String": {
+                                        "ASCII": {
+                                            "data": [
+                                                107,
+                                                101,
+                                                121,
+                                                45,
+                                                114,
+                                                111,
+                                                116,
+                                                97,
+                                                116,
+                                                105,
+                                                111,
+                                                110
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "type_signature": {
+                            "type_map": {
+                                "new-address": "PrincipalType",
+                                "new-aggregate-pubkey": {
+                                    "SequenceType": {
+                                        "BufferType": 33
+                                    }
+                                },
+                                "new-keys": {
+                                    "SequenceType": {
+                                        "ListType": {
+                                            "entry_type": {
+                                                "SequenceType": {
+                                                    "BufferType": 33
+                                                }
+                                            },
+                                            "max_len": 3
+                                        }
+                                    }
+                                },
+                                "new-signature-threshold": "UIntType",
+                                "topic": {
+                                    "SequenceType": {
+                                        "StringType": {
+                                            "ASCII": 12
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "event_index": 0,
+            "txid": "0xa9a493ccd6186b61f72fff3a106522ea008bb95fc415c70a1e9e2fc299b09eac",
+            "type": "contract_event"
+        }
+    ],
+    "index_block_hash": "0x7afdfc0be0557dae593f7c7fd6f0df8cd344ee8b579110062d1f4e3946aa41eb",
+    "matured_miner_rewards": [],
+    "miner_signature": "0x00f0d0eb6937c08a66334237b2458bd19d0ae0ad70c08f66bf2be586c22034a1954b87e97d732bf9c5782a8e3a48aa177a24cf006deac06784734bd2a7742cabe4",
+    "miner_txid": "0x08b60476a8549ef7b04a9210b2ece88207caefcd71654be7ed2a97218f05022b",
+    "parent_block_hash": "0xee15ba694fad86493b7ac36bbed2b0051098467bb6514e8f415e8f0c9dcd0855",
+    "parent_burn_block_hash": "0x094f2504beaff25578ce059dc7a780c205f901f889483ab0b350bfebc1bc48b5",
+    "parent_burn_block_height": 237,
+    "parent_burn_block_timestamp": 1730980669,
+    "parent_index_block_hash": "0xb586080b47665ca1e64fb390c36286fc7d3b4789f0ab1e399f1ea6bfe8b87c16",
+    "parent_microblock": "0x0000000000000000000000000000000000000000000000000000000000000000",
+    "parent_microblock_sequence": 0,
+    "pox_v1_unlock_height": 205,
+    "pox_v2_unlock_height": 207,
+    "pox_v3_unlock_height": 210,
+    "reward_set": null,
+    "signer_bitvec": "000800000001ff",
+    "signer_signature": [
+        "0065f05966e576587a63464a3cd185d028c7ed8474b74791e2b74b81a6fe8245b5056f4b628ea8ae24b88f6de6e981ed761220b57bd5f33cb36e05f28d60107e12",
+        "002fd875c9831056c325d13ab5805c61da612dcaaede0ac0a1e1952fb3064d0e26683e3b17163af2eb9b3379b1920e08fd6544a667202b806adcb8388a0d5a645b"
+    ],
+    "signer_signature_hash": "0x628838c7167591943eb6eeb88949b13c0ae6e7a323de6f4217101bd5028ebcca",
+    "tenure_height": 32,
+    "transactions": [
+        {
+            "burnchain_op": null,
+            "contract_abi": null,
+            "execution_cost": {
+                "read_count": 20,
+                "read_length": 25282,
+                "runtime": 180360,
+                "write_count": 6,
+                "write_length": 266
+            },
+            "microblock_hash": null,
+            "microblock_parent_hash": null,
+            "microblock_sequence": null,
+            "raw_result": "0x0703",
+            "raw_tx": "0x80800000000405f08277fe51877c890918bb778e0192309b307c3900000000000000050000000000002ccf000000030002007311430123d4cad97f4f7e86e023b28143130a18099ecf094d36fef0f6135c0200973520ac9d2d5db93bddcb789b7b17e6020382cd3b97e6247994516f88cfff5f4d2d8d584d50443e19ef5ae0c9313956b33d4d6be701321bc40425aea449ccf20200d488848e9bdff4c47564ba8e91fc5edb09a8860d9412361d03e9c0ad1049f0600858b19f7caca776b37bd57cc3968e2a9e9d932e0cb501f3a9932ca285cfaf4600020301000000000215f08277fe51877c890918bb778e0192309b307c3916736274632d626f6f7473747261702d7369676e65727313726f746174652d6b6579732d77726170706572000000030b00000003020000002102007311430123d4cad97f4f7e86e023b28143130a18099ecf094d36fef0f6135c0200000021031a4d9f4903da97498945a4e01a5023a1d53bc96ad670bfe03adf8a06c52e63800200000021035249137286c077ccee65ecc43e724b9b9e5a588e3d7f51e3b62f9624c2a49e46020000002102e77bbc2ff7d6a0bb53d0a736a1a95032c6251b9e54a2187d7fc9405ce330e9430100000000000000000000000000000002",
+            "status": "success",
+            "tx_index": 0,
+            "txid": "0xa9a493ccd6186b61f72fff3a106522ea008bb95fc415c70a1e9e2fc299b09eac"
+        },
+        {
+            "burnchain_op": null,
+            "contract_abi": null,
+            "execution_cost": {
+                "read_count": 0,
+                "read_length": 0,
+                "runtime": 0,
+                "write_count": 0,
+                "write_length": 0
+            },
+            "microblock_hash": null,
+            "microblock_parent_hash": null,
+            "microblock_sequence": null,
+            "raw_result": "0x0703",
+            "raw_tx": "0x8080000000040068de2dbb6c14aaba2900031876ea3771599edd3a0000000000000004000000000000012c0001cf853ab98e69ca34c8386bf85782871c301ea98a5a174fd97d8fff2aa6a1804404b56e23f7c38e4ed80067f4d9665bc6563d20fa7a321bfcf0a9ca726bab51e303020000000000051a7ce8e31e9120f4b3cb7bea0fed9de8556cadceb900000000000003e800000000000000000000000000000000000000000000000000000000000000000000",
+            "status": "success",
+            "tx_index": 1,
+            "txid": "0xe77dba0e1ba5f08a400a530d01f499885d5bb7e782a91174be6ac4494771044f"
+        }
+    ]
+}


### PR DESCRIPTION
## Description 
Closes: #797 

## Changes
 - Add parsing of `rotate-keys` print envents in the `new_block_handler`
     - Write the rotate-keys tx to the db
 - Add `KeyRotation` to `RegistryEvent`
 - Add `KeyRotationEvent` struct
 - Add event parsing logic

## Testing Information
- add unit tests

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
