### PR TITLE
Feat: validate deposits are below total and per-request-cap

### DIFF
--- a/signer/migrations/0003__create_tables.sql
+++ b/signer/migrations/0003__create_tables.sql
@@ -52,6 +52,9 @@ CREATE TABLE sbtc_signer.deposit_signers (
     -- this specifies whether the signer is a part of the signer set
     -- associated with the deposit_request.signers_public_key
     can_sign BOOLEAN NOT NULL,
+    -- This specifies whether the sending signer's blocklist client blocked
+    -- the deposit request. `true` here means the blocklist client did not
+    -- block the request.
     can_accept BOOLEAN NOT NULL,
     created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
     PRIMARY KEY (txid, output_index, signer_pub_key),

--- a/signer/src/bitcoin/utxo.rs
+++ b/signer/src/bitcoin/utxo.rs
@@ -162,9 +162,10 @@ impl SbtcRequests {
             })
             .map(RequestRef::Withdrawal);
 
-        // Now we filter deposit requests where the user's max fee could
-        // be less than the fee we may charge. This is simpler because
-        // deposit UTXOs have a known fixed size.
+        // Filter deposit requests based on two constraints:
+        // 1. The user's max fee must be >= our minimum required fee for deposits
+        //     (based on fixed deposit tx size)
+        // 2. The total amount being minted must stay under the maximum allowed mintable amount
         let minimum_deposit_fee = self.compute_minimum_fee(SOLO_DEPOSIT_TX_VSIZE);
 
         let mut amount_to_mint = 0;

--- a/signer/src/bitcoin/validation.rs
+++ b/signer/src/bitcoin/validation.rs
@@ -1282,14 +1282,18 @@ mod tests {
             ..Default::default()
         };
 
-        cache.deposit_reports = deposit_amounts
-            .iter()
+        let deposit_reports: Vec<(DepositRequestReport, SignerVotes)> = deposit_amounts
+            .into_iter()
             .enumerate()
