### PR TITLE
feat: Add custom root domain name option.

### DIFF
--- a/emily/cdk/lib/constants.ts
+++ b/emily/cdk/lib/constants.ts
@@ -29,4 +29,9 @@ export class Constants {
      * Default number of signer API keys to create.
      */
     static DEFAULT_NUM_SIGNER_API_KEYS: number = 3;
+
+    /**
+     * Prod stage name.
+     */
+    static PROD_STAGE_NAME: string = "prod";
 }

--- a/emily/cdk/lib/emily-stack-utils.ts
+++ b/emily/cdk/lib/emily-stack-utils.ts
@@ -36,6 +36,16 @@ export class EmilyStackUtils {
     private static numSignerApiKeys?: number;
 
     /*
+     * The hosted zone ID.
+     */
+    private static hostedZoneId?: string;
+
+    /*
+     * The custom root domain name.
+     */
+    private static customRootDomainName?: string;
+
+    /*
      * Returns the current stage name.
      */
     public static getStageName(): string {
@@ -91,6 +101,22 @@ export class EmilyStackUtils {
             throw new Error('Must define number of signer API keys');
         }
         return this.numSignerApiKeys
+    }
+
+    /*
+     * Returns the hosted zone ID or undefined if none is set.
+     */
+    public static getHostedZoneId(): string | undefined{
+        this.hostedZoneId ??= process.env.HOSTED_ZONE_ID;
+        return this.hostedZoneId;
+    }
+
+    /*
+     * Returns the custom root domain name or undefined if none is set.
+     */
+    public static getCustomRootDomainName(): string | undefined {
+        this.customRootDomainName ??= process.env.CUSTOM_ROOT_DOMAIN_NAME;
+        return this.customRootDomainName;
     }
 
     /*

--- a/emily/cdk/lib/emily-stack.ts
+++ b/emily/cdk/lib/emily-stack.ts
@@ -321,7 +321,7 @@ export class EmilyStack extends cdk.Stack {
             sourceArn: api.arnForExecuteApi(),
         });
 
-        // Only add the custom domain name it it's specified.
+        // Only add the custom domain name it's specified.
         let customRootDomainNameRoot = EmilyStackUtils.getCustomRootDomainName();
         let hostedZoneId = EmilyStackUtils.getHostedZoneId();
         if (customRootDomainNameRoot !== undefined) {

--- a/emily/cdk/lib/emily-stack.ts
+++ b/emily/cdk/lib/emily-stack.ts
@@ -4,6 +4,9 @@ import * as apig from 'aws-cdk-lib/aws-apigateway';
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as route53 from 'aws-cdk-lib/aws-route53';
+import * as route53Targets from 'aws-cdk-lib/aws-route53-targets';
+import * as certificatemanager from 'aws-cdk-lib/aws-certificatemanager';
 import { Construct } from 'constructs';
 import { Constants } from './constants';
 import { EmilyStackProps } from './emily-stack-props';
@@ -317,6 +320,61 @@ export class EmilyStack extends cdk.Stack {
             action: "lambda:InvokeFunction",
             sourceArn: api.arnForExecuteApi(),
         });
+
+        // Only add the custom domain name it it's specified.
+        let customRootDomainNameRoot = EmilyStackUtils.getCustomRootDomainName();
+        let hostedZoneId = EmilyStackUtils.getHostedZoneId();
+        if (customRootDomainNameRoot !== undefined) {
+            // Error if the hosted zone ID is not provided.
+            if (hostedZoneId === undefined) {
+                throw new Error("Custom domain name specified but hosted zone ID not provided.");
+            }
+
+            // Make the custom domain name. Add the stage name extension ot the domain name
+            // if it's not what we consider the "production" stage.
+            const customDomainName = EmilyStackUtils.getStageName() === Constants.PROD_STAGE_NAME
+                ? customRootDomainNameRoot
+                : `${EmilyStackUtils.getStageName()}.${customRootDomainNameRoot}`;
+
+            // Get zone.
+            const hostedZone = route53.HostedZone.fromHostedZoneAttributes(this, "HostedZone", {
+                hostedZoneId: hostedZoneId,
+                zoneName: customDomainName,
+            });
+
+            // Get certificate.
+            const certificate = new certificatemanager.Certificate(this, "DomainCertificate", {
+                domainName: customDomainName,
+                validation: certificatemanager.CertificateValidation.fromDns(hostedZone),
+            });
+
+            // Create a custom domain.
+            const customDomain = new apig.DomainName(this, "CustomDomain", {
+                domainName: customDomainName,
+                certificate: certificate,
+                // If the endpoint is in us-east-1 then we'll use EDGE because it's a better faster
+                // option globally. If the stack is in any region other than us-east-1 you'll need
+                // to make the certificate in us-east-1 independently and then reference it here if you
+                // want to use the EDGE endpoint type. That's a big pain and simply not worth it,
+                // especially if we only deploy "prod" in us-east-1.
+                endpointType: this.region == 'us-east-1' && !EmilyStackUtils.isDevelopmentStack()
+                    ? apig.EndpointType.EDGE
+                    : apig.EndpointType.REGIONAL,
+            });
+
+            // Map custom domain to API Gateway
+            new apig.BasePathMapping(this, "BasePathMapping", {
+                domainName: customDomain,
+                restApi: api,
+                stage: api.deploymentStage,
+            });
+
+            // Create a Route 53 alias record
+            new route53.ARecord(this, "AliasRecord", {
+                zone: hostedZone,
+                target: route53.RecordTarget.fromAlias(new route53Targets.ApiGatewayDomain(customDomain)),
+            });
+        }
 
         // Return api resource.
         return api;


### PR DESCRIPTION
## Description

Closes: #887 

## Changes

Adds root domain name specification support to the cdk template generation via the following ENV variables.
- `CUSTOM_ROOT_DOMAIN_NAME` which is the root domain name
- `HOSTED_ZONE_ID` which is the hosted zone ID provided in the AWS console

Note that if the `CUSTOM_ROOT_DOMAIN_NAME=sbtc-emily.com` then the api will be deployed differently based on stage:
- `stAgE` -> `stAgE.sbtc-emily.com`
- `beta` -> `beta.sbtc-emily.com`
- `prod` -> `sbtc-emily.com`

## Testing Information

Tested with a real deployment.

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
