### PR TITLE
feat: do not attempt to vote on requests more than once

### DIFF
--- a/signer/src/request_decider.rs
+++ b/signer/src/request_decider.rs
@@ -124,11 +124,13 @@ where
             .await?
             .ok_or(Error::NoChainTip)?;
 
+        let signer_public_key = self.signer_public_key();
+
         let span = tracing::Span::current();
         span.record("chain_tip", tracing::field::display(chain_tip));
 
         let deposit_requests = db
-            .get_pending_deposit_requests(&chain_tip, self.context_window)
+            .get_pending_deposit_requests(&chain_tip, self.context_window, &signer_public_key)
             .await?;
 
         for deposit_request in deposit_requests {

--- a/signer/src/request_decider.rs
+++ b/signer/src/request_decider.rs
@@ -139,7 +139,7 @@ where
         }
 
         let withdraw_requests = db
-            .get_pending_withdrawal_requests(&chain_tip, self.context_window)
+            .get_pending_withdrawal_requests(&chain_tip, self.context_window, &signer_public_key)
             .await?;
 
         for withdraw_request in withdraw_requests {

--- a/signer/src/storage/in_memory.rs
+++ b/signer/src/storage/in_memory.rs
@@ -244,8 +244,7 @@ impl Store {
         let context_window_end_block = std::iter::successors(first_block, |block| {
             self.bitcoin_blocks.get(&block.parent_hash)
         })
-        .skip(context_window as usize)
-        .next();
+        .nth(context_window as usize);
 
         let Some(stacks_chain_tip) = self.get_stacks_chain_tip(chain_tip) else {
             return Vec::new();

--- a/signer/src/storage/in_memory.rs
+++ b/signer/src/storage/in_memory.rs
@@ -8,7 +8,7 @@ use futures::TryStreamExt as _;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::collections::HashMap;
-// use std::collections::HashSet;
+use std::collections::HashSet;
 use std::sync::Arc;
 use time::OffsetDateTime;
 use tokio::sync::Mutex;
@@ -25,7 +25,7 @@ use crate::stacks::events::WithdrawalAcceptEvent;
 use crate::stacks::events::WithdrawalCreateEvent;
 use crate::stacks::events::WithdrawalRejectEvent;
 use crate::storage::model;
-// use crate::DEPOSIT_LOCKTIME_BLOCK_BUFFER;
+use crate::DEPOSIT_LOCKTIME_BLOCK_BUFFER;
 
 use super::util::get_utxo;
 
@@ -187,6 +187,38 @@ impl Store {
 
         get_utxo(aggregate_key, sbtc_txs)
     }
+
+    /// Get all deposit requests that are on the blockchain identified by
+    /// the chain tip within the context window.
+    pub fn get_deposit_requests(
+        &self,
+        chain_tip: &model::BitcoinBlockHash,
+        context_window: u16,
+    ) -> Vec<model::DepositRequest> {
+        (0..context_window)
+            // Find all tracked transaction IDs in the context window
+            .scan(chain_tip, |block_hash, _| {
+                let transaction_ids = self
+                    .bitcoin_block_to_transactions
+                    .get(*block_hash)
+                    .cloned()
+                    .unwrap_or_else(Vec::new);
+
+                let block = self.bitcoin_blocks.get(*block_hash)?;
+                *block_hash = &block.parent_hash;
+
+                Some(transaction_ids)
+            })
+            .flatten()
+            // Return all deposit requests associated with any of these transaction IDs
+            .flat_map(|txid| {
+                self.deposit_requests
+                    .values()
+                    .filter(move |req| req.txid == txid)
+                    .cloned()
+            })
+            .collect()
+    }
 }
 
 impl super::DbRead for SharedStore {
@@ -237,103 +269,90 @@ impl super::DbRead for SharedStore {
 
     async fn get_pending_deposit_requests(
         &self,
-        _chain_tip: &model::BitcoinBlockHash,
-        _context_window: u16,
-        _signer_public_key: &PublicKey,
+        chain_tip: &model::BitcoinBlockHash,
+        context_window: u16,
+        signer_public_key: &PublicKey,
     ) -> Result<Vec<model::DepositRequest>, Error> {
-        unimplemented!()
-        // let store = self.lock().await;
+        let store = self.lock().await;
 
-        // Ok((0..context_window)
-        //     // Find all tracked transaction IDs in the context window
-        //     .scan(chain_tip, |block_hash, _| {
-        //         let transaction_ids = store
-        //             .bitcoin_block_to_transactions
-        //             .get(*block_hash)
-        //             .cloned()
-        //             .unwrap_or_else(Vec::new);
+        let deposits_requests = store.get_deposit_requests(chain_tip, context_window);
+        let voted: HashSet<(model::BitcoinTxId, u32)> = store
+            .signer_to_deposit_request
+            .get(signer_public_key)
+            .cloned()
+            .unwrap_or(Vec::new())
+            .into_iter()
+            .collect();
 
-        //         let block = store.bitcoin_blocks.get(*block_hash)?;
-        //         *block_hash = &block.parent_hash;
+        let result = deposits_requests
+            .into_iter()
+            .filter(|x| !voted.contains(&(x.txid, x.output_index)))
+            .collect();
 
-        //         Some(transaction_ids)
-        //     })
-        //     .flatten()
-        //     // Return all deposit requests associated with any of these transaction IDs
-        //     .flat_map(|txid| {
-        //         store
-        //             .deposit_requests
-        //             .values()
-        //             .filter(move |req| req.txid == txid)
-        //             .cloned()
-        //     })
-        //     .collect())
+        Ok(result)
     }
 
     async fn get_pending_accepted_deposit_requests(
         &self,
-        _chain_tip: &model::BitcoinBlockHash,
-        _context_window: u16,
-        _threshold: u16,
+        chain_tip: &model::BitcoinBlockHash,
+        context_window: u16,
+        threshold: u16,
     ) -> Result<Vec<model::DepositRequest>, Error> {
-        unimplemented!()
-        // let pending_deposit_requests = self
-        //     .get_pending_deposit_requests(chain_tip, context_window)
-        //     .await?;
+        let store = self.lock().await;
+        let deposit_requests = store.get_deposit_requests(chain_tip, context_window);
 
-        // let threshold = threshold as usize;
-        // let store = self.lock().await;
+        let threshold = threshold as usize;
 
-        // // Add one to the acceptable unlock height because the chain tip is at height one less
-        // // than the height of the next block, which is the block for which we are assessing
-        // // the threshold.
-        // let minimum_acceptable_unlock_height =
-        //     store.bitcoin_blocks.get(chain_tip).unwrap().block_height as u32
-        //         + DEPOSIT_LOCKTIME_BLOCK_BUFFER as u32
-        //         + 1;
+        // Add one to the acceptable unlock height because the chain tip is at height one less
+        // than the height of the next block, which is the block for which we are assessing
+        // the threshold.
+        let minimum_acceptable_unlock_height =
+            store.bitcoin_blocks.get(chain_tip).unwrap().block_height as u32
+                + DEPOSIT_LOCKTIME_BLOCK_BUFFER as u32
+                + 1;
 
-        // // Get all canonical blocks in the context window.
-        // let canonical_bitcoin_blocks = std::iter::successors(Some(chain_tip), |block_hash| {
-        //     store
-        //         .bitcoin_blocks
-        //         .get(block_hash)
-        //         .map(|block| &block.parent_hash)
-        // })
-        // .take(context_window as usize)
-        // .collect::<HashSet<_>>();
+        // Get all canonical blocks in the context window.
+        let canonical_bitcoin_blocks = std::iter::successors(Some(chain_tip), |block_hash| {
+            store
+                .bitcoin_blocks
+                .get(block_hash)
+                .map(|block| &block.parent_hash)
+        })
+        .take(context_window as usize)
+        .collect::<HashSet<_>>();
 
-        // Ok(pending_deposit_requests
-        //     .into_iter()
-        //     .filter(|deposit_request| {
-        //         store
-        //             .bitcoin_transactions_to_blocks
-        //             .get(&deposit_request.txid)
-        //             .unwrap_or(&Vec::new())
-        //             .iter()
-        //             .filter(|block_hash| canonical_bitcoin_blocks.contains(block_hash))
-        //             .filter_map(|block_hash| store.bitcoin_blocks.get(block_hash))
-        //             .map(|block_included: &model::BitcoinBlock| {
-        //                 let unlock_height =
-        //                     block_included.block_height as u32 + deposit_request.lock_time;
-        //                 unlock_height >= minimum_acceptable_unlock_height
-        //             })
-        //             .next()
-        //             .unwrap_or(false)
-        //     })
-        //     .filter(|deposit_request| {
-        //         store
-        //             .deposit_request_to_signers
-        //             .get(&(deposit_request.txid, deposit_request.output_index))
-        //             .map(|signers| {
-        //                 signers
-        //                     .iter()
-        //                     .filter(|signer| signer.can_accept && signer.can_sign)
-        //                     .count()
-        //                     >= threshold
-        //             })
-        //             .unwrap_or_default()
-        //     })
-        //     .collect())
+        Ok(deposit_requests
+            .into_iter()
+            .filter(|deposit_request| {
+                store
+                    .bitcoin_transactions_to_blocks
+                    .get(&deposit_request.txid)
+                    .unwrap_or(&Vec::new())
+                    .iter()
+                    .filter(|block_hash| canonical_bitcoin_blocks.contains(block_hash))
+                    .filter_map(|block_hash| store.bitcoin_blocks.get(block_hash))
+                    .map(|block_included: &model::BitcoinBlock| {
+                        let unlock_height =
+                            block_included.block_height as u32 + deposit_request.lock_time;
+                        unlock_height >= minimum_acceptable_unlock_height
+                    })
+                    .next()
+                    .unwrap_or(false)
+            })
+            .filter(|deposit_request| {
+                store
+                    .deposit_request_to_signers
+                    .get(&(deposit_request.txid, deposit_request.output_index))
+                    .map(|signers| {
+                        signers
+                            .iter()
+                            .filter(|signer| signer.can_accept && signer.can_sign)
+                            .count()
+                            >= threshold
+                    })
+                    .unwrap_or_default()
+            })
+            .collect())
     }
 
     async fn get_accepted_deposit_requests(

--- a/signer/src/storage/mod.rs
+++ b/signer/src/storage/mod.rs
@@ -147,10 +147,15 @@ pub trait DbRead {
     ) -> impl Future<Output = Result<Vec<model::WithdrawalSigner>, Error>> + Send;
 
     /// Get pending withdrawal requests
+    ///
+    /// These are withdrawal requests that have been added to our database
+    /// but where the current signer has not made a decision on whether
+    /// they will sweep out the withdrawal funds and sweep transaction.
     fn get_pending_withdrawal_requests(
         &self,
         chain_tip: &model::BitcoinBlockHash,
         context_window: u16,
+        signer_public_key: &PublicKey,
     ) -> impl Future<Output = Result<Vec<model::WithdrawalRequest>, Error>> + Send;
 
     /// Get pending withdrawal requests that have been accepted by at least

--- a/signer/src/storage/mod.rs
+++ b/signer/src/storage/mod.rs
@@ -54,10 +54,15 @@ pub trait DbRead {
     ) -> impl Future<Output = Result<Option<model::StacksBlock>, Error>> + Send;
 
     /// Get pending deposit requests
+    ///
+    /// These are deposit requests that have been added to our database but
+    /// where the current signer has not made a decision on whether they
+    /// will sign for the deposit and sweep in the funds.
     fn get_pending_deposit_requests(
         &self,
         chain_tip: &model::BitcoinBlockHash,
         context_window: u16,
+        signer_public_key: &PublicKey,
     ) -> impl Future<Output = Result<Vec<model::DepositRequest>, Error>> + Send;
 
     /// Get pending deposit requests that have been accepted by at least

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -1250,7 +1250,7 @@ impl super::DbRead for PgStore {
             JOIN stacks_context_window sc USING (block_hash)
             LEFT JOIN sbtc_signer.withdrawal_signers AS ws
               ON ws.request_id = wr.request_id
-             AND ws.block_hash = deposit_requests.block_hash
+             AND ws.block_hash = wr.block_hash
              AND ws.signer_pub_key = $4
             WHERE ws.request_id IS NULL
             "#,

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -813,8 +813,7 @@ impl super::DbRead for PgStore {
               , deposit_requests.signers_public_key
               , deposit_requests.sender_script_pub_keys
             FROM transactions_in_window transactions
-            JOIN sbtc_signer.deposit_requests deposit_requests
-              ON deposit_requests.txid = transactions.txid
+            JOIN sbtc_signer.deposit_requests AS deposit_requests USING (txid)
             LEFT JOIN sbtc_signer.deposit_signers AS ds
               ON ds.txid = deposit_requests.txid
              AND ds.output_index = deposit_requests.output_index

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -815,7 +815,7 @@ impl super::DbRead for PgStore {
             FROM transactions_in_window transactions
             JOIN sbtc_signer.deposit_requests deposit_requests
               ON deposit_requests.txid = transactions.txid
-            LEFT JOIN sbtc_signer.deposit_signer AS ds
+            LEFT JOIN sbtc_signer.deposit_signers AS ds
               ON ds.txid = deposit_requests.txid
              AND ds.output_index = deposit_requests.output_index
              AND ds.signer_pub_key = $3

--- a/signer/src/testing/storage.rs
+++ b/signer/src/testing/storage.rs
@@ -8,6 +8,7 @@ use crate::storage::postgres::PgStore;
 use crate::storage::DbRead;
 
 pub mod model;
+pub mod postgres;
 
 /// The postgres connection string to the test database.
 pub const DATABASE_URL: &str = "postgres://postgres:postgres@localhost:5432/signer";

--- a/signer/src/testing/storage/postgres.rs
+++ b/signer/src/testing/storage/postgres.rs
@@ -26,9 +26,9 @@ impl PgStore {
               , dr.lock_time
               , dr.signers_public_key
               , dr.sender_script_pub_keys
-            FROM sbtc_signer.bitcoin_blockchain_of($1, $2) AS bc
-            JOIN sbtc_signer.bitcoin_transactions ON USING (block_hash)
-            JOIN sbtc_signer.deposit_requests AS dr ON USING (txid)
+            FROM sbtc_signer.bitcoin_blockchain_of($1, $2)
+            JOIN sbtc_signer.bitcoin_transactions USING (block_hash)
+            JOIN sbtc_signer.deposit_requests AS dr USING (txid)
             "#,
         )
         .bind(chain_tip)

--- a/signer/src/testing/storage/postgres.rs
+++ b/signer/src/testing/storage/postgres.rs
@@ -1,0 +1,61 @@
+//! A module with helper queryy functions.
+//!
+
+use crate::error::Error;
+use crate::storage::model;
+use crate::storage::postgres::PgStore;
+
+impl PgStore {
+    /// Get all deposit requests that have been confirmed within the
+    /// context window.
+    pub async fn get_deposit_requests(
+        &self,
+        chain_tip: &model::BitcoinBlockHash,
+        context_window: u16,
+    ) -> Result<Vec<model::DepositRequest>, Error> {
+        sqlx::query_as::<_, model::DepositRequest>(
+            r#"
+            WITH RECURSIVE context_window AS (
+                -- Anchor member: Initialize the recursion with the chain tip
+                SELECT block_hash, block_height, parent_hash, created_at, 1 AS depth
+                FROM sbtc_signer.bitcoin_blocks
+                WHERE block_hash = $1
+
+                UNION ALL
+
+                -- Recursive member: Fetch the parent block using the last block's parent_hash
+                SELECT parent.block_hash, parent.block_height, parent.parent_hash,
+                       parent.created_at, last.depth + 1
+                FROM sbtc_signer.bitcoin_blocks parent
+                JOIN context_window last ON parent.block_hash = last.parent_hash
+                WHERE last.depth < $2
+            ),
+            transactions_in_window AS (
+                SELECT transactions.txid
+                FROM context_window blocks_in_window
+                JOIN sbtc_signer.bitcoin_transactions transactions ON
+                    transactions.block_hash = blocks_in_window.block_hash
+            )
+            SELECT
+                deposit_requests.txid
+              , deposit_requests.output_index
+              , deposit_requests.spend_script
+              , deposit_requests.reclaim_script
+              , deposit_requests.recipient
+              , deposit_requests.amount
+              , deposit_requests.max_fee
+              , deposit_requests.lock_time
+              , deposit_requests.signers_public_key
+              , deposit_requests.sender_script_pub_keys
+            FROM transactions_in_window transactions
+            JOIN sbtc_signer.deposit_requests deposit_requests ON
+                deposit_requests.txid = transactions.txid
+            "#,
+        )
+        .bind(chain_tip)
+        .bind(i32::from(context_window))
+        .fetch_all(self.pool())
+        .await
+        .map_err(Error::SqlxQuery)
+    }
+}

--- a/signer/tests/integration/block_observer.rs
+++ b/signer/tests/integration/block_observer.rs
@@ -211,7 +211,7 @@ async fn load_latest_deposit_requests_persists_requests_from_past(blocks_ago: u6
 
     let chain_tip_info = rpc.get_chain_tips().unwrap().pop().unwrap();
     let deposit_requests = db
-        .get_pending_deposit_requests(&chain_tip_info.hash.into(), 100)
+        .get_deposit_requests(&chain_tip_info.hash.into(), 100)
         .await
         .unwrap();
 
@@ -246,10 +246,7 @@ async fn load_latest_deposit_requests_persists_requests_from_past(blocks_ago: u6
         .await
         .unwrap()
         .is_some());
-    let deposit_requests = db
-        .get_pending_deposit_requests(&chain_tip, 100)
-        .await
-        .unwrap();
+    let deposit_requests = db.get_deposit_requests(&chain_tip, 100).await.unwrap();
 
     assert_eq!(deposit_requests.len(), 2);
     let req_outpoints: HashSet<OutPoint> =

--- a/signer/tests/integration/emily.rs
+++ b/signer/tests/integration/emily.rs
@@ -34,6 +34,7 @@ use signer::emily_client::EmilyClient;
 use signer::emily_client::EmilyInteract;
 use signer::error::Error;
 use signer::keys;
+use signer::keys::PublicKey;
 use signer::keys::SignerScriptPubKey as _;
 use signer::network;
 use signer::stacks::api::TenureBlocks;
@@ -446,9 +447,11 @@ async fn deposit_flow() {
     let tx_coordinator_handle = tokio::spawn(async move { tx_coordinator.run().await });
 
     // There shouldn't be any request yet
+    let signer_public_key = PublicKey::from_private_key(&context.config().signer.private_key);
+    let chain_tip = bitcoin_chain_tip.block_hash;
     assert!(context
         .get_storage()
-        .get_pending_deposit_requests(&bitcoin_chain_tip.block_hash, context_window as u16)
+        .get_pending_deposit_requests(&chain_tip, context_window as u16, &signer_public_key)
         .await
         .unwrap()
         .is_empty());
@@ -477,9 +480,10 @@ async fn deposit_flow() {
         deposit_block_hash.into()
     );
     // and that now we have the deposit request
+    let deposit_block = deposit_block_hash.into();
     assert!(!context
         .get_storage()
-        .get_pending_deposit_requests(&deposit_block_hash.into(), context_window as u16)
+        .get_pending_deposit_requests(&deposit_block, context_window as u16, &signer_public_key)
         .await
         .unwrap()
         .is_empty());

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -366,6 +366,7 @@ async fn should_return_the_same_pending_deposit_requests_as_in_memory_store() {
             .expect("failed to get pending deposit requests");
 
         pending_deposit_requests.sort();
+        assert!(!pending_deposit_requests.is_empty());
 
         let mut pg_pending_deposit_requests = pg_store
             .get_pending_deposit_requests(&chain_tip, context_window, signer_public_key)
@@ -453,7 +454,7 @@ async fn get_pending_withdrawal_requests_only_pending() {
     backfill_bitcoin_blocks(&db, rpc, &setup.deposit_block_hash).await;
     let chain_tip = db.get_bitcoin_canonical_chain_tip().await.unwrap().unwrap();
 
-    // There aren't any deposit requests in the database.
+    // There aren't any withdrawal requests in the database.
     let signer_public_key = setup.signers.signer_keys()[0];
     let pending_requests = db
         .get_pending_withdrawal_requests(&chain_tip, 1000, &signer_public_key)

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -431,23 +431,26 @@ async fn should_return_the_same_pending_withdraw_requests_as_in_memory_store() {
             .expect("no chain tip"),
     );
 
-    let mut pending_withdraw_requests = in_memory_store
-        .get_pending_withdrawal_requests(&chain_tip, context_window)
-        .await
-        .expect("failed to get pending deposit requests");
+    for signer_public_key in signer_set.iter() {
+        let mut pending_withdraw_requests = in_memory_store
+            .get_pending_withdrawal_requests(&chain_tip, context_window, signer_public_key)
+            .await
+            .expect("failed to get pending deposit requests");
 
-    pending_withdraw_requests.sort();
+        pending_withdraw_requests.sort();
 
-    assert!(!pending_withdraw_requests.is_empty());
+        assert!(!pending_withdraw_requests.is_empty());
 
-    let mut pg_pending_withdraw_requests = pg_store
-        .get_pending_withdrawal_requests(&chain_tip, context_window)
-        .await
-        .expect("failed to get pending deposit requests");
+        let mut pg_pending_withdraw_requests = pg_store
+            .get_pending_withdrawal_requests(&chain_tip, context_window, signer_public_key)
+            .await
+            .expect("failed to get pending deposit requests");
 
-    pg_pending_withdraw_requests.sort();
+        pg_pending_withdraw_requests.sort();
 
-    assert_eq!(pending_withdraw_requests, pg_pending_withdraw_requests);
+        assert_eq!(pending_withdraw_requests, pg_pending_withdraw_requests);
+    }
+
     signer::testing::storage::drop_db(pg_store).await;
 }
 

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -316,62 +316,63 @@ async fn checking_stacks_blocks_exists_works() {
 
 /// This ensures that the postgres store and the in memory stores returns equivalent results
 /// when fetching pending deposit requests
-#[cfg_attr(not(feature = "integration-tests"), ignore)]
-#[tokio::test]
-async fn should_return_the_same_pending_deposit_requests_as_in_memory_store() {
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let mut pg_store = testing::storage::new_test_database(db_num, true).await;
-    let mut in_memory_store = storage::in_memory::Store::new_shared();
+// #[ignore]
+// #[cfg_attr(not(feature = "integration-tests"), ignore)]
+// #[tokio::test]
+// async fn should_return_the_same_pending_deposit_requests_as_in_memory_store() {
+//     let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
+//     let mut pg_store = testing::storage::new_test_database(db_num, true).await;
+//     let mut in_memory_store = storage::in_memory::Store::new_shared();
 
-    let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+//     let mut rng = rand::rngs::StdRng::seed_from_u64(42);
 
-    let num_signers = 7;
-    let context_window = 9;
-    let test_model_params = testing::storage::model::Params {
-        num_bitcoin_blocks: 20,
-        num_stacks_blocks_per_bitcoin_block: 3,
-        num_deposit_requests_per_block: 5,
-        num_withdraw_requests_per_block: 5,
-        num_signers_per_request: 0,
-    };
-    let signer_set = testing::wsts::generate_signer_set_public_keys(&mut rng, num_signers);
-    let test_data = TestData::generate(&mut rng, &signer_set, &test_model_params);
+//     let num_signers = 7;
+//     let context_window = 9;
+//     let test_model_params = testing::storage::model::Params {
+//         num_bitcoin_blocks: 20,
+//         num_stacks_blocks_per_bitcoin_block: 3,
+//         num_deposit_requests_per_block: 5,
+//         num_withdraw_requests_per_block: 5,
+//         num_signers_per_request: 0,
+//     };
+//     let signer_set = testing::wsts::generate_signer_set_public_keys(&mut rng, num_signers);
+//     let test_data = TestData::generate(&mut rng, &signer_set, &test_model_params);
 
-    test_data.write_to(&mut in_memory_store).await;
-    test_data.write_to(&mut pg_store).await;
+//     test_data.write_to(&mut in_memory_store).await;
+//     test_data.write_to(&mut pg_store).await;
 
-    let chain_tip = in_memory_store
-        .get_bitcoin_canonical_chain_tip()
-        .await
-        .expect("failed to get canonical chain tip")
-        .expect("no chain tip");
+//     let chain_tip = in_memory_store
+//         .get_bitcoin_canonical_chain_tip()
+//         .await
+//         .expect("failed to get canonical chain tip")
+//         .expect("no chain tip");
 
-    assert_eq!(
-        pg_store
-            .get_bitcoin_canonical_chain_tip()
-            .await
-            .expect("failed to get canonical chain tip")
-            .expect("no chain tip"),
-        chain_tip
-    );
+//     assert_eq!(
+//         pg_store
+//             .get_bitcoin_canonical_chain_tip()
+//             .await
+//             .expect("failed to get canonical chain tip")
+//             .expect("no chain tip"),
+//         chain_tip
+//     );
 
-    let mut pending_deposit_requests = in_memory_store
-        .get_pending_deposit_requests(&chain_tip, context_window)
-        .await
-        .expect("failed to get pending deposit requests");
+//     let mut pending_deposit_requests = in_memory_store
+//         .get_pending_deposit_requests(&chain_tip, context_window)
+//         .await
+//         .expect("failed to get pending deposit requests");
 
-    pending_deposit_requests.sort();
+//     pending_deposit_requests.sort();
 
-    let mut pg_pending_deposit_requests = pg_store
-        .get_pending_deposit_requests(&chain_tip, context_window)
-        .await
-        .expect("failed to get pending deposit requests");
+//     let mut pg_pending_deposit_requests = pg_store
+//         .get_pending_deposit_requests(&chain_tip, context_window)
+//         .await
+//         .expect("failed to get pending deposit requests");
 
-    pg_pending_deposit_requests.sort();
+//     pg_pending_deposit_requests.sort();
 
-    assert_eq!(pending_deposit_requests, pg_pending_deposit_requests);
-    signer::testing::storage::drop_db(pg_store).await;
-}
+//     assert_eq!(pending_deposit_requests, pg_pending_deposit_requests);
+//     signer::testing::storage::drop_db(pg_store).await;
+// }
 
 /// This ensures that the postgres store and the in memory stores returns equivalent results
 /// when fetching pending withdraw requests

--- a/signer/tests/integration/request_decider.rs
+++ b/signer/tests/integration/request_decider.rs
@@ -161,8 +161,9 @@ async fn handle_pending_deposit_request_address_script_pub_key() {
     // need a row in the dkg_shares table.
     setup.store_dkg_shares(&db).await;
 
+    let signer_public_key = setup.aggregated_signer.keypair.public_key().into();
     let mut requests = db
-        .get_pending_deposit_requests(&chain_tip, 100)
+        .get_pending_deposit_requests(&chain_tip, 100, &signer_public_key)
         .await
         .unwrap();
     // There should only be the one deposit request that we just fetched.
@@ -246,8 +247,9 @@ async fn handle_pending_deposit_request_not_in_signing_set() {
     // signing set.
     setup.store_dkg_shares(&db).await;
 
+    let signer_public_key = setup.aggregated_signer.keypair.public_key().into();
     let mut requests = db
-        .get_pending_deposit_requests(&chain_tip, 100)
+        .get_pending_deposit_requests(&chain_tip, 100, &signer_public_key)
         .await
         .unwrap();
     // There should only be the one deposit request that we just fetched.


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/684

## Changes

* Update the queries for `get_pending_deposit_requests` and `get_pending_withdrawal_requests` to ignore requests that the signer has voted on already.
* Update the in memory implementations of both functions.
* Add a helper query to maintain the same behavior in the `load_latest_deposit_requests_persists_requests_from_past` test.

## Testing Information

This PR adds integration tests that check the new behavior of the updated queries.

## Checklist:

- [x] I have performed a self-review of my code