### PR TITLE
feat: remove need of context window for signers utxo

### DIFF
--- a/signer/migrations/0007__create_bitcoin_blockchain_from.sql
+++ b/signer/migrations/0007__create_bitcoin_blockchain_from.sql
@@ -1,0 +1,43 @@
+-- Table-Valued Function (TVF) for fetching a Bitcoin blockchain from a given
+-- block hash, only fetching blocks to a specific height.
+--
+-- - chain_tip: The block hash to start the blockchain from ("chain tip").
+-- - min_block_height: The minimum height of all blocks that are returned.
+CREATE FUNCTION sbtc_signer.bitcoin_blockchain_from (
+    chain_tip BYTEA,
+    min_block_height INT
+)
+RETURNS TABLE (
+    block_hash BYTEA,
+    parent_hash BYTEA,
+    block_height BIGINT
+) 
+AS $$
+BEGIN
+    RETURN QUERY
+    WITH RECURSIVE blockchain AS (
+        SELECT
+            blocks.block_hash
+          , blocks.parent_hash
+          , blocks.block_height
+        FROM sbtc_signer.bitcoin_blocks as blocks
+        WHERE blocks.block_hash = chain_tip
+
+        UNION ALL
+
+        SELECT
+            parent.block_hash
+          , parent.parent_hash
+          , parent.block_height
+        FROM sbtc_signer.bitcoin_blocks AS parent
+        JOIN blockchain AS last
+          ON parent.block_hash = last.parent_hash
+        WHERE last.block_height >= min_block_height
+    )
+    SELECT
+        block_hash
+      , parent_hash
+      , block_height
+    FROM blockchain;
+END;
+$$ LANGUAGE plpgsql;

--- a/signer/migrations/0007__create_bitcoin_blockchain_from.sql
+++ b/signer/migrations/0007__create_bitcoin_blockchain_from.sql
@@ -35,9 +35,9 @@ BEGIN
         WHERE last.block_height >= min_block_height
     )
     SELECT
-        block_hash
-      , parent_hash
-      , block_height
-    FROM blockchain;
+        blocks.block_hash
+      , blocks.parent_hash
+      , blocks.block_height
+    FROM blockchain as blocks;
 END;
 $$ LANGUAGE plpgsql;

--- a/signer/migrations/0007__create_bitcoin_blockchain_from.sql
+++ b/signer/migrations/0007__create_bitcoin_blockchain_from.sql
@@ -1,5 +1,5 @@
 -- Table-Valued Function (TVF) for fetching a Bitcoin blockchain from a given
--- block hash, only fetching blocks to a specific height.
+-- block hash, only fetching blocks down to a specific height.
 --
 -- - chain_tip: The block hash to start the blockchain from ("chain tip").
 -- - min_block_height: The minimum height of all blocks that are returned.
@@ -32,7 +32,7 @@ BEGIN
         FROM sbtc_signer.bitcoin_blocks AS parent
         JOIN blockchain AS last
           ON parent.block_hash = last.parent_hash
-        WHERE last.block_height >= min_block_height
+        WHERE last.block_height > min_block_height
     )
     SELECT
         blocks.block_hash

--- a/signer/migrations/0007__create_bitcoin_blockchain_from.sql
+++ b/signer/migrations/0007__create_bitcoin_blockchain_from.sql
@@ -3,7 +3,7 @@
 --
 -- - chain_tip: The block hash to start the blockchain from ("chain tip").
 -- - min_block_height: The minimum height of all blocks that are returned.
