### PR TITLE
814 feature add api key security to private endpoints on emily openapi spec

### DIFF
--- a/.generated-sources/emily/openapi/build.rs
+++ b/.generated-sources/emily/openapi/build.rs
@@ -1,6 +1,9 @@
 use emily_handler::api;
 use emily_handler::common;
 use serde_json::json;
+use utoipa::openapi::security::ApiKeyValue;
+use utoipa::openapi::security::SecurityScheme;
+use utoipa::Modify;
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::Write;
@@ -8,6 +11,9 @@ use utoipa::OpenApi;
 
 #[derive(utoipa::OpenApi)]
 #[openapi(
+    // Add API key security scheme.
+    modifiers(&AwsApiKey, &AwsLambdaIntegration),
+    // Paths to be included in the OpenAPI specification.
     paths(
         // Health check endpoints.
         api::handlers::health::get_health,
@@ -30,6 +36,7 @@ use utoipa::OpenApi;
         // Testing endpoints.
         api::handlers::testing::wipe_databases,
     ),
+    // Components to be included in the OpenAPI specification.
     components(schemas(
         // Chainstate models.
         api::models::chainstate::Chainstate,
@@ -73,50 +80,72 @@ fn main() {
     println!("cargo:rerun-if-changed=../../../emily/handler/api");
     println!("cargo:rerun-if-changed=build.rs");
 
-    let mut api_doc = ApiDoc::openapi();
-    let new_extensions: HashMap<String, serde_json::Value> = new_operation_extensions();
-
-    // TODO(269): Change Emily API Lambda Integrations to use cdk constructs if possible instead of specification
-    // alteration.
-    //
-    // Add AWS extension to openapi specification so AWS CDK can attach the appropriate lambda endpoint.
-    api_doc
-        .paths
-        .paths
-        .iter_mut()
-        .flat_map(|(_, path_item)| path_item.operations.iter_mut())
-        .for_each(|(_, operation)| {
-            operation
-                .extensions
-                .get_or_insert(Default::default())
-                .extend(new_extensions.clone())
-        });
-
     // Generate string for api doc.
-    let spec_json = api_doc
+    let spec_json = ApiDoc::openapi()
+        // Make the spec pretty just because it's easier to read.
         .to_pretty_json()
         .expect("Failed to serialize OpenAPI spec");
 
     // Open and write to file.
-    let mut file =
-        File::create("emily-openapi-spec.json").expect("Failed to create OpenAPI spec file");
-    file.write_all(spec_json.as_bytes())
+    File::create("emily-openapi-spec.json")
+        .expect("Failed to create OpenAPI spec file")
+        .write_all(spec_json.as_bytes())
         .expect("Failed to write OpenAPI spec file");
 }
 
-/// Creates the map of the extensions to be included in each operation.
-fn new_operation_extensions() -> HashMap<String, serde_json::Value> {
-    let mut extensions: HashMap<String, serde_json::Value> = HashMap::new();
-    extensions.insert(
-        "x-amazon-apigateway-integration".to_string(),
-        json!({
-            "type": "aws_proxy",
-            // Note that it's always meant to be POST regardless of the verb in the api spec.
-            "httpMethod": "POST",
-            "uri": {
-                "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${OperationLambda}/invocations"
-            }
-        })
-    );
-    extensions
+/// Openapi spec modifier that adds the API Gateway API key to the OpenAPI specification.
+/// This adds the key as a schema type but is referenced by name in the paths need to
+/// require authentication.
+struct AwsApiKey;
+impl Modify for AwsApiKey {
+    /// Modify the OpenAPI specification to include the AWS API Gateway key.
+    fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
+        if let Some(schema) = openapi.components.as_mut() {
+            schema.add_security_scheme(
+                "ApiGatewayKey",
+                SecurityScheme::ApiKey(
+                    utoipa::openapi::security::ApiKey::Header(ApiKeyValue::with_description(
+                        "x-api-key",
+                        "AWS Apigateway key"
+                    )),
+                ),
+            );
+        }
+    }
+}
+
+/// Attaches the AWS Lambda integration to the OpenAPI specification. This is necessary
+/// for the AWS CDK to attach the lambda to the API Gateway.
+///
+/// TODO(269): Change Emily API Lambda Integrations to use cdk constructs if possible
+/// instead of specification alteration.
+struct AwsLambdaIntegration;
+impl Modify for AwsLambdaIntegration {
+    /// Add AWS extension to openapi specification so AWS CDK can attach the appropriate lambda endpoint.
+    fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
+        // Gather the extensions to be added to each operation.
+        let mut lambda_integration: HashMap<String, serde_json::Value> = HashMap::new();
+        lambda_integration.insert(
+            "x-amazon-apigateway-integration".to_string(),
+            json!({
+                "type": "aws_proxy",
+                // Note that it's always meant to be POST regardless of the verb in the api spec.
+                "httpMethod": "POST",
+                "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${OperationLambda}/invocations"
+                }
+            })
+        );
+        // Add extensions to each operation.
+        openapi
+            .paths
+            .paths.iter_mut()
+            .flat_map(|(_, path_item)| path_item.operations.iter_mut())
+            .for_each(|(_, operation)| {
+                operation
+                    .extensions
+                    .get_or_insert(Default::default())
+                    .extend(lambda_integration.clone())
+            });
+    }
 }

