### PR TITLE
fix: only accept deposits if all inputs are fine

### DIFF
--- a/signer/src/request_decider.rs
+++ b/signer/src/request_decider.rs
@@ -333,9 +333,9 @@ where
             .collect::<Vec<_>>()
             .await;
 
-        // If any of the inputs addresses are fine then we pass the deposit
+        // If all of the inputs addresses are fine then we pass the deposit
         // request.
-        let can_accept = responses.into_iter().any(|res| res.unwrap_or(false));
+        let can_accept = responses.into_iter().all(|res| res.unwrap_or(false));
         Ok(can_accept)
     }
 


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/1046

This came up recently and the more natural position is to reject a deposit if any input into the transaction is invalid.

## Changes

* Reject deposits if any of the inputs cannot be accepted.

## Testing Information

I do not believe we use the blocklist client in tests so they should all pass.

## Checklist:

- [x] I have performed a self-review of my code