-            .map(|(idx, amount)| {
-                let (report, votes) = create_test_report(idx as u8, amount);
+            .map(|(idx, amount)| create_test_report(idx as u8, amount))
+            .collect();
+
+        cache.deposit_reports = deposit_reports
+            .iter()
+            .map(|(report, votes)| {
                 (
                     (&report.outpoint.txid, report.outpoint.vout),
-                    (report.clone(), votes),
+                    (report.clone(), votes.clone()),
                 )
             })
             .collect();

--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -34,6 +34,7 @@ use crate::storage::model;
 use crate::storage::DbRead;
 use crate::storage::DbWrite;
 use bitcoin::hashes::Hash as _;
+use bitcoin::Amount;
 use bitcoin::BlockHash;
 use bitcoin::ScriptBuf;
 use bitcoin::Transaction;
@@ -153,6 +154,10 @@ where
                     tracing::info!("loading latest deposit requests from Emily");
                     if let Err(error) = self.load_latest_deposit_requests().await {
                         tracing::warn!(%error, "could not load latest deposit requests from Emily");
+                    }
+
+                    if let Err(error) = self.update_sbtc_limits().await {
+                        tracing::warn!(%error, "could not update sBTC limits");
                     }
 
                     self.context
@@ -470,6 +475,34 @@ impl<C: Context, B> BlockObserver<C, B> {
         self.extract_sbtc_transactions(block.block_hash(), &block.txdata)
             .await?;
 
+        Ok(())
+    }
+
+    /// Update the sBTC peg limits from Emily
+    async fn update_sbtc_limits(&self) -> Result<(), Error> {
+        let mut limits = self.context.get_emily_client().get_limits().await?;
+        let max_mintable = match limits.total_cap() {
+            None => Amount::MAX_MONEY,
+            Some(total_cap) => {
+                let sbtc_supply = self
+                    .context
+                    .get_stacks_client()
+                    .get_sbtc_total_supply(&self.context.config().signer.deployer)
+                    .await?;
+                // The maximum amount of sBTC that can be minted is the total cap
+                // minus the current supply.
+                total_cap.checked_sub(sbtc_supply).unwrap_or(Amount::ZERO)
+            }
+        };
+        limits.set_max_mintable_cap(Some(max_mintable));
+
+        let signer_state = self.context.state();
+        if limits == signer_state.get_current_limits() {
+            tracing::trace!(%limits, "sBTC limits have not changed");
+        } else {
+            tracing::debug!(%limits, "updated sBTC limits from Emily");
+            signer_state.update_current_limits(limits);
+        }
         Ok(())
     }
 }

--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -158,6 +158,7 @@ where
 
                     if let Err(error) = self.update_sbtc_limits().await {
                         tracing::warn!(%error, "could not update sBTC limits");
+                        continue;
                     }
 
                     self.context

--- a/signer/src/context/mod.rs
+++ b/signer/src/context/mod.rs
@@ -5,6 +5,7 @@ mod signer_context;
 mod signer_state;
 mod termination;
 
+use bitcoin::Amount;
 use tokio::sync::broadcast::error::RecvError;
 use tokio_stream::wrappers::ReceiverStream;
 
@@ -47,6 +48,26 @@ pub trait Context: Clone + Sync + Send {
     fn get_stacks_client(&self) -> impl StacksInteract + Clone + 'static;
     /// Get a handle to an Emily client.
     fn get_emily_client(&self) -> impl EmilyInteract + Clone + 'static;
+
+    /// Get the amount of sBTC that can be currently minted.
+    /// This is the total cap received from Emily minus the current supply.
+    fn get_mintable_sbtc_amount(
+        &self,
+    ) -> impl std::future::Future<Output = Result<Amount, Error>> + Send {
+        async {
+            // Get the total supply of sBTC.
+            let sbtc_supply = self
+                .get_stacks_client()
+                .get_sbtc_total_supply(&self.config().signer.deployer)
+                .await?;
+            // Get the total cap of sBTC that can be minted.
+            let sbtc_limits = self.get_emily_client().get_limits().await?;
+            // If we can't get the total cap, we assume that the total cap is
+            // the maximum possible amount of sBTC.
+            let total_cap = sbtc_limits.total_cap().unwrap_or(Amount::MAX_MONEY);
+            Ok(total_cap.checked_sub(sbtc_supply).unwrap_or(Amount::ZERO))
+        }
+    }
     /// Create a new signal stream containing signer messages from:
     /// 1. The signer network, as defined by the given network object
     ///    implementing [`MessageTransfer`].

--- a/signer/src/context/signer_state.rs
+++ b/signer/src/context/signer_state.rs
@@ -14,32 +14,12 @@ use crate::keys::PublicKey;
 #[derive(Debug, Default)]
 pub struct SignerState {
     current_signer_set: SignerSet,
-    current_limits: RwLock<SbtcLimits>,
 }
 
 impl SignerState {
     /// Get the current signer set.
     pub fn current_signer_set(&self) -> &SignerSet {
         &self.current_signer_set
-    }
-
-    /// Get the current sBTC limits.
-    pub fn get_current_limits(&self) -> SbtcLimits {
-        // We should never fail to acquire a lock from the RwLock so that it panics.
-        self.current_limits
-            .read()
-            .expect("BUG: Failed to acquire read lock")
-            .clone()
-    }
-
-    /// Update the current sBTC limits.
-    pub fn update_current_limits(&self, new_limits: SbtcLimits) {
-        // We should never fail to acquire a lock from the RwLock so that it panics.
-        let mut limits = self
-            .current_limits
-            .write()
-            .expect("BUG: Failed to acquire write lock");
-        *limits = new_limits;
     }
 }
 

--- a/signer/src/emily_client.rs
+++ b/signer/src/emily_client.rs
@@ -356,6 +356,7 @@ impl EmilyInteract for EmilyClient {
             total_cap,
             per_deposit_cap,
             per_withdrawal_cap,
+            None,
         ))
     }
 }

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -525,7 +525,7 @@ pub enum Error {
     DuplicateRequests,
 
     /// Error when deposit requests would exceed sBTC supply cap
-    #[error("Total deposit amount ({total_amount} sats) would exceed sBTC supply cap ({max_mintable} sats)")]
+    #[error("Total deposit amount ({total_amount} sats) would exceed sBTC supply cap (current max mintable is {max_mintable} sats)")]
     ExceedsSbtcSupplyCap {
         /// Total deposit amount in sats
         total_amount: u64,

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -523,6 +523,15 @@ pub enum Error {
     /// Indicates that the request packages contain duplicate deposit or withdrawal entries.
     #[error("The request packages contain duplicate deposit or withdrawal entries.")]
     DuplicateRequests,
+
+    /// Error when deposit requests would exceed sBTC supply cap
+    #[error("Total deposit amount ({total_amount} sats) would exceed sBTC supply cap ({max_mintable} sats)")]
+    ExceedsSbtcSupplyCap {
+        /// Total deposit amount in sats
+        total_amount: u64,
+        /// Maximum sBTC mintable
+        max_mintable: u64,
+    },
 }
 
 impl From<std::convert::Infallible> for Error {

--- a/signer/src/main.rs
+++ b/signer/src/main.rs
@@ -18,6 +18,7 @@ use signer::config::Settings;
 use signer::context::Context;
 use signer::context::SignerContext;
 use signer::emily_client::EmilyClient;
+use signer::emily_client::EmilyInteract as _;
 use signer::error::Error;
 use signer::network::libp2p::SignerSwarmBuilder;
 use signer::network::P2PNetwork;
@@ -89,6 +90,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     for signer in settings.signer.bootstrap_signing_set() {
         context.state().current_signer_set().add_signer(signer);
     }
+
+    // Update the initial sBTC peg limits for the signer. This call will block
+    // until we've successfully retrieved the limits from Emily.
+    update_initial_limits(&context).await;
 
     // Run the application components concurrently. We're `join!`ing them
     // here so that every component can shut itself down gracefully when
@@ -330,4 +335,34 @@ async fn run_request_decider(ctx: impl Context) -> Result<(), Error> {
     };
 
     decider.run().await
+}
+
+/// Update the initial limits for the signer upon startup. This method will
+/// re-try until it successfully fetches the limits from Emily.
+async fn update_initial_limits(ctx: &impl Context) {
+    let mut term = ctx.get_termination_handle();
+    let emily_client = ctx.get_emily_client();
+
+    let mut interval = tokio::time::interval(Duration::from_secs(10));
+
+    loop {
+        tokio::select! {
+            _ = term.wait_for_shutdown() => {
+                tracing::info!("Shutdown signaled, stopping limit update");
+                return;
+            }
+            _ = interval.tick() => {
+                match emily_client.get_limits().await {
+                    Ok(limits) => {
+                        tracing::debug!(%limits, "updated sBTC limits from Emily");
+                        ctx.state().update_current_limits(limits);
+                        return;
+                    }
+                    Err(error) => {
+                        tracing::warn!(%error, "failed to get limits from Emily, trying again");
+                    }
+                }
+            }
+        }
+    }
 }

--- a/signer/src/main.rs
+++ b/signer/src/main.rs
@@ -18,7 +18,6 @@ use signer::config::Settings;
 use signer::context::Context;
 use signer::context::SignerContext;
 use signer::emily_client::EmilyClient;
-use signer::emily_client::EmilyInteract as _;
 use signer::error::Error;
 use signer::network::libp2p::SignerSwarmBuilder;
 use signer::network::P2PNetwork;
@@ -90,10 +89,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     for signer in settings.signer.bootstrap_signing_set() {
         context.state().current_signer_set().add_signer(signer);
     }
-
-    // Update the initial sBTC peg limits for the signer. This call will block
-    // until we've successfully retrieved the limits from Emily.
-    update_initial_limits(&context).await;
 
     // Run the application components concurrently. We're `join!`ing them
     // here so that every component can shut itself down gracefully when
@@ -335,34 +330,4 @@ async fn run_request_decider(ctx: impl Context) -> Result<(), Error> {
     };
 
     decider.run().await
-}
-
-/// Update the initial limits for the signer upon startup. This method will
-/// re-try until it successfully fetches the limits from Emily.
-async fn update_initial_limits(ctx: &impl Context) {
-    let mut term = ctx.get_termination_handle();
-    let emily_client = ctx.get_emily_client();
-
-    let mut interval = tokio::time::interval(Duration::from_secs(10));
-
-    loop {
-        tokio::select! {
-            _ = term.wait_for_shutdown() => {
-                tracing::info!("Shutdown signaled, stopping limit update");
-                return;
-            }
-            _ = interval.tick() => {
-                match emily_client.get_limits().await {
-                    Ok(limits) => {
-                        tracing::debug!(%limits, "updated sBTC limits from Emily");
-                        ctx.state().update_current_limits(limits);
-                        return;
-                    }
-                    Err(error) => {
-                        tracing::warn!(%error, "failed to get limits from Emily, trying again");
-                    }
-                }
-            }
-        }
-    }
 }

--- a/signer/src/request_decider.rs
+++ b/signer/src/request_decider.rs
@@ -296,24 +296,6 @@ where
         &self,
         req: &model::WithdrawalRequest,
     ) -> Result<bool, Error> {
-        // If the withdrawal request is larger than the allowed per-withdrawal cap
-        // then no signer should accept this deposit.
-        if let Some(cap) = self
-            .context
-            .state()
-            .get_current_limits()
-            .per_withdrawal_cap()
-        {
-            if req.amount > cap.to_sat() {
-                tracing::info!(
-                    request_id = req.request_id,
-                    amount = %req.amount,
-                    "withdrawal request exceeds per-withdrawal cap"
-                );
-                return Ok(false);
-            }
-        }
-
         // If we have not configured a blocklist checker, then we can
         // return early.
         let Some(client) = self.blocklist_checker.as_ref() else {
@@ -329,20 +311,6 @@ where
     }
 
     async fn can_accept_deposit_request(&self, req: &model::DepositRequest) -> Result<bool, Error> {
-        // If the deposit request is larger than the allowed per-deposit cap
-        // then no signer should accept this deposit.
-        if let Some(per_deposit_cap) = self.context.state().get_current_limits().per_deposit_cap() {
-            if req.amount > per_deposit_cap.to_sat() {
-                tracing::info!(
-                    txid = %req.txid,
-                    outpoint = %req.outpoint(),
-                    amount = %req.amount,
-                    "deposit request exceeds per-deposit cap"
-                );
-                return Ok(false);
-            }
-        }
-
         // If we have not configured a blocklist checker, then we can
         // return early.
         let Some(client) = self.blocklist_checker.as_ref() else {

--- a/signer/src/testing/block_observer.rs
+++ b/signer/src/testing/block_observer.rs
@@ -486,7 +486,7 @@ impl EmilyInteract for TestHarness {
     }
 
     async fn get_limits(&self) -> Result<SbtcLimits, Error> {
-        unimplemented!()
+        Ok(SbtcLimits::default())
     }
 }
 

--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -5,7 +5,6 @@
 //!
 //! For more details, see the [`TxCoordinatorEventLoop`] documentation.
 
-use std::cmp::max;
 use std::collections::BTreeSet;
 use std::time::Duration;
 
@@ -1241,7 +1240,8 @@ where
             return Ok(None);
         }
 
-        let sbtc_limits = self.context.state().get_current_limits();
+        // Get the total cap of sBTC that can be minted.
+        let sbtc_limits = self.context.get_emily_client().get_limits().await?;
         // If we can't get the total cap, we assume that the total cap is
         // the maximum possible amount of sBTC.
         let total_cap = sbtc_limits.total_cap().unwrap_or(Amount::MAX);

--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -8,7 +8,6 @@
 use std::collections::BTreeSet;
 use std::time::Duration;
 
-use bitcoin::Amount;
 use blockstack_lib::chainstate::stacks::StacksTransaction;
 use futures::future::try_join_all;
 use futures::Stream;
@@ -1233,30 +1232,13 @@ where
         if deposits.is_empty() && withdrawals.is_empty() {
             return Ok(None);
         }
-        // Get the amount of sBTC that can be currently minted.
-        // This is the total cap received from Emily minus the current supply.
-        let sbtc_supply = self
-            .context
-            .get_stacks_client()
-            .get_sbtc_total_supply(&self.context.config().signer.deployer)
-            .await?;
-        let sbtc_limits = self.context.get_emily_client().get_limits().await?;
-        // If we can't get the total cap, we assume that the total cap is
-        // the maximum possible amount of sBTC.
-        let total_cap = sbtc_limits.total_cap().unwrap_or(Amount::MAX_MONEY);
-
-        let max_mintable = total_cap
-            .checked_sub(sbtc_supply)
-            .unwrap_or(Amount::ZERO)
-            .to_sat();
-
         Ok(Some(utxo::SbtcRequests {
             deposits,
             withdrawals,
             signer_state: self.get_btc_state(bitcoin_chain_tip, aggregate_key).await?,
             accept_threshold: threshold,
             num_signers,
-            max_mintable,
+            sbtc_limits: self.context.state().get_current_limits(),
         }))
     }
 

