### PR TITLE
fix: Install `ca-certificates` in CI images

### DIFF
--- a/.github/actions/dockerfiles/Dockerfile.blocklist-client.debian
+++ b/.github/actions/dockerfiles/Dockerfile.blocklist-client.debian
@@ -10,7 +10,9 @@ RUN apt-get install -y --no-install-recommends \
     make \
     protobuf-compiler \
     npm \
-    default-jre
+    default-jre && \
+        apt-get clean && rm -rf /var/lib/apt/lists/*
+
 RUN npm install -g pnpm@9
 RUN npm install -g @openapitools/openapi-generator-cli
 
@@ -22,4 +24,6 @@ RUN cargo build --bin blocklist-client
 # Create Docker image to run the signer.
 FROM debian:bookworm-slim AS blocklist-client
 COPY --from=build /code/sbtc/target/debug/blocklist-client /usr/local/bin/blocklist-client
+RUN apt-get update && apt-get install -y ca-certificates --no-install-recommends && \
+        apt-get clean && rm -rf /var/lib/apt/lists/*
 CMD ["/usr/local/bin/blocklist-client --config /blocklist-client-config.toml --migrate-db"]

--- a/.github/actions/dockerfiles/Dockerfile.signer.debian
+++ b/.github/actions/dockerfiles/Dockerfile.signer.debian
@@ -10,7 +10,9 @@ RUN apt-get install -y --no-install-recommends \
     make \
     protobuf-compiler \
     npm \
-    default-jre
+    default-jre && \
+        apt-get clean && rm -rf /var/lib/apt/lists/*
+
 RUN npm install -g pnpm@9
 RUN npm install -g @openapitools/openapi-generator-cli
 
@@ -22,4 +24,6 @@ RUN cargo build --bin signer
 # Create Docker image to run the signer.
 FROM debian:bookworm-slim AS signer
 COPY --from=build /code/sbtc/target/debug/signer /usr/local/bin/signer
+RUN apt-get update && apt-get install -y ca-certificates --no-install-recommends && \
+        apt-get clean && rm -rf /var/lib/apt/lists/*
 CMD ["/usr/local/bin/signer --config /signer-config.toml --migrate-db"]


### PR DESCRIPTION
There's a bug in the current CI Docker images that prevents Rust code from establishing TLS connections due to a lack of CA certificates. This fixes that.

Cherry-picked from #889.