### PR TITLE
fix: temporary timing fix (pre #956)

### DIFF
--- a/signer/src/main.rs
+++ b/signer/src/main.rs
@@ -311,6 +311,7 @@ async fn run_transaction_coordinator(ctx: impl Context) -> Result<(), Error> {
         dkg_max_duration: Duration::from_secs(120),
         sbtc_contracts_deployed: false,
         is_epoch3: false,
+        pre_sign_pause: Some(Duration::from_secs(20)),
     };
 
     coord.run().await

--- a/signer/src/testing/transaction_coordinator.rs
+++ b/signer/src/testing/transaction_coordinator.rs
@@ -74,6 +74,7 @@ where
                 signing_round_max_duration: Duration::from_secs(10),
                 dkg_max_duration: Duration::from_secs(10),
                 is_epoch3: true,
+                pre_sign_pause: Some(Duration::from_secs(1)),
             },
             context,
             is_started: Arc::new(AtomicBool::new(false)),

--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -161,6 +161,8 @@ pub struct TxCoordinatorEventLoop<Context, Network> {
     /// 3. If we are not in Nakamoto 3 or later, then the coordinator does
     /// not do any work.
     pub is_epoch3: bool,
+    /// TODO: Remove this, will be fixed in #956
+    pub pre_sign_pause: Option<Duration>,
 }
 
 /// This function defines which messages this event loop is interested
@@ -439,9 +441,12 @@ where
 
         // Share the list of requests with the signers.
         self.send_message(sbtc_requests, bitcoin_chain_tip).await?;
-        // Wait to reduce chance that the other signers will receive the subsequent
-        // messages before the BitcoinPreSignRequest one.
-        tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+
+        if let Some(pause) = self.pre_sign_pause {
+            // Wait to reduce chance that the other signers will receive the subsequent
+            // messages before the BitcoinPreSignRequest one.
+            tokio::time::sleep(pause).await;
+        }
 
         for mut transaction in transaction_package {
             self.sign_and_broadcast(

--- a/signer/tests/integration/emily.rs
+++ b/signer/tests/integration/emily.rs
@@ -442,6 +442,7 @@ async fn deposit_flow() {
         dkg_max_duration: Duration::from_secs(10),
         sbtc_contracts_deployed: true,
         is_epoch3: true,
+        pre_sign_pause: Some(Duration::from_secs(1)),
     };
     let tx_coordinator_handle = tokio::spawn(async move { tx_coordinator.run().await });
 

--- a/signer/tests/integration/transaction_coordinator.rs
+++ b/signer/tests/integration/transaction_coordinator.rs
@@ -553,6 +553,7 @@ async fn process_complete_deposit() {
         dkg_max_duration: Duration::from_secs(10),
         sbtc_contracts_deployed: true,
         is_epoch3: true,
+        pre_sign_pause: Some(Duration::from_secs(1)),
     };
     let tx_coordinator_handle = tokio::spawn(async move { tx_coordinator.run().await });
 
@@ -719,6 +720,7 @@ async fn deploy_smart_contracts_coordinator<F>(
         dkg_max_duration: Duration::from_secs(10),
         sbtc_contracts_deployed: false,
         is_epoch3: true,
+        pre_sign_pause: Some(Duration::from_secs(1)),
     };
     let tx_coordinator_handle = tokio::spawn(async move { tx_coordinator.run().await });
 
@@ -814,6 +816,7 @@ async fn get_signer_public_keys_and_aggregate_key_falls_back() {
         dkg_max_duration: Duration::from_secs(10),
         sbtc_contracts_deployed: true, // Skip contract deployment
         is_epoch3: true,
+        pre_sign_pause: Some(Duration::from_secs(1)),
     };
 
     // We need stacks blocks for the rotate-keys transactions.
@@ -1025,6 +1028,7 @@ async fn run_dkg_from_scratch() {
             dkg_max_duration: Duration::from_secs(10),
             sbtc_contracts_deployed: true, // Skip contract deployment
             is_epoch3: true,
+            pre_sign_pause: Some(Duration::from_secs(1)),
         });
 
     let tx_signer_processes = signers
@@ -1333,6 +1337,7 @@ async fn sign_bitcoin_transaction() {
             dkg_max_duration: Duration::from_secs(10),
             sbtc_contracts_deployed: true,
             is_epoch3: true,
+            pre_sign_pause: Some(Duration::from_secs(1)),
         };
         let counter = start_count.clone();
         tokio::spawn(async move {
@@ -1731,6 +1736,7 @@ async fn skip_smart_contract_deployment_and_key_rotation_if_up_to_date() {
             dkg_max_duration: Duration::from_secs(10),
             sbtc_contracts_deployed: true,
             is_epoch3: true,
+            pre_sign_pause: Some(Duration::from_secs(1)),
         };
         let counter = start_count.clone();
         tokio::spawn(async move {
@@ -1927,6 +1933,7 @@ async fn test_get_btc_state_with_no_available_sweep_transactions() {
         dkg_max_duration: std::time::Duration::from_secs(5),
         sbtc_contracts_deployed: false,
         is_epoch3: true,
+        pre_sign_pause: Some(Duration::from_secs(1)),
     };
 
     let aggregate_key = &PublicKey::from_private_key(&PrivateKey::new(&mut rng));
@@ -2063,6 +2070,7 @@ async fn test_get_btc_state_with_available_sweep_transactions_and_rbf() {
         dkg_max_duration: std::time::Duration::from_secs(5),
         sbtc_contracts_deployed: false,
         is_epoch3: true,
+        pre_sign_pause: Some(Duration::from_secs(1)),
     };
 
     let aggregate_key = &PublicKey::from_private_key(&PrivateKey::new(&mut rng));


### PR DESCRIPTION
## Description

A quick fix for testnet which raises the sleep time after pre-begin signing messages. Will be resolved properly in #956 .
