### PR TITLE
feat: add protobuf conversion impls

### DIFF
--- a/.generated-sources/blocklist-api/Cargo.toml
+++ b/.generated-sources/blocklist-api/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2021"
 serde = { version = "^1.0", features = ["derive"] }
 serde_with = { version = "^3.8", default-features = false, features = ["base64", "std", "macros"] }
 serde_json = "^1.0"
+serde_repr = "^0.1"
 url = "^2.5"
 uuid = { version = "^1.8", features = ["serde", "v4"] }
 reqwest = { version = "^0.12", features = ["json", "multipart"] }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1050,6 +1050,7 @@ dependencies = [
  "reqwest 0.12.4",
  "serde 1.0.203",
  "serde_json",
+ "serde_repr",
  "serde_with",
  "url",
  "uuid",

--- a/protobufs/stacks/signer/v1/decisions.proto
+++ b/protobufs/stacks/signer/v1/decisions.proto
@@ -8,14 +8,13 @@ import "stacks/common.proto";
 
 // Represents a decision to accept or reject a deposit request.
 message SignerDepositDecision {
-  // The bitcoin transaction ID of the transaction containing the deposit
-  // request. It must be 32 bytes.
+  // The bitcoin outpoint that uniquely identifies the deposit request.
   bitcoin.OutPoint outpoint = 1;
   // Whether or not the signer has accepted the deposit request.
-  bool accepted = 3;
+  bool accepted = 2;
   // This specifies whether the sending signer can provide signature shares
   // for the associated deposit request.
-  bool can_sign = 4;
+  bool can_sign = 3;
 }
 
 // Represents a decision to accept or reject a withdrawal request.

--- a/protobufs/stacks/signer/v1/decisions.proto
+++ b/protobufs/stacks/signer/v1/decisions.proto
@@ -10,9 +10,7 @@ import "stacks/common.proto";
 message SignerDepositDecision {
   // The bitcoin transaction ID of the transaction containing the deposit
   // request. It must be 32 bytes.
-  bitcoin.BitcoinTxid txid = 1;
-  // Index of the deposit request UTXO.
-  uint32 output_index = 2;
+  bitcoin.OutPoint outpoint = 1;
   // Whether or not the signer has accepted the deposit request.
   bool accepted = 3;
   // This specifies whether the sending signer can provide signature shares
@@ -20,8 +18,8 @@ message SignerDepositDecision {
   bool can_sign = 4;
 }
 
-// Represents a decision to accept or reject a deposit request.
-message SignerWithdrawDecision {
+// Represents a decision to accept or reject a withdrawal request.
+message SignerWithdrawalDecision {
   // ID of the withdraw request.
   uint64 request_id = 1;
   // The Stacks block ID of the Stacks block containing the request. It

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -387,6 +387,10 @@ pub enum Error {
     #[error("observer dropped")]
     ObserverDropped,
 
+    /// A required field in a protobuf type was not set.
+    #[error("a required protobuf field was not set")]
+    RequiredProtobufFieldMissing,
+
     /// Thrown when the recoverable signature has a public key that is
     /// unexpected.
     #[error("unexpected public key from signature. key {0}; digest: {1}")]

--- a/signer/src/keys.rs
+++ b/signer/src/keys.rs
@@ -28,6 +28,7 @@
 //! [^3]: https://github.com/Trust-Machines/p256k1/blob/3ecb941c1af13741d52335ef911693b6d6fda94b/p256k1/src/scalar.rs#L245-L257
 //! [^4]: https://github.com/bitcoin-core/secp256k1/blob/3fdf146bad042a17f6b2f490ef8bd9d8e774cdbd/src/scalar.h#L31-L36
 
+use std::ops::Deref;
 use std::str::FromStr;
 
 use bitcoin::ScriptBuf;
@@ -43,6 +44,13 @@ use crate::error::Error;
 #[derive(Copy, Clone, Debug, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct PublicKey(secp256k1::PublicKey);
+
+impl Deref for PublicKey {
+    type Target = secp256k1::PublicKey;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 impl From<&secp256k1::PublicKey> for PublicKey {
     fn from(value: &secp256k1::PublicKey) -> Self {

--- a/signer/src/proto/convert.rs
+++ b/signer/src/proto/convert.rs
@@ -258,6 +258,7 @@ impl From<SignerDepositDecision> for proto::SignerDepositDecision {
                 vout: value.output_index,
             }),
             accepted: value.accepted,
+            can_sign: value.can_sign,
         }
     }
 }
@@ -270,6 +271,7 @@ impl TryFrom<proto::SignerDepositDecision> for SignerDepositDecision {
             txid: outpoint.txid,
             output_index: outpoint.vout,
             accepted: value.accepted,
+            can_sign: value.can_sign,
         })
     }
 }

--- a/signer/src/proto/convert.rs
+++ b/signer/src/proto/convert.rs
@@ -1,0 +1,69 @@
+//! Conversion functions from protobufs to regular types
+//! 
+
+use crate::proto::Uint256;
+
+
+impl From<[u8; 32]> for Uint256 {
+    fn from(value: [u8; 32]) -> Self {
+        let mut part0 = [0u8; 8];
+        let mut part1 = [0u8; 8];
+        let mut part2 = [0u8; 8];
+        let mut part3 = [0u8; 8];
+
+        part0.copy_from_slice(&value[..8]);
+        part1.copy_from_slice(&value[8..16]);
+        part2.copy_from_slice(&value[16..24]);
+        part3.copy_from_slice(&value[24..32]);
+
+        Uint256 {
+            bits_part0: u64::from_le_bytes(part0),
+            bits_part1: u64::from_le_bytes(part1),
+            bits_part2: u64::from_le_bytes(part2),
+            bits_part3: u64::from_le_bytes(part3),
+        }
+    }
+}
+
+impl From<Uint256> for [u8; 32] {
+    fn from(value: Uint256) -> Self {
+        let mut bytes = [0u8; 32];
+
+        bytes[..8].copy_from_slice(&value.bits_part0.to_le_bytes());
+        bytes[8..16].copy_from_slice(&value.bits_part1.to_le_bytes());
+        bytes[16..24].copy_from_slice(&value.bits_part2.to_le_bytes());
+        bytes[24..32].copy_from_slice(&value.bits_part3.to_le_bytes());
+        bytes
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fake::Fake;
+    use fake::Faker;
+    use rand::rngs::OsRng;
+
+    #[test]
+    fn conversion_between_bytes_and_uint256() {
+        let number = Uint256 {
+            bits_part0: Faker.fake_with_rng(&mut OsRng),
+            bits_part1: Faker.fake_with_rng(&mut OsRng),
+            bits_part2: Faker.fake_with_rng(&mut OsRng),
+            bits_part3: Faker.fake_with_rng(&mut OsRng),
+        };
+
+        let bytes = <[u8; 32]>::from(number);
+        let round_trip_number = Uint256::from(bytes);
+        assert_eq!(round_trip_number, number);
+    }
+
+    #[test]
+    fn conversion_between_uint256_and_bytes() {
+        let bytes: [u8; 32] = Faker.fake_with_rng(&mut OsRng);
+        let number = Uint256::from(bytes);
+
+        let rount_trip_bytes = <[u8; 32]>::from(number);
+        assert_eq!(rount_trip_bytes, bytes);
+    }
+}

--- a/signer/src/proto/convert.rs
+++ b/signer/src/proto/convert.rs
@@ -1,8 +1,26 @@
 //! Conversion functions from protobufs to regular types
-//! 
+//!
+
+use secp256k1::ecdsa::RecoverableSignature;
+
+use crate::error::Error;
+use crate::keys::PublicKey;
+use crate::proto;
+use crate::storage::model::{BitcoinTxId, StacksTxId};
 
 use crate::proto::Uint256;
 
+pub trait RequiredField: Sized {
+    type Inner;
+    fn required(self) -> Result<Self::Inner, Error>;
+}
+
+impl<T> RequiredField for Option<T> {
+    type Inner = T;
+    fn required(self) -> Result<Self::Inner, Error> {
+        self.ok_or(Error::TypeConversion)
+    }
+}
 
 impl From<[u8; 32]> for Uint256 {
     fn from(value: [u8; 32]) -> Self {
@@ -37,6 +55,100 @@ impl From<Uint256> for [u8; 32] {
     }
 }
 
+impl From<PublicKey> for proto::PublicKey {
+    fn from(value: PublicKey) -> Self {
+        let (x_only, parity) = value.x_only_public_key();
+        proto::PublicKey {
+            x_only_public_key: Some(Uint256::from(x_only.serialize())),
+            parity_is_odd: parity == secp256k1::Parity::Odd,
+        }
+    }
+}
+
+impl TryFrom<proto::PublicKey> for PublicKey {
+    type Error = Error;
+    fn try_from(value: proto::PublicKey) -> Result<Self, Self::Error> {
+        let x_only: [u8; 32] = value.x_only_public_key.required()?.into();
+        let pk = secp256k1::XOnlyPublicKey::from_slice(&x_only).map_err(Error::InvalidPublicKey)?;
+        let parity = if value.parity_is_odd {
+            secp256k1::Parity::Odd
+        } else {
+            secp256k1::Parity::Even
+        };
+        let public_key = secp256k1::PublicKey::from_x_only_public_key(pk, parity);
+        Ok(Self::from(public_key))
+    }
+}
+
+impl From<RecoverableSignature> for proto::RecoverableSignature {
+    fn from(value: RecoverableSignature) -> Self {
+        let mut lower_bits = [0; 32];
+        let mut upper_bits = [0; 32];
+
+        let (recovery_id, bytes) = value.serialize_compact();
+
+        lower_bits.copy_from_slice(&bytes[..32]);
+        upper_bits.copy_from_slice(&bytes[32..]);
+
+        Self {
+            lower_bits: Some(Uint256::from(lower_bits)),
+            upper_bits: Some(Uint256::from(upper_bits)),
+            recovery_id: recovery_id.to_i32(),
+        }
+    }
+}
+
+impl TryFrom<proto::RecoverableSignature> for RecoverableSignature {
+    type Error = Error;
+    fn try_from(value: proto::RecoverableSignature) -> Result<Self, Self::Error> {
+        let mut data = [0; 64];
+
+        let lower_bits: [u8; 32] = value.lower_bits.required()?.into();
+        let upper_bits: [u8; 32] = value.upper_bits.required()?.into();
+
+        data[..32].copy_from_slice(&lower_bits);
+        data[32..].copy_from_slice(&upper_bits);
+
+        let recovery_id = secp256k1::ecdsa::RecoveryId::from_i32(value.recovery_id)
+            .map_err(Error::InvalidPublicKey)?;
+
+        RecoverableSignature::from_compact(&data, recovery_id)
+            .map_err(Error::InvalidRecoverableSignatureBytes)
+    }
+}
+
+impl From<StacksTxId> for proto::StacksTxid {
+    fn from(value: StacksTxId) -> Self {
+        proto::StacksTxid {
+            txid: Some(Uint256::from(value.into_bytes())),
+        }
+    }
+}
+
+impl TryFrom<proto::StacksTxid> for StacksTxId {
+    type Error = Error;
+    fn try_from(value: proto::StacksTxid) -> Result<Self, Self::Error> {
+        let bytes: [u8; 32] = value.txid.required()?.into();
+        Ok(StacksTxId::from(bytes))
+    }
+}
+
+impl From<BitcoinTxId> for proto::BitcoinTxid {
+    fn from(value: BitcoinTxId) -> Self {
+        proto::BitcoinTxid {
+            txid: Some(Uint256::from(value.into_bytes())),
+        }
+    }
+}
+
+impl TryFrom<proto::BitcoinTxid> for BitcoinTxId {
+    type Error = Error;
+    fn try_from(value: proto::BitcoinTxid) -> Result<Self, Self::Error> {
+        let bytes: [u8; 32] = value.txid.required()?.into();
+        Ok(BitcoinTxId::from(bytes))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -46,7 +158,7 @@ mod tests {
 
     #[test]
     fn conversion_between_bytes_and_uint256() {
-        let number = Uint256 {
+        let number = proto::Uint256 {
             bits_part0: Faker.fake_with_rng(&mut OsRng),
             bits_part1: Faker.fake_with_rng(&mut OsRng),
             bits_part2: Faker.fake_with_rng(&mut OsRng),
@@ -54,14 +166,14 @@ mod tests {
         };
 
         let bytes = <[u8; 32]>::from(number);
-        let round_trip_number = Uint256::from(bytes);
+        let round_trip_number = proto::Uint256::from(bytes);
         assert_eq!(round_trip_number, number);
     }
 
     #[test]
     fn conversion_between_uint256_and_bytes() {
         let bytes: [u8; 32] = Faker.fake_with_rng(&mut OsRng);
-        let number = Uint256::from(bytes);
+        let number = proto::Uint256::from(bytes);
 
         let rount_trip_bytes = <[u8; 32]>::from(number);
         assert_eq!(rount_trip_bytes, bytes);

--- a/signer/src/proto/convert.rs
+++ b/signer/src/proto/convert.rs
@@ -33,7 +33,7 @@ trait RequiredField: Sized {
 impl<T> RequiredField for Option<T> {
     type Inner = T;
     fn required(self) -> Result<Self::Inner, Error> {
-        self.ok_or(Error::TypeConversion)
+        self.ok_or(Error::RequiredProtobufFieldMissing)
     }
 }
 

--- a/signer/src/proto/generated/stacks.signer.v1.rs
+++ b/signer/src/proto/generated/stacks.signer.v1.rs
@@ -3,16 +3,15 @@
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SignerDepositDecision {
-    /// The bitcoin transaction ID of the transaction containing the deposit
-    /// request. It must be 32 bytes.
+    /// The bitcoin outpoint that uniquely identifies the deposit request.
     #[prost(message, optional, tag = "1")]
     pub outpoint: ::core::option::Option<super::super::super::bitcoin::OutPoint>,
     /// Whether or not the signer has accepted the deposit request.
-    #[prost(bool, tag = "3")]
+    #[prost(bool, tag = "2")]
     pub accepted: bool,
     /// This specifies whether the sending signer can provide signature shares
     /// for the associated deposit request.
-    #[prost(bool, tag = "4")]
+    #[prost(bool, tag = "3")]
     pub can_sign: bool,
 }
 /// Represents a decision to accept or reject a withdrawal request.

--- a/signer/src/proto/generated/stacks.signer.v1.rs
+++ b/signer/src/proto/generated/stacks.signer.v1.rs
@@ -6,10 +6,7 @@ pub struct SignerDepositDecision {
     /// The bitcoin transaction ID of the transaction containing the deposit
     /// request. It must be 32 bytes.
     #[prost(message, optional, tag = "1")]
-    pub txid: ::core::option::Option<super::super::super::bitcoin::BitcoinTxid>,
-    /// Index of the deposit request UTXO.
-    #[prost(uint32, tag = "2")]
-    pub output_index: u32,
+    pub outpoint: ::core::option::Option<super::super::super::bitcoin::OutPoint>,
     /// Whether or not the signer has accepted the deposit request.
     #[prost(bool, tag = "3")]
     pub accepted: bool,
@@ -18,10 +15,10 @@ pub struct SignerDepositDecision {
     #[prost(bool, tag = "4")]
     pub can_sign: bool,
 }
-/// Represents a decision to accept or reject a deposit request.
+/// Represents a decision to accept or reject a withdrawal request.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct SignerWithdrawDecision {
+pub struct SignerWithdrawalDecision {
     /// ID of the withdraw request.
     #[prost(uint64, tag = "1")]
     pub request_id: u64,

--- a/signer/src/proto/mod.rs
+++ b/signer/src/proto/mod.rs
@@ -3,8 +3,8 @@ mod generated;
 
 pub mod convert;
 
-pub use generated::crypto::wsts::*;
 pub use generated::bitcoin::*;
+pub use generated::crypto::wsts::*;
 pub use generated::crypto::*;
 pub use generated::stacks::signer::v1::stacks_transaction_sign_request::*;
 pub use generated::stacks::signer::v1::*;

--- a/signer/src/proto/mod.rs
+++ b/signer/src/proto/mod.rs
@@ -1,73 +1,11 @@
 #![allow(missing_docs)]
 mod generated;
 
+pub mod convert;
+
 pub use generated::crypto::wsts::*;
 pub use generated::crypto::*;
 pub use generated::stacks::signer::v1::stacks_transaction_sign_request::*;
 pub use generated::stacks::signer::v1::*;
 pub use generated::stacks::signer::*;
 pub use generated::stacks::*;
-
-impl From<[u8; 32]> for Uint256 {
-    fn from(value: [u8; 32]) -> Self {
-        let mut part0 = [0u8; 8];
-        let mut part1 = [0u8; 8];
-        let mut part2 = [0u8; 8];
-        let mut part3 = [0u8; 8];
-
-        part0.copy_from_slice(&value[..8]);
-        part1.copy_from_slice(&value[8..16]);
-        part2.copy_from_slice(&value[16..24]);
-        part3.copy_from_slice(&value[24..32]);
-
-        Uint256 {
-            bits_part0: u64::from_le_bytes(part0),
-            bits_part1: u64::from_le_bytes(part1),
-            bits_part2: u64::from_le_bytes(part2),
-            bits_part3: u64::from_le_bytes(part3),
-        }
-    }
-}
-
-impl From<Uint256> for [u8; 32] {
-    fn from(value: Uint256) -> Self {
-        let mut bytes = [0u8; 32];
-
-        bytes[..8].copy_from_slice(&value.bits_part0.to_le_bytes());
-        bytes[8..16].copy_from_slice(&value.bits_part1.to_le_bytes());
-        bytes[16..24].copy_from_slice(&value.bits_part2.to_le_bytes());
-        bytes[24..32].copy_from_slice(&value.bits_part3.to_le_bytes());
-        bytes
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use fake::Fake;
-    use fake::Faker;
-    use rand::rngs::OsRng;
-
-    #[test]
-    fn conversion_between_bytes_and_uint256() {
-        let number = Uint256 {
-            bits_part0: Faker.fake_with_rng(&mut OsRng),
-            bits_part1: Faker.fake_with_rng(&mut OsRng),
-            bits_part2: Faker.fake_with_rng(&mut OsRng),
-            bits_part3: Faker.fake_with_rng(&mut OsRng),
-        };
-
-        let bytes = <[u8; 32]>::from(number);
-        let round_trip_number = Uint256::from(bytes);
-        assert_eq!(round_trip_number, number);
-    }
-
-    #[test]
-    fn conversion_between_uint256_and_bytes() {
-        let bytes: [u8; 32] = Faker.fake_with_rng(&mut OsRng);
-        let number = Uint256::from(bytes);
-
-        let rount_trip_bytes = <[u8; 32]>::from(number);
-        assert_eq!(rount_trip_bytes, bytes);
-    }
-}

--- a/signer/src/proto/mod.rs
+++ b/signer/src/proto/mod.rs
@@ -4,6 +4,7 @@ mod generated;
 pub mod convert;
 
 pub use generated::crypto::wsts::*;
+pub use generated::bitcoin::*;
 pub use generated::crypto::*;
 pub use generated::stacks::signer::v1::stacks_transaction_sign_request::*;
 pub use generated::stacks::signer::v1::*;


### PR DESCRIPTION
## Description

This is more work on the path to https://github.com/stacks-network/sbtc/issues/412, and follows https://github.com/stacks-network/sbtc/pull/558, https://github.com/stacks-network/sbtc/pull/577, https://github.com/stacks-network/sbtc/pull/579, and https://github.com/stacks-network/sbtc/pull/727.

## Changes

* Add conversion implementations between some of the protobuf types and their sister types.

## Testing Information

This PR adds unit tests for all 13 conversion implementations.

## Checklist:

- [x] I have performed a self-review of my code
