### PR TITLE
Feat emily apigateway logs

### DIFF
--- a/emily/cdk/test/emily-stack.test.ts
+++ b/emily/cdk/test/emily-stack.test.ts
@@ -53,7 +53,8 @@ describe('EmilyStack Test', () => {
         });
 
         const lambdaResources = template.findResources('AWS::Lambda::Function');
-        expect(Object.keys(lambdaResources)).toHaveLength(1);
+        // One lambda for emily, another to handle the custom resource.
+        expect(Object.keys(lambdaResources)).toHaveLength(2);
         Object.keys(lambdaResources).forEach(lambdaLogicalId => {
             const environment = lambdaResources[lambdaLogicalId].Properties.Environment.Variables;
             console.log(environment);

--- a/emily/cdk/test/emily-stack.test.ts
+++ b/emily/cdk/test/emily-stack.test.ts
@@ -53,16 +53,16 @@ describe('EmilyStack Test', () => {
         });
 
         const lambdaResources = template.findResources('AWS::Lambda::Function');
-        // One lambda for emily, another to handle the custom resource.
-        expect(Object.keys(lambdaResources)).toHaveLength(2);
-        Object.keys(lambdaResources).forEach(lambdaLogicalId => {
-            const environment = lambdaResources[lambdaLogicalId].Properties.Environment.Variables;
-            console.log(environment);
-            expect(environment.DEPOSIT_TABLE_NAME).toMatch(`DepositTable-account-region-${Constants.UNIT_TEST_STAGE_NAME}`);
-            expect(environment.WITHDRAWAL_TABLE_NAME).toMatch(`WithdrawalTable-account-region-${Constants.UNIT_TEST_STAGE_NAME}`);
-            expect(environment.CHAINSTATE_TABLE_NAME).toMatch(`ChainstateTable-account-region-${Constants.UNIT_TEST_STAGE_NAME}`);
-            expect(environment.IS_LOCAL).toEqual("false");
-        });
+        Object.keys(lambdaResources)
+            .filter(lambdaLogicalId => lambdaLogicalId.startsWith('OperationLambda'))
+            .forEach(lambdaLogicalId => {
+                const environment = lambdaResources[lambdaLogicalId].Properties.Environment.Variables;
+                expect(environment.DEPOSIT_TABLE_NAME).toMatch(`DepositTable-account-region-${Constants.UNIT_TEST_STAGE_NAME}`);
+                expect(environment.WITHDRAWAL_TABLE_NAME).toMatch(`WithdrawalTable-account-region-${Constants.UNIT_TEST_STAGE_NAME}`);
+                expect(environment.CHAINSTATE_TABLE_NAME).toMatch(`ChainstateTable-account-region-${Constants.UNIT_TEST_STAGE_NAME}`);
+                expect(environment.LIMIT_TABLE_NAME).toMatch(`LimitTable-account-region-${Constants.UNIT_TEST_STAGE_NAME}`);
+                expect(environment.IS_LOCAL).toEqual("false");
+            });
     });
 
     it('should create a REST API', async () => {


### PR DESCRIPTION
## Description

Closes: #914

## Changes

Adds logs for Emily's apigateway. These logs can be found on cloudwatch.

There's some craziness around a custom resource required to setup permissions, which is a bummer, but it's no so bad.

## Testing Information

- tested on the `sbtc-emily-dev.com` endpoint and logs indeed showed up.

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
