### PR TITLE
chore: remove commented out libp2p code

### DIFF
--- a/signer/src/network/libp2p/event_loop.rs
+++ b/signer/src/network/libp2p/event_loop.rs
@@ -82,14 +82,6 @@ pub async fn run(ctx: &impl Context, swarm: Arc<Mutex<Swarm<SignerBehavior>>>) {
                     SwarmEvent::Behaviour(SignerBehaviorEvent::Gossipsub(event)) => {
                         handle_gossipsub_event(&mut swarm, ctx, event)
                     }
-                    // AutoNAT client protocol events.
-                    // SwarmEvent::Behaviour(SignerBehaviorEvent::AutonatClient(event)) => {
-                    //     handle_autonat_client_event(&mut swarm, ctx, event)
-                    // }
-                    // AutoNAT server protocol events.
-                    // SwarmEvent::Behaviour(SignerBehaviorEvent::AutonatServer(event)) => {
-                    //     handle_autonat_server_event(&mut swarm, event)
-                    // }
                     SwarmEvent::NewListenAddr { address, .. } => {
                         tracing::info!(%address, "Listener started");
                     }
@@ -205,95 +197,6 @@ pub async fn run(ctx: &impl Context, swarm: Arc<Mutex<Swarm<SignerBehavior>>>) {
 
     tracing::info!("libp2p event loop terminated");
 }
-
-// fn handle_autonat_client_event(
-//     _: &mut Swarm<SignerBehavior>,
-//     ctx: &impl Context,
-//     event: autonat::v2::client::Event,
-// ) {
-//     use autonat::v2::client::Event;
-
-//     match event {
-//         //  Match on successful AutoNAT test event
-//         Event {
-//             server,
-//             tested_addr,
-//             bytes_sent,
-//             result: Ok(()),
-//         } => {
-//             if !ctx.state().current_signer_set().is_allowed_peer(&server) {
-//                 tracing::debug!(
-//                     peer_id = %server,
-//                     %tested_addr,
-//                     %bytes_sent,
-//                     "AutoNAT (client) test successful, however the server is not a known signer; ignoring"
-//                 );
-//                 return;
-//             }
-
-//             tracing::trace!(peer_id = %server, %tested_addr, %bytes_sent, "AutoNAT (client) test successful");
-//         }
-//         // Match on failed AutoNAT test event
-//         Event {
-//             server,
-//             tested_addr,
-//             bytes_sent,
-//             result: Err(error),
-//         } => {
-//             if !ctx.state().current_signer_set().is_allowed_peer(&server) {
-//                 tracing::debug!(
-//                     peer_id = %server,
-//                     %tested_addr,
-//                     %bytes_sent,
-//                     "AutoNAT (client) test failed, however the server is not a known signer; ignoring"
-//                 );
-//                 return;
-//             }
-
-//             tracing::trace!(
-//                 peer_id = %server, %tested_addr, %bytes_sent, %error, "AutoNAT (client) test failed"
-//             );
-//         }
-//     }
-// }
-
-// fn handle_autonat_server_event(_: &mut Swarm<SignerBehavior>, event: autonat::v2::server::Event) {
-//     use autonat::v2::server::Event;
-
-//     match event {
-//         Event {
-//             all_addrs,
-//             client,
-//             tested_addr,
-//             data_amount,
-//             result: Ok(()),
-//         } => {
-//             tracing::trace!(
-//                 ?all_addrs,
-//                 %client,
-//                 %tested_addr,
-//                 %data_amount,
-//                 "AutoNAT (server) test successful"
-//             );
-//         }
-//         Event {
-//             all_addrs,
-//             client,
-//             tested_addr,
-//             data_amount,
-//             result: Err(error),
-//         } => {
-//             tracing::warn!(
-//                 ?all_addrs,
-//                 %client,
-//                 %tested_addr,
-//                 %data_amount,
-//                 %error,
-//                 "AutoNAT (server) test failed"
-//             );
-//         }
-//     }
-// }
 
 fn handle_mdns_event(swarm: &mut Swarm<SignerBehavior>, ctx: &impl Context, event: mdns::Event) {
     use mdns::Event;

--- a/signer/src/network/libp2p/swarm.rs
+++ b/signer/src/network/libp2p/swarm.rs
@@ -4,10 +4,6 @@ use std::time::Duration;
 
 use crate::context::Context;
 use crate::keys::PrivateKey;
-// use libp2p::autonat::v2::client::{
-//     Behaviour as AutoNatClientBehavior, Config as AutoNatClientConfig,
-// };
-//use libp2p::autonat::v2::server::Behaviour as AutoNatServerBehavior;
 use libp2p::identity::Keypair;
 use libp2p::kad::store::MemoryStore;
 use libp2p::swarm::behaviour::toggle::Toggle;
@@ -16,7 +12,6 @@ use libp2p::{
     gossipsub, identify, kad, mdns, noise, ping, /*relay,*/ tcp, yamux, Multiaddr, PeerId,
     Swarm, SwarmBuilder,
 };
-//use rand::rngs::OsRng;
 use tokio::sync::Mutex;
 
 use super::errors::SignerSwarmError;
@@ -29,10 +24,7 @@ pub struct SignerBehavior {
     mdns: Toggle<mdns::tokio::Behaviour>,
     kademlia: kad::Behaviour<MemoryStore>,
     ping: ping::Behaviour,
-    //relay: relay::Behaviour,
     identify: identify::Behaviour,
-    //autonat_server: AutoNatServerBehavior,
-    //autonat_client: AutoNatClientBehavior,
 }
 
 impl SignerBehavior {
@@ -69,16 +61,10 @@ impl SignerBehavior {
             mdns,
             kademlia: Self::kademlia(&keypair),
             ping: ping::Behaviour::default(),
-            //relay: relay::Behaviour::new(keypair.public().to_peer_id(), Default::default()),
             identify: identify::Behaviour::new(identify::Config::new(
                 identify::PUSH_PROTOCOL_NAME.to_string(),
                 keypair.public(),
             )),
-            //autonat_server: AutoNatServerBehavior::new(OsRng),
-            //autonat_client: AutoNatClientBehavior::new(
-            //    OsRng,
-            //    AutoNatClientConfig::default().with_probe_interval(Duration::from_secs(2)),
-            //),
         })
     }
 


### PR DESCRIPTION
## Description

Removes the commented-out libp2p auto-nat/relay functionality as we're not using it right now and we don't know if it works; but now we have the changes saved in a PR if/when we want to revisit.

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
