### PR TITLE
feat: run blocklist client for deposits that we cannot sign for

### DIFF
--- a/protobufs/stacks/signer/v1/decisions.proto
+++ b/protobufs/stacks/signer/v1/decisions.proto
@@ -10,8 +10,10 @@ import "stacks/common.proto";
 message SignerDepositDecision {
   // The bitcoin outpoint that uniquely identifies the deposit request.
   bitcoin.OutPoint outpoint = 1;
-  // Whether or not the signer has accepted the deposit request.
-  bool accepted = 2;
+  // This specifies whether the sending signer's blocklist client blocked
+  // the deposit request. `true` here means the blocklist client did not
+  // block the request.
+  bool can_accept = 2;
   // This specifies whether the sending signer can provide signature shares
   // for the associated deposit request.
   bool can_sign = 3;

--- a/signer/migrations/0003__create_tables.sql
+++ b/signer/migrations/0003__create_tables.sql
@@ -52,7 +52,7 @@ CREATE TABLE sbtc_signer.deposit_signers (
     -- this specifies whether the signer is a part of the signer set
     -- associated with the deposit_request.signers_public_key
     can_sign BOOLEAN NOT NULL,
-    is_accepted BOOLEAN NOT NULL,
+    can_accept BOOLEAN NOT NULL,
     created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
     PRIMARY KEY (txid, output_index, signer_pub_key),
     FOREIGN KEY (txid, output_index) REFERENCES sbtc_signer.deposit_requests(txid, output_index) ON DELETE CASCADE

--- a/signer/src/bitcoin/validation.rs
+++ b/signer/src/bitcoin/validation.rs
@@ -268,9 +268,9 @@ pub struct DepositRequestReport {
     /// This will only be `None` if we do not have a record of the deposit
     /// request.
     pub can_sign: Option<bool>,
-    /// Whether this signer accepted the deposit request or not. This
-    /// should only be `None` if we do not have a record of the deposit
-    /// request or if we cannot sign for the deposited funds.
+    /// Whether this signers' blocklist client accepted the deposit request
+    /// or not. This should only be `None` if we do not have a record of
+    /// the deposit request.
     pub can_accept: Option<bool>,
     /// The deposit amount
     pub amount: u64,

--- a/signer/src/bitcoin/validation.rs
+++ b/signer/src/bitcoin/validation.rs
@@ -384,7 +384,7 @@ mod tests {
         report: DepositRequestReport {
             status: DepositRequestStatus::Unconfirmed,
             can_sign: Some(true),
-            is_accepted: Some(true),
+            can_accept: Some(true),
             amount: 0,
             max_fee: u64::MAX,
             lock_time: LockTime::from_height(u16::MAX),
@@ -397,7 +397,7 @@ mod tests {
         report: DepositRequestReport {
             status: DepositRequestStatus::Spent(BitcoinTxId::from([1; 32])),
             can_sign: Some(true),
-            is_accepted: Some(true),
+            can_accept: Some(true),
             amount: 0,
             max_fee: u64::MAX,
             lock_time: LockTime::from_height(u16::MAX),
@@ -410,7 +410,7 @@ mod tests {
         report: DepositRequestReport {
             status: DepositRequestStatus::Confirmed(0, BitcoinBlockHash::from([0; 32])),
             can_sign: None,
-            is_accepted: Some(true),
+            can_accept: Some(true),
             amount: 0,
             max_fee: u64::MAX,
             lock_time: LockTime::from_height(u16::MAX),
@@ -423,7 +423,7 @@ mod tests {
         report: DepositRequestReport {
             status: DepositRequestStatus::Confirmed(0, BitcoinBlockHash::from([0; 32])),
             can_sign: Some(false),
-            is_accepted: Some(true),
+            can_accept: Some(true),
             amount: 0,
             max_fee: u64::MAX,
             lock_time: LockTime::from_height(u16::MAX),
@@ -436,7 +436,7 @@ mod tests {
         report: DepositRequestReport {
             status: DepositRequestStatus::Confirmed(0, BitcoinBlockHash::from([0; 32])),
             can_sign: Some(true),
-            is_accepted: Some(false),
+            can_accept: Some(false),
             amount: 0,
             max_fee: u64::MAX,
             lock_time: LockTime::from_height(u16::MAX),
@@ -449,7 +449,7 @@ mod tests {
         report: DepositRequestReport {
             status: DepositRequestStatus::Confirmed(0, BitcoinBlockHash::from([0; 32])),
             can_sign: Some(true),
-            is_accepted: Some(true),
+            can_accept: Some(true),
             amount: 0,
             max_fee: u64::MAX,
             lock_time: LockTime::from_height(DEPOSIT_LOCKTIME_BLOCK_BUFFER + 1),
@@ -462,7 +462,7 @@ mod tests {
         report: DepositRequestReport {
             status: DepositRequestStatus::Confirmed(0, BitcoinBlockHash::from([0; 32])),
             can_sign: Some(true),
-            is_accepted: Some(true),
+            can_accept: Some(true),
             amount: 0,
             max_fee: u64::MAX,
             lock_time: LockTime::from_height(DEPOSIT_LOCKTIME_BLOCK_BUFFER + 2),
@@ -475,7 +475,7 @@ mod tests {
         report: DepositRequestReport {
             status: DepositRequestStatus::Confirmed(0, BitcoinBlockHash::from([0; 32])),
             can_sign: Some(true),
-            is_accepted: Some(true),
+            can_accept: Some(true),
             amount: 0,
             max_fee: u64::MAX,
             lock_time: LockTime::from_512_second_intervals(u16::MAX),
@@ -488,7 +488,7 @@ mod tests {
         report: DepositRequestReport {
             status: DepositRequestStatus::Confirmed(0, BitcoinBlockHash::from([0; 32])),
             can_sign: Some(true),
-            is_accepted: Some(true),
+            can_accept: Some(true),
             amount: 0,
             max_fee: u64::MAX,
             lock_time: LockTime::from_height(DEPOSIT_LOCKTIME_BLOCK_BUFFER + 3),
@@ -517,7 +517,7 @@ mod tests {
         report: DepositRequestReport {
             status: DepositRequestStatus::Confirmed(0, BitcoinBlockHash::from([0; 32])),
             can_sign: Some(true),
-            is_accepted: Some(true),
+            can_accept: Some(true),
             amount: 0,
             max_fee: TX_FEE,
             lock_time: LockTime::from_height(DEPOSIT_LOCKTIME_BLOCK_BUFFER + 3),
@@ -530,7 +530,7 @@ mod tests {
         report: DepositRequestReport {
             status: DepositRequestStatus::Confirmed(0, BitcoinBlockHash::from([0; 32])),
             can_sign: Some(true),
-            is_accepted: Some(true),
+            can_accept: Some(true),
             amount: 0,
             max_fee: TX_FEE,
             lock_time: LockTime::from_height(DEPOSIT_LOCKTIME_BLOCK_BUFFER + 3),
@@ -543,7 +543,7 @@ mod tests {
         report: DepositRequestReport {
             status: DepositRequestStatus::Confirmed(0, BitcoinBlockHash::from([0; 32])),
             can_sign: Some(true),
-            is_accepted: Some(true),
+            can_accept: Some(true),
             amount: 0,
             max_fee: TX_FEE - 1,
             lock_time: LockTime::from_height(DEPOSIT_LOCKTIME_BLOCK_BUFFER + 3),

--- a/signer/src/message.rs
+++ b/signer/src/message.rs
@@ -252,8 +252,10 @@ pub struct SignerDepositDecision {
     pub txid: bitcoin::Txid,
     /// Index of the deposit request UTXO.
     pub output_index: u32,
-    /// Whether the signer has accepted the deposit request.
-    pub accepted: bool,
+    /// This specifies whether the sending signer's blocklist client
+    /// blocked the deposit request. `true` here means the blocklist client
+    /// did not block the request.
+    pub can_accept: bool,
     /// This specifies whether the sending signer can provide signature
     /// shares for the associated deposit request.
     pub can_sign: bool,
@@ -395,7 +397,7 @@ impl wsts::net::Signable for SignerDepositDecision {
         hasher.update("SIGNER_DEPOSIT_DECISION");
         hasher.update(self.txid);
         hasher.update(self.output_index.to_be_bytes());
-        hasher.update([self.accepted as u8]);
+        hasher.update([self.can_accept as u8]);
     }
 }
 

--- a/signer/src/proto/convert.rs
+++ b/signer/src/proto/convert.rs
@@ -257,7 +257,7 @@ impl From<SignerDepositDecision> for proto::SignerDepositDecision {
                 txid: Some(BitcoinTxId::from(value.txid).into()),
                 vout: value.output_index,
             }),
-            accepted: value.accepted,
+            can_accept: value.can_accept,
             can_sign: value.can_sign,
         }
     }
@@ -270,7 +270,7 @@ impl TryFrom<proto::SignerDepositDecision> for SignerDepositDecision {
         Ok(SignerDepositDecision {
             txid: outpoint.txid,
             output_index: outpoint.vout,
-            accepted: value.accepted,
+            can_accept: value.can_accept,
             can_sign: value.can_sign,
         })
     }

--- a/signer/src/proto/generated/stacks.signer.v1.rs
+++ b/signer/src/proto/generated/stacks.signer.v1.rs
@@ -6,9 +6,11 @@ pub struct SignerDepositDecision {
     /// The bitcoin outpoint that uniquely identifies the deposit request.
     #[prost(message, optional, tag = "1")]
     pub outpoint: ::core::option::Option<super::super::super::bitcoin::OutPoint>,
-    /// Whether or not the signer has accepted the deposit request.
+    /// This specifies whether the sending signer's blocklist client blocked
+    /// the deposit request. `true` here means the blocklist client did not
+    /// block the request.
     #[prost(bool, tag = "2")]
-    pub accepted: bool,
+    pub can_accept: bool,
     /// This specifies whether the sending signer can provide signature shares
     /// for the associated deposit request.
     #[prost(bool, tag = "3")]

--- a/signer/src/storage/in_memory.rs
+++ b/signer/src/storage/in_memory.rs
@@ -314,7 +314,11 @@ impl super::DbRead for SharedStore {
                     .deposit_request_to_signers
                     .get(&(deposit_request.txid, deposit_request.output_index))
                     .map(|signers| {
-                        signers.iter().filter(|signer| signer.can_accept).count() >= threshold
+                        signers
+                            .iter()
+                            .filter(|signer| signer.can_accept && signer.can_sign)
+                            .count()
+                            >= threshold
                     })
                     .unwrap_or_default()
             })

--- a/signer/src/storage/in_memory.rs
+++ b/signer/src/storage/in_memory.rs
@@ -314,7 +314,7 @@ impl super::DbRead for SharedStore {
                     .deposit_request_to_signers
                     .get(&(deposit_request.txid, deposit_request.output_index))
                     .map(|signers| {
-                        signers.iter().filter(|signer| signer.is_accepted).count() >= threshold
+                        signers.iter().filter(|signer| signer.can_accept).count() >= threshold
                     })
                     .unwrap_or_default()
             })
@@ -647,7 +647,7 @@ impl super::DbRead for SharedStore {
         let signers = self.get_deposit_signers(txid, output_index).await?;
         let mut signer_votes: HashMap<PublicKey, bool> = signers
             .iter()
-            .map(|vote| (vote.signer_pub_key, vote.is_accepted))
+            .map(|vote| (vote.signer_pub_key, vote.can_accept))
             .collect();
 
         // Now we might not have votes from every signer, so lets get the

--- a/signer/src/storage/mod.rs
+++ b/signer/src/storage/mod.rs
@@ -60,7 +60,11 @@ pub trait DbRead {
     ) -> impl Future<Output = Result<Vec<model::DepositRequest>, Error>> + Send;
 
     /// Get pending deposit requests that have been accepted by at least
-    /// `signatures_required` signers and has no responses
+    /// `signatures_required` signers and has no responses.
+    ///
+    /// For an individual signer, 'accepted' means their blocklist client
+    /// hasn't blocked the request and they are part of the signing set
+    /// that generated the aggregate key locking the deposit.
     fn get_pending_accepted_deposit_requests(
         &self,
         chain_tip: &model::BitcoinBlockHash,

--- a/signer/src/storage/model.rs
+++ b/signer/src/storage/model.rs
@@ -396,8 +396,8 @@ pub struct DepositSigner {
     pub output_index: u32,
     /// Public key of the signer.
     pub signer_pub_key: PublicKey,
-    /// Signals if the signer is prepared to sign for this request.
-    pub is_accepted: bool,
+    /// Signals if the signer will sign for this request if able.
+    pub can_accept: bool,
     /// This specifies whether the indicated signer_pub_key can sign for
     /// the associated deposit request.
     pub can_sign: bool,
@@ -679,8 +679,8 @@ impl From<Vec<SignerVote>> for SignerVotes {
     }
 }
 
-impl From<SignerVotes> for BitArray<[u8; 16]> {
-    fn from(votes: SignerVotes) -> BitArray<[u8; 16]> {
+impl From<&SignerVotes> for BitArray<[u8; 16]> {
+    fn from(votes: &SignerVotes) -> BitArray<[u8; 16]> {
         let mut signer_bitmap = BitArray::ZERO;
         votes
             .iter()
@@ -698,6 +698,12 @@ impl From<SignerVotes> for BitArray<[u8; 16]> {
             });
 
         signer_bitmap
+    }
+}
+
+impl From<SignerVotes> for BitArray<[u8; 16]> {
+    fn from(votes: SignerVotes) -> BitArray<[u8; 16]> {
+        Self::from(&votes)
     }
 }
 

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -96,11 +96,11 @@ pub fn extract_relevant_transactions(
 
 /// A convenience struct for retrieving a deposit request report
 #[derive(sqlx::FromRow)]
-struct StatusSummary {
+struct DepositStatusSummary {
     /// The current signer may not have a record of their vote for
-    /// the deposit. When that happens the `is_accepted` and
+    /// the deposit. When that happens the `can_accept` and
     /// `can_sign` fields will be None.
-    is_accepted: Option<bool>,
+    can_accept: Option<bool>,
     /// Whether this signer is a member of the signing set that generated
     /// the public key locking the deposit.
     can_sign: Option<bool>,
@@ -510,7 +510,7 @@ impl PgStore {
         txid: &model::BitcoinTxId,
         output_index: u32,
         signer_public_key: &PublicKey,
-    ) -> Result<Option<StatusSummary>, Error> {
+    ) -> Result<Option<DepositStatusSummary>, Error> {
         // We first get the least height for when the deposit request was
         // confirmed. This height serves as the stopping criteria for the
         // recursive part of the subsequent query.
@@ -520,7 +520,7 @@ impl PgStore {
         let Some(min_block_height) = min_block_height_fut.await? else {
             return Ok(None);
         };
-        sqlx::query_as::<_, StatusSummary>(
+        sqlx::query_as::<_, DepositStatusSummary>(
             r#"
             WITH RECURSIVE block_chain AS (
                 SELECT 
@@ -542,7 +542,7 @@ impl PgStore {
                 WHERE child.block_height >= $2
             )
             SELECT
-                ds.is_accepted
+                ds.can_accept
               , ds.can_sign
               , dr.amount
               , dr.max_fee
@@ -914,7 +914,7 @@ impl super::DbRead for PgStore {
             deposit_votes AS (
                 SELECT
                     signer_pub_key AS signer_public_key
-                  , is_accepted
+                  , can_accept AND can_sign AS is_accepted
                 FROM sbtc_signer.deposit_signers AS ds
                 WHERE TRUE
                   AND ds.txid = $2
@@ -1059,7 +1059,7 @@ impl super::DbRead for PgStore {
         Ok(Some(DepositRequestReport {
             status,
             can_sign: summary.can_sign,
-            is_accepted: summary.is_accepted,
+            can_accept: summary.can_accept,
             amount: summary.amount,
             max_fee: summary.max_fee,
             lock_time: bitcoin::relative::LockTime::from_consensus(summary.lock_time)
@@ -2025,7 +2025,7 @@ impl super::DbWrite for PgStore {
               ( txid
               , output_index
               , signer_pub_key
-              , is_accepted
+              , can_accept
               , can_sign
               )
             VALUES ($1, $2, $3, $4, $5)
@@ -2034,7 +2034,7 @@ impl super::DbWrite for PgStore {
         .bind(decision.txid)
         .bind(i32::try_from(decision.output_index).map_err(Error::ConversionDatabaseInt)?)
         .bind(decision.signer_pub_key)
-        .bind(decision.is_accepted)
+        .bind(decision.can_accept)
         .bind(decision.can_sign)
         .execute(&self.0)
         .await

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -859,7 +859,8 @@ impl super::DbRead for PgStore {
                 JOIN sbtc_signer.deposit_requests deposit_requests USING(txid)
                 JOIN sbtc_signer.deposit_signers signers USING(txid, output_index)
                 WHERE
-                    signers.is_accepted
+                    signers.can_accept
+                    AND signers.can_sign
                     AND (transactions.block_height + deposit_requests.lock_time) >= $4
                 GROUP BY deposit_requests.txid, deposit_requests.output_index
                 HAVING COUNT(signers.txid) >= $3
@@ -1078,7 +1079,7 @@ impl super::DbRead for PgStore {
                 txid
               , output_index
               , signer_pub_key
-              , is_accepted
+              , can_accept
               , can_sign
             FROM sbtc_signer.deposit_signers
             WHERE txid = $1 AND output_index = $2",

--- a/signer/src/testing/message.rs
+++ b/signer/src/testing/message.rs
@@ -66,12 +66,11 @@ impl fake::Dummy<fake::Faker> for message::SignerMessage {
 
 impl fake::Dummy<fake::Faker> for message::SignerDepositDecision {
     fn dummy_with_rng<R: rand::RngCore + ?Sized>(config: &fake::Faker, rng: &mut R) -> Self {
-        let can_sign = config.fake_with_rng(rng);
         Self {
             output_index: config.fake_with_rng(rng),
             txid: dummy::txid(config, rng),
-            accepted: can_sign,
-            can_sign,
+            can_accept: config.fake_with_rng(rng),
+            can_sign: config.fake_with_rng(rng),
         }
     }
 }

--- a/signer/src/testing/storage/model.rs
+++ b/signer/src/testing/storage/model.rs
@@ -406,7 +406,7 @@ impl DepositData {
                     txid: deposit_request.txid,
                     output_index: deposit_request.output_index,
                     signer_pub_key,
-                    is_accepted: fake::Faker.fake_with_rng(rng),
+                    can_accept: fake::Faker.fake_with_rng(rng),
                     can_sign: true,
                 })
                 .collect();

--- a/signer/src/testing/transaction_signer.rs
+++ b/signer/src/testing/transaction_signer.rs
@@ -827,7 +827,7 @@ where
             for deposit_request_block in blocks {
                 if context_window_block_hashes.contains(&deposit_request_block) {
                     assert_eq!(signer_decisions.len(), num_expected_decisions);
-                    assert!(signer_decisions.first().unwrap().is_accepted)
+                    assert!(signer_decisions.first().unwrap().can_accept)
                 } else {
                     assert_eq!(signer_decisions.len(), 0);
                 }

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -805,12 +805,12 @@ where
             .await?
             .unwrap_or(false);
 
-        let is_accepted = can_sign && self.can_accept_deposit_request(&request).await?;
+        let can_accept = self.can_accept_deposit_request(&request).await?;
 
         let msg = message::SignerDepositDecision {
             txid: request.txid.into(),
             output_index: request.output_index,
-            accepted: is_accepted,
+            can_accept,
             can_sign,
         };
 
@@ -818,7 +818,7 @@ where
             txid: request.txid,
             output_index: request.output_index,
             signer_pub_key: signer_public_key,
-            is_accepted,
+            can_accept,
             can_sign,
         };
 
@@ -923,7 +923,7 @@ where
             txid: decision.txid.into(),
             output_index: decision.output_index,
             signer_pub_key,
-            is_accepted: decision.accepted,
+            can_accept: decision.can_accept,
             can_sign: decision.can_sign,
         };
 

--- a/signer/tests/integration/emily.rs
+++ b/signer/tests/integration/emily.rs
@@ -503,7 +503,7 @@ async fn deposit_flow() {
                 txid: deposit_request.outpoint.txid.into(),
                 output_index: deposit_request.outpoint.vout,
                 signer_pub_key: signer_pub_key.clone(),
-                is_accepted: true,
+                can_accept: true,
                 can_sign: true,
             })
             .await

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -1236,28 +1236,28 @@ async fn fetching_deposit_request_votes() {
             txid,
             output_index,
             signer_pub_key: shares.signer_set_public_keys[0],
-            is_accepted: true,
+            can_accept: true,
             can_sign: true,
         },
         model::DepositSigner {
             txid,
             output_index,
             signer_pub_key: shares.signer_set_public_keys[1],
-            is_accepted: false,
+            can_accept: false,
             can_sign: true,
         },
         model::DepositSigner {
             txid,
             output_index,
             signer_pub_key: shares.signer_set_public_keys[2],
-            is_accepted: true,
+            can_accept: true,
             can_sign: true,
         },
         model::DepositSigner {
             txid,
             output_index,
             signer_pub_key: shares.signer_set_public_keys[3],
-            is_accepted: true,
+            can_accept: true,
             can_sign: true,
         },
     ];
@@ -1296,7 +1296,7 @@ async fn fetching_deposit_request_votes() {
         let actual_vote = actual_signer_vote_map
             .remove(&decision.signer_pub_key)
             .unwrap();
-        assert_eq!(actual_vote, Some(decision.is_accepted));
+        assert_eq!(actual_vote, Some(decision.can_accept));
     }
 
     // The remaining keys, the ones were we have not received a vote,
@@ -2667,7 +2667,7 @@ async fn deposit_report_with_only_deposit_request() {
     assert_eq!(report.amount, deposit_request.amount);
     assert_eq!(report_lock_time, deposit_request.lock_time);
     assert_eq!(report.max_fee, deposit_request.max_fee);
-    assert!(report.is_accepted.is_none());
+    assert!(report.can_accept.is_none());
     assert!(report.can_sign.is_none());
     // The transaction is not on the canonical bitcoin blockchain, so it
     // shows up as unconfirmed.
@@ -2751,7 +2751,7 @@ async fn deposit_report_with_deposit_request_reorged() {
     assert_eq!(report.amount, deposit_request.amount);
     assert_eq!(report_lock_time, deposit_request.lock_time);
     assert_eq!(report.max_fee, deposit_request.max_fee);
-    assert_eq!(report.is_accepted, Some(decision.is_accepted));
+    assert_eq!(report.can_accept, Some(decision.can_accept));
     assert_eq!(report.can_sign, Some(decision.can_sign));
     assert_eq!(report.status, DepositRequestStatus::Unconfirmed);
 
@@ -2851,7 +2851,7 @@ async fn deposit_report_with_deposit_request_spent() {
     assert_eq!(report.amount, deposit_request.amount);
     assert_eq!(report_lock_time, deposit_request.lock_time);
     assert_eq!(report.max_fee, deposit_request.max_fee);
-    assert_eq!(report.is_accepted, Some(decision.is_accepted));
+    assert_eq!(report.can_accept, Some(decision.can_accept));
     assert_eq!(report.can_sign, Some(decision.can_sign));
     assert_eq!(report.status, DepositRequestStatus::Spent(sweep_tx.txid));
 
@@ -2962,7 +2962,7 @@ async fn deposit_report_with_deposit_request_swept_but_swept_reorged() {
     assert_eq!(report.amount, deposit_request.amount);
     assert_eq!(report_lock_time, deposit_request.lock_time);
     assert_eq!(report.max_fee, deposit_request.max_fee);
-    assert_eq!(report.is_accepted, Some(decision.is_accepted));
+    assert_eq!(report.can_accept, Some(decision.can_accept));
     assert_eq!(report.can_sign, Some(decision.can_sign));
 
     let confirmed_height = chain_tip_block.block_height - 1;
@@ -2984,7 +2984,7 @@ async fn deposit_report_with_deposit_request_swept_but_swept_reorged() {
     assert_eq!(report.amount, deposit_request.amount);
     assert_eq!(report_lock_time, deposit_request.lock_time);
     assert_eq!(report.max_fee, deposit_request.max_fee);
-    assert_eq!(report.is_accepted, Some(decision.is_accepted));
+    assert_eq!(report.can_accept, Some(decision.can_accept));
     assert_eq!(report.can_sign, Some(decision.can_sign));
 
     let expected_status = DepositRequestStatus::Spent(sweep_tx.txid);
@@ -3062,7 +3062,7 @@ async fn deposit_report_with_deposit_request_confirmed() {
     assert_eq!(report.amount, deposit_request.amount);
     assert_eq!(report_lock_time, deposit_request.lock_time);
     assert_eq!(report.max_fee, deposit_request.max_fee);
-    assert_eq!(report.is_accepted, Some(decision.is_accepted));
+    assert_eq!(report.can_accept, Some(decision.can_accept));
     assert_eq!(report.can_sign, Some(decision.can_sign));
 
     let block = db.get_bitcoin_block(&chain_tip).await.unwrap().unwrap();

--- a/signer/tests/integration/setup.rs
+++ b/signer/tests/integration/setup.rs
@@ -289,7 +289,7 @@ impl TestSweepSetup {
                 txid: self.deposit_request.outpoint.txid.into(),
                 output_index: self.deposit_request.outpoint.vout,
                 signer_pub_key,
-                is_accepted: !is_rejected,
+                can_accept: !is_rejected,
                 can_sign: true,
             });
 

--- a/signer/tests/integration/transaction_signer.rs
+++ b/signer/tests/integration/transaction_signer.rs
@@ -652,11 +652,11 @@ async fn handle_pending_deposit_request_not_in_signing_set() {
     assert_eq!(votes.len(), 1);
 
     // can_sign should be false since the public key associated with our
-    // random private key is not in the signing set. And is_accepted is
-    // false whenever can_sign is false.
+    // random private key is not in the signing set. And can_accept is
+    // always true with the given blocklist client.
     let vote = votes.pop().unwrap();
     assert!(!vote.can_sign);
-    assert!(!vote.can_accept);
+    assert!(vote.can_accept);
 
     testing::storage::drop_db(db).await;
 }

--- a/signer/tests/integration/transaction_signer.rs
+++ b/signer/tests/integration/transaction_signer.rs
@@ -567,7 +567,7 @@ async fn handle_pending_deposit_request_address_script_pub_key() {
     // Also we are in the signing set so we can sign for the deposit.
     let vote = votes.pop().unwrap();
     assert!(vote.can_sign);
-    assert!(vote.is_accepted);
+    assert!(vote.can_accept);
 
     testing::storage::drop_db(db).await;
 }
@@ -656,7 +656,7 @@ async fn handle_pending_deposit_request_not_in_signing_set() {
     // false whenever can_sign is false.
     let vote = votes.pop().unwrap();
     assert!(!vote.can_sign);
-    assert!(!vote.is_accepted);
+    assert!(!vote.can_accept);
 
     testing::storage::drop_db(db).await;
 }


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/839, which is a small part of https://github.com/stacks-network/sbtc/issues/798.


## Changes

* Rename the `is_accepted` to `can_accept`, to note whether the deposit was blocked by the blocklist client.
* Always use the blocklist client for each deposit request, even if the signer is not part of the signer set that controls the public key locking the deposit.


## Testing Information

This is largely a refactor, with the only functional change being that we always call the blocklist client. For that change I updated the relevant integration tests.

## Checklist:

- [x] I have performed a self-review of my code
