### PR TITLE
748 feature emily client authentication

### DIFF
--- a/signer/src/bin/demo_cli.rs
+++ b/signer/src/bin/demo_cli.rs
@@ -14,7 +14,10 @@ use clarity::{
     vm::types::{PrincipalData, StandardPrincipalData},
 };
 use emily_client::{
-    apis::{configuration::Configuration, deposit_api},
+    apis::{
+        configuration::{ApiKey, Configuration},
+        deposit_api,
+    },
     models::CreateDepositRequestBody,
 };
 use fake::Fake as _;
@@ -105,16 +108,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let settings = Settings::new(Some("signer/src/config/default.toml"))?;
 
-    // Setup our Emily client configuration
+    // Setup our Emily client configuration by getting the first configured endpoint
+    // and using that to populate the client.
+    let emily_api_endpoint_config = settings
+        .emily
+        .endpoints
+        .first()
+        .expect("No Emily endpoints configured");
     let emily_client_config = Configuration {
-        base_path: settings
-            .emily
-            .endpoints
-            .first()
-            .expect("No Emily endpoints configured")
+        base_path: emily_api_endpoint_config
+            .endpoint
             .to_string()
             .trim_end_matches("/")
             .to_string(),
+        api_key: emily_api_endpoint_config
+            .api_key
+            .clone()
+            .map(|key_string| ApiKey { prefix: None, key: key_string }),
         ..Default::default()
     };
 

--- a/signer/src/config/default.toml
+++ b/signer/src/config/default.toml
@@ -18,17 +18,18 @@
 # !! Emily API Configuration
 # !! ==============================================================================
 [emily]
-# The URI(s) of the Emily API server to connect to.
+# The endpoint(s) of the Emily API server to connect to.
 #
 # You may specify multiple Emily API servers if you have them. They will be
 # tried round-robin until one succeeds.
 #
-# Format: ["http(s)://<host>:<port>", ..]
+# Format: [ { endpoint = "http(s)://<host>:<port>", api_key = "1234567890abcdef" }, ..]
 # Default: <none>
 # Required: true
 # Environment: SIGNER_EMILY__ENDPOINTS
+# Environment Example: '{"endpoint":"https://api.emilyexample.com","api_key":"1234567890abcdef"},..'
 endpoints = [
-    "http://localhost:3031"
+    { endpoint = "http://localhost:3031" },
 ]
 
 # !! ==============================================================================

--- a/signer/src/config/mod.rs
+++ b/signer/src/config/mod.rs
@@ -208,7 +208,7 @@ impl Validatable for EmilyClientConfig {
         }
         // Validate each endpoint configuration.
         for endpoint in &self.endpoints {
-            endpoint.validate(&settings)?;
+            endpoint.validate(settings)?;
         }
 
         Ok(())

