### PR TITLE
feat: ensure signers go through the bitcoin validation code path

### DIFF
--- a/signer/src/bitcoin/validation.rs
+++ b/signer/src/bitcoin/validation.rs
@@ -15,6 +15,7 @@ use crate::bitcoin::utxo::SignerBtcState;
 use crate::context::Context;
 use crate::error::Error;
 use crate::keys::PublicKey;
+use crate::message::BitcoinPreSignRequest;
 use crate::message::OutPointMessage;
 use crate::storage::model::BitcoinBlockHash;
 use crate::storage::model::BitcoinTxId;
@@ -29,6 +30,7 @@ use super::utxo::DepositRequest;
 use super::utxo::RequestRef;
 use super::utxo::Requests;
 use super::utxo::SignatureHash;
+use super::utxo::SignerUtxo;
 use super::utxo::UnsignedTransaction;
 use super::utxo::WithdrawalRequest;
 
@@ -43,16 +45,12 @@ pub struct BitcoinTxContext {
     /// The block height of the bitcoin chain tip identified by the
     /// `chain_tip` field.
     pub chain_tip_height: u64,
-    /// This contains each of the requests for the entire transaction
-    /// package. Each element in the vector corresponds to the requests
-    /// that will be included in a single bitcoin transaction.
-    pub request_packages: Vec<TxRequestIds>,
     /// This signer's public key.
     pub signer_public_key: PublicKey,
     /// The current aggregate key that was the output of DKG.
     pub aggregate_key: PublicKey,
-    /// The state of the signers.
-    pub signer_state: SignerBtcState,
+    /// The signers' UTXO.
+    pub utxo: SignerUtxo,
 }
 
 /// This type is a container for all deposits and withdrawals that are part
@@ -91,7 +89,7 @@ pub fn is_unique(packages: &[TxRequestIds]) -> bool {
     })
 }
 
