### PR TITLE
feat: change emily config to uri

### DIFF
--- a/docker/sbtc/signer/signer-config.toml
+++ b/docker/sbtc/signer/signer-config.toml
@@ -20,13 +20,13 @@
 # You may specify multiple Emily API servers if you have them. They will be
 # tried round-robin until one succeeds.
 #
-# Format: ["http(s)://<host>:<port>", ..]
+# Format: ["http(s)://[api-key@]<host>:<port>", ..]
 # Default: <none>
 # Required: true
 # Environment: SIGNER_EMILY__ENDPOINTS
-# Environment Example: '{"endpoint":"https://api.emilyexample.com","api_key":"1234567890abcdef"},..'
+# Environment Example: '"https://1234567890abcdef@api.emilyexample.com",..'
 endpoints = [
-    { endpoint = "http://emily-server:3031" },
+    "http://emily-server:3031",
 ]
 
 # !! ==============================================================================

--- a/envs/signer-1.env
+++ b/envs/signer-1.env
@@ -3,7 +3,7 @@ export SIGNER_BITCOIN__RPC_ENDPOINTS=http://devnet:devnet@localhost:18443
 export SIGNER_BITCOIN__BLOCK_HASH_STREAM_ENDPOINTS=tcp://localhost:28332
 export SIGNER_STACKS__ENDPOINTS=http://localhost:20443
 export SIGNER_SIGNER__EVENT_OBSERVER__BIND=0.0.0.0:8801
-
+export SIGNER_EMILY__ENDPOINTS=http://localhost:3031
 export SIGNER_SIGNER__DB_ENDPOINT=postgresql://postgres:postgres@localhost:5432/signer
 export SIGNER_SIGNER__PRIVATE_KEY=41634762d89dfa09133a4a8e9c1378d0161d29cd0a9433b51f1e3d32947a73dc
 export SIGNER_SIGNER__P2P__LISTEN_ON=tcp://127.0.0.1:41221

--- a/envs/signer-2.env
+++ b/envs/signer-2.env
@@ -3,7 +3,7 @@ export SIGNER_BITCOIN__RPC_ENDPOINTS=http://devnet:devnet@localhost:18443
 export SIGNER_BITCOIN__BLOCK_HASH_STREAM_ENDPOINTS=tcp://localhost:28332
 export SIGNER_STACKS__ENDPOINTS=http://localhost:20443
 export SIGNER_SIGNER__EVENT_OBSERVER__BIND=0.0.0.0:8802
-
+export SIGNER_EMILY__ENDPOINTS=http://localhost:3031
 export SIGNER_SIGNER__DB_ENDPOINT=postgresql://postgres:postgres@localhost:5433/signer
 export SIGNER_SIGNER__PRIVATE_KEY=9bfecf16c9c12792589dd2b843f850d5b89b81a04f8ab91c083bdf6709fbefee01
 export SIGNER_SIGNER__P2P__LISTEN_ON=tcp://127.0.0.1:41222

--- a/envs/signer-3.env
+++ b/envs/signer-3.env
@@ -3,7 +3,7 @@ export SIGNER_BITCOIN__RPC_ENDPOINTS=http://devnet:devnet@localhost:18443
 export SIGNER_BITCOIN__BLOCK_HASH_STREAM_ENDPOINTS=tcp://localhost:28332
 export SIGNER_STACKS__ENDPOINTS=http://localhost:20443
 export SIGNER_SIGNER__EVENT_OBSERVER__BIND=0.0.0.0:8803
-
+export SIGNER_EMILY__ENDPOINTS=http://localhost:3031
 export SIGNER_SIGNER__DB_ENDPOINT=postgresql://postgres:postgres@localhost:5434/signer
 export SIGNER_SIGNER__PRIVATE_KEY=3ec0ca5770a356d6cd1a9bfcbf6cd151eb1bd85c388cc00648ec4ef5853fdb7401
 export SIGNER_SIGNER__P2P__LISTEN_ON=tcp://127.0.0.1:41223

--- a/signer/src/bin/demo_cli.rs
+++ b/signer/src/bin/demo_cli.rs
@@ -117,14 +117,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .expect("No Emily endpoints configured");
     let emily_client_config = Configuration {
         base_path: emily_api_endpoint_config
-            .endpoint
             .to_string()
             .trim_end_matches("/")
             .to_string(),
-        api_key: emily_api_endpoint_config
-            .api_key
-            .clone()
-            .map(|key_string| ApiKey { prefix: None, key: key_string }),
+        api_key: if emily_api_endpoint_config.username().is_empty() {
+            None
+        } else {
+            Some(ApiKey {
+                prefix: None,
+                key: emily_api_endpoint_config.username().to_string(),
+            })
+        },
         ..Default::default()
     };
 

