### PR TITLE
Updated Clarity Maps

### DIFF
--- a/contracts/contracts/sbtc-deposit.clar
+++ b/contracts/contracts/sbtc-deposit.clar
@@ -38,7 +38,7 @@
     (let 
         (
             (current-signer-data (contract-call? .sbtc-registry get-current-signer-data))
-            (replay-fetch (contract-call? .sbtc-registry get-completed-deposit txid vout-index))    
+            (replay-fetch (contract-call? .sbtc-registry get-deposit-status txid vout-index))    
         )
 
         ;; Check that the caller is the current signer principal

--- a/contracts/contracts/sbtc-registry.clar
+++ b/contracts/contracts/sbtc-registry.clar
@@ -41,7 +41,12 @@
 ;; If status is `none`, the request is pending.
 ;; Otherwise, the boolean value indicates whether
 ;; the deposit was accepted.
-(define-map withdrawal-status uint bool)
+(define-map withdrawal-status uint {
+  status: bool,
+  sweep-txid: (optional (buff 32)),
+  sweep-burn-hash: (optional (buff 32)),
+  sweep-burn-height: (optional uint),
+})
 
 ;; Internal data structure to store completed
 ;; deposit requests & avoid replay attacks.
@@ -177,7 +182,12 @@
   (begin 
     (try! (is-protocol-caller))
     ;; Mark the withdrawal as completed
-    (map-insert withdrawal-status request-id true)
+    (map-insert withdrawal-status request-id {
+      status: true,
+      sweep-txid: (some sweep-txid),
+      sweep-burn-hash: (some burn-hash),
+      sweep-burn-height: (some burn-height),
+    })
     (print {
       topic: "withdrawal-accept",
       request-id: request-id,
@@ -206,7 +216,12 @@
   (begin 
     (try! (is-protocol-caller))
     ;; Mark the withdrawal as completed
-    (map-insert withdrawal-status request-id false)
+    (map-insert withdrawal-status request-id {
+      status: false,
+      sweep-txid: none,
+      sweep-burn-hash: none,
+      sweep-burn-height: none,
+    })
     (print {
       topic: "withdrawal-reject",
       request-id: request-id,

--- a/contracts/contracts/sbtc-registry.clar
+++ b/contracts/contracts/sbtc-registry.clar
@@ -41,8 +41,8 @@
 ;; If status is `none`, the request is pending.
 ;; Otherwise, the boolean value indicates whether
 ;; the deposit was accepted.
-(define-map is-accepted uint {
-  status: bool,
+(define-map withdrawal-status uint {
+  is-accepted: bool,
   sweep-txid: (optional (buff 32)),
   sweep-burn-hash: (optional (buff 32)),
   sweep-burn-height: (optional uint),
@@ -82,7 +82,7 @@
 (define-read-only (get-withdrawal-request (id uint))
   (match (map-get? withdrawal-requests id)
     request (some (merge request {
-      status: (map-get? is-accepted id)
+      status: (map-get? withdrawal-status id)
     }))
     none
   )
@@ -167,7 +167,7 @@
 )
 
 ;; Complete withdrawal request by noting the acceptance in the
-;; is-accepted state map.
+;; withdrawal-status state map.
 ;;
 ;; This function will emit a print event with the topic
 ;; "withdrawal-accept".
@@ -185,8 +185,8 @@
   (begin 
     (try! (is-protocol-caller))
     ;; Mark the withdrawal as completed
-    (map-insert is-accepted request-id {
-      status: true,
+    (map-insert withdrawal-status request-id {
+      is-accepted: true,
       sweep-txid: (some sweep-txid),
       sweep-burn-hash: (some burn-hash),
       sweep-burn-height: (some burn-height),
@@ -207,7 +207,7 @@
 )
 
 ;; Complete withdrawal request by noting the rejection in the 
-;; is-accepted state map.
+;; withdrawal-status state map.
 ;;
 ;; This function will emit a print event with the topic
 ;; "withdrawal-reject".
@@ -219,8 +219,8 @@
   (begin 
     (try! (is-protocol-caller))
     ;; Mark the withdrawal as completed
-    (map-insert is-accepted request-id {
-      status: false,
+    (map-insert withdrawal-status request-id {
+      is-accepted: false,
       sweep-txid: none,
       sweep-burn-hash: none,
       sweep-burn-height: none,

--- a/contracts/contracts/sbtc-registry.clar
+++ b/contracts/contracts/sbtc-registry.clar
@@ -58,6 +58,14 @@
   {
     amount: uint,
     recipient: principal,
+  }
+)
+
+;; Data structure to map successful deposit requests
+;; to their respective sweep transaction. Stores the
+;; txid, burn hash, and burn height.
+(define-map completed-deposit-sweep {txid: (buff 32), vout-index: uint}
+  {
     sweep-txid: (buff 32),
     sweep-burn-hash: (buff 32),
     sweep-burn-height: uint,
@@ -102,6 +110,12 @@
 ;; This function returns the fields of the completed-deposits map.
 (define-read-only (get-completed-deposit (txid (buff 32)) (vout-index uint))
   (map-get? completed-deposits {txid: txid, vout-index: vout-index})
+)
+
+;; Get a completed deposit sweep data by its transaction ID & vout index.
+;; This function returns the fields of the completed-deposit-sweep map.
+(define-read-only (get-completed-deposit-sweep-data (txid (buff 32)) (vout-index uint))
+  (map-get? completed-deposit-sweep {txid: txid, vout-index: vout-index})
 )
 
 ;; Get the current signer set.
@@ -261,6 +275,8 @@
     (map-insert completed-deposits {txid: txid, vout-index: vout-index} {
       amount: amount,
       recipient: recipient,
+    })
+    (map-insert completed-deposit-sweep {txid: txid, vout-index: vout-index} {
       sweep-txid: sweep-txid,
       sweep-burn-hash: burn-hash,
       sweep-burn-height: burn-height,

--- a/contracts/contracts/sbtc-registry.clar
+++ b/contracts/contracts/sbtc-registry.clar
@@ -59,7 +59,7 @@
 ;; Data structure to map successful deposit requests
 ;; to their respective sweep transaction. Stores the
 ;; txid, burn hash, and burn height.
-(define-map completed-deposit-sweep {txid: (buff 32), vout-index: uint}
+(define-map completed-deposits {txid: (buff 32), vout-index: uint}
   {
     amount: uint,
     recipient: principal,
@@ -106,13 +106,13 @@
 ;; Get a completed deposit by its transaction ID & vout index.
 ;; This function returns the fields of the completed-deposits map.
 (define-read-only (get-completed-deposit (txid (buff 32)) (vout-index uint))
-  (map-get? deposit-status {txid: txid, vout-index: vout-index})
+  (map-get? completed-deposits {txid: txid, vout-index: vout-index})
 )
 
 ;; Get a completed deposit sweep data by its transaction ID & vout index.
-;; This function returns the fields of the completed-deposit-sweep map.
-(define-read-only (get-completed-deposit-sweep-data (txid (buff 32)) (vout-index uint))
-  (map-get? completed-deposit-sweep {txid: txid, vout-index: vout-index})
+;; This function returns the fields of the completed-deposits map.
+(define-read-only (get-deposit-status (txid (buff 32)) (vout-index uint))
+  (map-get? deposit-status {txid: txid, vout-index: vout-index})
 )
 
 ;; Get the current signer set.
@@ -270,7 +270,7 @@
   (begin
     (try! (is-protocol-caller))
     (map-insert deposit-status {txid: txid, vout-index: vout-index} true)
-    (map-insert completed-deposit-sweep {txid: txid, vout-index: vout-index} {
+    (map-insert completed-deposits {txid: txid, vout-index: vout-index} {
       amount: amount,
       recipient: recipient,
       sweep-txid: sweep-txid,

--- a/contracts/contracts/sbtc-registry.clar
+++ b/contracts/contracts/sbtc-registry.clar
@@ -41,7 +41,7 @@
 ;; If status is `none`, the request is pending.
 ;; Otherwise, the boolean value indicates whether
 ;; the deposit was accepted.
-(define-map withdrawal-status uint {
+(define-map is-accepted uint {
   status: bool,
   sweep-txid: (optional (buff 32)),
   sweep-burn-hash: (optional (buff 32)),
@@ -77,12 +77,12 @@
 
 ;; Read-only functions
 ;; Get a withdrawal request by its ID.
-;; This function returns the fields of the withrawal
+;; This function returns the fields of the withdrawal
 ;; request, along with its status.
 (define-read-only (get-withdrawal-request (id uint))
   (match (map-get? withdrawal-requests id)
     request (some (merge request {
-      status: (map-get? withdrawal-status id)
+      status: (map-get? is-accepted id)
     }))
     none
   )
@@ -167,7 +167,7 @@
 )
 
 ;; Complete withdrawal request by noting the acceptance in the
-;; withdrawal-status state map.
+;; is-accepted state map.
 ;;
 ;; This function will emit a print event with the topic
 ;; "withdrawal-accept".
@@ -185,7 +185,7 @@
   (begin 
     (try! (is-protocol-caller))
     ;; Mark the withdrawal as completed
-    (map-insert withdrawal-status request-id {
+    (map-insert is-accepted request-id {
       status: true,
       sweep-txid: (some sweep-txid),
       sweep-burn-hash: (some burn-hash),
@@ -207,7 +207,7 @@
 )
 
 ;; Complete withdrawal request by noting the rejection in the 
-;; withdrawal-status state map.
+;; is-accepted state map.
 ;;
 ;; This function will emit a print event with the topic
 ;; "withdrawal-reject".
@@ -219,7 +219,7 @@
   (begin 
     (try! (is-protocol-caller))
     ;; Mark the withdrawal as completed
-    (map-insert withdrawal-status request-id {
+    (map-insert is-accepted request-id {
       status: false,
       sweep-txid: none,
       sweep-burn-hash: none,

--- a/contracts/contracts/sbtc-registry.clar
+++ b/contracts/contracts/sbtc-registry.clar
@@ -53,7 +53,10 @@
 (define-map completed-deposits {txid: (buff 32), vout-index: uint}
   {
     amount: uint,
-    recipient: principal
+    recipient: principal,
+    sweep-txid: (buff 32),
+    sweep-burn-hash: (buff 32),
+    sweep-burn-height: uint,
   }
 )
 
@@ -252,7 +255,10 @@
     (try! (is-protocol-caller))
     (map-insert completed-deposits {txid: txid, vout-index: vout-index} {
       amount: amount,
-      recipient: recipient
+      recipient: recipient,
+      sweep-txid: sweep-txid,
+      sweep-burn-hash: burn-hash,
+      sweep-burn-height: burn-height,
     })
     (print {
       topic: "completed-deposit",

--- a/contracts/tests/clarigen-types.ts
+++ b/contracts/tests/clarigen-types.ts
@@ -875,21 +875,6 @@ export const contracts = {
           { name: "txid", type: { buffer: { length: 32 } } },
           { name: "vout-index", type: "uint128" },
         ],
-        outputs: { type: { optional: "bool" } },
-      } as TypedAbiFunction<
-        [
-          txid: TypedAbiArg<Uint8Array, "txid">,
-          voutIndex: TypedAbiArg<number | bigint, "voutIndex">,
-        ],
-        boolean | null
-      >,
-      getCompletedDepositSweepData: {
-        name: "get-completed-deposit-sweep-data",
-        access: "read_only",
-        args: [
-          { name: "txid", type: { buffer: { length: 32 } } },
-          { name: "vout-index", type: "uint128" },
-        ],
         outputs: {
           type: {
             optional: {
@@ -990,6 +975,21 @@ export const contracts = {
           type: { list: { type: { buffer: { length: 33 } }, length: 128 } },
         },
       } as TypedAbiFunction<[], Uint8Array[]>,
+      getDepositStatus: {
+        name: "get-deposit-status",
+        access: "read_only",
+        args: [
+          { name: "txid", type: { buffer: { length: 32 } } },
+          { name: "vout-index", type: "uint128" },
+        ],
+        outputs: { type: { optional: "bool" } },
+      } as TypedAbiFunction<
+        [
+          txid: TypedAbiArg<Uint8Array, "txid">,
+          voutIndex: TypedAbiArg<number | bigint, "voutIndex">,
+        ],
+        boolean | null
+      >,
       getWithdrawalRequest: {
         name: "get-withdrawal-request",
         access: "read_only",
@@ -1052,8 +1052,8 @@ export const contracts = {
         key: { buffer: { length: 33 } },
         value: "bool",
       } as TypedAbiMap<Uint8Array, boolean>,
-      completedDepositSweep: {
-        name: "completed-deposit-sweep",
+      completedDeposits: {
+        name: "completed-deposits",
         key: {
           tuple: [
             { name: "txid", type: { buffer: { length: 32 } } },

--- a/contracts/tests/clarigen-types.ts
+++ b/contracts/tests/clarigen-types.ts
@@ -901,6 +901,29 @@ export const contracts = {
           sweepTxid: Uint8Array;
         } | null
       >,
+      getCompletedWithdrawalSweepData: {
+        name: "get-completed-withdrawal-sweep-data",
+        access: "read_only",
+        args: [{ name: "id", type: "uint128" }],
+        outputs: {
+          type: {
+            optional: {
+              tuple: [
+                { name: "sweep-burn-hash", type: { buffer: { length: 32 } } },
+                { name: "sweep-burn-height", type: "uint128" },
+                { name: "sweep-txid", type: { buffer: { length: 32 } } },
+              ],
+            },
+          },
+        },
+      } as TypedAbiFunction<
+        [id: TypedAbiArg<number | bigint, "id">],
+        {
+          sweepBurnHash: Uint8Array;
+          sweepBurnHeight: bigint;
+          sweepTxid: Uint8Array;
+        } | null
+      >,
       getCurrentAggregatePubkey: {
         name: "get-current-aggregate-pubkey",
         access: "read_only",
@@ -973,28 +996,7 @@ export const contracts = {
                   },
                 },
                 { name: "sender", type: "principal" },
-                {
-                  name: "status",
-                  type: {
-                    optional: {
-                      tuple: [
-                        { name: "is-accepted", type: "bool" },
-                        {
-                          name: "sweep-burn-hash",
-                          type: { optional: { buffer: { length: 32 } } },
-                        },
-                        {
-                          name: "sweep-burn-height",
-                          type: { optional: "uint128" },
-                        },
-                        {
-                          name: "sweep-txid",
-                          type: { optional: { buffer: { length: 32 } } },
-                        },
-                      ],
-                    },
-                  },
-                },
+                { name: "status", type: { optional: "bool" } },
               ],
             },
           },
@@ -1010,12 +1012,7 @@ export const contracts = {
             version: Uint8Array;
           };
           sender: string;
-          status: {
-            isAccepted: boolean;
-            sweepBurnHash: Uint8Array | null;
-            sweepBurnHeight: bigint | null;
-            sweepTxid: Uint8Array | null;
-          } | null;
+          status: boolean | null;
         } | null
       >,
       isProtocolCaller: {
@@ -1070,6 +1067,24 @@ export const contracts = {
           sweepTxid: Uint8Array;
         }
       >,
+      completedWithdrawalSweep: {
+        name: "completed-withdrawal-sweep",
+        key: "uint128",
+        value: {
+          tuple: [
+            { name: "sweep-burn-hash", type: { buffer: { length: 32 } } },
+            { name: "sweep-burn-height", type: "uint128" },
+            { name: "sweep-txid", type: { buffer: { length: 32 } } },
+          ],
+        },
+      } as TypedAbiMap<
+        number | bigint,
+        {
+          sweepBurnHash: Uint8Array;
+          sweepBurnHeight: bigint;
+          sweepTxid: Uint8Array;
+        }
+      >,
       multiSigAddress: {
         name: "multi-sig-address",
         key: "principal",
@@ -1116,29 +1131,8 @@ export const contracts = {
       withdrawalStatus: {
         name: "withdrawal-status",
         key: "uint128",
-        value: {
-          tuple: [
-            { name: "is-accepted", type: "bool" },
-            {
-              name: "sweep-burn-hash",
-              type: { optional: { buffer: { length: 32 } } },
-            },
-            { name: "sweep-burn-height", type: { optional: "uint128" } },
-            {
-              name: "sweep-txid",
-              type: { optional: { buffer: { length: 32 } } },
-            },
-          ],
-        },
-      } as TypedAbiMap<
-        number | bigint,
-        {
-          isAccepted: boolean;
-          sweepBurnHash: Uint8Array | null;
-          sweepBurnHeight: bigint | null;
-          sweepTxid: Uint8Array | null;
-        }
-      >,
+        value: "bool",
+      } as TypedAbiMap<number | bigint, boolean>,
     },
     variables: {
       ERR_AGG_PUBKEY_REPLAY: {

--- a/contracts/tests/clarigen-types.ts
+++ b/contracts/tests/clarigen-types.ts
@@ -1070,6 +1070,32 @@ export const contracts = {
           sweepTxid: Uint8Array;
         }
       >,
+      isAccepted: {
+        name: "is-accepted",
+        key: "uint128",
+        value: {
+          tuple: [
+            { name: "status", type: "bool" },
+            {
+              name: "sweep-burn-hash",
+              type: { optional: { buffer: { length: 32 } } },
+            },
+            { name: "sweep-burn-height", type: { optional: "uint128" } },
+            {
+              name: "sweep-txid",
+              type: { optional: { buffer: { length: 32 } } },
+            },
+          ],
+        },
+      } as TypedAbiMap<
+        number | bigint,
+        {
+          status: boolean;
+          sweepBurnHash: Uint8Array | null;
+          sweepBurnHeight: bigint | null;
+          sweepTxid: Uint8Array | null;
+        }
+      >,
       multiSigAddress: {
         name: "multi-sig-address",
         key: "principal",
@@ -1111,32 +1137,6 @@ export const contracts = {
             version: Uint8Array;
           };
           sender: string;
-        }
-      >,
-      withdrawalStatus: {
-        name: "withdrawal-status",
-        key: "uint128",
-        value: {
-          tuple: [
-            { name: "status", type: "bool" },
-            {
-              name: "sweep-burn-hash",
-              type: { optional: { buffer: { length: 32 } } },
-            },
-            { name: "sweep-burn-height", type: { optional: "uint128" } },
-            {
-              name: "sweep-txid",
-              type: { optional: { buffer: { length: 32 } } },
-            },
-          ],
-        },
-      } as TypedAbiMap<
-        number | bigint,
-        {
-          status: boolean;
-          sweepBurnHash: Uint8Array | null;
-          sweepBurnHeight: bigint | null;
-          sweepTxid: Uint8Array | null;
         }
       >,
     },

--- a/contracts/tests/clarigen-types.ts
+++ b/contracts/tests/clarigen-types.ts
@@ -881,6 +881,9 @@ export const contracts = {
               tuple: [
                 { name: "amount", type: "uint128" },
                 { name: "recipient", type: "principal" },
+                { name: "sweep-burn-hash", type: { buffer: { length: 32 } } },
+                { name: "sweep-burn-height", type: "uint128" },
+                { name: "sweep-txid", type: { buffer: { length: 32 } } },
               ],
             },
           },
@@ -893,6 +896,9 @@ export const contracts = {
         {
           amount: bigint;
           recipient: string;
+          sweepBurnHash: Uint8Array;
+          sweepBurnHeight: bigint;
+          sweepTxid: Uint8Array;
         } | null
       >,
       getCurrentAggregatePubkey: {
@@ -1046,6 +1052,9 @@ export const contracts = {
           tuple: [
             { name: "amount", type: "uint128" },
             { name: "recipient", type: "principal" },
+            { name: "sweep-burn-hash", type: { buffer: { length: 32 } } },
+            { name: "sweep-burn-height", type: "uint128" },
+            { name: "sweep-txid", type: { buffer: { length: 32 } } },
           ],
         },
       } as TypedAbiMap<
@@ -1056,6 +1065,9 @@ export const contracts = {
         {
           amount: bigint;
           recipient: string;
+          sweepBurnHash: Uint8Array;
+          sweepBurnHeight: bigint;
+          sweepTxid: Uint8Array;
         }
       >,
       multiSigAddress: {

--- a/contracts/tests/clarigen-types.ts
+++ b/contracts/tests/clarigen-types.ts
@@ -881,6 +881,31 @@ export const contracts = {
               tuple: [
                 { name: "amount", type: "uint128" },
                 { name: "recipient", type: "principal" },
+              ],
+            },
+          },
+        },
+      } as TypedAbiFunction<
+        [
+          txid: TypedAbiArg<Uint8Array, "txid">,
+          voutIndex: TypedAbiArg<number | bigint, "voutIndex">,
+        ],
+        {
+          amount: bigint;
+          recipient: string;
+        } | null
+      >,
+      getCompletedDepositSweepData: {
+        name: "get-completed-deposit-sweep-data",
+        access: "read_only",
+        args: [
+          { name: "txid", type: { buffer: { length: 32 } } },
+          { name: "vout-index", type: "uint128" },
+        ],
+        outputs: {
+          type: {
+            optional: {
+              tuple: [
                 { name: "sweep-burn-hash", type: { buffer: { length: 32 } } },
                 { name: "sweep-burn-height", type: "uint128" },
                 { name: "sweep-txid", type: { buffer: { length: 32 } } },
@@ -894,8 +919,6 @@ export const contracts = {
           voutIndex: TypedAbiArg<number | bigint, "voutIndex">,
         ],
         {
-          amount: bigint;
-          recipient: string;
           sweepBurnHash: Uint8Array;
           sweepBurnHeight: bigint;
           sweepTxid: Uint8Array;
@@ -1037,6 +1060,32 @@ export const contracts = {
         key: { buffer: { length: 33 } },
         value: "bool",
       } as TypedAbiMap<Uint8Array, boolean>,
+      completedDepositSweep: {
+        name: "completed-deposit-sweep",
+        key: {
+          tuple: [
+            { name: "txid", type: { buffer: { length: 32 } } },
+            { name: "vout-index", type: "uint128" },
+          ],
+        },
+        value: {
+          tuple: [
+            { name: "sweep-burn-hash", type: { buffer: { length: 32 } } },
+            { name: "sweep-burn-height", type: "uint128" },
+            { name: "sweep-txid", type: { buffer: { length: 32 } } },
+          ],
+        },
+      } as TypedAbiMap<
+        {
+          txid: Uint8Array;
+          voutIndex: number | bigint;
+        },
+        {
+          sweepBurnHash: Uint8Array;
+          sweepBurnHeight: bigint;
+          sweepTxid: Uint8Array;
+        }
+      >,
       completedDeposits: {
         name: "completed-deposits",
         key: {
@@ -1049,9 +1098,6 @@ export const contracts = {
           tuple: [
             { name: "amount", type: "uint128" },
             { name: "recipient", type: "principal" },
-            { name: "sweep-burn-hash", type: { buffer: { length: 32 } } },
-            { name: "sweep-burn-height", type: "uint128" },
-            { name: "sweep-txid", type: { buffer: { length: 32 } } },
           ],
         },
       } as TypedAbiMap<
@@ -1062,9 +1108,6 @@ export const contracts = {
         {
           amount: bigint;
           recipient: string;
-          sweepBurnHash: Uint8Array;
-          sweepBurnHeight: bigint;
-          sweepTxid: Uint8Array;
         }
       >,
       completedWithdrawalSweep: {

--- a/contracts/tests/clarigen-types.ts
+++ b/contracts/tests/clarigen-types.ts
@@ -875,25 +875,13 @@ export const contracts = {
           { name: "txid", type: { buffer: { length: 32 } } },
           { name: "vout-index", type: "uint128" },
         ],
-        outputs: {
-          type: {
-            optional: {
-              tuple: [
-                { name: "amount", type: "uint128" },
-                { name: "recipient", type: "principal" },
-              ],
-            },
-          },
-        },
+        outputs: { type: { optional: "bool" } },
       } as TypedAbiFunction<
         [
           txid: TypedAbiArg<Uint8Array, "txid">,
           voutIndex: TypedAbiArg<number | bigint, "voutIndex">,
         ],
-        {
-          amount: bigint;
-          recipient: string;
-        } | null
+        boolean | null
       >,
       getCompletedDepositSweepData: {
         name: "get-completed-deposit-sweep-data",
@@ -906,6 +894,8 @@ export const contracts = {
           type: {
             optional: {
               tuple: [
+                { name: "amount", type: "uint128" },
+                { name: "recipient", type: "principal" },
                 { name: "sweep-burn-hash", type: { buffer: { length: 32 } } },
                 { name: "sweep-burn-height", type: "uint128" },
                 { name: "sweep-txid", type: { buffer: { length: 32 } } },
@@ -919,6 +909,8 @@ export const contracts = {
           voutIndex: TypedAbiArg<number | bigint, "voutIndex">,
         ],
         {
+          amount: bigint;
+          recipient: string;
           sweepBurnHash: Uint8Array;
           sweepBurnHeight: bigint;
           sweepTxid: Uint8Array;
@@ -1070,6 +1062,8 @@ export const contracts = {
         },
         value: {
           tuple: [
+            { name: "amount", type: "uint128" },
+            { name: "recipient", type: "principal" },
             { name: "sweep-burn-hash", type: { buffer: { length: 32 } } },
             { name: "sweep-burn-height", type: "uint128" },
             { name: "sweep-txid", type: { buffer: { length: 32 } } },
@@ -1081,33 +1075,11 @@ export const contracts = {
           voutIndex: number | bigint;
         },
         {
+          amount: bigint;
+          recipient: string;
           sweepBurnHash: Uint8Array;
           sweepBurnHeight: bigint;
           sweepTxid: Uint8Array;
-        }
-      >,
-      completedDeposits: {
-        name: "completed-deposits",
-        key: {
-          tuple: [
-            { name: "txid", type: { buffer: { length: 32 } } },
-            { name: "vout-index", type: "uint128" },
-          ],
-        },
-        value: {
-          tuple: [
-            { name: "amount", type: "uint128" },
-            { name: "recipient", type: "principal" },
-          ],
-        },
-      } as TypedAbiMap<
-        {
-          txid: Uint8Array;
-          voutIndex: number | bigint;
-        },
-        {
-          amount: bigint;
-          recipient: string;
         }
       >,
       completedWithdrawalSweep: {
@@ -1127,6 +1099,22 @@ export const contracts = {
           sweepBurnHeight: bigint;
           sweepTxid: Uint8Array;
         }
+      >,
+      depositStatus: {
+        name: "deposit-status",
+        key: {
+          tuple: [
+            { name: "txid", type: { buffer: { length: 32 } } },
+            { name: "vout-index", type: "uint128" },
+          ],
+        },
+        value: "bool",
+      } as TypedAbiMap<
+        {
+          txid: Uint8Array;
+          voutIndex: number | bigint;
+        },
+        boolean
       >,
       multiSigAddress: {
         name: "multi-sig-address",

--- a/contracts/tests/clarigen-types.ts
+++ b/contracts/tests/clarigen-types.ts
@@ -978,7 +978,7 @@ export const contracts = {
                   type: {
                     optional: {
                       tuple: [
-                        { name: "status", type: "bool" },
+                        { name: "is-accepted", type: "bool" },
                         {
                           name: "sweep-burn-hash",
                           type: { optional: { buffer: { length: 32 } } },
@@ -1011,7 +1011,7 @@ export const contracts = {
           };
           sender: string;
           status: {
-            status: boolean;
+            isAccepted: boolean;
             sweepBurnHash: Uint8Array | null;
             sweepBurnHeight: bigint | null;
             sweepTxid: Uint8Array | null;
@@ -1070,32 +1070,6 @@ export const contracts = {
           sweepTxid: Uint8Array;
         }
       >,
-      isAccepted: {
-        name: "is-accepted",
-        key: "uint128",
-        value: {
-          tuple: [
-            { name: "status", type: "bool" },
-            {
-              name: "sweep-burn-hash",
-              type: { optional: { buffer: { length: 32 } } },
-            },
-            { name: "sweep-burn-height", type: { optional: "uint128" } },
-            {
-              name: "sweep-txid",
-              type: { optional: { buffer: { length: 32 } } },
-            },
-          ],
-        },
-      } as TypedAbiMap<
-        number | bigint,
-        {
-          status: boolean;
-          sweepBurnHash: Uint8Array | null;
-          sweepBurnHeight: bigint | null;
-          sweepTxid: Uint8Array | null;
-        }
-      >,
       multiSigAddress: {
         name: "multi-sig-address",
         key: "principal",
@@ -1137,6 +1111,32 @@ export const contracts = {
             version: Uint8Array;
           };
           sender: string;
+        }
+      >,
+      withdrawalStatus: {
+        name: "withdrawal-status",
+        key: "uint128",
+        value: {
+          tuple: [
+            { name: "is-accepted", type: "bool" },
+            {
+              name: "sweep-burn-hash",
+              type: { optional: { buffer: { length: 32 } } },
+            },
+            { name: "sweep-burn-height", type: { optional: "uint128" } },
+            {
+              name: "sweep-txid",
+              type: { optional: { buffer: { length: 32 } } },
+            },
+          ],
+        },
+      } as TypedAbiMap<
+        number | bigint,
+        {
+          isAccepted: boolean;
+          sweepBurnHash: Uint8Array | null;
+          sweepBurnHeight: bigint | null;
+          sweepTxid: Uint8Array | null;
         }
       >,
     },

--- a/contracts/tests/clarigen-types.ts
+++ b/contracts/tests/clarigen-types.ts
@@ -967,7 +967,28 @@ export const contracts = {
                   },
                 },
                 { name: "sender", type: "principal" },
-                { name: "status", type: { optional: "bool" } },
+                {
+                  name: "status",
+                  type: {
+                    optional: {
+                      tuple: [
+                        { name: "status", type: "bool" },
+                        {
+                          name: "sweep-burn-hash",
+                          type: { optional: { buffer: { length: 32 } } },
+                        },
+                        {
+                          name: "sweep-burn-height",
+                          type: { optional: "uint128" },
+                        },
+                        {
+                          name: "sweep-txid",
+                          type: { optional: { buffer: { length: 32 } } },
+                        },
+                      ],
+                    },
+                  },
+                },
               ],
             },
           },
@@ -983,7 +1004,12 @@ export const contracts = {
             version: Uint8Array;
           };
           sender: string;
-          status: boolean | null;
+          status: {
+            status: boolean;
+            sweepBurnHash: Uint8Array | null;
+            sweepBurnHeight: bigint | null;
+            sweepTxid: Uint8Array | null;
+          } | null;
         } | null
       >,
       isProtocolCaller: {
@@ -1078,8 +1104,29 @@ export const contracts = {
       withdrawalStatus: {
         name: "withdrawal-status",
         key: "uint128",
-        value: "bool",
-      } as TypedAbiMap<number | bigint, boolean>,
+        value: {
+          tuple: [
+            { name: "status", type: "bool" },
+            {
+              name: "sweep-burn-hash",
+              type: { optional: { buffer: { length: 32 } } },
+            },
+            { name: "sweep-burn-height", type: { optional: "uint128" } },
+            {
+              name: "sweep-txid",
+              type: { optional: { buffer: { length: 32 } } },
+            },
+          ],
+        },
+      } as TypedAbiMap<
+        number | bigint,
+        {
+          status: boolean;
+          sweepBurnHash: Uint8Array | null;
+          sweepBurnHeight: bigint | null;
+          sweepTxid: Uint8Array | null;
+        }
+      >,
     },
     variables: {
       ERR_AGG_PUBKEY_REPLAY: {

--- a/contracts/tests/sbtc-deposit.test.ts
+++ b/contracts/tests/sbtc-deposit.test.ts
@@ -176,9 +176,6 @@ describe("sBTC deposit contract", () => {
       expect(receipt1).toStrictEqual({
         amount: 1000n,
         recipient: deployer,
-        sweepTxid: sweepTxid,
-        sweepBurnHash: burnHash,
-        sweepBurnHeight: BigInt(burnHeight),
       });
     });
   });

--- a/contracts/tests/sbtc-deposit.test.ts
+++ b/contracts/tests/sbtc-deposit.test.ts
@@ -167,7 +167,7 @@ describe("sBTC deposit contract", () => {
         deployer
       );
       const receipt1 = rov(
-        registry.getCompletedDeposit({
+        registry.getDepositStatus({
           txid: new Uint8Array(32).fill(0),
           voutIndex: 0,
         }),

--- a/contracts/tests/sbtc-deposit.test.ts
+++ b/contracts/tests/sbtc-deposit.test.ts
@@ -153,7 +153,7 @@ describe("sBTC deposit contract", () => {
 
     test("Call get-complete-deposit placeholder", () => {
       const { burnHeight, burnHash } = getCurrentBurnInfo();
-
+      const sweepTxid = new Uint8Array(32).fill(2);
       txOk(
         deposit.completeDepositWrapper({
           txid: new Uint8Array(32).fill(0),
@@ -162,7 +162,7 @@ describe("sBTC deposit contract", () => {
           recipient: deployer,
           burnHash,
           burnHeight,
-          sweepTxid: new Uint8Array(32).fill(2),
+          sweepTxid: sweepTxid,
         }),
         deployer
       );
@@ -176,6 +176,9 @@ describe("sBTC deposit contract", () => {
       expect(receipt1).toStrictEqual({
         amount: 1000n,
         recipient: deployer,
+        sweepTxid: sweepTxid,
+        sweepBurnHash: burnHash,
+        sweepBurnHeight: BigInt(burnHeight),
       });
     });
   });

--- a/contracts/tests/sbtc-deposit.test.ts
+++ b/contracts/tests/sbtc-deposit.test.ts
@@ -173,10 +173,7 @@ describe("sBTC deposit contract", () => {
         }),
         deployer
       );
-      expect(receipt1).toStrictEqual({
-        amount: 1000n,
-        recipient: deployer,
-      });
+      expect(receipt1).toStrictEqual(true);
     });
   });
   describe("complete many deposits", () => {

--- a/contracts/tests/sbtc-withdrawal.test.ts
+++ b/contracts/tests/sbtc-withdrawal.test.ts
@@ -576,7 +576,7 @@ describe("Accepting a withdrawal request", () => {
       maxFee: defaultMaxFee,
       blockHeight: BigInt(simnet.blockHeight - 3),
       status: {
-        status: true,
+        isAccepted: true,
         sweepTxid: sweepTxid,
         sweepBurnHash: burnHash,
         sweepBurnHeight: BigInt(burnHeight),
@@ -654,7 +654,7 @@ describe("Accepting a withdrawal request", () => {
       maxFee: defaultMaxFee,
       blockHeight: BigInt(simnet.blockHeight - 3),
       status: {
-        status: false,
+        isAccepted: false,
         sweepTxid: null,
         sweepBurnHash: null,
         sweepBurnHeight: null,

--- a/contracts/tests/sbtc-withdrawal.test.ts
+++ b/contracts/tests/sbtc-withdrawal.test.ts
@@ -575,12 +575,7 @@ describe("Accepting a withdrawal request", () => {
       amount: defaultAmount,
       maxFee: defaultMaxFee,
       blockHeight: BigInt(simnet.blockHeight - 3),
-      status: {
-        isAccepted: true,
-        sweepTxid: sweepTxid,
-        sweepBurnHash: burnHash,
-        sweepBurnHeight: BigInt(burnHeight),
-      },
+      status: true,
     });
   });
   test("reject withdrawal sets withdrawal-status to false", () => {
@@ -653,12 +648,7 @@ describe("Accepting a withdrawal request", () => {
       amount: defaultAmount,
       maxFee: defaultMaxFee,
       blockHeight: BigInt(simnet.blockHeight - 3),
-      status: {
-        isAccepted: false,
-        sweepTxid: null,
-        sweepBurnHash: null,
-        sweepBurnHeight: null,
-      },
+      status: false,
     });
 
     // An event is emitted properly

--- a/contracts/tests/sbtc-withdrawal.test.ts
+++ b/contracts/tests/sbtc-withdrawal.test.ts
@@ -527,6 +527,7 @@ describe("Accepting a withdrawal request", () => {
   test("accept withdrawal sets withdrawal-status to true", () => {
     // Alice initiates withdrawalrequest
     const { burnHeight, burnHash } = getCurrentBurnInfo();
+    const sweepTxid = new Uint8Array(32).fill(1);
     txOk(
       deposit.completeDepositWrapper({
         txid: new Uint8Array(32).fill(0),
@@ -535,7 +536,7 @@ describe("Accepting a withdrawal request", () => {
         recipient: alice,
         burnHash,
         burnHeight: BigInt(burnHeight),
-        sweepTxid: new Uint8Array(32).fill(1),
+        sweepTxid: sweepTxid,
       }),
       deployer
     );
@@ -556,7 +557,7 @@ describe("Accepting a withdrawal request", () => {
         fee: defaultMaxFee,
         burnHash,
         burnHeight,
-        sweepTxid: new Uint8Array(32).fill(1),
+        sweepTxid: sweepTxid,
       }),
       deployer
     );
@@ -574,7 +575,12 @@ describe("Accepting a withdrawal request", () => {
       amount: defaultAmount,
       maxFee: defaultMaxFee,
       blockHeight: BigInt(simnet.blockHeight - 3),
-      status: true,
+      status: {
+        status: true,
+        sweepTxid: sweepTxid,
+        sweepBurnHash: burnHash,
+        sweepBurnHeight: BigInt(burnHeight),
+      },
     });
   });
   test("reject withdrawal sets withdrawal-status to false", () => {
@@ -647,7 +653,12 @@ describe("Accepting a withdrawal request", () => {
       amount: defaultAmount,
       maxFee: defaultMaxFee,
       blockHeight: BigInt(simnet.blockHeight - 3),
-      status: false,
+      status: {
+        status: false,
+        sweepTxid: null,
+        sweepBurnHash: null,
+        sweepBurnHeight: null,
+      },
     });
 
     // An event is emitted properly


### PR DESCRIPTION
## Description
Updates two structs in the sbtc-registry contract to stored data already passed through.
 
Closes: #800 

## Changes
The 'sbtc-registry' Clarity smart contract

## Testing Information
All unit tests effected are now updated.

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