-impl BitcoinTxContext {
+impl BitcoinPreSignRequest {
     /// Validate the current bitcoin transaction.
     pub async fn pre_validation<C>(&self, _ctx: &C) -> Result<(), Error>
     where
@@ -111,16 +109,24 @@ impl BitcoinTxContext {
     pub async fn construct_package_sighashes<C>(
         &self,
         ctx: &C,
+        btc_ctx: &BitcoinTxContext,
     ) -> Result<Vec<BitcoinTxValidationData>, Error>
     where
         C: Context + Send + Sync,
     {
-        let mut signer_state = self.signer_state;
+        self.pre_validation()?;
+        let mut signer_state = SignerBtcState {
+            fee_rate: self.fee_rate,
+            utxo: btc_ctx.utxo,
+            public_key: bitcoin::XOnlyPublicKey::from(btc_ctx.aggregate_key),
+            last_fees: self.last_fees,
+            magic_bytes: [b'T', b'3'], //TODO(#472): Use the correct magic bytes.
+        };
         let mut outputs = Vec::new();
 
-        for requests in self.request_packages.iter() {
+        for requests in self.request_package.iter() {
             let (output, new_signer_state) = self
-                .construct_tx_sighashes(ctx, requests, signer_state)
+                .construct_tx_sighashes(ctx, btc_ctx, requests, signer_state)
                 .await?;
             signer_state = new_signer_state;
             outputs.push(output);
@@ -138,6 +144,7 @@ impl BitcoinTxContext {
     async fn construct_tx_sighashes<C>(
         &self,
         ctx: &C,
+        btc_ctx: &BitcoinTxContext,
         requests: &TxRequestIds,
         signer_state: SignerBtcState,
     ) -> Result<(BitcoinTxValidationData, SignerBtcState), Error>
@@ -146,9 +153,9 @@ impl BitcoinTxContext {
     {
         let db = ctx.get_storage();
 
-        let signer_public_key = &self.signer_public_key;
-        let aggregate_key = &self.aggregate_key;
-        let chain_tip = &self.chain_tip;
+        let signer_public_key = &btc_ctx.signer_public_key;
+        let aggregate_key = &btc_ctx.aggregate_key;
+        let chain_tip = &btc_ctx.chain_tip;
 
         let mut deposits = Vec::new();
         let mut withdrawals = Vec::new();
@@ -160,7 +167,7 @@ impl BitcoinTxContext {
                 db.get_deposit_request_report(chain_tip, &txid, output_index, signer_public_key);
 
             let Some(report) = report_future.await? else {
-                return Err(InputValidationResult::Unknown.into_error(self));
+                return Err(InputValidationResult::Unknown.into_error(btc_ctx));
             };
 
             let votes = db
@@ -174,7 +181,7 @@ impl BitcoinTxContext {
             let report_future = db.get_withdrawal_request_report(chain_tip, id, signer_public_key);
 
             let Some(report) = report_future.await? else {
-                return Err(WithdrawalValidationResult::Unknown.into_error(self));
+                return Err(WithdrawalValidationResult::Unknown.into_error(btc_ctx));
             };
 
             let votes = db
@@ -207,11 +214,11 @@ impl BitcoinTxContext {
         let out = BitcoinTxValidationData {
             signer_sighash: sighashes.signer_sighash(),
             deposit_sighashes: sighashes.deposit_sighashes(),
-            chain_tip: self.chain_tip,
+            chain_tip: btc_ctx.chain_tip,
             tx: tx.tx.clone(),
             tx_fee: Amount::from_sat(tx.tx_fee),
             reports,
-            chain_tip_height: self.chain_tip_height,
+            chain_tip_height: btc_ctx.chain_tip_height,
         };
 
         Ok((out, signer_state))

--- a/signer/src/bitcoin/validation.rs
+++ b/signer/src/bitcoin/validation.rs
@@ -79,10 +79,10 @@ impl From<&Requests<'_>> for TxRequestIds {
 }
 
 /// Check that this does not contain duplicate deposits or withdrawals.
-pub fn is_unique(packages: &[TxRequestIds]) -> bool {
+pub fn is_unique(package: &[TxRequestIds]) -> bool {
     let mut deposits_set = HashSet::new();
     let mut withdrawals_set = HashSet::new();
-    packages.iter().all(|reqs| {
+    package.iter().all(|reqs| {
         let deposits = reqs.deposits.iter().all(|out| deposits_set.insert(out));
         let withdrawals = reqs.withdrawals.iter().all(|id| withdrawals_set.insert(id));
         deposits && withdrawals
@@ -91,16 +91,11 @@ pub fn is_unique(packages: &[TxRequestIds]) -> bool {
 
 impl BitcoinPreSignRequest {
     /// Validate the current bitcoin transaction.
-    pub async fn pre_validation<C>(&self, _ctx: &C) -> Result<(), Error>
-    where
-        C: Context + Send + Sync,
-    {
-        if !is_unique(&self.request_packages) {
+    pub fn pre_validation(&self) -> Result<(), Error> {
+        if !is_unique(&self.request_package) {
             return Err(Error::DuplicateRequests);
         }
 
-        // TODO: check that we have not received a different transaction
-        // package during this tenure.
         Ok(())
     }
 

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -9,6 +9,7 @@ use crate::emily_client::EmilyClientError;
 use crate::stacks::contracts::DepositValidationError;
 use crate::stacks::contracts::RotateKeysValidationError;
 use crate::stacks::contracts::WithdrawalAcceptValidationError;
+use crate::storage::model::SigHash;
 
 /// Top-level signer error
 #[derive(Debug, thiserror::Error)]
@@ -75,9 +76,14 @@ pub enum Error {
     SigHashConversion(#[source] bitcoin::hashes::FromSliceError),
 
     /// This happens when the tx-signer is validating the sighash and it is
-    /// unknown or is known by has failed validation.
-    #[error("the given sighash is unknown or known and failed validation")]
-    InvalidSigHash,
+    /// known but has failed validation.
+    #[error("the given sighash is known and failed validation: {0}")]
+    InvalidSigHash(SigHash),
+
+    /// This happens when the tx-signer is validating the sighash and it
+    /// does not have a row for it in the database.
+    #[error("the given sighash is unknown: {0}")]
+    UnknownSigHash(SigHash),
 
     /// This should never happen
     #[error("observed a tenure identified by a StacksBlockId with with no blocks")]

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -69,6 +69,16 @@ pub enum Error {
     #[error("bitcoin validation error: {0}")]
     BitcoinValidation(#[from] Box<crate::bitcoin::validation::BitcoinValidationError>),
 
+    /// This can only be thrown when the number of bytes for a sighash or
+    /// not exactly equal to 32. This should never occur.
+    #[error("could not convert message in nonce request to sighash {0}")]
+    SigHashConversion(#[source] bitcoin::hashes::FromSliceError),
+
+    /// This happens when the tx-signer is validating the sighash and it is
+    /// unknown or is known by has failed validation.
+    #[error("the given sighash is unknown or known and failed validation")]
+    InvalidSigHash,
+
     /// This should never happen
     #[error("observed a tenure identified by a StacksBlockId with with no blocks")]
     EmptyStacksTenure,

--- a/signer/src/message.rs
+++ b/signer/src/message.rs
@@ -362,9 +362,11 @@ impl From<OutPointMessage> for OutPoint {
 /// The transaction context needed by the signers to reconstruct the transaction.
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct BitcoinPreSignRequest {
-    /// The set of sBTC requests with additional relevant
-    /// information for the transaction.
-    pub requests: Vec<TxRequestIds>,
+    /// The set of sBTC request identifiers. This contains each of the
+    /// requests for the entire transaction package. Each element in the
+    /// vector corresponds to the requests that will be included in a
+    /// single bitcoin transaction.
+    pub request_package: Vec<TxRequestIds>,
     /// The current market fee rate in sat/vByte.
     pub fee_rate: f64,
     /// The total fee amount and the fee rate for the last transaction that
@@ -532,7 +534,7 @@ impl wsts::net::Signable for TxRequestIds {
 impl wsts::net::Signable for BitcoinPreSignRequest {
     fn hash(&self, hasher: &mut sha2::Sha256) {
         hasher.update("SIGNER_NEW_BITCOIN_TX_CONTEXT");
-        for request in &self.requests {
+        for request in &self.request_package {
             request.hash(hasher);
         }
         hasher.update(self.fee_rate.to_be_bytes());

--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -429,7 +429,7 @@ where
         // Get the requests from the transaction package because they have been split into
         // multiple transactions.
         let sbtc_requests = BitcoinPreSignRequest {
-            requests: transaction_package
+            request_package: transaction_package
                 .iter()
                 .map(|tx| (&tx.requests).into())
                 .collect(),

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -383,9 +383,9 @@ where
             .collect();
 
         tracing::debug!("storing sigashes to the database");
-        db.write_bitcoin_txs_sighashes(deposits_sighashes).await?;
+        db.write_bitcoin_txs_sighashes(&deposits_sighashes).await?;
 
-        db.write_bitcoin_withdrawals_outputs(withdrawals_outputs)
+        db.write_bitcoin_withdrawals_outputs(&withdrawals_outputs)
             .await?;
 
         Ok(())

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -382,7 +382,7 @@ where
             .flat_map(|s| s.to_withdrawal_rows())
             .collect();
 
-        tracing::debug!("storing sigashes to the database");
+        tracing::debug!("storing sighashes to the database");
         db.write_bitcoin_txs_sighashes(&deposits_sighashes).await?;
 
         db.write_bitcoin_withdrawals_outputs(&withdrawals_outputs)
@@ -747,7 +747,7 @@ where
         Ok(())
     }
 
-    /// Check whether we will sign the message, which is assumed to be
+    /// Check whether we will sign the message, which is supposed to be
     /// bitcoin sighash
     async fn validate_bitcoin_sign_request<D>(db: &D, message: &[u8]) -> Result<(), Error>
     where

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -356,15 +356,10 @@ where
             .get_signer_set_and_aggregate_key(bitcoin_chain_tip)
             .await?;
 
-        let utxo = db
-            .get_signer_utxo(bitcoin_chain_tip, self.context_window)
-            .await?
-            .ok_or(Error::MissingSignerUtxo)?;
-
         let btc_ctx = BitcoinTxContext {
             chain_tip: *bitcoin_chain_tip,
             chain_tip_height: bitcoin_block.block_height,
-            utxo,
+            context_window: self.context_window,
             signer_public_key: self.signer_public_key(),
             aggregate_key: maybe_aggregate_key.ok_or(Error::NoDkgShares)?,
         };

--- a/signer/src/wsts_state_machine.rs
+++ b/signer/src/wsts_state_machine.rs
@@ -86,7 +86,7 @@ impl SignerStateMachine {
         signer_private_key: PrivateKey,
     ) -> Result<Self, error::Error>
     where
-        S: storage::DbRead + storage::DbWrite,
+        S: storage::DbRead,
     {
         let encrypted_shares = storage
             .get_encrypted_dkg_shares(&aggregate_key)

--- a/signer/tests/integration/bitcoin_validation.rs
+++ b/signer/tests/integration/bitcoin_validation.rs
@@ -148,7 +148,7 @@ async fn one_tx_per_request_set() {
         .construct_package_sighashes(&ctx, &btc_ctx)
         .await
         .unwrap();
-    // There a re a few invariants that we uphold for our validation data.
+    // There are a few invariants that we uphold for our validation data.
     // These are things like "the transaction ID per package must be the
     // same", we check for them here.
     validation_data.assert_invariants();
@@ -250,7 +250,7 @@ async fn one_invalid_deposit_invalidates_tx() {
         .construct_package_sighashes(&ctx, &btc_ctx)
         .await
         .unwrap();
-    // There a re a few invariants that we uphold for our validation data.
+    // There are a few invariants that we uphold for our validation data.
     // These are things like "the transaction ID per package must be the
     // same", we check for them here.
     validation_data.assert_invariants();
@@ -592,7 +592,7 @@ async fn sighashes_match_from_sbtc_requests_object() {
         .construct_package_sighashes(&ctx, &btc_ctx)
         .await
         .unwrap();
-    // There a re a few invariants that we uphold for our validation data.
+    // There are a few invariants that we uphold for our validation data.
     // These are things like "the transaction ID per package must be the
     // same", we check for them here.
     validation_data.assert_invariants();

--- a/signer/tests/integration/bitcoin_validation.rs
+++ b/signer/tests/integration/bitcoin_validation.rs
@@ -180,6 +180,9 @@ async fn one_tx_per_request_set() {
     assert!(deposit.is_valid_tx);
 }
 
+/// Test that including a single invalid transaction in a set of requests
+/// results in the entire bitcoin transaction being invalid, and that will
+/// sign for the associated sighashes are all false.
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn one_invalid_deposit_invalidates_tx() {

--- a/signer/tests/integration/bitcoin_validation.rs
+++ b/signer/tests/integration/bitcoin_validation.rs
@@ -8,16 +8,16 @@ use rand::seq::SliceRandom;
 use rand::SeedableRng as _;
 
 use sbtc::testing::regtest;
-use signer::bitcoin::utxo::Fees;
 use signer::bitcoin::utxo::SbtcRequests;
 use signer::bitcoin::utxo::SignerBtcState;
+use signer::bitcoin::utxo::SignerUtxo;
 use signer::bitcoin::validation::BitcoinTxContext;
 use signer::bitcoin::validation::BitcoinTxValidationData;
 use signer::bitcoin::validation::InputValidationResult;
 use signer::bitcoin::validation::TxRequestIds;
 use signer::context::Context;
 use signer::error::Error;
-use signer::keys::PublicKey;
+use signer::message::BitcoinPreSignRequest;
 use signer::storage::model::BitcoinBlockHash;
 use signer::storage::model::TxPrevoutType;
 use signer::storage::DbRead as _;
@@ -29,62 +29,30 @@ use crate::setup::{backfill_bitcoin_blocks, TestSignerSet};
 use crate::setup::{DepositAmounts, TestSweepSetup2};
 use crate::DATABASE_NUM;
 
-pub struct TestSignerState {
-    /// This signer's current view of the chain tip of the canonical
-    /// bitcoin blockchain. It is the block hash of the block on the
-    /// bitcoin blockchain with the greatest height.
-    pub chain_tip: BitcoinBlockHash,
-    /// How many bitcoin blocks back from the chain tip the signer will
-    /// look for requests.
-    pub context_window: u16,
-    /// The current market fee rate in sat/vByte.
-    pub fee_rate: f64,
-    /// The total fee amount and the fee rate for the last transaction that
-    /// used this UTXO as an input.
-    pub last_fee: Option<Fees>,
-    /// The current aggregate key that was the output of DKG.
-    pub aggregate_key: PublicKey,
-    /// Two byte prefix for BTC transactions that are related to the Stacks
-    /// blockchain.
-    pub magic_bytes: [u8; 2],
+const TEST_FEE_RATE: f64 = 10.0;
+const TEST_CONTEXT_WINDOW: u16 = 1000;
+
+/// Fetch the signers' outstanding UTXO.
+///
+/// The returned state is the essential information for the signers
+/// UTXO
+async fn get_signer_utxo<C>(ctx: &C, chain_tip: &BitcoinBlockHash) -> Result<SignerUtxo, Error>
+where
+    C: Context + Send + Sync,
+{
+    ctx.get_storage()
+        .get_signer_utxo(chain_tip, TEST_CONTEXT_WINDOW)
+        .await?
+        .ok_or(Error::MissingSignerUtxo)
 }
 
-impl TestSignerState {
-    fn with_defaults(chain_tip: BitcoinBlockHash, aggregate_key: PublicKey) -> Self {
-        Self {
-            chain_tip,
-            context_window: 1000,
-            fee_rate: 10.0,
-            last_fee: None,
-            aggregate_key,
-            magic_bytes: [b'T', b'3'],
-        }
-    }
-    /// Fetch the signers' BTC state and the aggregate key.
-    ///
-    /// The returned state is the essential information for the signers
-    /// UTXO, and information about the current fees and any fees paid for
-    /// transactions currently in the mempool.
-    pub async fn get_btc_state<C>(&self, ctx: &C) -> Result<SignerBtcState, Error>
-    where
-        C: Context + Send + Sync,
-    {
-        // We need to know the signers UTXO, so let's fetch that.
-        let db = ctx.get_storage();
-        let utxo = db
-            .get_signer_utxo(&self.chain_tip, self.context_window)
-            .await?
-            .ok_or(Error::MissingSignerUtxo)?;
-
-        let btc_state = SignerBtcState {
-            fee_rate: self.fee_rate,
-            utxo,
-            public_key: bitcoin::XOnlyPublicKey::from(self.aggregate_key),
-            last_fees: self.last_fee,
-            magic_bytes: self.magic_bytes,
-        };
-
-        Ok(btc_state)
+fn signer_btc_state(req: &BitcoinPreSignRequest, btc_ctx: &BitcoinTxContext) -> SignerBtcState {
+    SignerBtcState {
+        utxo: btc_ctx.utxo,
+        fee_rate: req.fee_rate,
+        public_key: btc_ctx.aggregate_key.into(),
+        last_fees: req.last_fees,
+        magic_bytes: [b'T', b'3'],
     }
 }
 
@@ -159,22 +127,28 @@ async fn one_tx_per_request_set() {
 
     let aggregate_key = setup.signers.signer.keypair.public_key().into();
 
-    let test_state = TestSignerState::with_defaults(chain_tip, aggregate_key);
+    let request = BitcoinPreSignRequest {
+        request_package: vec![TxRequestIds {
+            deposits: setup.deposit_outpoint_messages(),
+            withdrawals: Vec::new(),
+        }],
+        fee_rate: TEST_FEE_RATE,
+        last_fees: None,
+    };
 
     let btc_ctx = BitcoinTxContext {
         chain_tip: chain_tip_block.block_hash,
         chain_tip_height: chain_tip_block.block_height,
-        request_packages: vec![TxRequestIds {
-            deposits: setup.deposit_outpoint_messages(),
-            withdrawals: Vec::new(),
-        }],
         signer_public_key: setup.signers.keys[0],
         aggregate_key,
-        signer_state: test_state.get_btc_state(&ctx).await.unwrap(),
+        utxo: get_signer_utxo(&ctx, &chain_tip).await.unwrap(),
     };
 
-    let validation_data = btc_ctx.construct_package_sighashes(&ctx).await.unwrap();
-    // There are a few invariants that we uphold for our validation data.
+    let validation_data = request
+        .construct_package_sighashes(&ctx, &btc_ctx)
+        .await
+        .unwrap();
+    // There a re a few invariants that we uphold for our validation data.
     // These are things like "the transaction ID per package must be the
     // same", we check for them here.
     validation_data.assert_invariants();
@@ -252,22 +226,28 @@ async fn one_invalid_deposit_invalidates_tx() {
 
     let aggregate_key = setup.signers.signer.keypair.public_key().into();
 
-    let test_state = TestSignerState::with_defaults(chain_tip, aggregate_key);
+    let request = BitcoinPreSignRequest {
+        request_package: vec![TxRequestIds {
+            deposits: setup.deposit_outpoint_messages(),
+            withdrawals: Vec::new(),
+        }],
+        fee_rate: TEST_FEE_RATE,
+        last_fees: None,
+    };
 
     let btc_ctx = BitcoinTxContext {
         chain_tip: chain_tip_block.block_hash,
         chain_tip_height: chain_tip_block.block_height,
-        request_packages: vec![TxRequestIds {
-            deposits: setup.deposit_outpoint_messages(),
-            withdrawals: Vec::new(),
-        }],
         signer_public_key: setup.signers.keys[0],
         aggregate_key,
-        signer_state: test_state.get_btc_state(&ctx).await.unwrap(),
+        utxo: get_signer_utxo(&ctx, &chain_tip).await.unwrap(),
     };
 
-    let validation_data = btc_ctx.construct_package_sighashes(&ctx).await.unwrap();
-    // There are a few invariants that we uphold for our validation data.
+    let validation_data = request
+        .construct_package_sighashes(&ctx, &btc_ctx)
+        .await
+        .unwrap();
+    // There a re a few invariants that we uphold for our validation data.
     // These are things like "the transaction ID per package must be the
     // same", we check for them here.
     validation_data.assert_invariants();
@@ -363,21 +343,25 @@ async fn one_withdrawal_errors_validation() {
 
     let aggregate_key = setup.signers.signer.keypair.public_key().into();
 
-    let test_state = TestSignerState::with_defaults(chain_tip, aggregate_key);
+    let request = BitcoinPreSignRequest {
+        request_package: vec![TxRequestIds {
+            deposits: setup.deposit_outpoint_messages(),
+            withdrawals: setup.withdrawal_ids(),
+        }],
+        fee_rate: TEST_FEE_RATE,
+        last_fees: None,
+    };
 
     let btc_ctx = BitcoinTxContext {
         chain_tip: chain_tip_block.block_hash,
         chain_tip_height: chain_tip_block.block_height,
-        request_packages: vec![TxRequestIds {
-            deposits: setup.deposit_outpoint_messages(),
-            withdrawals: setup.withdrawal_ids(),
-        }],
         signer_public_key: setup.signers.keys[0],
         aggregate_key,
-        signer_state: test_state.get_btc_state(&ctx).await.unwrap(),
+        utxo: get_signer_utxo(&ctx, &chain_tip).await.unwrap(),
     };
 
-    let result = btc_ctx.construct_package_sighashes(&ctx).await;
+    let result = request.construct_package_sighashes(&ctx, &btc_ctx).await;
+
     assert!(result.is_err());
 }
 
@@ -450,21 +434,29 @@ async fn cannot_sign_deposit_is_ok() {
 
     // Now we construct the validation data, including the sighashes.
     let aggregate_key = setup.signers.signer.keypair.public_key().into();
-    let test_state = TestSignerState::with_defaults(chain_tip, aggregate_key);
+
+    let request = BitcoinPreSignRequest {
+        request_package: vec![TxRequestIds {
+            deposits: setup.deposit_outpoint_messages(),
+            withdrawals: Vec::new(),
+        }],
+        fee_rate: TEST_FEE_RATE,
+        last_fees: None,
+    };
 
     let btc_ctx = BitcoinTxContext {
         chain_tip: chain_tip_block.block_hash,
         chain_tip_height: chain_tip_block.block_height,
-        request_packages: vec![TxRequestIds {
-            deposits: setup.deposit_outpoint_messages(),
-            withdrawals: Vec::new(),
-        }],
         signer_public_key: setup.signers.keys[0],
         aggregate_key,
-        signer_state: test_state.get_btc_state(&ctx).await.unwrap(),
+        utxo: get_signer_utxo(&ctx, &chain_tip).await.unwrap(),
     };
 
-    let validation_data = btc_ctx.construct_package_sighashes(&ctx).await.unwrap();
+    let validation_data = request
+        .construct_package_sighashes(&ctx, &btc_ctx)
+        .await
+        .unwrap();
+
     // There are a few invariants that we uphold for our validation data.
     // These are things like "the transaction ID per package must be the
     // same", we check for them here.
@@ -518,7 +510,7 @@ async fn cannot_sign_deposit_is_ok() {
             .map(|(_, req, _)| req.clone())
             .collect(),
         withdrawals: Vec::new(),
-        signer_state: btc_ctx.signer_state,
+        signer_state: signer_btc_state(&request, &btc_ctx),
         accept_threshold: 2,
         num_signers: 3,
     };
@@ -576,22 +568,28 @@ async fn sighashes_match_from_sbtc_requests_object() {
 
     let aggregate_key = setup.signers.signer.keypair.public_key().into();
 
-    let test_state = TestSignerState::with_defaults(chain_tip, aggregate_key);
+    let request = BitcoinPreSignRequest {
+        request_package: vec![TxRequestIds {
+            deposits: setup.deposit_outpoint_messages(),
+            withdrawals: Vec::new(),
+        }],
+        fee_rate: TEST_FEE_RATE,
+        last_fees: None,
+    };
 
     let btc_ctx = BitcoinTxContext {
         chain_tip: chain_tip_block.block_hash,
         chain_tip_height: chain_tip_block.block_height,
-        request_packages: vec![TxRequestIds {
-            deposits: setup.deposit_outpoint_messages(),
-            withdrawals: Vec::new(),
-        }],
         signer_public_key: setup.signers.keys[0],
         aggregate_key,
-        signer_state: test_state.get_btc_state(&ctx).await.unwrap(),
+        utxo: get_signer_utxo(&ctx, &chain_tip).await.unwrap(),
     };
 
-    let validation_data = btc_ctx.construct_package_sighashes(&ctx).await.unwrap();
-    // There are a few invariants that we uphold for our validation data.
+    let validation_data = request
+        .construct_package_sighashes(&ctx, &btc_ctx)
+        .await
+        .unwrap();
+    // There a re a few invariants that we uphold for our validation data.
     // These are things like "the transaction ID per package must be the
     // same", we check for them here.
     validation_data.assert_invariants();
@@ -641,7 +639,7 @@ async fn sighashes_match_from_sbtc_requests_object() {
             .map(|(_, req, _)| req.clone())
             .collect(),
         withdrawals: Vec::new(),
-        signer_state: btc_ctx.signer_state,
+        signer_state: signer_btc_state(&request, &btc_ctx),
         accept_threshold: 2,
         num_signers: 3,
     };
@@ -707,26 +705,35 @@ async fn outcome_is_independent_of_input_order() {
 
     let aggregate_key = setup.signers.signer.keypair.public_key().into();
 
-    let test_state = TestSignerState::with_defaults(chain_tip, aggregate_key);
-    let mut btc_ctx = BitcoinTxContext {
-        chain_tip: chain_tip_block.block_hash,
-        chain_tip_height: chain_tip_block.block_height,
-        request_packages: vec![TxRequestIds {
+    let mut request = BitcoinPreSignRequest {
+        request_package: vec![TxRequestIds {
             deposits: setup.deposit_outpoint_messages(),
             withdrawals: Vec::new(),
         }],
-        signer_public_key: setup.signers.keys[0],
-        aggregate_key,
-        signer_state: test_state.get_btc_state(&ctx).await.unwrap(),
+        fee_rate: TEST_FEE_RATE,
+        last_fees: None,
     };
 
-    // The outcome is independent of the ordering of the input IDs.
-    let validation_data1 = btc_ctx.construct_package_sighashes(&ctx).await.unwrap();
+    let btc_ctx = BitcoinTxContext {
+        chain_tip: chain_tip_block.block_hash,
+        chain_tip_height: chain_tip_block.block_height,
+        signer_public_key: setup.signers.keys[0],
+        aggregate_key,
+        utxo: get_signer_utxo(&ctx, &chain_tip).await.unwrap(),
+    };
+
+    let validation_data1 = request
+        .construct_package_sighashes(&ctx, &btc_ctx)
+        .await
+        .unwrap();
     let set1 = &validation_data1[0];
     let input_rows1 = set1.to_input_rows();
 
-    btc_ctx.request_packages[0].deposits.shuffle(&mut rng);
-    let validation_data2 = btc_ctx.construct_package_sighashes(&ctx).await.unwrap();
+    request.request_package[0].deposits.shuffle(&mut rng);
+    let validation_data2 = request
+        .construct_package_sighashes(&ctx, &btc_ctx)
+        .await
+        .unwrap();
     let set2 = &validation_data2[0];
     let input_rows2 = set2.to_input_rows();
 

--- a/signer/tests/integration/transaction_signer.rs
+++ b/signer/tests/integration/transaction_signer.rs
@@ -529,21 +529,12 @@ pub async fn assert_should_be_able_to_handle_sbtc_requests() {
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
     let fee_rate = 1.3;
     // Build the test context with mocked clients
-    let mut ctx = TestContext::builder()
+    let ctx = TestContext::builder()
         .with_storage(db.clone())
         .with_mocked_bitcoin_client()
         .with_mocked_emily_client()
         .with_mocked_stacks_client()
         .build();
-
-    // Build the test context with mocked clients
-    ctx.with_bitcoin_client(|client| {
-        client
-            .expect_estimate_fee_rate()
-            .times(2)
-            .returning(move || Box::pin(async move { Ok(fee_rate) }));
-    })
-    .await;
 
     let (rpc, faucet) = sbtc::testing::regtest::initialize_blockchain();
 
@@ -585,7 +576,7 @@ pub async fn assert_should_be_able_to_handle_sbtc_requests() {
 
     let sbtc_context = BitcoinPreSignRequest {
         request_package: vec![sbtc_requests],
-        fee_rate: fee_rate,
+        fee_rate,
         last_fees: None,
     };
 


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/793, closes https://github.com/stacks-network/sbtc/issues/696, closes https://github.com/stacks-network/sbtc/issues/286, and closes https://github.com/stacks-network/sbtc/issues/296.

## Changes

* Do the pre-validation check.
* Make sure the tx-signer checks the sighash in WSTS messages.
* Do not construct the Signers' BTC state in the tx-signer.
* Slight refactor to better reflect the meaning of things of what is being validated, which is the pre-sign request and not the bitcoin context.

## Testing Information

I need to add some.

## Checklist:

- [ ] I have performed a self-review of my code