--- a/signer/src/bin/demo_cli.rs
+++ b/signer/src/bin/demo_cli.rs
@@ -110,24 +110,30 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Setup our Emily client configuration by getting the first configured endpoint
     // and using that to populate the client.
-    let emily_api_endpoint_config = settings
+    let mut emily_api_endpoint = settings
         .emily
         .endpoints
         .first()
-        .expect("No Emily endpoints configured");
+        .expect("No Emily endpoints configured")
+        .clone();
+
+    let emily_api_key = if emily_api_endpoint.username().is_empty() {
+        None
+    } else {
+        Some(ApiKey {
+            prefix: None,
+            key: emily_api_endpoint.username().to_string(),
+        })
+    };
+
+    let _ = emily_api_endpoint.set_username("");
+
     let emily_client_config = Configuration {
-        base_path: emily_api_endpoint_config
+        base_path: emily_api_endpoint
             .to_string()
             .trim_end_matches("/")
             .to_string(),
-        api_key: if emily_api_endpoint_config.username().is_empty() {
-            None
-        } else {
-            Some(ApiKey {
-                prefix: None,
-                key: emily_api_endpoint_config.username().to_string(),
-            })
-        },
+        api_key: emily_api_key,
         ..Default::default()
     };
 

--- a/signer/src/config/default.toml
+++ b/signer/src/config/default.toml
@@ -23,13 +23,13 @@
 # You may specify multiple Emily API servers if you have them. They will be
 # tried round-robin until one succeeds.
 #
-# Format: [ { endpoint = "http(s)://<host>:<port>", api_key = "1234567890abcdef" }, ..]
+# Format: ["http(s)://[api-key@]<host>:<port>", ..]
 # Default: <none>
 # Required: true
 # Environment: SIGNER_EMILY__ENDPOINTS
-# Environment Example: '{"endpoint":"https://api.emilyexample.com","api_key":"1234567890abcdef"},..'
+# Environment Example: '"https://1234567890abcdef@api.emilyexample.com",..'
 endpoints = [
-    { endpoint = "http://localhost:3031" },
+    "http://localhost:3031",
 ]
 
 # !! ==============================================================================