--- a/signer/tests/integration/bitcoin_validation.rs
+++ b/signer/tests/integration/bitcoin_validation.rs
@@ -513,6 +513,7 @@ async fn cannot_sign_deposit_is_ok() {
         signer_state: signer_btc_state(&ctx, &request, &btc_ctx).await,
         accept_threshold: 2,
         num_signers: 3,
+        max_mintable: u64::MAX,
     };
     let txs = sbtc_requests.construct_transactions().unwrap();
     assert_eq!(txs.len(), 1);
@@ -642,6 +643,7 @@ async fn sighashes_match_from_sbtc_requests_object() {
         signer_state: signer_btc_state(&ctx, &request, &btc_ctx).await,
         accept_threshold: 2,
         num_signers: 3,
+        max_mintable: u64::MAX,
     };
     let txs = sbtc_requests.construct_transactions().unwrap();
     assert_eq!(txs.len(), 1);

--- a/signer/tests/integration/block_observer.rs
+++ b/signer/tests/integration/block_observer.rs
@@ -25,6 +25,7 @@ use sbtc::testing::regtest;
 use sbtc::testing::regtest::Recipient;
 use signer::bitcoin::utxo::SbtcRequests;
 use signer::bitcoin::utxo::SignerBtcState;
+use signer::context::SbtcLimits;
 use signer::emily_client::EmilyClient;
 use signer::error::Error;
 use signer::keys::SignerScriptPubKey as _;
