### PR TITLE
fix: remove the foreign key constraint on rotate-keys event table

### DIFF
--- a/signer/migrations/0003__create_tables.sql
+++ b/signer/migrations/0003__create_tables.sql
@@ -133,8 +133,7 @@ CREATE TABLE sbtc_signer.rotate_keys_transactions (
     -- This is one of those fields that might not be required in the future
     -- when Schnorr signatures are introduced.
     signatures_required INTEGER NOT NULL,
-    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    FOREIGN KEY (txid) REFERENCES sbtc_signer.transactions(txid) ON DELETE CASCADE
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL
 );
 
 CREATE TABLE sbtc_signer.completed_deposit_events (


### PR DESCRIPTION
## Description

The other event tables do not have such a constraint, because we cannot know whether the transaction has been written to the table before the event.

## Changes

* Remove the foreign key constraint

## Testing Information

## Checklist:

- [x] I have performed a self-review of my code
