### PR TITLE
823 feature integrate emily api with aws api gateway

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,6 @@ config = "0.11.0"
 futures = "0.3.24"
 hashbrown = "0.14.5"
 http = "1.1.0"
-lambda_runtime = "0.11.1"
 # This is necessary to compile the AWS Lambda as a lambda.
 openssl = { version = "0.10.66", features = ["vendored"] }
 p256k1 = "7.1.0"

--- a/emily/cdk/lib/emily-stack.ts
+++ b/emily/cdk/lib/emily-stack.ts
@@ -206,12 +206,12 @@ export class EmilyStack extends cdk.Stack {
         const operationLambdaId: string = "OperationLambda";
         const operationLambda: lambda.Function = new lambda.Function(this, operationLambdaId, {
             functionName: EmilyStackUtils.getResourceName(operationLambdaId, props),
-            architecture: EmilyStackUtils.getLambdaArchitecture(props),
+            architecture: lambda.Architecture.X86_64,
             runtime: lambda.Runtime.PROVIDED_AL2023,
             code: lambda.Code.fromAsset(EmilyStackUtils.getPathFromProjectRoot(
                 props.stageName === Constants.UNIT_TEST_STAGE_NAME
                     ? "emily/cdk/test/assets/empty-lambda.zip"
-                    : "target/lambda/emily-handler/bootstrap.zip"
+                    : "target/lambda/emily-lambda/bootstrap.zip"
             )),
             // Lambda should be very fast. Something is wrong if it takes > 5 seconds.
             timeout: cdk.Duration.seconds(5),

--- a/emily/cdk/package.json
+++ b/emily/cdk/package.json
@@ -6,6 +6,9 @@
   },
   "scripts": {
     "synth": "tsc && npx aws-cdk synth -q --no-staging",
+    "build-lambda": "cd ../handler && cargo lambda build --bin emily-lambda --release --output-format zip --x86-64",
+    "deploy": "npx aws-cdk deploy",
+    "build-deploy": "npm run build-lambda && npm run deploy",
     "watch": "tsc -w",
     "test": "jest",
     "clean": "rm -rf node_modules .cdk.staging cdk.out .generated-sources"

--- a/emily/handler/src/api/routes/mod.rs
+++ b/emily/handler/src/api/routes/mod.rs
@@ -5,6 +5,9 @@ use crate::context::EmilyContext;
 use super::handlers;
 use warp::Filter;
 
+#[cfg(feature = "testing")]
+use tracing::debug;
+
 /// Chainstate routes.
 mod chainstate;
 /// Deposit routes.
@@ -27,6 +30,7 @@ pub fn routes(
         .or(deposit::routes(context.clone()))
         .or(withdrawal::routes(context.clone()))
         .or(testing::routes(context))
+        .or(verbose_not_found_route())
         // Convert reply to tuple to that more routes can be added to the returned filter.
         .map(|reply| (reply,))
 }
@@ -42,4 +46,38 @@ pub fn routes(
         .or(withdrawal::routes(context))
         // Convert reply to tuple to that more routes can be added to the returned filter.
         .map(|reply| (reply,))
+}
+
+/// This function sets up the routes expecting the AWS stage to be passed in as the very
+/// first segment of the path. AWS does this by default, and it's not something we can
+/// change.
+pub fn routes_with_stage_prefix(
+    context: EmilyContext,
+) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
+    // Get the AWS Stage name and then ignore it, but print it in the logs if
+    // we're in debug mode.
+    warp::path::param::<String>()
+        .and(routes(context))
+        .map(|stage, reply| {
+            debug!("AWS stage: {}", stage);
+            (reply,)
+        })
+}
+
+/// A verbose route that will return a 404 with the full path and peeked path.
+///
+/// This is useful if you called the API and it doesn't recognize the call that was made internally,
+/// but APIGateway let it through.
+#[cfg(feature = "testing")]
+fn verbose_not_found_route() -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    warp::any()
+        .and(warp::get())
+        .and(warp::path::full())
+        .and(warp::path::peek())
+        .map(|full_path, peek_path| {
+            warp::reply::with_status(
+            format!("Endpoint not found. Full: {:?} | Peek: {:?}", full_path, peek_path),
+            warp::http::StatusCode::NOT_FOUND,
+            )
+        })
 }

--- a/emily/handler/src/api/routes/mod.rs
+++ b/emily/handler/src/api/routes/mod.rs
@@ -69,15 +69,19 @@ pub fn routes_with_stage_prefix(
 /// This is useful if you called the API and it doesn't recognize the call that was made internally,
 /// but APIGateway let it through.
 #[cfg(feature = "testing")]
-fn verbose_not_found_route() -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+fn verbose_not_found_route(
+) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
     warp::any()
         .and(warp::get())
         .and(warp::path::full())
         .and(warp::path::peek())
         .map(|full_path, peek_path| {
             warp::reply::with_status(
-            format!("Endpoint not found. Full: {:?} | Peek: {:?}", full_path, peek_path),
-            warp::http::StatusCode::NOT_FOUND,
+                format!(
+                    "Endpoint not found. Full: {:?} | Peek: {:?}",
+                    full_path, peek_path
+                ),
+                warp::http::StatusCode::NOT_FOUND,
             )
         })
 }

--- a/emily/handler/src/database/accessors.rs
+++ b/emily/handler/src/database/accessors.rs
@@ -2,7 +2,10 @@
 
 use aws_sdk_dynamodb::types::AttributeValue;
 use serde_dynamo::Item;
-use tracing::{info, warn};
+#[cfg(feature = "testing")]
+use tracing::info;
+
+use tracing::warn;
 
 use crate::common::error::{Error, Inconsistency};
 
@@ -620,6 +623,7 @@ where
     .await
 }
 
