### PR TITLE
refactor: simplify block observer

### DIFF
--- a/signer/src/main.rs
+++ b/signer/src/main.rs
@@ -257,16 +257,10 @@ async fn run_block_observer(ctx: impl Context) -> Result<(), Error> {
     .await
     .unwrap();
 
-    // TODO: Get clients from context when implemented
-    let emily_client: ApiFallbackClient<EmilyClient> = TryFrom::try_from(&config.emily)?;
-    let stacks_client: ApiFallbackClient<StacksClient> = TryFrom::try_from(&config)?;
-
     // TODO: We should have a new() method that builds from the context
     let block_observer = block_observer::BlockObserver {
         context: ctx,
         bitcoin_blocks: stream.to_block_hash_stream(),
-        stacks_client,
-        emily_client,
         horizon: 20,
     };
 

--- a/signer/tests/integration/block_observer.rs
+++ b/signer/tests/integration/block_observer.rs
@@ -183,8 +183,6 @@ async fn load_latest_deposit_requests_persists_requests_from_past(blocks_ago: u6
 
     let block_observer = BlockObserver {
         context: ctx.clone(),
-        stacks_client: ctx.stacks_client.clone(),
-        emily_client: ctx.emily_client.clone(),
         bitcoin_blocks: ReceiverStream::new(receiver),
         horizon,
     };
@@ -311,8 +309,6 @@ async fn link_blocks() {
 
     let block_observer = BlockObserver {
         context: ctx.clone(),
-        stacks_client: ctx.stacks_client.clone(),
-        emily_client: ctx.emily_client.clone(),
         bitcoin_blocks: ReceiverStream::new(receiver),
         horizon: 10,
     };
@@ -494,8 +490,6 @@ async fn block_observer_stores_donation_and_sbtc_utxos() {
 
     let block_observer = BlockObserver {
         context: ctx.clone(),
-        stacks_client: ctx.stacks_client.clone(),
-        emily_client: ctx.emily_client.clone(),
         bitcoin_blocks: ReceiverStream::new(receiver),
         horizon: 2,
     };

--- a/signer/tests/integration/block_observer.rs
+++ b/signer/tests/integration/block_observer.rs
@@ -593,11 +593,13 @@ async fn block_observer_stores_donation_and_sbtc_utxos() {
     let depositor_utxo = depositor.get_utxos(rpc, None).pop().unwrap();
 
     let deposit_amount = 2_500_000;
+    let max_fee = deposit_amount / 2;
     let signers_public_key = shares.aggregate_key.into();
     let (deposit_tx, deposit_request, _) = make_deposit_request(
         &depositor,
         deposit_amount,
         depositor_utxo,
+        max_fee,
         signers_public_key,
     );
     rpc.send_raw_transaction(&deposit_tx).unwrap();

--- a/signer/tests/integration/emily.rs
+++ b/signer/tests/integration/emily.rs
@@ -420,8 +420,6 @@ async fn deposit_flow() {
     let block_observer = block_observer::BlockObserver {
         context: context.clone(),
         bitcoin_blocks: block_stream,
-        stacks_client: stacks_client,
-        emily_client: emily_client.clone(),
         horizon: 1,
     };
 

--- a/signer/tests/integration/emily.rs
+++ b/signer/tests/integration/emily.rs
@@ -229,10 +229,12 @@ async fn deposit_flow() {
         amount: Amount::from_sat(deposit_config.amount + deposit_config.max_fee),
         height: 0,
     };
+    let max_fee = deposit_config.amount / 2;
     let (deposit_tx, deposit_request, _) = make_deposit_request(
         &depositor,
         deposit_config.amount,
         depositor_utxo,
+        max_fee,
         deposit_config.aggregate_key.into(),
     );
 

--- a/signer/tests/integration/rbf.rs
+++ b/signer/tests/integration/rbf.rs
@@ -68,14 +68,15 @@ fn generate_depositor(rpc: &Client, faucet: &Faucet, signer: &Recipient) -> Depo
         .unwrap()
         .unwrap();
 
-    let depositor_utxo = FullUtxo {
+    let utxo = FullUtxo {
         outpoint,
         script: tx_out.script_pub_key.script().unwrap(),
         tx_out,
     };
 
+    let max_fee = amount / 2;
     let (deposit_tx, deposit_request, _) =
-        make_deposit_request(&depositor, amount, depositor_utxo, signers_public_key);
+        make_deposit_request(&depositor, amount, utxo, max_fee, signers_public_key);
     rpc.send_raw_transaction(&deposit_tx).unwrap();
     deposit_request
 }

--- a/signer/tests/integration/setup.rs
+++ b/signer/tests/integration/setup.rs
@@ -109,12 +109,13 @@ impl TestSweepSetup {
         faucet.generate_blocks(1);
 
         // Now lets make a deposit transaction and submit it
-        let depositor_utxo = depositor.get_utxos(rpc, None).pop().unwrap();
+        let utxo = depositor.get_utxos(rpc, None).pop().unwrap();
 
         more_asserts::assert_lt!(amount, 50_000_000);
+        let max_fee = amount / 2;
 
         let (deposit_tx, deposit_request, deposit_info) =
-            make_deposit_request(&depositor, amount, depositor_utxo, signers_public_key);
+            make_deposit_request(&depositor, amount, utxo, max_fee, signers_public_key);
         rpc.send_raw_transaction(&deposit_tx).unwrap();
         let deposit_block_hash = faucet.generate_blocks(1).pop().unwrap();
 

--- a/signer/tests/integration/transaction_coordinator.rs
+++ b/signer/tests/integration/transaction_coordinator.rs
@@ -1382,8 +1382,6 @@ async fn sign_bitcoin_transaction() {
 
         let block_observer = BlockObserver {
             context: ctx.clone(),
-            stacks_client: ctx.stacks_client.clone(),
-            emily_client: ctx.emily_client.clone(),
             bitcoin_blocks: ReceiverStream::new(receiver),
             horizon: 10,
         };

--- a/signer/tests/integration/transaction_coordinator.rs
+++ b/signer/tests/integration/transaction_coordinator.rs
@@ -1454,12 +1454,13 @@ async fn sign_bitcoin_transaction() {
     //   request transaction. Submit it and inform Emily about it.
     // =========================================================================
     // Now lets make a deposit transaction and submit it
-    let depositor_utxo = depositor.get_utxos(rpc, None).pop().unwrap();
+    let utxo = depositor.get_utxos(rpc, None).pop().unwrap();
 
     let amount = 2_500_000;
     let signers_public_key = shares.aggregate_key.into();
+    let max_fee = amount / 2;
     let (deposit_tx, deposit_request, _) =
-        make_deposit_request(&depositor, amount, depositor_utxo, signers_public_key);
+        make_deposit_request(&depositor, amount, utxo, max_fee, signers_public_key);
     rpc.send_raw_transaction(&deposit_tx).unwrap();
 
     assert_eq!(deposit_tx.compute_txid(), deposit_request.outpoint.txid);

--- a/signer/tests/integration/utxo_construction.rs
+++ b/signer/tests/integration/utxo_construction.rs
@@ -58,6 +58,7 @@ pub fn make_deposit_request<U>(
     depositor: &Recipient,
     amount: u64,
     utxo: U,
+    max_fee: u64,
     signers_public_key: XOnlyPublicKey,
 ) -> (Transaction, DepositRequest, DepositInfo)
 where
@@ -66,7 +67,7 @@ where
     let fee = regtest::BITCOIN_CORE_FALLBACK_FEE.to_sat();
     let deposit_inputs = DepositScriptInputs {
         signers_public_key,
-        max_fee: amount / 2,
+        max_fee,
         recipient: PrincipalData::from(StacksAddress::burn_address(false)),
     };
     let reclaim_inputs = ReclaimScriptInputs::try_new(50, ScriptBuf::new()).unwrap();
@@ -181,11 +182,13 @@ fn deposits_add_to_controlled_amounts() {
     // Now lets make a deposit transaction and submit it
     let depositor_utxo = depositor.get_utxos(rpc, None).pop().unwrap();
     let deposit_amount = 25_000_000;
+    let max_fee = deposit_amount / 2;
 
     let (deposit_tx, deposit_request, _) = make_deposit_request(
         &depositor,
         deposit_amount,
         depositor_utxo,
+        max_fee,
         signers_public_key,
     );
     rpc.send_raw_transaction(&deposit_tx).unwrap();


### PR DESCRIPTION
## Description

These are easy changes that came up in another branch.

## Changes

* Remove the redundant fields of the block observer.
* Allow the max-fee to be set when creating deposit requests in integration tests.

## Testing Information

This is a refactor, if tests pass then all is good.

## Checklist:

- [x] I have performed a self-review of my code
