### PR TITLE
feat: get last bitcoin fees from sweep tables (#809)

### DIFF
--- a/signer/migrations/0003__create_tables.sql
+++ b/signer/migrations/0003__create_tables.sql
@@ -196,6 +196,8 @@ CREATE TABLE sbtc_signer.sweep_transactions (
     amount BIGINT NOT NULL,
     -- The fee paid for the transaction.
     fee BIGINT NOT NULL,
+    -- The _vsize_ of the transaction in bytes.
+    vsize INTEGER NOT NULL,
     -- The Bitcoin block hash at which this package was created.
     created_at_block_hash BYTEA NOT NULL,
     -- The Bitcoin market fee rate at the time this package was created.

--- a/signer/src/bitcoin/client.rs
+++ b/signer/src/bitcoin/client.rs
@@ -23,7 +23,7 @@ use crate::{error::Error, util::ApiFallbackClient};
 use super::rpc::BitcoinCoreClient;
 use super::rpc::BitcoinTxInfo;
 use super::rpc::GetTxResponse;
-use super::{utxo, BitcoinInteract};
+use super::BitcoinInteract;
 
 /// Implement the [`TryFrom`] trait for a slice of [`Url`]s to allow for a
 /// [`ApiFallbackClient`] to be implicitly created from a list of URLs.
@@ -66,11 +66,6 @@ impl BitcoinInteract for ApiFallbackClient<BitcoinCoreClient> {
         // TODO(542)
         self.exec(|client, _| BitcoinInteract::estimate_fee_rate(client))
             .await
-    }
-
-    async fn get_last_fee(&self, utxo: bitcoin::OutPoint) -> Result<Option<utxo::Fees>, Error> {
-        // TODO(541)
-        self.exec(|client, _| client.get_last_fee(utxo)).await
     }
 
     async fn broadcast_transaction(&self, tx: &bitcoin::Transaction) -> Result<(), Error> {

--- a/signer/src/bitcoin/mod.rs
+++ b/signer/src/bitcoin/mod.rs
@@ -44,13 +44,6 @@ pub trait BitcoinInteract: Sync + Send {
     // This should be implemented with the help of the `fees::EstimateFees` trait
     fn estimate_fee_rate(&self) -> impl std::future::Future<Output = Result<f64, Error>> + Send;
 
-    /// Get the total fee amount and the fee rate for the last transaction that
-    /// used the given UTXO as an input.
-    fn get_last_fee(
-        &self,
-        utxo: bitcoin::OutPoint,
-    ) -> impl Future<Output = Result<Option<utxo::Fees>, Error>> + Send;
-
     /// Broadcast transaction
     fn broadcast_transaction(
         &self,

--- a/signer/src/bitcoin/rpc.rs
+++ b/signer/src/bitcoin/rpc.rs
@@ -6,7 +6,6 @@ use bitcoin::Amount;
 use bitcoin::Block;
 use bitcoin::BlockHash;
 use bitcoin::Denomination;
-use bitcoin::OutPoint;
 use bitcoin::Transaction;
 use bitcoin::Txid;
 use bitcoin::Wtxid;
@@ -351,10 +350,5 @@ impl BitcoinInteract for BitcoinCoreClient {
         // src/bitcoin/fees.rs module.
         self.estimate_fee_rate(1)
             .map(|estimate| estimate.sats_per_vbyte)
-    }
-
-    async fn get_last_fee(&self, _: OutPoint) -> Result<Option<super::utxo::Fees>, Error> {
-        // TODO(541): implement this
-        Ok(None)
     }
 }

--- a/signer/src/bitcoin/utxo.rs
+++ b/signer/src/bitcoin/utxo.rs
@@ -67,12 +67,23 @@ const SATS_PER_VBYTE_INCREMENT: f64 = 0.001;
 const OP_RETURN_VERSION: u8 = 0;
 
 /// Describes the fees for a transaction.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Fees {
     /// The total fee paid in sats for the transaction.
     pub total: u64,
     /// The fee rate paid in sats per virtual byte.
     pub rate: f64,
+}
+
+impl Fees {
+    /// A zero-fee [`Fees`] instance.
+    pub const ZERO: Self = Self { total: 0, rate: 0.0 };
+}
+
+/// A trait for getting the fees for a given instance.
+pub trait GetFees {
+    /// Get the [`Fees`] for this instance.
+    fn get_fees(&self) -> Fees;
 }
 
 /// Summary of the Signers' UTXO and information necessary for

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -12,6 +12,10 @@ use crate::stacks::contracts::WithdrawalAcceptValidationError;
 /// Top-level signer error
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
+    /// Indicates that a sweep transaction with the specified txid could not be found.
+    #[error("sweep transaction not found: {0}")]
+    MissingSweepTransaction(bitcoin::Txid),
+
     /// The nakamoto start height could not be determined.
     #[error("nakamoto start height could not be determined")]
     MissingNakamotoStartHeight,

--- a/signer/src/message.rs
+++ b/signer/src/message.rs
@@ -151,6 +151,8 @@ pub struct SweepTransactionInfo {
     pub amount: u64,
     /// The fee paid for this transaction.
     pub fee: u64,
+    /// The virtual size of this transaction (in bytes).
+    pub vsize: u32,
     /// The Bitcoin block hash at which this transaction was created.
     pub created_at_block_hash: bitcoin::BlockHash,
     /// The market fee rate at the time of this transaction.
@@ -164,6 +166,10 @@ pub struct SweepTransactionInfo {
 impl SweepTransactionInfo {
     /// Creates a [`SweepTransactionInfo`] from an [`UnsignedTransaction`] and a
     /// Bitcoin block hash.
+    ///
+    /// **Note that it is important that this function is called after the
+    /// transaction has been signed**, as otherwise the `vbytes` size will not
+    /// be correct.
     pub fn from_unsigned_at_block(
         block_hash: &bitcoin::BlockHash,
         unsigned: &crate::bitcoin::utxo::UnsignedTransaction,
@@ -208,6 +214,8 @@ impl SweepTransactionInfo {
                 .signers_script_pubkey(),
             amount: unsigned.output_amounts(),
             fee: unsigned.tx_fee,
+            // the vsize should never be larger than u32::MAX
+            vsize: unsigned.tx.vsize() as u32,
             market_fee_rate: unsigned.signer_utxo.fee_rate,
             created_at_block_hash: *block_hash,
             swept_deposits,

--- a/signer/src/storage/mod.rs
+++ b/signer/src/storage/mod.rs
@@ -246,6 +246,13 @@ pub trait DbRead {
         chain_tip: &model::BitcoinBlockHash,
         context_window: u16,
     ) -> impl Future<Output = Result<Option<model::SweepTransaction>, Error>> + Send;
+
+    /// Get the sweep transaction package for the given previous transaction id
+    /// (i.e. the previous output that was spent from the then-UTXO).
+    fn get_sweep_transaction_package(
+        &self,
+        prevout_txid: &model::BitcoinTxId,
+    ) -> impl Future<Output = Result<Vec<model::SweepTransaction>, Error>> + Send;
 }
 
 /// Represents the ability to write data to the signer storage.

--- a/signer/src/testing/block_observer.rs
+++ b/signer/src/testing/block_observer.rs
@@ -225,10 +225,6 @@ impl BitcoinInteract for TestHarness {
         unimplemented!()
     }
 
-    async fn get_last_fee(&self, _utxo: bitcoin::OutPoint) -> Result<Option<utxo::Fees>, Error> {
-        unimplemented!()
-    }
-
     async fn broadcast_transaction(&self, _tx: &bitcoin::Transaction) -> Result<(), Error> {
         unimplemented!()
     }

--- a/signer/src/testing/context.rs
+++ b/signer/src/testing/context.rs
@@ -302,13 +302,6 @@ impl BitcoinInteract for WrappedMock<MockBitcoinInteract> {
         self.inner.lock().await.estimate_fee_rate().await
     }
 
-    async fn get_last_fee(
-        &self,
-        utxo: bitcoin::OutPoint,
-    ) -> Result<Option<crate::bitcoin::utxo::Fees>, Error> {
-        self.inner.lock().await.get_last_fee(utxo).await
-    }
-
     async fn broadcast_transaction(&self, tx: &bitcoin::Transaction) -> Result<(), Error> {
         self.inner.lock().await.broadcast_transaction(tx).await
     }

--- a/signer/src/testing/transaction_coordinator.rs
+++ b/signer/src/testing/transaction_coordinator.rs
@@ -173,11 +173,6 @@ where
                     .expect_estimate_fee_rate()
                     .times(1)
                     .returning(|| Box::pin(async { Ok(1.3) }));
-
-                client
-                    .expect_get_last_fee()
-                    .once()
-                    .returning(|_| Box::pin(async { Ok(None) }));
             })
             .await;
 
@@ -320,11 +315,6 @@ where
                     .expect_estimate_fee_rate()
                     .times(1)
                     .returning(|| Box::pin(async { Ok(1.3) }));
-
-                client
-                    .expect_get_last_fee()
-                    .once()
-                    .returning(|_| Box::pin(async { Ok(None) }));
             })
             .await;
 

--- a/signer/tests/integration/emily.rs
+++ b/signer/tests/integration/emily.rs
@@ -268,12 +268,6 @@ async fn deposit_flow() {
                 .once()
                 // Dummy value
                 .returning(|| Box::pin(async { Ok(1.3) }));
-
-            client
-                .expect_get_last_fee()
-                .once()
-                // Dummy value -- we don't need to worry about RBF
-                .returning(|_| Box::pin(async { Ok(None) }));
         })
         .await;
 

--- a/signer/tests/integration/rbf.rs
+++ b/signer/tests/integration/rbf.rs
@@ -13,12 +13,15 @@ use rand::distributions::Uniform;
 use rand::Rng;
 use signer::bitcoin::utxo::DepositRequest;
 use signer::bitcoin::utxo::Fees;
+use signer::bitcoin::utxo::GetFees as _;
 use signer::bitcoin::utxo::RequestRef;
 use signer::bitcoin::utxo::SbtcRequests;
 use signer::bitcoin::utxo::SignerBtcState;
 use signer::bitcoin::utxo::SignerUtxo;
 use signer::bitcoin::utxo::UnsignedTransaction;
 use signer::bitcoin::utxo::WithdrawalRequest;
+use signer::message::SweepTransactionInfo;
+use signer::storage::model;
 use signer::storage::model::ScriptPubKey;
 
 use crate::utxo_construction::generate_withdrawal;
@@ -157,7 +160,8 @@ pub fn transaction_with_rbf(
     };
     let (rpc, faucet) = regtest::initialize_blockchain();
 
-    // Step 1: Construct and send a simple BTC transaction.
+    // ** Step 1 **
+    // Construct and send a simple BTC transaction.
     let signer = Recipient::new(AddressType::P2tr);
     let signers_public_key = signer.keypair.x_only_public_key().0;
 
@@ -188,7 +192,7 @@ pub fn transaction_with_rbf(
         })
         .collect();
 
-    faucet.generate_blocks(1);
+    let block_hash = faucet.generate_blocks(1);
     // We deposited the transaction to the signer, but it's not clear to the
     // wallet tracking the signer's address that the deposit is associated
     // with the signer since it's hidden within the merkle tree.
@@ -231,7 +235,7 @@ pub fn transaction_with_rbf(
     // Okay, lets submit the transaction. We also do a sanity check where
     // we try to submit an RBF transaction with an insufficient fee bump.
     // We need to note the fee for original transaction, so it is returned.
-    let (last_fee, last_fee_rate) = {
+    let fees = {
         // There should only be one transaction here since there is only one
         // deposit request and no withdrawal requests.
         let mut transactions: Vec<UnsignedTransaction> = requests.construct_transactions().unwrap();
@@ -248,7 +252,16 @@ pub fn transaction_with_rbf(
             last_size += unsigned.tx.vsize();
         });
 
-        // Step 2: create an RBF transaction that will fail.
+        // Simulate that we've retrieved the sweep transaction package from the db.
+        // We want to do this before step #2 so we can use the fees paid in the
+        // last successful transaction package when we return them further down.
+        let sweeps: Vec<model::SweepTransaction> = transactions
+            .iter()
+            .map(|tx| (&SweepTransactionInfo::from_unsigned_at_block(&block_hash[0], &tx)).into())
+            .collect();
+
+        // ** Step 2 **
+        // Ccreate an RBF transaction that will fail.
         //
         // This is a little sanity check where we submit an RBF transaction
         // but where we change the fee but an amount that is too small.
@@ -269,17 +282,22 @@ pub fn transaction_with_rbf(
             }
             _ => panic!("Unexpected response when sending bad replacement transaction"),
         }
-        (last_fee, last_fee as f64 / last_size as f64)
+
+        // Calculate the fees based on the last sweep transaction package.
+        let fees = sweeps.get_fees();
+
+        // Just double-check that the fees are what we expect.
+        assert_eq!(fees.total, last_fee);
+        assert_eq!(fees.rate, last_fee as f64 / last_size as f64);
+
+        // Return the fees so we can use them in the next step.
+        fees
     };
 
     // Step 3. Construct an RBF transaction
     //
     // Let's update the request state with the new fee rate, the last fee amount paid
     // and modify the outstanding deposits and withdrawals.
-    let fees = Fees {
-        total: last_fee,
-        rate: last_fee_rate,
-    };
     let requests = recreate_request_state(requests, &ctx, &deposits, &withdrawals, fees);
 
     let mut transactions = requests.construct_transactions().unwrap();
@@ -303,7 +321,7 @@ pub fn transaction_with_rbf(
     let fee_rate = total_fees as f64 / total_size as f64;
 
     more_asserts::assert_ge!(fee_rate, ctx.rbf_fee_rate);
-    more_asserts::assert_gt!(total_fees, last_fee);
+    more_asserts::assert_gt!(total_fees, fees.total);
 
     let deposit_amounts: u64 = requests.deposits.iter().map(|req| req.amount).sum();
     let withdrawal_amounts: u64 = requests.withdrawals.iter().map(|req| req.amount).sum();

--- a/signer/tests/integration/transaction_signer.rs
+++ b/signer/tests/integration/transaction_signer.rs
@@ -93,6 +93,7 @@ fn sweep_transaction_info<R: rand::RngCore>(
         created_at_block_hash,
         amount: 100,
         fee: 1,
+        vsize: 50,
         market_fee_rate: 1.2,
         signer_prevout_txid: testing::dummy::txid(&fake::Faker, rng),
         signer_prevout_amount: 1,


### PR DESCRIPTION
## Description

Closes: #809

## Changes

Removes the `BitcoinInteract::get_last_fees()` (described in #541, replaced by #809) and replaces it with logic to retrieve the `Fees` from the latest sweep transaction package.

## Testing Information

RBF tests updated to use the `sweep_transactions` method.

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