--- a/signer/src/config/mod.rs
+++ b/signer/src/config/mod.rs
@@ -159,49 +159,12 @@ pub struct BlocklistClientConfig {
 #[derive(Deserialize, Clone, Debug)]
 pub struct EmilyClientConfig {
     /// Emily API endpoints.
-    pub endpoints: Vec<EmilyEndpointConfig>,
-}
-
-/// Emily API endpoint configuration.
-#[derive(Deserialize, Clone, Debug)]
-pub struct EmilyEndpointConfig {
-    /// The emily API endpoint that the signer will use.
-    #[serde(deserialize_with = "url_deserializer_single")]
-    pub endpoint: Url,
-    /// API key for the Emily API endpoint.
-    /// If the api key is not provided we assume the API doesn't need one.
-    pub api_key: Option<String>,
-}
-
-impl Validatable for EmilyEndpointConfig {
-    fn validate(&self, _: &Settings) -> Result<(), ConfigError> {
-        // If an API key is provided it needs to be non-empty.
-        if let Some(api_key) = self.api_key.as_ref() {
-            if api_key.is_empty() {
-                return Err(ConfigError::Message(
-                    "[emily_client.endpoints] API key cannot be specified yet empty".to_string(),
-                ));
-            }
-        }
-
-        if !["http", "https"].contains(&self.endpoint.scheme()) {
-            return Err(ConfigError::Message(
-                "[emily_client.endpoints] Invalid URL scheme: must be HTTP or HTTPS".to_string(),
-            ));
-        }
-
-        if self.endpoint.host_str().is_none() {
-            return Err(ConfigError::Message(
-                "[emily_client.endpoints] Invalid URL: host is required".to_string(),
-            ));
-        }
-
-        Ok(())
-    }
+    #[serde(deserialize_with = "url_deserializer_vec")]
+    pub endpoints: Vec<Url>,
 }
 
 impl Validatable for EmilyClientConfig {
-    fn validate(&self, settings: &Settings) -> Result<(), ConfigError> {
+    fn validate(&self, _: &Settings) -> Result<(), ConfigError> {
         // At least one endpoint must be provided.
         if self.endpoints.is_empty() {
             return Err(ConfigError::Message(
@@ -210,7 +173,18 @@ impl Validatable for EmilyClientConfig {
         }
         // Validate each endpoint configuration.
         for endpoint in &self.endpoints {
-            endpoint.validate(settings)?;
+            if !["http", "https"].contains(&endpoint.scheme()) {
+                return Err(ConfigError::Message(
+                    "[emily_client.endpoints] Invalid URL scheme: must be HTTP or HTTPS"
+                        .to_string(),
+                ));
+            }
+
+            if endpoint.host_str().is_none() {
+                return Err(ConfigError::Message(
+                    "[emily_client.endpoints] Invalid URL: host is required".to_string(),
+                ));
+            }
         }
 
         Ok(())

--- a/signer/src/emily_client.rs
+++ b/signer/src/emily_client.rs
@@ -28,7 +28,6 @@ use url::Url;
 use crate::bitcoin::utxo::RequestRef;
 use crate::bitcoin::utxo::UnsignedTransaction;
 use crate::config::EmilyClientConfig;
-use crate::config::EmilyEndpointConfig;
 use crate::error::Error;
 use crate::storage::model::BitcoinTxId;
 use crate::storage::model::StacksBlock;
@@ -138,24 +137,15 @@ impl TryFrom<&Url> for EmilyClient {
     type Error = Error;
     /// Initialize a new Emily client from just a URL for testing scenarios.
     fn try_from(url: &Url) -> Result<Self, Self::Error> {
-        let emily_endpoint_config = EmilyEndpointConfig {
-            endpoint: url.clone(),
-            api_key: None,
+        let mut url = url.clone();
+        let api_key = if url.username().is_empty() {
+            None
+        } else {
+            Some(ApiKey {
+                prefix: None,
+                key: url.username().to_string(),
+            })
         };
-        Self::try_from(&emily_endpoint_config)
-    }
-}
-
-impl TryFrom<&EmilyEndpointConfig> for EmilyClient {
-    type Error = Error;
-
-    /// Attempt to create an Emily client from a URL. Note that for the Signer,
-    /// this should already have been validated by the configuration, but we do
-    /// the checks here anyway to keep them close to the implementation.
-    fn try_from(endpoint_config: &EmilyEndpointConfig) -> Result<Self, Self::Error> {
-        // Extract the info.
-        let url = endpoint_config.endpoint.clone();
-        let maybe_api_key = endpoint_config.api_key.clone();
 
         // Must be HTTP or HTTPS
         if !["http", "https"].contains(&url.scheme()) {
@@ -167,15 +157,16 @@ impl TryFrom<&EmilyEndpointConfig> for EmilyClient {
             return Err(EmilyClientError::InvalidUrlHostRequired(url.to_string()).into());
         }
 
+        // We don't really care if this fails, the failure modes are handled by
+        // the above checks. We just don't want the base_path below to contain
+        // the api key.
+        let _ = url.set_username("");
+
         let mut config = EmilyApiConfig::new();
         // Url::parse defaults `path` to `/` even if the parsed url was without the trailing `/`
         // causing the api calls to have two leading slashes in the path (getting a 404)
         config.base_path = url.to_string().trim_end_matches("/").to_string();
-
-        // Add the API key if present.
-        if let Some(api_key) = maybe_api_key {
-            config.api_key = Some(ApiKey { prefix: None, key: api_key });
-        }
+        config.api_key = api_key;
 
         Ok(Self { config })
     }
@@ -409,11 +400,9 @@ mod tests {
     #[test]
     fn try_from_url_with_key() {
         // Arrange.
-        let url = Url::parse("http://localhost:8080/").unwrap();
-        let api_key = Some("test_key".to_string());
-        let emily_endpoint_config = EmilyEndpointConfig { endpoint: url, api_key };
+        let url = Url::parse("http://test_key@localhost:8080").unwrap();
         // Act.
-        let client = EmilyClient::try_from(&emily_endpoint_config).unwrap();
+        let client = EmilyClient::try_from(&url).unwrap();
         // Assert.
         assert_eq!(client.config.base_path, "http://localhost:8080");
         assert_eq!(client.config.api_key.unwrap().key, "test_key");
@@ -423,9 +412,8 @@ mod tests {
     fn try_from_url_without_key() {
         // Arrange.
         let url = Url::parse("http://localhost:8080").unwrap();
-        let emily_endpoint_config = EmilyEndpointConfig { endpoint: url, api_key: None };
         // Act.
-        let client = EmilyClient::try_from(&emily_endpoint_config).unwrap();
+        let client = EmilyClient::try_from(&url).unwrap();
         // Assert.
         assert_eq!(client.config.base_path, "http://localhost:8080");
         assert!(client.config.api_key.is_none());


### PR DESCRIPTION
## Description

Changes the Emily endpoint config to a URI in the format `http(s)://[api-key@]<host>:<port>`.

Making this change primarily due to the fact that things aren't working well with environment variables and the URI format already supports authentication information.

## Changes

- Modified the emily endpoint format in config
- Updated tests
- Updated demo-cli
- Added the env vars to the local signer `.env` files 1-3.

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
