### PR TITLE
feat: update the block observer horizon parameter

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -103,6 +103,8 @@ services:
       - emily-dynamodb
     environment:
       - DYNAMODB_ENDPOINT=http://emily-dynamodb:8000
+    profiles:
+      - default
 
   # Runs the Emily server.
   emily-server:
@@ -124,6 +126,8 @@ services:
       - DEFAULT_PER_WITHDRAWAL_CAP=100000000
     ports:
       - "3031:3031"
+    profiles:
+      - default
 
   # sBTC Signers.
   # ------------------

--- a/docker/prodlike/config/signer-config.toml
+++ b/docker/prodlike/config/signer-config.toml
@@ -152,6 +152,12 @@ bootstrap_signatures_required = 15
 # TODO(715): Expect this to change after testing.
 bitcoin_processing_delay = 0
 
+# The number of blocks back the block observer should look for unprocessed
+# blocks before proceeding.
+# Required: true
+# Environment: SIGNER_SIGNER__BITCOIN_BLOCK_HORIZON
+bitcoin_block_horizon = 1500
+
 # How many bitcoin blocks back from the chain tip the signer will look for
 # requests. Must be strictly positive.
 #

--- a/docker/sbtc/signer/signer-config.toml
+++ b/docker/sbtc/signer/signer-config.toml
@@ -108,6 +108,12 @@ network = "regtest"
 # TODO(715): Add default delay (15 seconds? see #701)
 bitcoin_processing_delay = 3
 
+# The number of blocks back the block observer should look for unprocessed
+# blocks before proceeding.
+# Required: true
+# Environment: SIGNER_SIGNER__BITCOIN_BLOCK_HORIZON
+bitcoin_block_horizon = 1500
+
 # How many bitcoin blocks back from the chain tip the signer will look for
 # requests. Must be strictly positive.
 #

--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -243,6 +243,12 @@ impl<C: Context, B> BlockObserver<C, B> {
                 .await?
                 .ok_or(Error::MissingBitcoinBlock(block_hash.into()))?;
 
+            // TODO(685): Remove this and replace with a better limiting
+            // condition.
+            if block.bip34_block_height().unwrap_or(0) == 0 {
+                break;
+            }
+
             block_hash = block.header.prev_blockhash;
             blocks.push(block);
         }

--- a/signer/src/config/default.toml
+++ b/signer/src/config/default.toml
@@ -145,6 +145,12 @@ bootstrap_signatures_required = 2
 # TODO(715): Add default delay (15 seconds? see #701)
 bitcoin_processing_delay = 0
 
+# The number of blocks back the block observer should look for unprocessed
+# blocks before proceeding.
+# Required: true
+# Environment: SIGNER_SIGNER__BITCOIN_BLOCK_HORIZON
+bitcoin_block_horizon = 1000
+
 # How many bitcoin blocks back from the chain tip the signer will look for
 # requests. Must be strictly positive.
 #

--- a/signer/src/config/default.toml
+++ b/signer/src/config/default.toml
@@ -149,7 +149,7 @@ bitcoin_processing_delay = 0
 # blocks before proceeding.
 # Required: true
 # Environment: SIGNER_SIGNER__BITCOIN_BLOCK_HORIZON
-bitcoin_block_horizon = 1000
+bitcoin_block_horizon = 1500
 
 # How many bitcoin blocks back from the chain tip the signer will look for
 # requests. Must be strictly positive.

--- a/signer/src/config/mod.rs
+++ b/signer/src/config/mod.rs
@@ -494,6 +494,7 @@ mod tests {
         );
         assert!(!settings.signer.bootstrap_signing_set.is_empty());
         assert_eq!(settings.signer.bootstrap_signatures_required, 2);
+        assert_eq!(settings.signer.bitcoin_block_horizon, 2000);
         assert_eq!(settings.signer.context_window, 10000);
         assert_eq!(
             settings.signer.bitcoin_presign_request_max_duration,
@@ -818,6 +819,15 @@ mod tests {
             settings.unwrap_err(),
             ConfigError::Message(msg) if msg == Error::DecodeHexBytes(hex_err).to_string()
         ));
+    }
+
+    #[test]
+    fn horizon_parameter_works() {
+        clear_env();
+
+        std::env::set_var("SIGNER_SIGNER__BITCOIN_BLOCK_HORIZON", "1234");
+        let config = Settings::new_from_default_config().unwrap();
+        assert_eq!(config.signer.bitcoin_block_horizon, 1234);
     }
 
     #[test]

--- a/signer/src/config/mod.rs
+++ b/signer/src/config/mod.rs
@@ -494,7 +494,7 @@ mod tests {
         );
         assert!(!settings.signer.bootstrap_signing_set.is_empty());
         assert_eq!(settings.signer.bootstrap_signatures_required, 2);
-        assert_eq!(settings.signer.bitcoin_block_horizon, 2000);
+        assert_eq!(settings.signer.bitcoin_block_horizon, 1500);
         assert_eq!(settings.signer.context_window, 10000);
         assert_eq!(
             settings.signer.bitcoin_presign_request_max_duration,

--- a/signer/src/config/mod.rs
+++ b/signer/src/config/mod.rs
@@ -235,6 +235,9 @@ pub struct SignerConfig {
     /// coordinator will time out and return an error.
     #[serde(deserialize_with = "duration_seconds_deserializer")]
     pub dkg_max_duration: std::time::Duration,
+    /// The number of blocks back the block observer should look for
+    /// unprocessed blocks before proceeding.
+    pub bitcoin_block_horizon: u32,
 }
 
 impl Validatable for SignerConfig {

--- a/signer/src/main.rs
+++ b/signer/src/main.rs
@@ -301,7 +301,7 @@ async fn run_block_observer(ctx: impl Context) -> Result<(), Error> {
     let block_observer = block_observer::BlockObserver {
         context: ctx,
         bitcoin_blocks: stream.to_block_hash_stream(),
-        horizon: 20,
+        horizon: config.signer.bitcoin_block_horizon,
     };
 
     block_observer.run().await


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/1018.

## Changes

* Make the block observer horizon parameter configurable and set it to 1500.
* Minor fixup for devenv.

## Testing Information

I tested this in devenv and everything works. But to run devenv I needed to essentially remove the caps, which I did using:
```diff
diff --git a/signer/src/block_observer.rs b/signer/src/block_observer.rs
index 1711dc5f..dc38417a 100644
--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -488,7 +488,7 @@ impl<C: Context, B> BlockObserver<C, B> {

     /// Update the sBTC peg limits from Emily
     async fn update_sbtc_limits(&self) -> Result<(), Error> {
-        let limits = self.context.get_emily_client().get_limits().await?;
+        let limits = self.context.get_emily_client().get_limits().await.unwrap_or_default();
         let max_mintable = match limits.total_cap() {
             Amount::MAX_MONEY => Amount::MAX_MONEY,
             total_cap => {
```

So looks like devenv basically works, but we need to make sure we have some default caps in Emily in devenv. I'm not sure how it is configured in testnet.

## Checklist:

- [x] I have performed a self-review of my code