@@ -102,6 +103,11 @@ async fn load_latest_deposit_requests_persists_requests_from_past(blocks_ago: u6
             .expect_get_deposits()
             .times(1..)
             .returning(move || Box::pin(std::future::ready(Ok(emily_client_response.clone()))));
+
+        client
+            .expect_get_limits()
+            .times(1..)
+            .returning(|| Box::pin(async { Ok(SbtcLimits::default()) }));
     })
     .await;
 
@@ -617,7 +623,7 @@ async fn block_observer_stores_donation_and_sbtc_utxos() {
         },
         accept_threshold: 4,
         num_signers: 7,
-        max_mintable: u64::MAX,
+        sbtc_limits: SbtcLimits::default(),
     };
 
     let mut transactions = requests.construct_transactions().unwrap();

--- a/signer/tests/integration/block_observer.rs
+++ b/signer/tests/integration/block_observer.rs
@@ -355,7 +355,7 @@ async fn link_blocks() {
 async fn fetch_output(db: &PgStore, output_type: TxOutputType) -> Vec<TxOutput> {
     sqlx::query_as::<_, TxOutput>(
         r#"
-        SELECT 
+        SELECT
             txid
           , output_index
           , amount
@@ -374,7 +374,7 @@ async fn fetch_output(db: &PgStore, output_type: TxOutputType) -> Vec<TxOutput> 
 async fn fetch_input(db: &PgStore, output_type: TxPrevoutType) -> Vec<TxPrevout> {
     sqlx::query_as::<_, TxPrevout>(
         r#"
-        SELECT 
+        SELECT
             txid
           , prevout_txid
           , prevout_output_index
@@ -617,6 +617,7 @@ async fn block_observer_stores_donation_and_sbtc_utxos() {
         },
         accept_threshold: 4,
         num_signers: 7,
+        max_mintable: u64::MAX,
     };
 
     let mut transactions = requests.construct_transactions().unwrap();

--- a/signer/tests/integration/emily.rs
+++ b/signer/tests/integration/emily.rs
@@ -652,6 +652,7 @@ async fn get_limits_works() {
         Some(Amount::from_sat(100)),
         Some(Amount::from_sat(90)),
         Some(Amount::from_sat(80)),
+        None,
     );
 
     assert_eq!(limits, expected);

--- a/signer/tests/integration/rbf.rs
+++ b/signer/tests/integration/rbf.rs
@@ -231,6 +231,7 @@ pub fn transaction_with_rbf(
         },
         accept_threshold: failure_threshold,
         num_signers: 2 * failure_threshold,
+        max_mintable: u64::MAX,
     };
 
     // Okay, lets submit the transaction. We also do a sanity check where

--- a/signer/tests/integration/rbf.rs
+++ b/signer/tests/integration/rbf.rs
@@ -20,6 +20,7 @@ use signer::bitcoin::utxo::SignerBtcState;
 use signer::bitcoin::utxo::SignerUtxo;
 use signer::bitcoin::utxo::UnsignedTransaction;
 use signer::bitcoin::utxo::WithdrawalRequest;
+use signer::context::SbtcLimits;
 use signer::message::SweepTransactionInfo;
 use signer::storage::model;
 use signer::storage::model::ScriptPubKey;
@@ -231,7 +232,7 @@ pub fn transaction_with_rbf(
         },
         accept_threshold: failure_threshold,
         num_signers: 2 * failure_threshold,
-        max_mintable: u64::MAX,
+        sbtc_limits: SbtcLimits::default(),
     };
 
     // Okay, lets submit the transaction. We also do a sanity check where

--- a/signer/tests/integration/setup.rs
+++ b/signer/tests/integration/setup.rs
@@ -25,6 +25,7 @@ use signer::bitcoin::utxo::SignerUtxo;
 use signer::block_observer::BlockObserver;
 use signer::block_observer::Deposit;
 use signer::config::Settings;
+use signer::context::SbtcLimits;
 use signer::keys::PublicKey;
 use signer::keys::SignerScriptPubKey;
 use signer::message;
@@ -149,7 +150,7 @@ impl TestSweepSetup {
             },
             accept_threshold: 4,
             num_signers: 7,
-            max_mintable: u64::MAX,
+            sbtc_limits: SbtcLimits::default(),
         };
 
         // There should only be one transaction here since there is only
@@ -749,7 +750,7 @@ impl TestSweepSetup2 {
             },
             accept_threshold: 4,
             num_signers: 7,
-            max_mintable: u64::MAX,
+            sbtc_limits: SbtcLimits::default(),
         };
 
         // There should only be one transaction here since there is only

