### PR TITLE
feat: add config for disabling mdns

### DIFF
--- a/docker/sbtc/signer/signer-config.toml
+++ b/docker/sbtc/signer/signer-config.toml
@@ -231,3 +231,12 @@ listen_on = []
 # Required: false
 # Environment: SIGNER_SIGNER__P2P__PUBLIC_ENDPOINTS
 public_endpoints = []
+
+# Enables/disables mDNS (multicast DNS) discovery. mDNS allows sBTC signers
+# running on the same local network to discover each other without explicitly
+# providing them as seed nodes.
+#
+# Default: false
+# Required: false
+# Environment: SIGNER_SIGNER__P2P__ENABLE_MDNS
+enable_mdns = false

--- a/signer/src/config/default.toml
+++ b/signer/src/config/default.toml
@@ -241,3 +241,12 @@ listen_on = ["tcp://0.0.0.0:4122", "quic-v1://0.0.0.0:4122"]
 # Required: false
 # Environment: SIGNER_SIGNER__P2P__PUBLIC_ENDPOINTS
 public_endpoints = []
+
+# Enables/disables mDNS (multicast DNS) discovery. mDNS allows sBTC signers
+# running on the same local network to discover each other without explicitly
+# providing them as seed nodes.
+#
+# Default: false
+# Required: false
+# Environment: SIGNER_SIGNER__P2P__ENABLE_MDNS
+enable_mdns = true

--- a/signer/src/config/mod.rs
+++ b/signer/src/config/mod.rs
@@ -129,6 +129,10 @@ pub struct P2PNetworkConfig {
     /// public endpoint(s).
     #[serde(deserialize_with = "p2p_multiaddr_deserializer_vec")]
     pub public_endpoints: Vec<Multiaddr>,
+    /// Enable mDNS discovery for the P2P network. This is useful for local
+    /// testing and development.
+    #[serde(default)]
+    pub enable_mdns: bool,
 }
 
 impl Validatable for P2PNetworkConfig {


### PR DESCRIPTION
## Description

Just a little config option for enabling/disabling mDNS peer discovery -- mDNS is mostly useful in a dev/test setting (for our use-case), but I want to be 100% sure that we don't get any accidental mDNS discoveries in our testnet deploy to ensure that we're testing how real-world signers will discover eachother, i.e. force them to use seed addresses and WAN discovery via Kademlia.

## Testing Information

I didn't add any explicit test for this, but I verified that disabling this value in `default.toml` breaks the existing tests (which rely on mDNS).
I disabled this for the `devenv` configs as those have explicit seeds.

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