--- a/.generated-sources/emily/openapi/build.rs
+++ b/.generated-sources/emily/openapi/build.rs
@@ -1,12 +1,13 @@
 use emily_handler::api;
 use emily_handler::common;
 use serde_json::json;
-use utoipa::openapi::security::ApiKeyValue;
-use utoipa::openapi::security::SecurityScheme;
-use utoipa::Modify;
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::Write;
+use utoipa::openapi::security::ApiKey;
+use utoipa::openapi::security::ApiKeyValue;
+use utoipa::openapi::security::SecurityScheme;
+use utoipa::Modify;
 use utoipa::OpenApi;
 
 #[derive(utoipa::OpenApi)]
@@ -103,12 +104,10 @@ impl Modify for AwsApiKey {
         if let Some(schema) = openapi.components.as_mut() {
             schema.add_security_scheme(
                 "ApiGatewayKey",
-                SecurityScheme::ApiKey(
-                    utoipa::openapi::security::ApiKey::Header(ApiKeyValue::with_description(
-                        "x-api-key",
-                        "AWS Apigateway key"
-                    )),
-                ),
+                SecurityScheme::ApiKey(ApiKey::Header(ApiKeyValue::with_description(
+                    "x-api-key",
+                    "AWS Apigateway key",
+                ))),
             );
         }
     }
@@ -139,7 +138,8 @@ impl Modify for AwsLambdaIntegration {
         // Add extensions to each operation.
         openapi
             .paths
-            .paths.iter_mut()
+            .paths
+            .iter_mut()
             .flat_map(|(_, path_item)| path_item.operations.iter_mut())
             .for_each(|(_, operation)| {
                 operation

--- a/.generated-sources/emily/openapi/emily-openapi-spec.json
+++ b/.generated-sources/emily/openapi/emily-openapi-spec.json
@@ -134,6 +134,11 @@
             }
           }
         },
+        "security": [
+          {
+            "ApiGatewayKey": []
+          }
+        ],
         "x-amazon-apigateway-integration": {
           "httpMethod": "POST",
           "type": "aws_proxy",
@@ -210,6 +215,11 @@
             }
           }
         },
+        "security": [
+          {
+            "ApiGatewayKey": []
+          }
+        ],
         "x-amazon-apigateway-integration": {
           "httpMethod": "POST",
           "type": "aws_proxy",
@@ -543,6 +553,11 @@
             }
           }
         },
+        "security": [
+          {
+            "ApiGatewayKey": []
+          }
+        ],
         "x-amazon-apigateway-integration": {
           "httpMethod": "POST",
           "type": "aws_proxy",
@@ -799,6 +814,11 @@
             }
           }
         },
+        "security": [
+          {
+            "ApiGatewayKey": []
+          }
+        ],
         "x-amazon-apigateway-integration": {
           "httpMethod": "POST",
           "type": "aws_proxy",
@@ -832,6 +852,11 @@
             "description": "Internal server error"
           }
         },
+        "security": [
+          {
+            "ApiGatewayKey": []
+          }
+        ],
         "x-amazon-apigateway-integration": {
           "httpMethod": "POST",
           "type": "aws_proxy",
@@ -1008,6 +1033,11 @@
             }
           }
         },
