### PR TITLE
feat: do not bail when coordinator fails to create bitcoin transactions

### DIFF
--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -324,12 +324,16 @@ where
         self.check_and_submit_rotate_key_transaction(&bitcoin_chain_tip, &aggregate_key)
             .await?;
 
-        self.construct_and_sign_bitcoin_sbtc_transactions(
-            &bitcoin_chain_tip,
-            &aggregate_key,
-            &signer_public_keys,
-        )
-        .await?;
+        if let Err(error) = self
+            .construct_and_sign_bitcoin_sbtc_transactions(
+                &bitcoin_chain_tip,
+                &aggregate_key,
+                &signer_public_keys,
+            )
+            .await
+        {
+            tracing::error!(%error, "Failed to construct and sign bitcoin transactions");
+        }
 
         self.construct_and_sign_stacks_sbtc_response_transactions(
             &bitcoin_chain_tip,


### PR DESCRIPTION
Closes: #1007

## Changes
- Modify `process_new_blocks` to catch and log errors coming from `construct_and_sign_bitcoin_sbtc_transactions` so that it can continue processing stacks transactions.