### PR TITLE
chore: add ca-certificates to docker image

### DIFF
--- a/docker/sbtc/signer/Dockerfile
+++ b/docker/sbtc/signer/Dockerfile
@@ -1,4 +1,9 @@
 FROM sbtc-build:latest AS build
+
 FROM debian:bookworm-slim AS runtime
 COPY --from=build /code/sbtc/target/debug/signer /usr/local/bin/signer
+
+RUN apt-get update && apt-get install -y ca-certificates --no-install-recommends && \
+        apt-get clean && rm -rf /var/lib/apt/lists/*
+
 ENTRYPOINT ["/usr/local/bin/signer --config /signer-config.toml --migrate-db"]


### PR DESCRIPTION
## Description

## Changes

Add `ca-certificates` to signers image to enable connecting via https to Emily.

## Testing Information

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