--- a/signer/tests/integration/setup.rs
+++ b/signer/tests/integration/setup.rs
@@ -149,6 +149,7 @@ impl TestSweepSetup {
             },
             accept_threshold: 4,
             num_signers: 7,
+            max_mintable: u64::MAX,
         };
 
         // There should only be one transaction here since there is only
@@ -748,6 +749,7 @@ impl TestSweepSetup2 {
             },
             accept_threshold: 4,
             num_signers: 7,
+            max_mintable: u64::MAX,
         };
 
         // There should only be one transaction here since there is only

--- a/signer/tests/integration/transaction_coordinator.rs
+++ b/signer/tests/integration/transaction_coordinator.rs
@@ -9,6 +9,7 @@ use bitcoin::consensus::Encodable as _;
 use bitcoin::hashes::Hash as _;
 use bitcoin::Address;
 use bitcoin::AddressType;
+use bitcoin::Amount;
 use bitcoin::BlockHash;
 use bitcoin::Transaction;
 use bitcoincore_rpc::RpcApi as _;
@@ -480,6 +481,11 @@ async fn process_complete_deposit() {
                 .expect_estimate_fees()
                 .once()
                 .returning(move |_, _, _| Box::pin(async move { Ok(25505) }));
+
+            client
+                .expect_get_sbtc_total_supply()
+                .once()
+                .returning(move |_| Box::pin(async move { Ok(Amount::ZERO) }));
         })
         .await;
 
