### PR TITLE
fix: address the lingering bug when converting a `Point` into a `PublicKey`

### DIFF
--- a/signer/src/keys.rs
+++ b/signer/src/keys.rs
@@ -140,16 +140,9 @@ impl From<PublicKey> for p256k1::point::Point {
 impl TryFrom<&p256k1::point::Point> for PublicKey {
     type Error = Error;
     fn try_from(value: &p256k1::point::Point) -> Result<Self, Self::Error> {
-        let x_data = value.x().to_bytes();
-
-        let pk = secp256k1::XOnlyPublicKey::from_slice(&x_data).map_err(Error::InvalidPublicKey)?;
-        let parity = if value.has_even_y() {
-            Parity::Even
-        } else {
-            Parity::Odd
-        };
-
-        let public_key = secp256k1::PublicKey::from_x_only_public_key(pk, parity);
+        let data = value.compress().data;
+        let public_key =
+            secp256k1::PublicKey::from_slice(&data).map_err(Error::InvalidPublicKey)?;
         Ok(Self(public_key))
     }
 }

--- a/signer/src/keys.rs
+++ b/signer/src/keys.rs
@@ -33,7 +33,6 @@ use std::str::FromStr;
 
 use bitcoin::ScriptBuf;
 use bitcoin::TapTweakHash;
-use secp256k1::Parity;
 use secp256k1::SECP256K1;
 use serde::Deserialize;
 use serde::Serialize;
@@ -455,6 +454,7 @@ mod tests {
     use super::*;
 
     use rand::rngs::OsRng;
+    use secp256k1::Parity;
     use secp256k1::SecretKey;
     use stacks_common::util::secp256k1::Secp256k1PrivateKey;
     use stacks_common::util::secp256k1::Secp256k1PublicKey;

--- a/signer/src/keys.rs
+++ b/signer/src/keys.rs
@@ -540,9 +540,13 @@ mod tests {
         let point1 = p256k1::point::Point::from(scalar);
         // Because we started with a valid private key, the point is not
         // the point at infinity, so we will have a valid public key.
-        let public_key = PublicKey::try_from(&point1).unwrap();
+        let public_key1 = PublicKey::try_from(&point1).unwrap();
+        // These two libraries should map to the same public key givent he
+        // same secret key.
+        let public_key2 = sk.public_key(SECP256K1).into();
+        assert_eq!(public_key1, public_key2);
         // We map back to make sure that this works
-        let point2 = p256k1::point::Point::from(public_key);
+        let point2 = p256k1::point::Point::from(public_key1);
         assert_eq!(point1, point2)
     }
 

--- a/signer/src/keys.rs
+++ b/signer/src/keys.rs
@@ -540,7 +540,7 @@ mod tests {
         // keys while p256k1::scalar::Scalar does, so we start with a that
         // library to make sure that we always generate a valid public key
         // when using PublicKey::try_from below (although it's extremely
-        // unlikely that we would generate an invalid one anyway). 
+        // unlikely that we would generate an invalid one anyway).
         let sk = secp256k1::SecretKey::new(&mut OsRng);
         let scalar = p256k1::scalar::Scalar::from(sk.secret_bytes());
         let point1 = p256k1::point::Point::from(scalar);


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/999

## Changes

* Go through the compressed point implementation when converting a `p256k1::point::Point` into the crate `PublicKey`.

## Testing Information

This adds some tests to make sure that we do not get caught off-guard by the bug that we found.

## Checklist:

- [x] I have performed a self-review of my code