--- a/signer/src/config/mod.rs
+++ b/signer/src/config/mod.rs
@@ -157,30 +157,58 @@ pub struct BlocklistClientConfig {
 #[derive(Deserialize, Clone, Debug)]
 pub struct EmilyClientConfig {
     /// Emily API endpoints.
-    #[serde(deserialize_with = "url_deserializer_vec")]
-    pub endpoints: Vec<Url>,
+    pub endpoints: Vec<EmilyEndpointConfig>,
+}
+
+/// Emily API endpoint configuration.
+#[derive(Deserialize, Clone, Debug)]
+pub struct EmilyEndpointConfig {
+    /// The emily API endpoint that the signer will use.
+    #[serde(deserialize_with = "url_deserializer_single")]
+    pub endpoint: Url,
+    /// API key for the Emily API endpoint.
+    /// If the api key is not provided we assume the API doesn't need one.
+    pub api_key: Option<String>,
+}
+
+impl Validatable for EmilyEndpointConfig {
+    fn validate(&self, _: &Settings) -> Result<(), ConfigError> {
+        // If an API key is provided it needs to be non-empty.
+        if let Some(api_key) = self.api_key.as_ref() {
+            if api_key.is_empty() {
+                return Err(ConfigError::Message(
+                    "[emily_client.endpoints] API key cannot be specified yet empty".to_string(),
+                ));
+            }
+        }
+
+        if !["http", "https"].contains(&self.endpoint.scheme()) {
+            return Err(ConfigError::Message(
+                "[emily_client.endpoints] Invalid URL scheme: must be HTTP or HTTPS".to_string(),
+            ));
+        }
+
+        if self.endpoint.host_str().is_none() {
+            return Err(ConfigError::Message(
+                "[emily_client.endpoints] Invalid URL: host is required".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
 }
 
 impl Validatable for EmilyClientConfig {
-    fn validate(&self, _: &Settings) -> Result<(), ConfigError> {
+    fn validate(&self, settings: &Settings) -> Result<(), ConfigError> {
+        // At least one endpoint must be provided.
         if self.endpoints.is_empty() {
             return Err(ConfigError::Message(
                 "[emily_client] At least one Emily API endpoint must be provided".to_string(),
             ));
         }
-
+        // Validate each endpoint configuration.
         for endpoint in &self.endpoints {
-            if !["http", "https"].contains(&endpoint.scheme()) {
-                return Err(ConfigError::Message(
-                    "[emily_client] Invalid URL scheme: must be HTTP or HTTPS".to_string(),
-                ));
-            }
-
-            if endpoint.host_str().is_none() {
-                return Err(ConfigError::Message(
-                    "[emily_client] Invalid URL: host is required".to_string(),
-                ));
-            }
+            endpoint.validate(&settings)?;
         }
 
         Ok(())

--- a/signer/src/context/signer_context.rs
+++ b/signer/src/context/signer_context.rs
@@ -5,7 +5,7 @@ use url::Url;
 
 use crate::{
     bitcoin::BitcoinInteract,
-    config::Settings,
+    config::{EmilyClientConfig, Settings},
     emily_client::EmilyInteract,
     error::Error,
     stacks::api::StacksInteract,
@@ -49,17 +49,17 @@ where
     S: DbRead + DbWrite + Clone + Sync + Send + 'static,
     BC: for<'a> TryFrom<&'a [Url]> + BitcoinInteract + Clone + 'static,
     ST: for<'a> TryFrom<&'a Settings> + StacksInteract + Clone + Sync + Send + 'static,
-    EM: for<'a> TryFrom<&'a [Url]> + EmilyInteract + Clone + Sync + Send + 'static,
+    EM: for<'a> TryFrom<&'a EmilyClientConfig> + EmilyInteract + Clone + Sync + Send + 'static,
     Error: for<'a> From<<BC as TryFrom<&'a [Url]>>::Error>,
     Error: for<'a> From<<ST as TryFrom<&'a Settings>>::Error>,
-    Error: for<'a> From<<EM as TryFrom<&'a [Url]>>::Error>,
+    Error: for<'a> From<<EM as TryFrom<&'a EmilyClientConfig>>::Error>,
 {
     /// Initializes a new [`SignerContext`], automatically creating clients
     /// based on the provided types.
     pub fn init(config: Settings, db: S) -> Result<Self, Error> {
         let bc = BC::try_from(&config.bitcoin.rpc_endpoints)?;
         let st = ST::try_from(&config)?;
-        let em = EM::try_from(&config.emily.endpoints)?;
+        let em = EM::try_from(&config.emily)?;
 
         Ok(Self::new(config, db, bc, st, em))
     }

--- a/signer/src/main.rs
+++ b/signer/src/main.rs
@@ -256,8 +256,7 @@ async fn run_block_observer(ctx: impl Context) -> Result<(), Error> {
     .unwrap();
 
     // TODO: Get clients from context when implemented
-    let emily_client: ApiFallbackClient<EmilyClient> =
-        TryFrom::try_from(&config.emily.endpoints[..])?;
+    let emily_client: ApiFallbackClient<EmilyClient> = TryFrom::try_from(&config.emily)?;
     let stacks_client: ApiFallbackClient<StacksClient> = TryFrom::try_from(&config)?;
 
     // TODO: We should have a new() method that builds from the context


### PR DESCRIPTION
## Description

Adds API Keys to the Emily Client section of the signer config.

Closes: #748 

## Changes

Adds a new configuration option for the EmilyConfig to include an api key for every endpoint.
- Updated the configuration documentation
- Updated relevant configuration creation functions

## Testing Information

### Unit tests
I added an additional configuration unit test.

### Integration
I didn't include this in the PR, but I tested this with integration tests against a version of the API deployed that required API Keys. 

For each place in the `signer` integration tests that instantiated an API I replaced the old logic with an actual API and key.

```rust
    let emily_client =
        EmilyClient::try_from(&Url::parse("http://localhost:3031").unwrap()).unwrap();
```
Converted to
```rust
    // We need to populate our databases, so let's fetch the data.
    let emily_config = EmilyEndpointConfig {
        endpoint: Url::parse("https://API_ID.execute-api.us-west-2.amazonaws.com/dev").unwrap(),
        api_key: Some("ACTUAL_API_KEY".to_string()),
    };
    let emily_client =
        EmilyClient::try_from(&emily_config).unwrap();
```
And in doing this everything worked perfectly except the signer integration test `signer::emily::deposit_flow` which needed the following on line `572` so that Emily had time to catch up:

```rust
    tokio::time::sleep(Duration::from_millis(50)).await;
```

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