@@ -1309,6 +1315,11 @@ async fn sign_bitcoin_transaction() {
                     Ok(SubmitTxResponse::Acceptance(txid))
                 })
             });
+            // The coordinator will get the total supply of sBTC to
+            // determine the amount of mintable sBTC.
+            client
+                .expect_get_sbtc_total_supply()
+                .returning(move |_| Box::pin(async move { Ok(Amount::ZERO) }));
         })
         .await;
     }

--- a/signer/tests/integration/transaction_signer.rs
+++ b/signer/tests/integration/transaction_signer.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
 
-use bitcoin::Amount;
 use fake::Fake as _;
 use fake::Faker;
 use futures::future::join_all;
@@ -14,7 +13,6 @@ use signer::bitcoin::utxo::Requests;
 use signer::bitcoin::utxo::UnsignedTransaction;
 use signer::bitcoin::validation::TxRequestIds;
 use signer::context::Context;
-use signer::context::SbtcLimits;
 use signer::context::SignerEvent;
 use signer::context::SignerSignal;
 use signer::context::TxSignerEvent;
@@ -531,28 +529,12 @@ pub async fn assert_should_be_able_to_handle_sbtc_requests() {
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
     let fee_rate = 1.3;
     // Build the test context with mocked clients
-    let mut ctx = TestContext::builder()
+    let ctx = TestContext::builder()
         .with_storage(db.clone())
         .with_mocked_bitcoin_client()
         .with_mocked_emily_client()
         .with_mocked_stacks_client()
         .build();
-
-    ctx.with_emily_client(|client| {
-        client
-            .expect_get_limits()
-            .times(1)
-            .returning(|| Box::pin(async { Ok(SbtcLimits::new(None, None, None)) }));
-    })
-    .await;
-
-    ctx.with_stacks_client(|client| {
-        client
-            .expect_get_sbtc_total_supply()
-            .times(1)
-            .returning(|_| Box::pin(async { Ok(Amount::ZERO) }));
-    })
-    .await;
 
     let (rpc, faucet) = sbtc::testing::regtest::initialize_blockchain();
 

--- a/signer/tests/integration/utxo_construction.rs
+++ b/signer/tests/integration/utxo_construction.rs
@@ -223,6 +223,7 @@ fn deposits_add_to_controlled_amounts() {
         },
         accept_threshold: 4,
         num_signers: 7,
+        max_mintable: u64::MAX,
     };
 
     // There should only be one transaction here since there is only one