+        "security": [
+          {
+            "ApiGatewayKey": []
+          }
+        ],
         "x-amazon-apigateway-integration": {
           "httpMethod": "POST",
           "type": "aws_proxy",
@@ -1084,6 +1114,11 @@
             }
           }
         },
+        "security": [
+          {
+            "ApiGatewayKey": []
+          }
+        ],
         "x-amazon-apigateway-integration": {
           "httpMethod": "POST",
           "type": "aws_proxy",
@@ -1866,6 +1901,14 @@
             "description": "The status message of the withdrawal."
           }
         }
+      }
+    },
+    "securitySchemes": {
+      "ApiGatewayKey": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-api-key",
+        "description": "AWS Apigateway key"
       }
     }
   }

--- a/emily/handler/src/api/handlers/chainstate.rs
+++ b/emily/handler/src/api/handlers/chainstate.rs
@@ -93,7 +93,8 @@ pub async fn get_chainstate_at_height(
         (status = 404, description = "Address not found", body = ErrorResponse),
         (status = 405, description = "Method not allowed", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse)
-    )
+    ),
+    security(("ApiGatewayKey" = []))
 )]
 pub async fn set_chainstate(context: EmilyContext, body: Chainstate) -> impl warp::reply::Reply {
     // Internal handler so `?` can be used correctly while still returning a reply.
@@ -127,7 +128,8 @@ pub async fn set_chainstate(context: EmilyContext, body: Chainstate) -> impl war
         (status = 404, description = "Address not found", body = ErrorResponse),
         (status = 405, description = "Method not allowed", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse)
-    )
+    ),
+    security(("ApiGatewayKey" = []))
 )]
 pub async fn update_chainstate(
     context: EmilyContext,

--- a/emily/handler/src/api/handlers/deposit.rs
+++ b/emily/handler/src/api/handlers/deposit.rs
@@ -303,7 +303,8 @@ fn scripts_to_resource_parameters(
         (status = 404, description = "Address not found", body = ErrorResponse),
         (status = 405, description = "Method not allowed", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse)
-    )
+    ),
+    security(("ApiGatewayKey" = []))
 )]
 pub async fn update_deposits(
     context: EmilyContext,

--- a/emily/handler/src/api/handlers/health.rs
+++ b/emily/handler/src/api/handlers/health.rs
@@ -15,7 +15,8 @@ use crate::common::error::Error;
         (status = 404, description = "Address not found", body = ErrorResponse),
         (status = 405, description = "Method not allowed", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse)
-    )
+    ),
+    security(("ApiGatewayKey" = []))
 )]
 pub async fn get_health() -> impl warp::reply::Reply {
     Error::NotImplemented

--- a/emily/handler/src/api/handlers/testing.rs
+++ b/emily/handler/src/api/handlers/testing.rs
@@ -20,7 +20,8 @@ use crate::database::accessors;
         (status = 404, description = "Address not found"),
         (status = 405, description = "Method not allowed"),
         (status = 500, description = "Internal server error")
-    )
+    ),
+    security(("ApiGatewayKey" = []))
 )]
 pub async fn wipe_databases(context: EmilyContext) -> impl warp::reply::Reply {
     // Internal handler so `?` can be used correctly while still returning a reply.

--- a/emily/handler/src/api/handlers/withdrawal.rs
+++ b/emily/handler/src/api/handlers/withdrawal.rs
@@ -120,7 +120,8 @@ pub async fn get_withdrawals(
         (status = 404, description = "Address not found", body = ErrorResponse),
         (status = 405, description = "Method not allowed", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse)
-    )
+    ),
+    security(("ApiGatewayKey" = []))
 )]
 pub async fn create_withdrawal(
     context: EmilyContext,
@@ -198,7 +199,8 @@ pub async fn create_withdrawal(
         (status = 404, description = "Address not found", body = ErrorResponse),
         (status = 405, description = "Method not allowed", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse)
-    )
+    ),
+    security(("ApiGatewayKey" = []))
 )]
 pub async fn update_withdrawals(
     context: EmilyContext,


### PR DESCRIPTION
## Description

Closes: #814 

Adds api key level security to private Emily API endpoints.

## Changes

- Adds openapi template builder modifiers so the API keys can be added
- Adds the security requirement to the API endpoints 

## Testing Information

- Tested with integration tests and building.

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
