### PR TITLE
feat: Add blocklist client publishing to dockerhub

### DIFF
--- a/.github/actions/dockerfiles/Dockerfile.blocklist-client.debian
+++ b/.github/actions/dockerfiles/Dockerfile.blocklist-client.debian
@@ -17,9 +17,9 @@ RUN npm install -g @openapitools/openapi-generator-cli
 WORKDIR /code/sbtc
 COPY . .
 RUN make install && make build
-RUN cargo build --release --bin signer
+RUN cargo build --release --bin blocklist-client
 
 # Create Docker image to run the signer.
 FROM debian:bookworm-slim AS signer
-COPY --from=build /code/sbtc/target/release/signer /usr/local/bin/signer
-CMD ["/usr/local/bin/signer --config /signer-config.toml --migrate-db"]
+COPY --from=build /code/sbtc/target/release/blocklist-client /usr/local/bin/blocklist-client
+CMD ["/usr/local/bin/blocklist-client --config /blocklist-client-config.toml --migrate-db"]

--- a/.github/workflows/image-build.yaml
+++ b/.github/workflows/image-build.yaml
@@ -33,6 +33,7 @@ jobs:
           - debian
         docker_target:
           - signer
+          - blocklist-client
 
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Description

Closes: #843

## Changes

Adds publishing of the blocklist client docker compose.

## Testing Information

Currently being tested locally, not tested yet.

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
