### PR TITLE
Embed public and private shares into DkgBegin messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3147,7 +3147,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if 1.0.0",
- "windows-targets 0.52.5",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -4400,9 +4400,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "p256k1"
-version = "7.1.0"
+version = "7.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a40a031a559eb38c35a14096f21c366254501a06d41c4b327d2a7515d713a5b7"
+checksum = "f8641765697df03a529cd21181fbccd1cad9f66086c24252b91c16bf38cdddd6"
 dependencies = [
  "bindgen",
  "bitvec",
@@ -7759,8 +7759,8 @@ dependencies = [
 
 [[package]]
 name = "wsts"
-version = "10.0.0"
-source = "git+https://github.com/Trust-Machines/wsts.git?rev=c90232f929e1433f0eac8175512541be32d4e2c0#c90232f929e1433f0eac8175512541be32d4e2c0"
+version = "11.0.0"
+source = "git+https://github.com/Trust-Machines/wsts.git?rev=e78101f923f517440e389f9da7bbf0e89bd901c8#e78101f923f517440e389f9da7bbf0e89bd901c8"
 dependencies = [
  "aes-gcm",
  "bs58 0.5.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7760,7 +7760,7 @@ dependencies = [
 [[package]]
 name = "wsts"
 version = "10.0.0"
-source = "git+https://github.com/Trust-Machines/wsts.git?rev=ebd7d7775ad5e44cdbf4f5c1fb468bdf6c467265#ebd7d7775ad5e44cdbf4f5c1fb468bdf6c467265"
+source = "git+https://github.com/Trust-Machines/wsts.git?rev=c90232f929e1433f0eac8175512541be32d4e2c0#c90232f929e1433f0eac8175512541be32d4e2c0"
 dependencies = [
  "aes-gcm",
  "bs58 0.5.1",

--- a/protobufs/crypto/wsts/wsts.proto
+++ b/protobufs/crypto/wsts/wsts.proto
@@ -47,6 +47,8 @@ message DkgPrivateBegin {
   repeated uint32 signer_ids = 2;
   // Key IDs who responded in time for this DKG round
   repeated uint32 key_ids = 3;
+  // Public shares from all signers in this DKG round
+  DkgPublicShares dkg_public_shares = 4;
 }
 
 // DKG private shares message from signer to all signers and coordinator
@@ -89,6 +91,8 @@ message DkgEndBegin {
   repeated uint32 signer_ids = 2;
   // Key IDs who responded in time for this DKG round
   repeated uint32 key_ids = 3;
+  // Private shares from all signers in this DKG round
+  map<uint32, DkgPrivateShares> dkg_private_shares = 4;
 }
 
 // DKG end message from signers to coordinator

--- a/signer/Cargo.toml
+++ b/signer/Cargo.toml
@@ -50,7 +50,7 @@ tracing-attributes.workspace = true
 tracing-subscriber = { workspace = true }
 url.workspace = true
 # wsts.workspace = true
-wsts = { git = "https://github.com/Trust-Machines/wsts.git", rev = "c90232f929e1433f0eac8175512541be32d4e2c0" }
+wsts = { git = "https://github.com/Trust-Machines/wsts.git", rev = "e78101f923f517440e389f9da7bbf0e89bd901c8" }
 zeromq.workspace = true
 hex.workspace = true
 cfg-if = "1.0"

--- a/signer/Cargo.toml
+++ b/signer/Cargo.toml
@@ -50,7 +50,7 @@ tracing-attributes.workspace = true
 tracing-subscriber = { workspace = true }
 url.workspace = true
 # wsts.workspace = true
-wsts = { git = "https://github.com/Trust-Machines/wsts.git", rev = "ebd7d7775ad5e44cdbf4f5c1fb468bdf6c467265" }
+wsts = { git = "https://github.com/Trust-Machines/wsts.git", rev = "c90232f929e1433f0eac8175512541be32d4e2c0" }
 zeromq.workspace = true
 hex.workspace = true
 cfg-if = "1.0"

--- a/signer/src/main.rs
+++ b/signer/src/main.rs
@@ -320,7 +320,7 @@ async fn run_transaction_signer(ctx: impl Context) -> Result<(), Error> {
         rng: rand::thread_rng(),
         signer_private_key: config.signer.private_key,
         wsts_state_machines: HashMap::new(),
-        dkg_begin_pause: None,//Some(Duration::from_secs(10)),
+        dkg_begin_pause: None, //Some(Duration::from_secs(10)),
     };
 
     signer.run().await

--- a/signer/src/main.rs
+++ b/signer/src/main.rs
@@ -320,7 +320,7 @@ async fn run_transaction_signer(ctx: impl Context) -> Result<(), Error> {
         rng: rand::thread_rng(),
         signer_private_key: config.signer.private_key,
         wsts_state_machines: HashMap::new(),
-        dkg_begin_pause: Some(Duration::from_secs(10)),
+        dkg_begin_pause: None,//Some(Duration::from_secs(10)),
     };
 
     signer.run().await

--- a/signer/src/proto/convert.rs
+++ b/signer/src/proto/convert.rs
@@ -1958,11 +1958,12 @@ mod tests {
         }
     }
     impl Dummy<Unit> for DkgPrivateBegin {
-        fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &Unit, rng: &mut R) -> Self {
+        fn dummy_with_rng<R: rand::Rng + ?Sized>(config: &Unit, rng: &mut R) -> Self {
             DkgPrivateBegin {
                 dkg_id: Faker.fake_with_rng(rng),
                 signer_ids: Faker.fake_with_rng(rng),
                 key_ids: Faker.fake_with_rng(rng),
+                dkg_public_shares: config.fake_with_rng(rng),
             }
         }
     }
@@ -1987,11 +1988,12 @@ mod tests {
     }
 
     impl Dummy<Unit> for DkgEndBegin {
-        fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &Unit, rng: &mut R) -> Self {
+        fn dummy_with_rng<R: rand::Rng + ?Sized>(config: &Unit, rng: &mut R) -> Self {
             DkgEndBegin {
                 dkg_id: Faker.fake_with_rng(rng),
                 signer_ids: Faker.fake_with_rng(rng),
                 key_ids: Faker.fake_with_rng(rng),
+                dkg_private_shares: config.fake_with_rng(rng),
             }
         }
     }
@@ -2234,6 +2236,24 @@ mod tests {
     }
 
     impl Dummy<Unit> for BTreeMap<u32, DkgPublicShares> {
+        fn dummy_with_rng<R: rand::Rng + ?Sized>(config: &Unit, rng: &mut R) -> Self {
+            fake::vec![(); 0..20]
+                .into_iter()
+                .map(|_| (Faker.fake_with_rng(rng), config.fake_with_rng(rng)))
+                .collect()
+        }
+    }
+
+    impl Dummy<Unit> for hashbrown::HashMap<u32, DkgPublicShares> {
+        fn dummy_with_rng<R: rand::Rng + ?Sized>(config: &Unit, rng: &mut R) -> Self {
+            fake::vec![(); 0..20]
+                .into_iter()
+                .map(|_| (Faker.fake_with_rng(rng), config.fake_with_rng(rng)))
+                .collect()
+        }
+    }
+
+    impl Dummy<Unit> for hashbrown::HashMap<u32, DkgPrivateShares> {
         fn dummy_with_rng<R: rand::Rng + ?Sized>(config: &Unit, rng: &mut R) -> Self {
             fake::vec![(); 0..20]
                 .into_iter()

--- a/signer/src/proto/generated/crypto.wsts.rs
+++ b/signer/src/proto/generated/crypto.wsts.rs
@@ -137,6 +137,9 @@ pub struct DkgPrivateBegin {
     /// Key IDs who responded in time for this DKG round
     #[prost(uint32, repeated, tag = "3")]
     pub key_ids: ::prost::alloc::vec::Vec<u32>,
+    /// Public shares from all signers in this DKG round
+    #[prost(message, optional, tag = "4")]
+    pub dkg_public_shares: ::core::option::Option<DkgPublicShares>,
 }
 /// DKG private shares message from signer to all signers and coordinator
 /// This maps to this type <<https://github.com/Trust-Machines/wsts/blob/2d6cb87218bb8dd9ed0519356afe57a0b9a697cb/src/net.rs#L185-L195>>
@@ -193,6 +196,9 @@ pub struct DkgEndBegin {
     /// Key IDs who responded in time for this DKG round
     #[prost(uint32, repeated, tag = "3")]
     pub key_ids: ::prost::alloc::vec::Vec<u32>,
+    /// Private shares from all signers in this DKG round
+    #[prost(btree_map = "uint32, message", tag = "4")]
+    pub dkg_private_shares: ::prost::alloc::collections::BTreeMap<u32, DkgPrivateShares>,
 }
 /// DKG end message from signers to coordinator
 /// This maps to this type <<https://github.com/Trust-Machines/wsts/blob/2d6cb87218bb8dd9ed0519356afe57a0b9a697cb/src/net.rs#L246-L255>>

--- a/signer/src/testing/message.rs
+++ b/signer/src/testing/message.rs
@@ -132,6 +132,7 @@ impl fake::Dummy<fake::Faker> for message::WstsMessage {
             dkg_id: config.fake_with_rng(rng),
             signer_ids: config.fake_with_rng(rng),
             key_ids: config.fake_with_rng(rng),
+            dkg_private_shares: Default::default(),
         };
 
         Self {

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -532,7 +532,7 @@ where
         &mut self,
         msg: &message::WstsMessage,
         bitcoin_chain_tip: &model::BitcoinBlockHash,
-        msg_public_key: PublicKey,
+        _msg_public_key: PublicKey,
         chain_tip_report: &MsgChainTipReport,
     ) -> Result<(), Error> {
         match &msg.inner {
@@ -574,6 +574,7 @@ where
                 self.relay_message(msg.txid, &msg.inner, bitcoin_chain_tip)
                     .await?;
             }
+<<<<<<< HEAD
             WstsNetMessage::DkgPublicShares(dkg_public_shares) => {
                 tracing::info!(
                     signer_id = %dkg_public_shares.signer_id,
@@ -616,6 +617,8 @@ where
                 self.relay_message(msg.txid, &msg.inner, bitcoin_chain_tip)
                     .await?;
             }
+=======
+>>>>>>> 6ac8fba2 (PoC embedding dkg shares into begin messages)
             WstsNetMessage::DkgEndBegin(_) => {
                 tracing::info!("handling DkgEndBegin");
                 if !chain_tip_report.sender_is_coordinator {
@@ -691,7 +694,11 @@ where
                     }
                 }
             }
-            WstsNetMessage::NonceResponse(_) | WstsNetMessage::SignatureShareResponse(_) => {
+
+            WstsNetMessage::DkgPublicShares(_)
+            | WstsNetMessage::DkgPrivateShares(_)
+            | WstsNetMessage::NonceResponse(_)
+            | WstsNetMessage::SignatureShareResponse(_) => {
                 tracing::trace!("ignoring message");
             }
         }

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -39,6 +39,7 @@ use crate::wsts_state_machine::SignerStateMachine;
 use bitcoin::hashes::Hash;
 use bitcoin::TapSighash;
 use futures::StreamExt;
+use rand::rngs::OsRng;
 use wsts::net::DkgEnd;
 use wsts::net::DkgStatus;
 use wsts::net::Message as WstsNetMessage;
@@ -574,51 +575,6 @@ where
                 self.relay_message(msg.txid, &msg.inner, bitcoin_chain_tip)
                     .await?;
             }
-<<<<<<< HEAD
-            WstsNetMessage::DkgPublicShares(dkg_public_shares) => {
-                tracing::info!(
-                    signer_id = %dkg_public_shares.signer_id,
-                    "handling DkgPublicShares",
-                );
-                let public_keys = match self.wsts_state_machines.get(&msg.txid) {
-                    Some(state_machine) => &state_machine.public_keys,
-                    None => return Err(Error::MissingStateMachine),
-                };
-                let signer_public_key = match public_keys.signers.get(&dkg_public_shares.signer_id)
-                {
-                    Some(key) => PublicKey::from(key),
-                    None => return Err(Error::MissingPublicKey),
-                };
-
-                if signer_public_key != msg_public_key {
-                    return Err(Error::InvalidSignature);
-                }
-                self.relay_message(msg.txid, &msg.inner, bitcoin_chain_tip)
-                    .await?;
-            }
-            WstsNetMessage::DkgPrivateShares(dkg_private_shares) => {
-                tracing::info!(
-                    signer_id = %dkg_private_shares.signer_id,
-                    "handling DkgPrivateShares"
-                );
-                let public_keys = match self.wsts_state_machines.get(&msg.txid) {
-                    Some(state_machine) => &state_machine.public_keys,
-                    None => return Err(Error::MissingStateMachine),
-                };
-                let signer_public_key = match public_keys.signers.get(&dkg_private_shares.signer_id)
-                {
-                    Some(key) => PublicKey::from(key),
-                    None => return Err(Error::MissingPublicKey),
-                };
-
-                if signer_public_key != msg_public_key {
-                    return Err(Error::InvalidSignature);
-                }
-                self.relay_message(msg.txid, &msg.inner, bitcoin_chain_tip)
-                    .await?;
-            }
-=======
->>>>>>> 6ac8fba2 (PoC embedding dkg shares into begin messages)
             WstsNetMessage::DkgEndBegin(_) => {
                 tracing::info!("handling DkgEndBegin");
                 if !chain_tip_report.sender_is_coordinator {
@@ -718,12 +674,13 @@ where
             return Ok(());
         };
 
-        let outbound_messages = state_machine.process(msg).map_err(Error::Wsts)?;
+        let mut rng = OsRng;
+        let outbound_messages = state_machine.process(msg, &mut rng).map_err(Error::Wsts)?;
 
         for outbound_message in outbound_messages.iter() {
             // The WSTS state machine assume we read our own messages
             state_machine
-                .process(outbound_message)
+                .process(outbound_message, &mut rng)
                 .map_err(Error::Wsts)?;
         }
 

--- a/signer/src/wsts_state_machine.rs
+++ b/signer/src/wsts_state_machine.rs
@@ -12,6 +12,7 @@ use crate::keys::SignerScriptPubKey as _;
 use crate::storage;
 use crate::storage::model;
 
+use rand::rngs::OsRng;
 use wsts::common::PolyCommitment;
 use wsts::state_machine::coordinator::Coordinator as _;
 use wsts::state_machine::coordinator::State as WstsState;
@@ -65,6 +66,7 @@ impl SignerStateMachine {
             return Err(error::Error::InvalidConfiguration);
         };
 
+        let mut rng = OsRng;
         let state_machine = WstsStateMachine::new(
             threshold,
             num_parties,
@@ -73,6 +75,8 @@ impl SignerStateMachine {
             key_ids,
             signer_private_key.into(),
             public_keys,
+            true,
+            &mut rng,
         );
 
         Ok(Self(state_machine))
@@ -215,6 +219,7 @@ impl CoordinatorStateMachine {
             sign_timeout: None,
             signer_key_ids,
             signer_public_keys,
+            embed_public_private_shares: true,
         };
 
         let wsts_coordinator = WstsCoordinator::new(config);

--- a/signer/tests/integration/transaction_coordinator.rs
+++ b/signer/tests/integration/transaction_coordinator.rs
@@ -1141,7 +1141,7 @@ async fn run_dkg_from_scratch() {
         testing::storage::drop_db(db).await;
     }
 }
-
+use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 /// Test that three signers can successfully sign and broadcast a bitcoin
 /// transaction.
 ///
@@ -1174,6 +1174,10 @@ async fn run_dkg_from_scratch() {
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn sign_bitcoin_transaction() {
+    tracing_subscriber::registry()
+        .with(fmt::layer())
+        .with(EnvFilter::from_default_env())
+        .init();
     let (_, signer_key_pairs): (_, [Keypair; 3]) = testing::wallet::regtest_bootstrap_wallet();
     let (rpc, faucet) = regtest::initialize_blockchain();
 


### PR DESCRIPTION
## Description

This change fixes the race condition that arises during `DKG` from the interplay of our networking stack, usage of `WSTS`, and `WSTS` itself.   It uses recent `WSTS` changes to embed public and private shares into the various `DkgBegin` messages.  This avoids the case where a signer receives `DKG` public or private shares before the corresponding `DkgBegin`.

Closes: #929 

## Changes

## Testing Information

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