@@ -287,6 +288,7 @@ fn withdrawals_reduce_to_signers_amounts() {
         },
         accept_threshold: 4,
         num_signers: 7,
+        max_mintable: u64::MAX,
     };
 
     // There should only be one transaction here since there is only one

--- a/signer/tests/integration/utxo_construction.rs
+++ b/signer/tests/integration/utxo_construction.rs
@@ -29,6 +29,7 @@ use signer::bitcoin::utxo::SbtcRequests;
 use signer::bitcoin::utxo::SignerBtcState;
 use signer::bitcoin::utxo::SignerUtxo;
 use signer::bitcoin::utxo::WithdrawalRequest;
+use signer::context::SbtcLimits;
 use stacks_common::types::chainstate::StacksAddress;
 
 use regtest::Recipient;
@@ -223,7 +224,7 @@ fn deposits_add_to_controlled_amounts() {
         },
         accept_threshold: 4,
         num_signers: 7,
-        max_mintable: u64::MAX,
+        sbtc_limits: SbtcLimits::default(),
     };
 
     // There should only be one transaction here since there is only one
@@ -288,7 +289,7 @@ fn withdrawals_reduce_to_signers_amounts() {
         },
         accept_threshold: 4,
         num_signers: 7,
-        max_mintable: u64::MAX,
+        sbtc_limits: SbtcLimits::default(),
     };
 
     // There should only be one transaction here since there is only one


### PR DESCRIPTION
# Issue Description

Closes: #856

## Changes
  - `SbtcRequests` now filters out deposit requests that would cause the total transaction amount to exceed the cap.  
      - The filtering logic is straightforward and processes deposits in the order they were received.
  - Signers revalidate `BitcoinPreSignRequest` to ensure the total sum of deposits does not exceed the cap.  
  - Individual transactions are also checked against the per-request cap in the validate function. (Maybe I should remove it from there and just merge the check on the `can_accept` field of the `SignerDepositDecision` - like in the original implementation from Cyle)
  - A new `ValidationCache` struct caches `DepositRequestReport` and `SignerVotes` from the database.  
     - This prevents redundant queries during pre-validation and per-request validation steps.

## Testing Information
  - Added unit tests for filtering deposit requests that exceed the total cap when creating new transactions.  
  - Added unit tests for validating full transactions on the signer side.
  - Adapted existing tests to align with the new logic.

  - Still need to add tests for validating individual requests for the `AmountTooHigh` error. (That may be removed)





