### PR TITLE
feat: add back the target field in our logs

### DIFF
--- a/signer/src/emily_client.rs
+++ b/signer/src/emily_client.rs
@@ -323,7 +323,7 @@ impl EmilyInteract for EmilyClient {
     async fn set_chainstate(&self, chainstate: Chainstate) -> Result<Chainstate, Error> {
         chainstate_api::set_chainstate(&self.config, chainstate)
             .await
-            .inspect_err(|error| tracing::info!(%error, "error for set_chainstate"))
+            .inspect_err(|error| tracing::info!(?error, "error for set_chainstate"))
             .map_err(EmilyClientError::AddChainstateEntry)
             .map_err(Error::EmilyApi)
     }

--- a/signer/src/emily_client.rs
+++ b/signer/src/emily_client.rs
@@ -323,7 +323,7 @@ impl EmilyInteract for EmilyClient {
     async fn set_chainstate(&self, chainstate: Chainstate) -> Result<Chainstate, Error> {
         chainstate_api::set_chainstate(&self.config, chainstate)
             .await
-            .inspect_err(|e| tracing::info!(?e, "Error for set_chainstate"))
+            .inspect_err(|e| tracing::info!(%e, "error for set_chainstate"))
             .map_err(EmilyClientError::AddChainstateEntry)
             .map_err(Error::EmilyApi)
     }

--- a/signer/src/emily_client.rs
+++ b/signer/src/emily_client.rs
@@ -323,7 +323,7 @@ impl EmilyInteract for EmilyClient {
     async fn set_chainstate(&self, chainstate: Chainstate) -> Result<Chainstate, Error> {
         chainstate_api::set_chainstate(&self.config, chainstate)
             .await
-            .inspect_err(|e| tracing::info!(%e, "error for set_chainstate"))
+            .inspect_err(|error| tracing::info!(%error, "error for set_chainstate"))
             .map_err(EmilyClientError::AddChainstateEntry)
             .map_err(Error::EmilyApi)
     }

--- a/signer/src/logging.rs
+++ b/signer/src/logging.rs
@@ -23,7 +23,7 @@ fn setup_logging_json(directives: &str) {
     let main_layer = tracing_subscriber::fmt::layer()
         .json()
         .flatten_event(true)
-        .with_target(false)
+        .with_target(true)
         .with_current_span(false)
         .with_span_list(true)
         .with_line_number(true)


### PR DESCRIPTION
## Description

We mistakenly took it out.

## Changes

* Add back the target
* ~~Display the error~~, we want to see the request body when we get an error.

## Testing Information

This shouldn't affect anything besides logs

## Checklist:

- [x] I have performed a self-review of my code