-CREATE FUNCTION sbtc_signer.bitcoin_blockchain_from (
+CREATE FUNCTION sbtc_signer.bitcoin_blockchain_until (
     chain_tip BYTEA,
     min_block_height BIGINT
 )

--- a/signer/migrations/0007__create_bitcoin_blockchain_from.sql
+++ b/signer/migrations/0007__create_bitcoin_blockchain_from.sql
@@ -5,7 +5,7 @@
 -- - min_block_height: The minimum height of all blocks that are returned.
 CREATE FUNCTION sbtc_signer.bitcoin_blockchain_from (
     chain_tip BYTEA,
-    min_block_height INT
+    min_block_height BIGINT
 )
 RETURNS TABLE (
     block_hash BYTEA,

--- a/signer/migrations/0008__create_indices_bitcoin_tx_tables.sql
+++ b/signer/migrations/0008__create_indices_bitcoin_tx_tables.sql
@@ -1,3 +1,3 @@
 CREATE INDEX ix_bitcoin_tx_inputs_prevout_type ON sbtc_signer.bitcoin_tx_inputs(prevout_type);
-CREATE INDEX ix_bitcoin_tx_ouputs_ouput_type ON sbtc_signer.bitcoin_tx_ouputs(output_type);
+CREATE INDEX ix_bitcoin_tx_ouputs_ouput_type ON sbtc_signer.bitcoin_tx_outputs(output_type);
 CREATE INDEX ix_bitcoin_blocks_block_height ON sbtc_signer.bitcoin_blocks(block_height);

--- a/signer/migrations/0008__create_indices_bitcoin_tx_tables.sql
+++ b/signer/migrations/0008__create_indices_bitcoin_tx_tables.sql
@@ -1,0 +1,3 @@
+CREATE INDEX ix_bitcoin_tx_inputs_prevout_type ON sbtc_signer.bitcoin_tx_inputs(prevout_type);
+CREATE INDEX ix_bitcoin_tx_ouputs_ouput_type ON sbtc_signer.bitcoin_tx_ouputs(output_type);
+CREATE INDEX ix_bitcoin_blocks_block_height ON sbtc_signer.bitcoin_blocks(block_height);

--- a/signer/src/bitcoin/validation.rs
+++ b/signer/src/bitcoin/validation.rs
@@ -214,7 +214,7 @@ impl BitcoinPreSignRequest {
 
         let signer_utxo = ctx
             .get_storage()
-            .get_signer_utxo(&btc_ctx.chain_tip, btc_ctx.context_window)
+            .get_signer_utxo(&btc_ctx.chain_tip)
             .await?
             .ok_or(Error::MissingSignerUtxo)?;
 

--- a/signer/src/lib.rs
+++ b/signer/src/lib.rs
@@ -67,3 +67,8 @@ pub const DEPOSIT_LOCKTIME_BLOCK_BUFFER: u16 = 3;
 /// This is the capacity of the channel used for messages sent within the
 /// signer.
 pub const SIGNER_CHANNEL_CAPACITY: usize = 1024;
+
+/// The maximum number of blocks that can be affected by a reorg on the
+/// bitcoin blockchain. This is used when adding a buffer when searching
+/// for the signers UTXO.
+pub const MAX_REORG_BLOCK_COUNT: i64 = 10;

--- a/signer/src/lib.rs
+++ b/signer/src/lib.rs
@@ -72,3 +72,7 @@ pub const SIGNER_CHANNEL_CAPACITY: usize = 1024;
 /// bitcoin blockchain. This is used when adding a buffer when searching
 /// for the signers UTXO.
 pub const MAX_REORG_BLOCK_COUNT: i64 = 10;
+
+/// The maximum number of sweep transactions that the signers can confirm
+/// per block.
+pub const MAX_TX_PER_BITCOIN_BLOCK: i64 = 25;

--- a/signer/src/storage/in_memory.rs
+++ b/signer/src/storage/in_memory.rs
@@ -651,7 +651,6 @@ impl super::DbRead for SharedStore {
     async fn get_signer_utxo(
         &self,
         chain_tip: &model::BitcoinBlockHash,
-        context_window: u16,
     ) -> Result<Option<SignerUtxo>, Error> {
         let Some(dkg_shares) = self.get_latest_encrypted_dkg_shares().await? else {
             return Ok(None);
@@ -662,6 +661,7 @@ impl super::DbRead for SharedStore {
         let bitcoin_blocks = &store.bitcoin_blocks;
         let first = bitcoin_blocks.get(chain_tip);
 
+        let context_window = 1000;
         // Traverse the canonical chain backwards and find the first block containing relevant sbtc tx(s)
         let sbtc_txs = std::iter::successors(first, |block| bitcoin_blocks.get(&block.parent_hash))
             .take(context_window as usize)

--- a/signer/src/storage/mod.rs
+++ b/signer/src/storage/mod.rs
@@ -247,13 +247,10 @@ pub trait DbRead {
     /// 3. The output is unspent. It is possible for more than one
     ///    transaction within the same block to satisfy points 1-3, but if
     ///    the signers have one or more transactions within a block,
-    ///    exactly one output satisfying points 1-3 will be unspent.
-    /// 4. The block that includes the transaction that satisfies points
-    ///    1-4 has the greatest height of all such blocks.
+    ///    exactly one output satisfying points 1-2 will be unspent.
     fn get_signer_utxo(
         &self,
         chain_tip: &model::BitcoinBlockHash,
-        context_window: u16,
     ) -> impl Future<Output = Result<Option<SignerUtxo>, Error>> + Send;
 
     /// For the given outpoint and aggregate key, get the list all signer

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -558,7 +558,6 @@ impl PgStore {
                 WHERE bti.prevout_type = 'signers_input'
                   AND bb.block_height <= $1
                 GROUP BY bti.txid, bti.prevout_txid
-                LIMIT $2
             ),
             tx_chain AS (
                 SELECT

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -424,10 +424,11 @@ impl PgStore {
     /// The signers outstanding UTXO is a UTXO that is confirmed on the
     /// canonical bitcoin blockchain. But regardless of which blockchain
     /// that is, we know that it is very unlikely to have been affected by
-    /// a reorg of more than 10 blocks deep. That means that if we look back
-    /// at least 10 blocks before the best candidate for the signers' UTXO,
-    /// we are very likely to find a transaction output that is on the best
-    /// bitcoin blockchain.
+    /// a reorg of more than [`MAX_REORG_BLOCK_COUNT`] blocks deep. That
+    /// means that if we look back at least [`MAX_REORG_BLOCK_COUNT`]
+    /// blocks before the best candidate for the signers' UTXO, we are very
+    /// likely to find a transaction output that is on the best bitcoin
+    /// blockchain.
     pub async fn minimum_utxo_height(
         &self,
         output_type: model::TxOutputType,
@@ -435,7 +436,7 @@ impl PgStore {
         // Get the block height of the unspent transaction that was most
         // recently confirmed. Note that we are not filtering by the
         // blockchain identified by a chain tip, we just want the UTXO with
-        // maximum height, event if it has been reorged.
+        // maximum height, even if it has been reorged.
         let confirmed_height_candidate = sqlx::query_scalar::<_, i64>(
             r#"
             WITH confirmed_sweeps AS (

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -28,7 +28,9 @@ use crate::stacks::events::WithdrawalCreateEvent;
 use crate::stacks::events::WithdrawalRejectEvent;
 use crate::storage::model;
 use crate::storage::model::TransactionType;
+
 use crate::DEPOSIT_LOCKTIME_BLOCK_BUFFER;
+use crate::MAX_REORG_BLOCK_COUNT;
 
 /// All migration scripts from the `signer/migrations` directory.
 static PGSQL_MIGRATIONS: include_dir::Dir =
@@ -48,10 +50,6 @@ const CONTRACT_NAMES: [&str; 4] = [
     // BTC on chain.
     "sbtc-withdrawal",
 ];
-
-/// The maximum number of blocks that can be affected by a reorg on the
-/// bitcoin blockchain. This is typically 6, but let's go with 10. Why not?
-const MAX_REORG_BLOCK_COUNT: i64 = 10;
 
 #[rustfmt::skip]
 const CONTRACT_FUNCTION_NAMES: [(&str, TransactionType); 5] = [
@@ -430,7 +428,7 @@ impl PgStore {
     /// at least 10 blocks before the best candidate for the signers' UTXO,
     /// we are very likely to find a transaction output that is on the best
     /// bitcoin blockchain.
-    async fn minimum_utxo_height(
+    pub async fn minimum_utxo_height(
         &self,
         output_type: model::TxOutputType,
     ) -> Result<Option<i64>, Error> {

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -463,7 +463,7 @@ impl PgStore {
     ///   sole UTXO and creates a new one. This function "crawls" the chain
     ///   of transactions, starting at the most recently confirmed one,
     ///   until it goes back at least [`MAX_REORG_BLOCK_COUNT`] blocks
-    ///   worth of transactions. A blocks with height greater than or equal
+    ///   worth of transactions. A block with height greater than or equal
     ///   to the height returned here should contain the transaction with
     ///   the signers' UTXO, and won't if there is a reorg spanning more
     ///   than [`MAX_REORG_BLOCK_COUNT`] blocks.

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -1731,7 +1731,7 @@ impl super::DbRead for PgStore {
         chain_tip: &model::BitcoinBlockHash,
     ) -> Result<Option<SignerUtxo>, Error> {
         // If we've swept funds before, then will have a signer output and
-        // a minimum UTXO height, so let's try that first. 
+        // a minimum UTXO height, so let's try that first.
         let Some(min_block_height) = self.minimum_utxo_height().await? else {
             // If the above functon returns None then we know that there
             // have been no confirmed sweep transactions thus far, so let's
@@ -1747,7 +1747,7 @@ impl super::DbRead for PgStore {
         let fut = self.get_utxo(chain_tip, output_type, min_block_height);
         match fut.await? {
             res @ Some(_) => Ok(res),
-            None => self.get_donation_utxo(chain_tip).await
+            None => self.get_donation_utxo(chain_tip).await,
         }
     }
 

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -417,7 +417,7 @@ impl PgStore {
 
     /// Return the height of the earliest block in which a donation UTXO
     /// has been confirmed.
-    /// 
+    ///
     /// # Notes
     ///
     /// This function does not check whether the donation output has been

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -366,7 +366,6 @@ impl PgStore {
     async fn get_utxo(
         &self,
         chain_tip: &model::BitcoinBlockHash,
-        context_window: u16,
         txo_type: model::TxOutputType,
     ) -> Result<Option<SignerUtxo>, Error> {
         let pg_utxo = sqlx::query_as::<_, PgSignerUtxo>(
@@ -1528,14 +1527,13 @@ impl super::DbRead for PgStore {
     async fn get_signer_utxo(
         &self,
         chain_tip: &model::BitcoinBlockHash,
-        context_window: u16,
     ) -> Result<Option<SignerUtxo>, Error> {
         let txo_type = model::TxOutputType::SignersOutput;
-        if let Some(pg_utxo) = self.get_utxo(chain_tip, context_window, txo_type).await? {
+        if let Some(pg_utxo) = self.get_utxo(chain_tip, txo_type).await? {
             return Ok(Some(pg_utxo));
         }
         let txo_type = model::TxOutputType::Donation;
-        self.get_utxo(chain_tip, context_window, txo_type).await
+        self.get_utxo(chain_tip, txo_type).await
     }
 
     async fn in_canonical_bitcoin_blockchain(

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -381,7 +381,7 @@ impl PgStore {
             r#"
             WITH bitcoin_blockchain AS (
                 SELECT block_hash
-                FROM bitcoin_blockchain_from($1, $2)
+                FROM bitcoin_blockchain_until($1, $2)
             ),
             confirmed_sweeps AS (
                 SELECT
@@ -569,7 +569,7 @@ impl PgStore {
             FROM sbtc_signer.swept_deposits AS sd
             JOIN sbtc_signer.bitcoin_transactions AS bt
               ON bt.txid = sd.sweep_transaction_txid
-            JOIN sbtc_signer.bitcoin_blockchain_from($1, $2) USING (block_hash)
+            JOIN sbtc_signer.bitcoin_blockchain_until($1, $2) USING (block_hash)
             WHERE sd.deposit_request_txid = $3
               AND sd.deposit_request_output_index = $4
             LIMIT 1
@@ -626,7 +626,7 @@ impl PgStore {
               , bc.block_hash
             FROM sbtc_signer.deposit_requests AS dr
             JOIN sbtc_signer.bitcoin_transactions USING (txid)
-            LEFT JOIN sbtc_signer.bitcoin_blockchain_from($1, $2) AS bc USING (block_hash)
+            LEFT JOIN sbtc_signer.bitcoin_blockchain_until($1, $2) AS bc USING (block_hash)
             LEFT JOIN sbtc_signer.deposit_signers AS ds
               ON dr.txid = ds.txid
              AND dr.output_index = ds.output_index

--- a/signer/src/testing/transaction_coordinator.rs
+++ b/signer/src/testing/transaction_coordinator.rs
@@ -627,7 +627,7 @@ where
         assert_eq!(chain_tip, block_ref.block_hash);
 
         let signer_utxo = storage
-            .get_signer_utxo(&chain_tip, self.context_window)
+            .get_signer_utxo(&chain_tip)
             .await
             .unwrap()
             .expect("no signer utxo");
@@ -726,7 +726,7 @@ where
                 public_key: bitcoin::XOnlyPublicKey::from(aggregate_key),
             };
             let signer_utxo = storage
-                .get_signer_utxo(&chain_tip.block_hash, self.context_window)
+                .get_signer_utxo(&chain_tip.block_hash)
                 .await
                 .unwrap()
                 .expect("no signer utxo");
@@ -735,12 +735,7 @@ where
 
         // Check context window
         assert!(storage
-            .get_signer_utxo(&block_c2.block_hash, 1)
-            .await
-            .unwrap()
-            .is_none());
-        assert!(storage
-            .get_signer_utxo(&block_c2.block_hash, 2)
+            .get_signer_utxo(&block_c2.block_hash)
             .await
             .unwrap()
             .is_some());
@@ -835,7 +830,7 @@ where
         assert_eq!(chain_tip, block_ref.block_hash);
 
         let signer_utxo = storage
-            .get_signer_utxo(&chain_tip, self.context_window)
+            .get_signer_utxo(&chain_tip)
             .await
             .unwrap()
             .expect("no signer utxo");
@@ -928,7 +923,7 @@ where
 
         // Check with chain tip A1
         let signer_utxo = storage
-            .get_signer_utxo(&block_a1.block_hash, self.context_window)
+            .get_signer_utxo(&block_a1.block_hash)
             .await
             .unwrap()
             .expect("no signer utxo");
@@ -943,7 +938,7 @@ where
 
         // Check with chain tip A2
         let signer_utxo = storage
-            .get_signer_utxo(&block_a2.block_hash, self.context_window)
+            .get_signer_utxo(&block_a2.block_hash)
             .await
             .unwrap()
             .expect("no signer utxo");
@@ -958,7 +953,7 @@ where
 
         // Check with chain tip B1
         let signer_utxo = storage
-            .get_signer_utxo(&block_b1.block_hash, self.context_window)
+            .get_signer_utxo(&block_b1.block_hash)
             .await
             .unwrap()
             .expect("no signer utxo");

--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -1233,7 +1233,7 @@ where
         let utxo = self
             .context
             .get_storage()
-            .get_signer_utxo(chain_tip, self.context_window)
+            .get_signer_utxo(chain_tip)
             .await?
             .ok_or(Error::MissingSignerUtxo)?;
 

--- a/signer/tests/integration/bitcoin_validation.rs
+++ b/signer/tests/integration/bitcoin_validation.rs
@@ -41,7 +41,7 @@ where
 {
     let signer_utxo = ctx
         .get_storage()
-        .get_signer_utxo(&btc_ctx.chain_tip, btc_ctx.context_window)
+        .get_signer_utxo(&btc_ctx.chain_tip)
         .await
         .unwrap()
         .unwrap();

--- a/signer/tests/integration/block_observer.rs
+++ b/signer/tests/integration/block_observer.rs
@@ -612,7 +612,7 @@ async fn block_observer_stores_donation_and_sbtc_utxos() {
         deposits: vec![deposit_request.clone()],
         withdrawals: Vec::new(),
         signer_state: SignerBtcState {
-            utxo: db.get_signer_utxo(&chain_tip, 10).await.unwrap().unwrap(),
+            utxo: db.get_signer_utxo(&chain_tip).await.unwrap().unwrap(),
             fee_rate: 10.0,
             public_key: signers_public_key,
             last_fees: None,

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -14,6 +14,7 @@ use blockstack_lib::types::chainstate::StacksAddress;
 use futures::future::join_all;
 use futures::StreamExt;
 use rand::rngs::StdRng;
+use rand::seq::IteratorRandom;
 use rand::seq::SliceRandom;
 
 use signer::bitcoin::validation::DepositConfirmationStatus;
@@ -63,7 +64,6 @@ use fake::Fake;
 use rand::SeedableRng;
 use signer::testing::context::*;
 use signer::DEPOSIT_LOCKTIME_BLOCK_BUFFER;
-use signer::MAX_REORG_BLOCK_COUNT;
 use test_case::test_case;
 use test_log::test;
 
@@ -3330,104 +3330,112 @@ async fn get_deposit_request_returns_returns_inserted_deposit_request() {
     signer::testing::storage::drop_db(db).await;
 }
 
-/// In this test we check that minimum_utxo_height returns an answer that
-/// is [`MAX_REORG_BLOCK_COUNT`] less than the actual block height of the UTXO.
-#[cfg_attr(not(feature = "integration-tests"), ignore)]
-#[tokio::test]
-async fn minimum_utxo_height_handles_straightforward_case() {
-    let db_num = testing::storage::DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
-    let mut rng = rand::rngs::StdRng::seed_from_u64(51);
-
-    // We just need some bitcoin blocks in the database, and this creates
-    // some where not all of them are on the same blockchain.
-    let num_signers = 3;
-    let test_params = testing::storage::model::Params {
-        num_bitcoin_blocks: 30,
-        num_stacks_blocks_per_bitcoin_block: 1,
-        num_deposit_requests_per_block: 0,
-        num_withdraw_requests_per_block: 0,
-        num_signers_per_request: num_signers,
-    };
-
-    let signer_set = testing::wsts::generate_signer_set_public_keys(&mut rng, num_signers);
-    let test_data = TestData::generate(&mut rng, &signer_set, &test_params);
-
-    test_data.write_to(&db).await;
-
-    let chain_tip = db.get_bitcoin_canonical_chain_tip().await.unwrap().unwrap();
-    let chain_tip_block_height = db
-        .get_bitcoin_block(&chain_tip)
-        .await
-        .unwrap()
-        .unwrap()
-        .block_height;
-
-    // Sanity check, the minimum height is None, since we don't have a UTXO
-    // in the database yet.
-    let output_type = model::TxOutputType::SignersOutput;
-    assert!(db.minimum_utxo_height().await.unwrap().is_none());
-
-    // Let's write the signers UTXO to the database.
-    let mut swept_prevout: model::TxPrevout = fake::Faker.fake_with_rng(&mut rng);
-    swept_prevout.prevout_output_index = 0;
-    swept_prevout.prevout_type = model::TxPrevoutType::SignersInput;
-
-    let mut swept_output: model::TxOutput = fake::Faker.fake_with_rng(&mut rng);
-    swept_output.txid = swept_prevout.txid;
-    swept_output.output_type = output_type;
-    swept_output.output_index = 0;
-
-    let sweep_tx_model = model::Transaction {
-        tx_type: model::TransactionType::SbtcTransaction,
-        txid: swept_prevout.txid.to_byte_array(),
-        tx: Vec::new(),
-        block_hash: chain_tip.to_byte_array(),
-    };
-    let sweep_tx_ref = model::BitcoinTxRef {
-        txid: swept_prevout.txid,
-        block_hash: chain_tip,
-    };
-    db.write_transaction(&sweep_tx_model).await.unwrap();
-    db.write_bitcoin_transaction(&sweep_tx_ref).await.unwrap();
-    db.write_tx_prevout(&swept_prevout).await.unwrap();
-    db.write_tx_output(&swept_output).await.unwrap();
-
-    // Now that we have the signers' UTXO in the database, we can compute
-    // the minimum height. Here it should just be the actual height minus
-    // MAX_REORG_BLOCK_COUNT.
-    let expected_min_height = chain_tip_block_height as i64 - MAX_REORG_BLOCK_COUNT;
-    let min_height = db.minimum_utxo_height().await.unwrap().unwrap();
-    assert_eq!(min_height, expected_min_height);
-
-    signer::testing::storage::drop_db(db).await;
+/// This struct is for testing different conditions when attempting to
+/// retrieve the signers' UTXO.
+struct ReorgDescription<const N: usize> {
+    /// An array that indicates the height that includes at least one sweep
+    /// transaction.
+    sweep_heights: [u64; N],
+    /// This is the height where there is a reorg.
+    reorg_height: u64,
+    /// This is the height of the donation. It must be less than or equal
+    /// to the minimum sweep height indicated by `sweep_heights`.
+    donation_height: u64,
+    /// The expected height of the UTXO returned by
+    /// [`DbRead::get_signer_utxo`].
+    utxo_height: Option<u64>,
+    /// When we create sweep package, this field controls how many
+    /// transactions are created in the package.
+    num_transactions: std::ops::Range<u8>,
 }
 
-/// In this test we check that minimum_utxo_height returns an answer that
-/// is [`MAX_REORG_BLOCK_COUNT`] less than the actual block height of the
-/// dontation UTXO.
+impl<const N: usize> ReorgDescription<N> {
+    fn num_blocks(&self) -> u64 {
+        self.sweep_heights.into_iter().max().unwrap_or_default()
+    }
+}
+
+/// In these tests we check that [`DbRead::get_signer_utxo`] returns the
+/// expected UTXO when there is a reorg. The test is setup as follows
+/// 1. Populate the database with some minimal bitcoin blockchain data.
+/// 2. For each block between the current block and the number-of-blocks to
+///    generate, create a random number of transactions where we spend the
+///    last output and create a new one.
+/// 3. Note the last transaction created in each bitcoin block.
+/// 4. Create a new chain starting at the height indicated by
+///    `reorg_height`, making sure that it is longer than the current
+///    blockchain in the database, so that it is the best chain.
+/// 5. Get the signers' UTXO and check that the transaction ID matches the
+///    one expected.
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
+#[test_case(ReorgDescription {
+    sweep_heights: [0, 3, 4, 5],
+    reorg_height: 4,
+    donation_height: 0,
+    utxo_height: Some(4),
+    num_transactions: std::ops::Range { start: 1, end: 2 },
+}; "vanilla reorg")]
+#[test_case(ReorgDescription {
+    sweep_heights: [0, 3, 4, 5],
+    reorg_height: 2,
+    donation_height: 0,
+    utxo_height: Some(0),
+    num_transactions: std::ops::Range { start: 1, end: 2 },
+}; "near-complete-reorg")]
+#[test_case(ReorgDescription {
+    sweep_heights: [0, 6, 10, 12],
+    reorg_height: 7,
+    donation_height: 0,
+    utxo_height: Some(6),
+    num_transactions: std::ops::Range { start: 1, end: 2 },
+}; "partial-reorg")]
+#[test_case(ReorgDescription {
+    sweep_heights: [0, 6, 20, 21],
+    reorg_height: 19,
+    donation_height: 0,
+    utxo_height: Some(6),
+    num_transactions: std::ops::Range { start: 1, end: 2 },
+}; "long-gap-reorg")]
+#[test_case(ReorgDescription {
+    sweep_heights: [3, 4, 5],
+    reorg_height: 2,
+    donation_height: 3,
+    utxo_height: None,
+    num_transactions: std::ops::Range { start: 1, end: 2 },
+}; "complete-reorg")]
+#[test_case(ReorgDescription {
+    sweep_heights: [1, 7, 17, 18, 19, 20, 21],
+    reorg_height: 16,
+    donation_height: 0,
+    utxo_height: Some(7),
+    num_transactions: std::ops::Range { start: 25, end: 26 },
+}; "busy-bridge-with-reorg")]
 #[tokio::test]
-async fn minimum_donation_utxo_height_returns_height_of_earliest_donation() {
+async fn signer_utxo_reorg_suite<const N: usize>(desc: ReorgDescription<N>) {
     let db_num = testing::storage::DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
     let db = testing::storage::new_test_database(db_num, true).await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
 
-    // We just need some bitcoin blocks in the database, and this creates
-    // some where not all of them are on the same blockchain.
+    // We just need some basic data in the database. The only value that
+    // matters is `num_bitcoin_blocks`, and it must be positive.
     let num_signers = 3;
     let test_params = testing::storage::model::Params {
-        num_bitcoin_blocks: 30,
+        num_bitcoin_blocks: 1,
         num_stacks_blocks_per_bitcoin_block: 1,
         num_deposit_requests_per_block: 0,
         num_withdraw_requests_per_block: 0,
         num_signers_per_request: num_signers,
     };
 
+    // Let's generate some dummy data and write it into the database.
     let signer_set = testing::wsts::generate_signer_set_public_keys(&mut rng, num_signers);
     let test_data = TestData::generate(&mut rng, &signer_set, &test_params);
-
     test_data.write_to(&db).await;
+
+    // We need some DKG shares here, since we identify the signers' UTXO by
+    // the fact that the signers can sign for the UTXO.
+    let dkg_shares: model::EncryptedDkgShares = fake::Faker.fake_with_rng(&mut rng);
+    db.write_encrypted_dkg_shares(&dkg_shares).await.unwrap();
 
     let chain_tip = db.get_bitcoin_canonical_chain_tip().await.unwrap().unwrap();
     let original_chain_tip_ref: model::BitcoinBlockRef = db
@@ -3437,165 +3445,107 @@ async fn minimum_donation_utxo_height_returns_height_of_earliest_donation() {
         .unwrap()
         .into();
 
-    // Sanity check, the minimum height is None, since we don't have a UTXO
-    // in the database yet.
-    let output_type = model::TxOutputType::Donation;
-    assert!(db.minimum_utxo_height().await.unwrap().is_none());
+    // This will store the last transaction ID for all transaction packages
+    // created in a block with a sweep.
+    let mut expected_sweep_txids = BTreeMap::new();
 
-    // Let's write the donation UTXO to the database.
     let mut swept_output: model::TxOutput = fake::Faker.fake_with_rng(&mut rng);
-    swept_output.output_type = output_type;
-
-    let sweep_tx_model = model::Transaction {
-        tx_type: model::TransactionType::SbtcTransaction,
-        txid: swept_output.txid.to_byte_array(),
-        tx: Vec::new(),
-        block_hash: chain_tip.to_byte_array(),
-    };
-    let sweep_tx_ref = model::BitcoinTxRef {
-        txid: swept_output.txid,
-        block_hash: chain_tip,
-    };
-    db.write_transaction(&sweep_tx_model).await.unwrap();
-    db.write_bitcoin_transaction(&sweep_tx_ref).await.unwrap();
-    db.write_tx_output(&swept_output).await.unwrap();
-
-    // Now that we have the signers' UTXO in the database, we can compute
-    // the minimum height. Here it should just be the actual height minus
-    // MAX_REORG_BLOCK_COUNT.
-    let min_height = db.minimum_donation_txo_height().await.unwrap().unwrap() as u64;
-    assert_eq!(min_height, original_chain_tip_ref.block_height);
-
-    // In a few blocks, we use the donation in a sweep transaction, so
-    // let's add some blocks.
     let mut chain_tip_ref = original_chain_tip_ref;
-    for _ in 0..4 {
+    let mut reorg_block_ref = chain_tip_ref;
+
+    for height in 0..=desc.num_blocks() {
+        // We need a UTXO to "bootstrap" the signers, so maybe we should
+        // create one now.
+        if height == desc.donation_height {
+            swept_output.output_type = model::TxOutputType::Donation;
+            swept_output.output_index = 0;
+            swept_output.amount = 0;
+            swept_output.script_pubkey = dkg_shares.script_pubkey.clone();
+
+            let sweep_tx_model = model::Transaction {
+                tx_type: model::TransactionType::Donation,
+                txid: swept_output.txid.to_byte_array(),
+                tx: Vec::new(),
+                block_hash: chain_tip_ref.block_hash.to_byte_array(),
+            };
+            let sweep_tx_ref = model::BitcoinTxRef {
+                txid: swept_output.txid,
+                block_hash: chain_tip_ref.block_hash,
+            };
+            db.write_transaction(&sweep_tx_model).await.unwrap();
+            db.write_bitcoin_transaction(&sweep_tx_ref).await.unwrap();
+            db.write_tx_output(&swept_output).await.unwrap();
+        }
+
+        // Maybe there is a sweep package in this bitcoin block. If so
+        // let's generate a random number of transactions in a transaction
+        // package.
+        if desc.sweep_heights.contains(&height) {
+            let num_transactions = desc.num_transactions.clone().choose(&mut rng).unwrap();
+
+            for _ in 0..num_transactions {
+                let mut swept_prevout: model::TxPrevout = fake::Faker.fake_with_rng(&mut rng);
+                swept_prevout.prevout_txid = swept_output.txid;
+                swept_prevout.prevout_output_index = 0;
+                swept_prevout.prevout_type = model::TxPrevoutType::SignersInput;
+
+                swept_output.txid = swept_prevout.txid;
+                swept_output.output_type = model::TxOutputType::SignersOutput;
+                swept_output.output_index = 0;
+                swept_output.script_pubkey = dkg_shares.script_pubkey.clone();
+
+                let sweep_tx_model = model::Transaction {
+                    tx_type: model::TransactionType::SbtcTransaction,
+                    txid: swept_prevout.txid.to_byte_array(),
+                    tx: Vec::new(),
+                    block_hash: chain_tip_ref.block_hash.to_byte_array(),
+                };
+                let sweep_tx_ref = model::BitcoinTxRef {
+                    txid: swept_prevout.txid,
+                    block_hash: chain_tip_ref.block_hash,
+                };
+                db.write_transaction(&sweep_tx_model).await.unwrap();
+                db.write_bitcoin_transaction(&sweep_tx_ref).await.unwrap();
+                db.write_tx_prevout(&swept_prevout).await.unwrap();
+                db.write_tx_output(&swept_output).await.unwrap();
+
+                expected_sweep_txids.insert(height, swept_prevout.txid);
+            }
+        }
+
+        // We need to note the block that we need to branch from for our reorg.
+        if height == desc.reorg_height {
+            reorg_block_ref = chain_tip_ref;
+        }
+
+        // And now for the blockchain data.
         let (new_data, new_chain_tip_ref) =
             test_data.new_block(&mut rng, &signer_set, &test_params, Some(&chain_tip_ref));
         chain_tip_ref = new_chain_tip_ref;
         new_data.write_to(&db).await;
     }
 
-    // Let's write the signers UTXO to the database, where we spend the
-    // donation.
-    let mut swept_output: model::TxOutput = fake::Faker.fake_with_rng(&mut rng);
-    swept_output.output_type = model::TxOutputType::Donation;
-
-    let sweep_tx_model = model::Transaction {
-        tx_type: model::TransactionType::SbtcTransaction,
-        txid: swept_output.txid.to_byte_array(),
-        tx: Vec::new(),
-        block_hash: chain_tip_ref.block_hash.to_byte_array(),
-    };
-    let sweep_tx_ref = model::BitcoinTxRef {
-        txid: swept_output.txid,
-        block_hash: chain_tip_ref.block_hash,
-    };
-    db.write_transaction(&sweep_tx_model).await.unwrap();
-    db.write_bitcoin_transaction(&sweep_tx_ref).await.unwrap();
-    db.write_tx_output(&swept_output).await.unwrap();
-
-    let min_donation_height = db.minimum_donation_txo_height().await.unwrap().unwrap() as u64;
-    assert_eq!(min_donation_height, original_chain_tip_ref.block_height);
-
-    signer::testing::storage::drop_db(db).await;
-}
-
-/// In this test we check that minimum_utxo_height returns an answer that
-/// is equal to the height of the block that confirmed the transaction
-/// containing the second-best candidate for the signers' UTXO if there is
-/// a large gap between best and second-best candidates is greater than
-/// [`MAX_REORG_BLOCK_COUNT`] blocks.
-#[cfg_attr(not(feature = "integration-tests"), ignore)]
-#[tokio::test]
-async fn minimum_utxo_height_large_sweep_gap() {
-    let db_num = testing::storage::DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
-    let mut rng = rand::rngs::StdRng::seed_from_u64(51);
-
-    let num_signers = 3;
-    let test_params = testing::storage::model::Params {
-        num_bitcoin_blocks: 10,
-        num_stacks_blocks_per_bitcoin_block: 1,
-        num_deposit_requests_per_block: 0,
-        num_withdraw_requests_per_block: 0,
-        num_signers_per_request: num_signers,
-    };
-
-    let signer_set = testing::wsts::generate_signer_set_public_keys(&mut rng, num_signers);
-    let test_data = TestData::generate(&mut rng, &signer_set, &test_params);
-
-    test_data.write_to(&db).await;
+    // And now for creating the reorg blocks.
+    for _ in 0..=(desc.num_blocks() - desc.reorg_height) + 1 {
+        let (new_data, new_chain_tip_ref) =
+            test_data.new_block(&mut rng, &signer_set, &test_params, Some(&reorg_block_ref));
+        reorg_block_ref = new_chain_tip_ref;
+        new_data.write_to(&db).await;
+    }
 
     let chain_tip = db.get_bitcoin_canonical_chain_tip().await.unwrap().unwrap();
-    let original_chain_tip_ref: model::BitcoinBlockRef = db
-        .get_bitcoin_block(&chain_tip)
-        .await
-        .unwrap()
-        .unwrap()
-        .into();
 
-    let output_type = model::TxOutputType::SignersOutput;
-    let mut swept_output: model::TxOutput = fake::Faker.fake_with_rng(&mut rng);
-    swept_output.output_type = output_type;
-    swept_output.output_index = 0;
-
-    let mut swept_prevout: model::TxPrevout = fake::Faker.fake_with_rng(&mut rng);
-    swept_prevout.txid = swept_output.txid;
-    swept_prevout.prevout_output_index = 0;
-    swept_prevout.prevout_type = model::TxPrevoutType::SignersInput;
-
-    let sweep_tx_model = model::Transaction {
-        tx_type: model::TransactionType::SbtcTransaction,
-        txid: swept_output.txid.to_byte_array(),
-        tx: Vec::new(),
-        block_hash: chain_tip.to_byte_array(),
+    // Let's make sure we get the expected signer UTXO.
+    let utxo = db.get_signer_utxo(&chain_tip).await.unwrap();
+    match desc.utxo_height {
+        Some(height) => {
+            let txid: model::BitcoinTxId = utxo.unwrap().outpoint.txid.into();
+            assert_eq!(&txid, expected_sweep_txids.get(&height).unwrap());
+        }
+        None => {
+            assert!(utxo.is_none());
+        }
     };
-    let sweep_tx_ref = model::BitcoinTxRef {
-        txid: swept_output.txid,
-        block_hash: chain_tip,
-    };
-    db.write_transaction(&sweep_tx_model).await.unwrap();
-    db.write_bitcoin_transaction(&sweep_tx_ref).await.unwrap();
-    db.write_tx_prevout(&swept_prevout).await.unwrap();
-    db.write_tx_output(&swept_output).await.unwrap();
-
-    let mut chain_tip_ref = original_chain_tip_ref;
-    for _ in 0..12 {
-        let (new_data, new_chain_tip_ref) =
-            test_data.new_block(&mut rng, &signer_set, &test_params, Some(&chain_tip_ref));
-        chain_tip_ref = new_chain_tip_ref;
-        new_data.write_to(&db).await;
-    }
-
-    let mut swept_output2: model::TxOutput = fake::Faker.fake_with_rng(&mut rng);
-    swept_output2.output_type = output_type;
-    swept_output2.output_index = 0;
-
-    //
-    let mut swept_prevout2: model::TxPrevout = fake::Faker.fake_with_rng(&mut rng);
-    swept_prevout2.txid = swept_output2.txid;
-    swept_prevout2.prevout_output_index = 0;
-    swept_prevout2.prevout_type = model::TxPrevoutType::SignersInput;
-    swept_prevout2.prevout_txid = swept_output.txid;
-
-    let sweep_tx_model = model::Transaction {
-        tx_type: model::TransactionType::SbtcTransaction,
-        txid: swept_prevout2.txid.to_byte_array(),
-        tx: Vec::new(),
-        block_hash: chain_tip_ref.block_hash.to_byte_array(),
-    };
-    let sweep_tx_ref = model::BitcoinTxRef {
-        txid: swept_prevout2.txid,
-        block_hash: chain_tip_ref.block_hash,
-    };
-    db.write_transaction(&sweep_tx_model).await.unwrap();
-    db.write_bitcoin_transaction(&sweep_tx_ref).await.unwrap();
-    db.write_tx_prevout(&swept_prevout2).await.unwrap();
-    db.write_tx_output(&swept_output2).await.unwrap();
-
-    let min_height = db.minimum_utxo_height().await.unwrap().unwrap();
-    assert_eq!(min_height, original_chain_tip_ref.block_height as i64);
 
     signer::testing::storage::drop_db(db).await;
 }

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -3356,7 +3356,7 @@ impl<const N: usize> ReorgDescription<N> {
 }
 
 /// In these tests we check that [`DbRead::get_signer_utxo`] returns the
-/// expected UTXO when there is a reorg. The test is setup as follows
+/// expected UTXO when there is a reorg. The test is set up as follows
 /// 1. Populate the database with some minimal bitcoin blockchain data.
 /// 2. For each block between the current block and the number-of-blocks to
 ///    generate, create a random number of transactions where we spend the

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -3429,24 +3429,24 @@ async fn minimum_utxo_height_large_sweep_gap() {
         .unwrap()
         .into();
 
-    let mut swept_prevout: model::TxPrevout = fake::Faker.fake_with_rng(&mut rng);
-    swept_prevout.prevout_output_index = 0;
-    swept_prevout.prevout_type = model::TxPrevoutType::SignersInput;
-
     let output_type = model::TxOutputType::SignersOutput;
     let mut swept_output: model::TxOutput = fake::Faker.fake_with_rng(&mut rng);
-    swept_output.txid = swept_prevout.txid;
     swept_output.output_type = output_type;
     swept_output.output_index = 0;
 
+    let mut swept_prevout: model::TxPrevout = fake::Faker.fake_with_rng(&mut rng);
+    swept_prevout.txid = swept_output.txid;
+    swept_prevout.prevout_output_index = 0;
+    swept_prevout.prevout_type = model::TxPrevoutType::SignersInput;
+
     let sweep_tx_model = model::Transaction {
         tx_type: model::TransactionType::SbtcTransaction,
-        txid: swept_prevout.txid.to_byte_array(),
+        txid: swept_output.txid.to_byte_array(),
         tx: Vec::new(),
         block_hash: chain_tip.to_byte_array(),
     };
     let sweep_tx_ref = model::BitcoinTxRef {
-        txid: swept_prevout.txid,
+        txid: swept_output.txid,
         block_hash: chain_tip,
     };
     db.write_transaction(&sweep_tx_model).await.unwrap();
@@ -3462,17 +3462,16 @@ async fn minimum_utxo_height_large_sweep_gap() {
         new_data.write_to(&db).await;
     }
 
-    //
-    let mut swept_prevout2: model::TxPrevout = fake::Faker.fake_with_rng(&mut rng);
-    swept_prevout2.prevout_output_index = 0;
-    swept_prevout2.prevout_type = model::TxPrevoutType::SignersInput;
-    swept_prevout2.prevout_txid = swept_prevout.txid;
-
-    let output_type = model::TxOutputType::SignersOutput;
     let mut swept_output2: model::TxOutput = fake::Faker.fake_with_rng(&mut rng);
-    swept_output2.txid = swept_prevout2.txid;
     swept_output2.output_type = output_type;
     swept_output2.output_index = 0;
+
+    //
+    let mut swept_prevout2: model::TxPrevout = fake::Faker.fake_with_rng(&mut rng);
+    swept_prevout2.txid = swept_output2.txid;
+    swept_prevout2.prevout_output_index = 0;
+    swept_prevout2.prevout_type = model::TxPrevoutType::SignersInput;
+    swept_prevout2.prevout_txid = swept_output.txid;
 
     let sweep_tx_model = model::Transaction {
         tx_type: model::TransactionType::SbtcTransaction,

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -3463,7 +3463,7 @@ async fn minimum_donation_utxo_height_returns_height_of_earliest_donation() {
     // Now that we have the signers' UTXO in the database, we can compute
     // the minimum height. Here it should just be the actual height minus
     // MAX_REORG_BLOCK_COUNT.
-    let min_height = db.minimum_donation_utxo_height().await.unwrap().unwrap() as u64;
+    let min_height = db.minimum_donation_txo_height().await.unwrap().unwrap() as u64;
     assert_eq!(min_height, original_chain_tip_ref.block_height);
 
     // In a few blocks, we use the donation in a sweep transaction, so
@@ -3495,7 +3495,7 @@ async fn minimum_donation_utxo_height_returns_height_of_earliest_donation() {
     db.write_bitcoin_transaction(&sweep_tx_ref).await.unwrap();
     db.write_tx_output(&swept_output).await.unwrap();
 
-    let min_donation_height = db.minimum_donation_utxo_height().await.unwrap().unwrap() as u64;
+    let min_donation_height = db.minimum_donation_txo_height().await.unwrap().unwrap() as u64;
     assert_eq!(min_donation_height, original_chain_tip_ref.block_height);
 
     signer::testing::storage::drop_db(db).await;

--- a/signer/tests/integration/transaction_coordinator.rs
+++ b/signer/tests/integration/transaction_coordinator.rs
@@ -2022,7 +2022,7 @@ async fn test_get_btc_state_with_no_available_sweep_transactions() {
 
     // Get the signer UTXO and assert that it is the one we just wrote.
     let utxo = db
-        .get_signer_utxo(&chain_tip, 10)
+        .get_signer_utxo(&chain_tip)
         .await
         .unwrap()
         .expect("no signer utxo");
@@ -2154,7 +2154,7 @@ async fn test_get_btc_state_with_available_sweep_transactions_and_rbf() {
 
     // Get the signer UTXO and assert that it is the one we just wrote.
     let utxo = db
-        .get_signer_utxo(&chain_tip, 10)
+        .get_signer_utxo(&chain_tip)
         .await
         .unwrap()
         .expect("no signer utxo");

--- a/signer/tests/integration/transaction_signer.rs
+++ b/signer/tests/integration/transaction_signer.rs
@@ -579,7 +579,7 @@ pub async fn assert_should_be_able_to_handle_sbtc_requests() {
     let sbtc_state = signer::bitcoin::utxo::SignerBtcState {
         utxo: ctx
             .get_storage()
-            .get_signer_utxo(&chain_tip, 10000)
+            .get_signer_utxo(&chain_tip)
             .await
             .unwrap()
             .unwrap(),


### PR DESCRIPTION
## Description

Closes #1004 

## Changes

* Add a new table valued function for getting the bitcoin blockchain until a certain height.
* Change the `get_signer_utxo` to not require the context window.

## Testing Information

I added integration tests, but they need comments.

## Checklist:

- [ ] I have performed a self-review of my code
