### PR TITLE
feat: Address possible underflow during reorg

### DIFF
--- a/emily/handler/src/api/handlers/internal.rs
+++ b/emily/handler/src/api/handlers/internal.rs
@@ -113,9 +113,9 @@ pub async fn execute_reorg_handler(
     // and withdrawal table we'll wipe out all the history that's no longer relevant.
 
     // Get all deposits that would be impacted by this reorg.
-    let all_deposits = accessors::get_all_deposit_entries_modified_after_height(
+    let all_deposits = accessors::get_all_deposit_entries_modified_from_height(
         context,
-        request.canonical_tip.stacks_block_height - 1,
+        request.canonical_tip.stacks_block_height,
         None,
     )
     .await?;
@@ -152,9 +152,9 @@ pub async fn execute_reorg_handler(
     );
 
     // Get all withdrawals that would be impacted by this reorg.
-    let all_withdrawals = accessors::get_all_withdrawal_entries_modified_after_height(
+    let all_withdrawals = accessors::get_all_withdrawal_entries_modified_from_height(
         context,
-        request.canonical_tip.stacks_block_height - 1,
+        request.canonical_tip.stacks_block_height,
         None,
     )
     .await?;

--- a/emily/handler/src/database/accessors.rs
+++ b/emily/handler/src/database/accessors.rs
@@ -87,15 +87,15 @@ const ALL_STATUSES: &[Status] = &[
     Status::Reprocessing,
 ];
 
-/// Gets all deposit entries modified after a given height.
-pub async fn get_all_deposit_entries_modified_after_height(
+/// Gets all deposit entries modified from (on or after) a given height.
+pub async fn get_all_deposit_entries_modified_from_height(
     context: &EmilyContext,
     minimum_height: u64,
     maybe_page_size: Option<i32>,
 ) -> Result<Vec<DepositInfoEntry>, Error> {
     let mut all = Vec::new();
     for status in ALL_STATUSES {
-        let mut received = get_all_deposit_entries_modified_after_height_with_status(
+        let mut received = get_all_deposit_entries_modified_from_height_with_status(
             context,
             status,
             minimum_height,
@@ -108,8 +108,8 @@ pub async fn get_all_deposit_entries_modified_after_height(
     Ok(all)
 }
 
-/// Gets all deposit entries modified after a given height.
-pub async fn get_all_deposit_entries_modified_after_height_with_status(
+/// Gets all deposit entries modified from (on or after) a given height.
+pub async fn get_all_deposit_entries_modified_from_height_with_status(
     context: &EmilyContext,
     status: &Status,
     minimum_height: u64,
@@ -120,7 +120,7 @@ pub async fn get_all_deposit_entries_modified_after_height_with_status(
         context,
         status,
         &minimum_height,
-        ">",
+        ">=",
         maybe_page_size,
     )
     .await
@@ -303,15 +303,15 @@ pub async fn get_withdrawal_entries(
     .await
 }
 
-/// Gets all withdrawal entries modified after a given height.
-pub async fn get_all_withdrawal_entries_modified_after_height(
+/// Gets all withdrawal entries modified from (on or after) a given height.
+pub async fn get_all_withdrawal_entries_modified_from_height(
     context: &EmilyContext,
     minimum_height: u64,
     maybe_page_size: Option<i32>,
 ) -> Result<Vec<WithdrawalInfoEntry>, Error> {
     let mut all = Vec::new();
     for status in ALL_STATUSES {
-        let mut received = get_all_withdrawal_entries_modified_after_height_with_status(
+        let mut received = get_all_withdrawal_entries_modified_from_height_with_status(
             context,
             status,
             minimum_height,
@@ -324,8 +324,8 @@ pub async fn get_all_withdrawal_entries_modified_after_height(
     Ok(all)
 }
 
-/// Gets all withdrawal entries modified after a given height.
-pub async fn get_all_withdrawal_entries_modified_after_height_with_status(
+/// Gets all withdrawal entries modified from (on or after) a given height.
+pub async fn get_all_withdrawal_entries_modified_from_height_with_status(
     context: &EmilyContext,
     status: &Status,
     minimum_height: u64,
@@ -336,7 +336,7 @@ pub async fn get_all_withdrawal_entries_modified_after_height_with_status(
         context,
         status,
         &minimum_height,
-        ">",
+        ">=",
         maybe_page_size,
     )
     .await


### PR DESCRIPTION
## Description

Closes: #526 

Prevents the possible underflow during a chainstate reorg: I swapped a `tip_height - 1` followed by an exclusive search of deposits/withdrawals modified after a height to an inclusive search of deposits/withdrawals modified from `tip_height`.

## Changes

Described above.

## Testing Information

Tested with integration tests.

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