+#[cfg(feature = "testing")]
 async fn delete_entry<T: TableIndexTrait>(
     context: &EmilyContext,
     key: &<<T as TableIndexTrait>::Entry as EntryTrait>::Key,

--- a/emily/handler/src/database/entries/mod.rs
+++ b/emily/handler/src/database/entries/mod.rs
@@ -46,9 +46,9 @@
 
 use std::{collections::HashMap, fmt::Debug};
 
+use aws_sdk_dynamodb::types::AttributeValue;
 #[cfg(feature = "testing")]
 use aws_sdk_dynamodb::types::{DeleteRequest, WriteRequest};
-use aws_sdk_dynamodb::types::AttributeValue;
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use serde::{Deserialize, Serialize};
 use serde_dynamo::Item;

--- a/emily/handler/src/database/entries/mod.rs
+++ b/emily/handler/src/database/entries/mod.rs
@@ -46,7 +46,9 @@
 
 use std::{collections::HashMap, fmt::Debug};
 
-use aws_sdk_dynamodb::types::{AttributeValue, DeleteRequest, WriteRequest};
+#[cfg(feature = "testing")]
+use aws_sdk_dynamodb::types::{DeleteRequest, WriteRequest};
+use aws_sdk_dynamodb::types::AttributeValue;
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use serde::{Deserialize, Serialize};
 use serde_dynamo::Item;
@@ -335,6 +337,7 @@ pub(crate) trait TableIndexTrait {
     }
 
     /// Get all entries from a dynamodb table.
+    #[cfg(feature = "testing")]
     async fn get_all_entries(
         dynamodb_client: &aws_sdk_dynamodb::Client,
         settings: &Settings,
@@ -366,6 +369,7 @@ pub(crate) trait TableIndexTrait {
     }
 
     /// Generic delete table entry.
+    #[cfg(feature = "testing")]
     async fn delete_entry(
         dynamodb_client: &aws_sdk_dynamodb::Client,
         settings: &Settings,
@@ -387,6 +391,7 @@ pub(crate) trait TableIndexTrait {
     }
 
     /// Deletes every entry in a table with the specified keys.
+    #[cfg(feature = "testing")]
     async fn delete_entries(
         dynamodb_client: &aws_sdk_dynamodb::Client,
         settings: &Settings,


### PR DESCRIPTION
## Description

Closes: #823 

## Changes

Addresses the core issues in #823:

1. Adds handling for the stagename in the route path when compiling as a lambda
2. Always compiles the emily lambda for `x86` processors and specifies the lambda to be `x86` architecture always.
3.  Specifies the lambda architecture to always be `x86` 

It also adds a few helpful and noninvasive changes.

1. Adds two deployment related scripts to the `emily/cdk` npm project: 
    - `build-lambda` which builds the emily lambda for the right architecture
    - `deploy` which deploys the emily cdk stack
    - `build-deploy` which runs both `build-lambda` and `deploy` in a single script
2. Adds a feature where when Emily doesn't recognize a path it's sent and is compiled with the feature `testing`, it will return a `404` error, but will provide a response body that says what path it actually received and the part of the path didn't have any kind of match.
3. Removes an unnecessary dependency.

## Testing Information

Tested against a real deployment by running integration tests against it 
- Running the integration tests against the real deployment required that I change the `config.rs` implementation for the `emily/handler` integration tests such that when a host is provided without a port it will assume it's a full url and ignore adding `http` as a prefix. This is a bit clunky so I opted not to add it to this PR, but you can see it in a commit [here](https://github.com/stacks-network/sbtc/commit/16549d0d2593a5585ed3b7fbdc945f7a12c22294). Additionally, th

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
