### PR TITLE
feat: 801 feature extend db schemas to save all data from new block print events

### DIFF
--- a/signer/migrations/0003__create_tables.sql
+++ b/signer/migrations/0003__create_tables.sql
@@ -126,9 +126,10 @@ CREATE TABLE sbtc_signer.stacks_transactions (
 );
 
 CREATE TABLE sbtc_signer.rotate_keys_transactions (
-    txid BYTEA PRIMARY KEY,
-    aggregate_key BYTEA NOT NULL,
-    signer_set BYTEA[] NOT NULL,
+    txid            BYTEA PRIMARY KEY,
+    address         TEXT    NOT NULL,
+    aggregate_key   BYTEA   NOT NULL,
+    signer_set      BYTEA[] NOT NULL,
     -- This is one of those fields that might not be required in the future
     -- when Schnorr signatures are introduced.
     signatures_required INTEGER NOT NULL,
@@ -137,13 +138,16 @@ CREATE TABLE sbtc_signer.rotate_keys_transactions (
 );
 
 CREATE TABLE sbtc_signer.completed_deposit_events (
-    id           BIGSERIAL PRIMARY KEY,
-    txid         BYTEA   NOT NULL,
-    block_hash   BYTEA   NOT NULL,
-    amount       BIGINT  NOT NULL,
-    bitcoin_txid BYTEA   NOT NULL,
-    output_index BIGINT  NOT NULL,
-    created_at   TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL
+    id                  BIGSERIAL PRIMARY KEY,
+    txid                BYTEA   NOT NULL,
+    block_hash          BYTEA   NOT NULL,
+    amount              BIGINT  NOT NULL,
+    bitcoin_txid        BYTEA   NOT NULL,
+    output_index        BIGINT  NOT NULL,
+    sweep_block_hash    BYTEA   NOT NULL,
+    sweep_block_height  BIGINT  NOT NULL,
+    sweep_txid          BYTEA   NOT NULL,
+    created_at          TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL
 );
 
 CREATE TABLE sbtc_signer.withdrawal_create_events (
@@ -160,15 +164,18 @@ CREATE TABLE sbtc_signer.withdrawal_create_events (
 );
 
 CREATE TABLE sbtc_signer.withdrawal_accept_events (
-    id            BIGSERIAL PRIMARY KEY,
-    txid          BYTEA   NOT NULL,
-    block_hash    BYTEA   NOT NULL,
-    request_id    BIGINT  NOT NULL,
-    signer_bitmap BYTEA   NOT NULL,
-    bitcoin_txid  BYTEA   NOT NULL,
-    output_index  BIGINT  NOT NULL,
-    fee           BIGINT  NOT NULL,
-    created_at    TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL
+    id                  BIGSERIAL PRIMARY KEY,
+    txid                BYTEA   NOT NULL,
+    block_hash          BYTEA   NOT NULL,
+    request_id          BIGINT  NOT NULL,
+    signer_bitmap       BYTEA   NOT NULL,
+    bitcoin_txid        BYTEA   NOT NULL,
+    output_index        BIGINT  NOT NULL,
+    fee                 BIGINT  NOT NULL,
+    sweep_block_hash    BYTEA   NOT NULL,
+    sweep_block_height  BIGINT  NOT NULL,
+    sweep_txid          BYTEA   NOT NULL,
+    created_at          TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL
 );
 
 CREATE TABLE sbtc_signer.withdrawal_reject_events (

--- a/signer/src/api/new_block.rs
+++ b/signer/src/api/new_block.rs
@@ -116,8 +116,6 @@ pub async fn new_block_handler(state: State<ApiState<impl Context>>, body: Strin
         bitcoin_anchor: BitcoinBlockHash::from(new_block_event.burn_block_hash),
     };
     let block_id = new_block_event.index_block_hash;
-    let bitcoin_block_hash = new_block_event.burn_block_hash.to_hex();
-    let bitcoin_block_height = new_block_event.burn_block_height as u64;
 
     // Create vectors to store the processed events for Emily.
     let mut completed_deposits = Vec::new();
@@ -127,24 +125,16 @@ pub async fn new_block_handler(state: State<ApiState<impl Context>>, body: Strin
     for (ev, txid) in events {
         let tx_info = TxInfo { txid, block_id };
         let res = match RegistryEvent::try_new(ev.value, tx_info) {
-            Ok(RegistryEvent::CompletedDeposit(event)) => handle_completed_deposit(
-                &api.ctx,
-                event,
-                &stacks_chaintip,
-                bitcoin_block_hash.clone(),
-                bitcoin_block_height,
-            )
-            .await
-            .map(|x| completed_deposits.push(x)),
-            Ok(RegistryEvent::WithdrawalAccept(event)) => handle_withdrawal_accept(
-                &api.ctx,
-                event,
-                &stacks_chaintip,
-                bitcoin_block_hash.clone(),
-                bitcoin_block_height,
-            )
-            .await
-            .map(|x| updated_withdrawals.push(x)),
+            Ok(RegistryEvent::CompletedDeposit(event)) => {
+                handle_completed_deposit(&api.ctx, event, &stacks_chaintip)
+                    .await
+                    .map(|x| completed_deposits.push(x))
+            }
+            Ok(RegistryEvent::WithdrawalAccept(event)) => {
+                handle_withdrawal_accept(&api.ctx, event, &stacks_chaintip)
+                    .await
+                    .map(|x| updated_withdrawals.push(x))
+            }
             Ok(RegistryEvent::WithdrawalReject(event)) => {
                 handle_withdrawal_reject(&api.ctx, event, &stacks_chaintip)
                     .await
@@ -242,10 +232,6 @@ pub async fn new_block_handler(state: State<ApiState<impl Context>>, body: Strin
 /// - `event`: The deposit event to be processed.
 /// - `stacks_chaintip`: Current chaintip information for the Stacks blockchain,
 ///   including block height and hash.
-/// - `bitcoin_block_hash`: The hash of the Bitcoin block containing the
-///   fullfilling tx.
-/// - `bitcoin_block_height`: The height of the Bitcoin block containing the
-///   fullfilling tx.
 ///
 /// # Returns
 /// - `Result<DepositUpdate, Error>`: On success, returns a `DepositUpdate` struct containing
@@ -255,12 +241,6 @@ async fn handle_completed_deposit(
     ctx: &impl Context,
     event: CompletedDepositEvent,
     stacks_chaintip: &StacksBlock,
-    // TODO (#493): We need the `bitcoin_block_hash` and `bitcoin_block_height`
-    // of the block that included the fulfilling Bitcoin transaction.
-    // After #493 is resolved, this value should be contained in the event itself
-    // and these parameters should be removed.
-    bitcoin_block_hash: String,
-    bitcoin_block_height: u64,
 ) -> Result<DepositUpdate, Error> {
     ctx.get_storage_mut()
         .write_completed_deposit_event(&event)
@@ -271,8 +251,8 @@ async fn handle_completed_deposit(
         bitcoin_txid: event.outpoint.txid.to_string(),
         status: Status::Confirmed,
         fulfillment: Some(Some(Box::new(Fulfillment {
-            bitcoin_block_hash,
-            bitcoin_block_height,
+            bitcoin_block_hash: event.sweep_block_hash.to_string(),
+            bitcoin_block_height: event.sweep_block_height,
             bitcoin_tx_index: event.outpoint.vout,
             bitcoin_txid: event.outpoint.txid.to_string(),
             btc_fee: 1, // TODO (#712): We need to get the fee from the transaction. Currently missing from the event.
@@ -290,10 +270,6 @@ async fn handle_completed_deposit(
 /// # Parameters
 /// - `ctx`: Shared application context with configuration and database access.
 /// - `event`: The withdrawal acceptance event to be processed.
-/// - `bitcoin_block_hash`: The hash of the Bitcoin block containing the
-///   fullfilling tx.
-/// - `bitcoin_block_height`: The height of the Bitcoin block containing the
-///   fullfilling tx.
 /// - `stacks_chaintip`: Current Stacks blockchain chaintip information for
 ///   context on block height and hash.
 ///
@@ -305,12 +281,6 @@ async fn handle_withdrawal_accept(
     ctx: &impl Context,
     event: WithdrawalAcceptEvent,
     stacks_chaintip: &StacksBlock,
-    // TODO (#493): We need the `bitcoin_block_hash` and `bitcoin_block_height`
-    // of the block that included the fulfilling Bitcoin transaction.
-    // After #493 is resolved, this value should be contained in the event itself
-    // and these parameters should be removed.
-    bitcoin_block_hash: String,
-    bitcoin_block_height: u64,
 ) -> Result<WithdrawalUpdate, Error> {
     ctx.get_storage_mut()
         .write_withdrawal_accept_event(&event)
@@ -320,8 +290,8 @@ async fn handle_withdrawal_accept(
         request_id: event.request_id,
         status: Status::Confirmed,
         fulfillment: Some(Some(Box::new(Fulfillment {
-            bitcoin_block_hash,
-            bitcoin_block_height,
+            bitcoin_block_hash: event.sweep_block_hash.to_string(),
+            bitcoin_block_height: event.sweep_block_height,
             bitcoin_tx_index: event.outpoint.vout,
             bitcoin_txid: event.outpoint.txid.to_string(),
             btc_fee: event.fee,
@@ -663,14 +633,7 @@ mod tests {
             last_update_block_hash: stacks_chaintip.block_hash.to_hex(),
             last_update_height: stacks_chaintip.block_height,
         };
-        let res = handle_completed_deposit(
-            &ctx,
-            event,
-            stacks_chaintip,
-            bitcoin_block.block_hash.to_string(),
-            bitcoin_block.block_height,
-        )
-        .await;
+        let res = handle_completed_deposit(&ctx, event, stacks_chaintip).await;
 
         assert!(res.is_ok());
         assert_eq!(res.unwrap(), expectation);
@@ -739,14 +702,7 @@ mod tests {
             last_update_block_hash: stacks_chaintip.block_hash.to_hex(),
             last_update_height: stacks_chaintip.block_height,
         };
-        let res = handle_withdrawal_accept(
-            &ctx,
-            event,
-            stacks_chaintip,
-            bitcoin_block.block_hash.to_string(),
-            bitcoin_block.block_height,
-        )
-        .await;
+        let res = handle_withdrawal_accept(&ctx, event, stacks_chaintip).await;
 
         assert!(res.is_ok());
         assert_eq!(res.unwrap(), expectation);

--- a/signer/src/api/new_block.rs
+++ b/signer/src/api/new_block.rs
@@ -401,6 +401,7 @@ async fn handle_key_rotation(
 ) -> Result<(), Error> {
     let key_rotation_tx = RotateKeysTransaction {
         txid: stacks_txid,
+        address: event.new_address.into(),
         aggregate_key: event.new_aggregate_pubkey.into(),
         signer_set: event.new_keys.into_iter().map(Into::into).collect(),
         signatures_required: event.new_signature_threshold,
@@ -642,6 +643,9 @@ mod tests {
             txid: *stacks_txid,
             block_id: *stacks_chaintip.block_hash,
             amount: 100,
+            sweep_block_hash: *bitcoin_block.block_hash,
+            sweep_block_height: bitcoin_block.block_height,
+            sweep_txid: *txid,
         };
         let expectation = DepositUpdate {
             bitcoin_tx_output_index: event.outpoint.vout,
@@ -714,6 +718,9 @@ mod tests {
             block_id: *stacks_tx.block_hash,
             fee: 1,
             signer_bitmap: BitArray::<_>::ZERO,
+            sweep_block_hash: *bitcoin_block.block_hash,
+            sweep_block_height: bitcoin_block.block_height,
+            sweep_txid: *txid,
         };
 
         // Expected struct to be added to the accepted_withdrawals vector

--- a/signer/src/stacks/wallet.rs
+++ b/signer/src/stacks/wallet.rs
@@ -462,6 +462,7 @@ mod tests {
     use crate::stacks::contracts::ReqContext;
     use crate::storage::model;
     use crate::storage::model::RotateKeysTransaction;
+    use crate::storage::model::StacksPrincipal;
     use crate::storage::DbWrite;
     use crate::testing::context::ConfigureMockedClients;
     use crate::testing::context::TestContext;
@@ -693,6 +694,9 @@ mod tests {
         // Let's store the key information about this wallet into the database
         let rotate_keys = RotateKeysTransaction {
             txid: fake::Faker.fake_with_rng(&mut rng),
+            address: StacksPrincipal::from(clarity::vm::types::PrincipalData::from(
+                wallet1.address().clone(),
+            )),
             aggregate_key: *wallet1.stacks_aggregate_key(),
             signer_set: signer_keys.clone(),
             signatures_required: wallet1.signatures_required,

--- a/signer/src/storage/model.rs
+++ b/signer/src/storage/model.rs
@@ -470,6 +470,9 @@ pub struct SweptWithdrawalRequest {
     /// The block id of the stacks block that includes this sweep
     /// transaction.
     pub sweep_block_hash: BitcoinBlockHash,
+    /// The block height of the block that includes the sweep transaction.
+    #[sqlx(try_from = "i64")]
+    pub sweep_block_height: u64,
     /// Request ID of the withdrawal request. These are supposed to be
     /// unique, but there can be duplicates if there is a reorg that
     /// affects a transaction that calls the `initiate-withdrawal-request`
@@ -533,6 +536,8 @@ pub struct EncryptedDkgShares {
 pub struct RotateKeysTransaction {
     /// Transaction ID.
     pub txid: StacksTxId,
+    /// The address that deployed the contract.
+    pub address: StacksPrincipal,
     /// The aggregate key for these shares.
     ///
     /// TODO(511): maybe make the aggregate key private. Set it using the

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -1426,6 +1426,7 @@ impl super::DbRead for PgStore {
             )
             SELECT
                 rkt.txid
+              , rkt.address
               , rkt.aggregate_key
               , rkt.signer_set
               , rkt.signatures_required
@@ -2244,14 +2245,16 @@ impl super::DbWrite for PgStore {
             r#"
             INSERT INTO sbtc_signer.rotate_keys_transactions (
                   txid
+                , address
                 , aggregate_key
                 , signer_set
                 , signatures_required)
             VALUES
-                ($1, $2, $3, $4)
+                ($1, $2, $3, $4, $5)
             ON CONFLICT DO NOTHING"#,
         )
         .bind(key_rotation.txid)
+        .bind(&key_rotation.address)
         .bind(key_rotation.aggregate_key)
         .bind(&key_rotation.signer_set)
         .bind(i32::from(key_rotation.signatures_required))
@@ -2274,14 +2277,20 @@ impl super::DbWrite for PgStore {
           , amount
           , bitcoin_txid
           , output_index
+          , sweep_block_hash
+          , sweep_block_height
+          , sweep_txid
         )
-        VALUES ($1, $2, $3, $4, $5)",
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
         )
         .bind(event.txid.0)
         .bind(event.block_id.0)
         .bind(i64::try_from(event.amount).map_err(Error::ConversionDatabaseInt)?)
         .bind(event.outpoint.txid.to_byte_array())
         .bind(i64::from(event.outpoint.vout))
+        .bind(event.sweep_block_hash.to_byte_array())
+        .bind(i64::try_from(event.sweep_block_height).map_err(Error::ConversionDatabaseInt)?)
+        .bind(event.sweep_txid.to_byte_array())
         .execute(&self.0)
         .await
         .map_err(Error::SqlxQuery)?;
@@ -2336,8 +2345,11 @@ impl super::DbWrite for PgStore {
           , bitcoin_txid
           , output_index
           , fee
+          , sweep_block_hash
+          , sweep_block_height
+          , sweep_txid
         )
-        VALUES ($1, $2, $3, $4, $5, $6, $7)",
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)",
         )
         .bind(event.txid.0)
         .bind(event.block_id.0)
@@ -2346,6 +2358,9 @@ impl super::DbWrite for PgStore {
         .bind(event.outpoint.txid.to_byte_array())
         .bind(i64::from(event.outpoint.vout))
         .bind(i64::try_from(event.fee).map_err(Error::ConversionDatabaseInt)?)
+        .bind(event.sweep_block_hash.to_byte_array())
+        .bind(i64::try_from(event.sweep_block_height).map_err(Error::ConversionDatabaseInt)?)
+        .bind(event.sweep_txid.to_byte_array())
         .execute(&self.0)
         .await
         .map_err(Error::SqlxQuery)?;

--- a/signer/src/testing/wsts.rs
+++ b/signer/src/testing/wsts.rs
@@ -10,6 +10,7 @@ use crate::network;
 use crate::storage;
 use crate::storage::model;
 use crate::storage::model::EncryptedDkgShares;
+use crate::storage::model::StacksPrincipal;
 use crate::wsts_state_machine;
 
 use fake::Fake;
@@ -19,6 +20,7 @@ use wsts::state_machine::coordinator::frost;
 use crate::ecdsa::SignEcdsa as _;
 use crate::network::MessageTransfer as _;
 
+use stacks_common::types::chainstate::StacksAddress;
 use wsts::net::SignatureType;
 use wsts::state_machine::coordinator::Coordinator as _;
 use wsts::state_machine::StateMachine as _;
@@ -545,9 +547,13 @@ impl SignerSet {
             tx_type: model::TransactionType::RotateKeys,
             block_hash: stacks_chain_tip.block_hash.to_bytes(),
         };
+        let address = StacksPrincipal::from(clarity::vm::types::PrincipalData::from(
+            StacksAddress::p2pkh(false, &shares.aggregate_key.into()),
+        ));
 
         let rotate_keys_tx = model::RotateKeysTransaction {
             aggregate_key: shares.aggregate_key,
+            address,
             txid,
             signer_set: self.signer_keys(),
             signatures_required: self.signers.len() as u16,

--- a/signer/tests/fixtures/completed-deposit-event.json
+++ b/signer/tests/fixtures/completed-deposit-event.json
@@ -75,6 +75,89 @@
                             "output-index": {
                                 "UInt": 4294967295
                             },
+                            "burn-hash": {
+                                "Sequence": {
+                                    "Buffer": {
+                                        "data": [
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1
+                                        ]
+                                    }
+                                }
+                            },
+                            "burn-height": {
+                                "UInt": 42
+                            },
+                            "sweep-txid": {
+                                "Sequence": {
+                                    "Buffer": {
+                                        "data": [
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2
+                                        ]
+                                    }
+                                }
+                            },
                             "topic": {
                                 "Sequence": {
                                     "String": {
@@ -112,6 +195,17 @@
                                     }
                                 },
                                 "output-index": "UIntType",
+                                "burn-hash": {
+                                    "SequenceType": {
+                                        "BufferType": 32
+                                    }
+                                },
+                                "burn-height": "UIntType",
+                                "sweep-txid": {
+                                    "SequenceType": {
+                                        "BufferType": 32
+                                    }
+                                },
                                 "topic": {
                                     "SequenceType": {
                                         "StringType": {

--- a/signer/tests/fixtures/withdrawal-accept-event.json
+++ b/signer/tests/fixtures/withdrawal-accept-event.json
@@ -81,6 +81,89 @@
                             "signer-bitmap": {
                                 "UInt": 0
                             },
+                            "burn-hash": {
+                                "Sequence": {
+                                    "Buffer": {
+                                        "data": [
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1,
+                                            1
+                                        ]
+                                    }
+                                }
+                            },
+                            "burn-height": {
+                                "UInt": 42
+                            },
+                            "sweep-txid": {
+                                "Sequence": {
+                                    "Buffer": {
+                                        "data": [
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2,
+                                            2
+                                        ]
+                                    }
+                                }
+                            },
                             "topic": {
                                 "Sequence": {
                                     "String": {
@@ -120,6 +203,17 @@
                                 "output-index": "UIntType",
                                 "request-id": "UIntType",
                                 "signer-bitmap": "UIntType",
+                                "burn-hash": {
+                                    "SequenceType": {
+                                        "BufferType": 32
+                                    }
+                                },
+                                "burn-height": "UIntType",
+                                "sweep-txid": {
+                                    "SequenceType": {
+                                        "BufferType": 32
+                                    }
+                                },
                                 "topic": {
                                     "SequenceType": {
                                         "StringType": {

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -1912,6 +1912,9 @@ async fn get_swept_deposit_requests_does_not_return_deposit_requests_with_respon
         block_id: *setup_canonical_event_block.block_hash,
         amount: setup_canonical.deposit_request.amount,
         outpoint: setup_canonical.deposit_request.outpoint,
+        sweep_block_hash: setup_canonical.deposit_block_hash,
+        sweep_block_height: 42,
+        sweep_txid: setup_canonical.deposit_request.outpoint.txid,
     };
     db.write_completed_deposit_event(&event).await.unwrap();
 
@@ -1921,6 +1924,9 @@ async fn get_swept_deposit_requests_does_not_return_deposit_requests_with_respon
         block_id: *setup_fork_event_block.block_hash,
         amount: setup_fork.deposit_request.amount,
         outpoint: setup_fork.deposit_request.outpoint,
+        sweep_block_hash: setup_fork.deposit_block_hash,
+        sweep_block_height: 42,
+        sweep_txid: setup_fork.deposit_request.outpoint.txid,
     };
     db.write_completed_deposit_event(&event).await.unwrap();
 
@@ -1950,6 +1956,9 @@ async fn get_swept_deposit_requests_does_not_return_deposit_requests_with_respon
         block_id: *setup_fork_event_block.block_hash,
         amount: setup_fork.deposit_request.amount,
         outpoint: setup_fork.deposit_request.outpoint,
+        sweep_block_hash: setup_fork.deposit_block_hash,
+        sweep_block_height: 42,
+        sweep_txid: setup_fork.deposit_request.outpoint.txid,
     };
     db.write_completed_deposit_event(&event).await.unwrap();
 
@@ -2103,6 +2112,9 @@ async fn get_swept_deposit_requests_response_tx_reorged() {
         block_id: *original_event_block.block_hash,
         amount: setup.deposit_request.amount,
         outpoint: setup.deposit_request.outpoint,
+        sweep_block_hash: setup.deposit_block_hash,
+        sweep_block_height: 42,
+        sweep_txid: setup.deposit_request.outpoint.txid,
     };
     db.write_completed_deposit_event(&event).await.unwrap();
 


### PR DESCRIPTION
## Description

Closes: #801, #726

## Changes
- Extended the CompletedDepositEvent, WithdrawalAcceptEvent, and KeyRotationEvent structs to contain the missing data
- Extended the corresponding events parsing methods in `RawTupleData`
- Extended the DB migrations to contain the new data
- Extended the `completed_deposit_event`, `write_withdrawal_accept_event`, and `write_rotate_keys_transaction` to save the new data.
- Set the `DepositUpdate` and `WithdrawalUpdate` in `handle_withdrawal_accept` and `handle_completed_deposit` with the real block values from the event, replacing the old dummy ones.
- 
## Testing Information
- add new unit and integration tests, and adapt old ones.

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
