### PR TITLE
feat: Enable DynamoDB Point in Time Backup

### DIFF
--- a/emily/cdk/lib/emily-stack.ts
+++ b/emily/cdk/lib/emily-stack.ts
@@ -123,6 +123,7 @@ export class EmilyStack extends cdk.Stack {
             },
             removalPolicy: removalPolicy,
             billingMode: dynamodb.BillingMode.PAY_PER_REQUEST, // On-demand provisioning
+            pointInTimeRecovery: true,
         });
 
         const indexName: string = "DepositStatus";
@@ -178,6 +179,7 @@ export class EmilyStack extends cdk.Stack {
             },
             removalPolicy: removalPolicy,
             billingMode: dynamodb.BillingMode.PAY_PER_REQUEST, // On-demand provisioning
+            pointInTimeRecovery: true,
         });
 
         const indexName: string = "WithdrawalStatus";
@@ -231,6 +233,7 @@ export class EmilyStack extends cdk.Stack {
             },
             removalPolicy: removalPolicy,
             billingMode: dynamodb.BillingMode.PAY_PER_REQUEST, // On-demand provisioning
+            pointInTimeRecovery: true,
         });
     }
 
@@ -259,6 +262,7 @@ export class EmilyStack extends cdk.Stack {
             },
             removalPolicy: removalPolicy,
             billingMode: dynamodb.BillingMode.PAY_PER_REQUEST, // On-demand provisioning
+            pointInTimeRecovery: true,
         });
     }
 

--- a/emily/cdk/lib/emily-stack.ts
+++ b/emily/cdk/lib/emily-stack.ts
@@ -37,12 +37,14 @@ export class EmilyStack extends cdk.Stack {
             ? cdk.RemovalPolicy.DESTROY
             : cdk.RemovalPolicy.RETAIN;
 
+        const enablePointInTime: undefined | boolean = EmilyStackUtils.isDevelopmentStack() ? undefined : true;
         const depositTableId: string = 'DepositTable';
         const depositTableName: string = EmilyStackUtils.getResourceName(depositTableId, props);
         const depositTable: dynamodb.Table = this.createOrUpdateDepositTable(
             depositTableId,
             depositTableName,
             persistentResourceRemovalPolicy,
+            enablePointInTime,
         );
 
         const withdrawalTableId: string = 'WithdrawalTable';
@@ -51,6 +53,7 @@ export class EmilyStack extends cdk.Stack {
             withdrawalTableId,
             withdrawalTableName,
             persistentResourceRemovalPolicy,
+            enablePointInTime,
         );
 
         const chainstateTableId: string = 'ChainstateTable';
@@ -59,6 +62,7 @@ export class EmilyStack extends cdk.Stack {
             chainstateTableId,
             chainstateTableName,
             persistentResourceRemovalPolicy,
+            enablePointInTime,
         );
 
         const limitTableId: string = 'LimitTable';
@@ -67,6 +71,7 @@ export class EmilyStack extends cdk.Stack {
             limitTableId,
             limitTableName,
             persistentResourceRemovalPolicy,
+            enablePointInTime,
         );
 
         if (!EmilyStackUtils.isTablesOnly()) {
@@ -110,6 +115,7 @@ export class EmilyStack extends cdk.Stack {
         depositTableId: string,
         depositTableName: string,
         removalPolicy: cdk.RemovalPolicy,
+        enablePointInTime: undefined | boolean,
     ): dynamodb.Table {
         const table: dynamodb.Table = new dynamodb.Table(this, depositTableId, {
             tableName: depositTableName,
@@ -123,7 +129,7 @@ export class EmilyStack extends cdk.Stack {
             },
             removalPolicy: removalPolicy,
             billingMode: dynamodb.BillingMode.PAY_PER_REQUEST, // On-demand provisioning
-            pointInTimeRecovery: EmilyStackUtils.isDevelopmentStack() ? undefined : true,
+            pointInTimeRecovery: enablePointInTime,
         });
 
         const indexName: string = "DepositStatus";
@@ -165,6 +171,7 @@ export class EmilyStack extends cdk.Stack {
         tableId: string,
         tableName: string,
         removalPolicy: cdk.RemovalPolicy,
+        enablePointInTime: undefined | boolean,
     ): dynamodb.Table {
         // Create DynamoDB table to store the messages. Encrypted by default.
         const table: dynamodb.Table = new dynamodb.Table(this, tableId, {
@@ -179,7 +186,7 @@ export class EmilyStack extends cdk.Stack {
             },
             removalPolicy: removalPolicy,
             billingMode: dynamodb.BillingMode.PAY_PER_REQUEST, // On-demand provisioning
-            pointInTimeRecovery: EmilyStackUtils.isDevelopmentStack() ? undefined : true,
+            pointInTimeRecovery: enablePointInTime,
         });
 
         const indexName: string = "WithdrawalStatus";
@@ -219,6 +226,7 @@ export class EmilyStack extends cdk.Stack {
         tableId: string,
         tableName: string,
         removalPolicy: cdk.RemovalPolicy,
+        enablePointInTime: undefined | boolean,
     ): dynamodb.Table {
         // Create DynamoDB table to store the messages. Encrypted by default.
         return new dynamodb.Table(this, tableId, {
@@ -233,7 +241,7 @@ export class EmilyStack extends cdk.Stack {
             },
             removalPolicy: removalPolicy,
             billingMode: dynamodb.BillingMode.PAY_PER_REQUEST, // On-demand provisioning
-            pointInTimeRecovery: EmilyStackUtils.isDevelopmentStack() ? undefined : true,
+            pointInTimeRecovery: enablePointInTime,
         });
     }
 
@@ -248,6 +256,7 @@ export class EmilyStack extends cdk.Stack {
         tableId: string,
         tableName: string,
         removalPolicy: cdk.RemovalPolicy,
+        enablePointInTime: undefined | boolean,
     ): dynamodb.Table {
         // Create DynamoDB table to store the messages. Encrypted by default.
         return new dynamodb.Table(this, tableId, {
@@ -262,7 +271,7 @@ export class EmilyStack extends cdk.Stack {
             },
             removalPolicy: removalPolicy,
             billingMode: dynamodb.BillingMode.PAY_PER_REQUEST, // On-demand provisioning
-            pointInTimeRecovery: EmilyStackUtils.isDevelopmentStack() ? undefined : true,
+            pointInTimeRecovery: enablePointInTime,
         });
     }
 

--- a/emily/cdk/lib/emily-stack.ts
+++ b/emily/cdk/lib/emily-stack.ts
@@ -123,7 +123,7 @@ export class EmilyStack extends cdk.Stack {
             },
             removalPolicy: removalPolicy,
             billingMode: dynamodb.BillingMode.PAY_PER_REQUEST, // On-demand provisioning
-            pointInTimeRecovery: true,
+            pointInTimeRecovery: !EmilyStackUtils.isDevelopmentStack(),
         });
 
         const indexName: string = "DepositStatus";
@@ -179,7 +179,7 @@ export class EmilyStack extends cdk.Stack {
             },
             removalPolicy: removalPolicy,
             billingMode: dynamodb.BillingMode.PAY_PER_REQUEST, // On-demand provisioning
-            pointInTimeRecovery: true,
+            pointInTimeRecovery: !EmilyStackUtils.isDevelopmentStack(),
         });
 
         const indexName: string = "WithdrawalStatus";
@@ -233,7 +233,7 @@ export class EmilyStack extends cdk.Stack {
             },
             removalPolicy: removalPolicy,
             billingMode: dynamodb.BillingMode.PAY_PER_REQUEST, // On-demand provisioning
-            pointInTimeRecovery: true,
+            pointInTimeRecovery: !EmilyStackUtils.isDevelopmentStack(),
         });
     }
 
@@ -262,7 +262,7 @@ export class EmilyStack extends cdk.Stack {
             },
             removalPolicy: removalPolicy,
             billingMode: dynamodb.BillingMode.PAY_PER_REQUEST, // On-demand provisioning
-            pointInTimeRecovery: true,
+            pointInTimeRecovery: !EmilyStackUtils.isDevelopmentStack(),
         });
     }
 

--- a/emily/cdk/lib/emily-stack.ts
+++ b/emily/cdk/lib/emily-stack.ts
@@ -123,7 +123,7 @@ export class EmilyStack extends cdk.Stack {
             },
             removalPolicy: removalPolicy,
             billingMode: dynamodb.BillingMode.PAY_PER_REQUEST, // On-demand provisioning
-            pointInTimeRecovery: !EmilyStackUtils.isDevelopmentStack(),
+            pointInTimeRecovery: false,
         });
 
         const indexName: string = "DepositStatus";
@@ -179,7 +179,7 @@ export class EmilyStack extends cdk.Stack {
             },
             removalPolicy: removalPolicy,
             billingMode: dynamodb.BillingMode.PAY_PER_REQUEST, // On-demand provisioning
-            pointInTimeRecovery: !EmilyStackUtils.isDevelopmentStack(),
+            pointInTimeRecovery: false,
         });
 
         const indexName: string = "WithdrawalStatus";
@@ -233,7 +233,7 @@ export class EmilyStack extends cdk.Stack {
             },
             removalPolicy: removalPolicy,
             billingMode: dynamodb.BillingMode.PAY_PER_REQUEST, // On-demand provisioning
-            pointInTimeRecovery: !EmilyStackUtils.isDevelopmentStack(),
+            pointInTimeRecovery: false,
         });
     }
 
@@ -262,7 +262,7 @@ export class EmilyStack extends cdk.Stack {
             },
             removalPolicy: removalPolicy,
             billingMode: dynamodb.BillingMode.PAY_PER_REQUEST, // On-demand provisioning
-            pointInTimeRecovery: !EmilyStackUtils.isDevelopmentStack(),
+            pointInTimeRecovery: false,
         });
     }
 

--- a/emily/cdk/lib/emily-stack.ts
+++ b/emily/cdk/lib/emily-stack.ts
@@ -37,14 +37,17 @@ export class EmilyStack extends cdk.Stack {
             ? cdk.RemovalPolicy.DESTROY
             : cdk.RemovalPolicy.RETAIN;
 
-        const enablePointInTime: undefined | boolean = EmilyStackUtils.isDevelopmentStack() ? undefined : true;
+        // we should support 'undefine' type because the PIT option is not available in local DynamoDB
+        // and will make it crash
+        const pointInTimeRecovery: undefined | boolean = EmilyStackUtils.isDevelopmentStack() ? undefined : true;
+
         const depositTableId: string = 'DepositTable';
         const depositTableName: string = EmilyStackUtils.getResourceName(depositTableId, props);
         const depositTable: dynamodb.Table = this.createOrUpdateDepositTable(
             depositTableId,
             depositTableName,
             persistentResourceRemovalPolicy,
-            enablePointInTime,
+            pointInTimeRecovery,
         );
 
         const withdrawalTableId: string = 'WithdrawalTable';
@@ -53,7 +56,7 @@ export class EmilyStack extends cdk.Stack {
             withdrawalTableId,
             withdrawalTableName,
             persistentResourceRemovalPolicy,
-            enablePointInTime,
+            pointInTimeRecovery,
         );
 
         const chainstateTableId: string = 'ChainstateTable';
@@ -62,7 +65,7 @@ export class EmilyStack extends cdk.Stack {
             chainstateTableId,
             chainstateTableName,
             persistentResourceRemovalPolicy,
-            enablePointInTime,
+            pointInTimeRecovery,
         );
 
         const limitTableId: string = 'LimitTable';
@@ -71,7 +74,7 @@ export class EmilyStack extends cdk.Stack {
             limitTableId,
             limitTableName,
             persistentResourceRemovalPolicy,
-            enablePointInTime,
+            pointInTimeRecovery,
         );
 
         if (!EmilyStackUtils.isTablesOnly()) {
@@ -115,7 +118,7 @@ export class EmilyStack extends cdk.Stack {
         depositTableId: string,
         depositTableName: string,
         removalPolicy: cdk.RemovalPolicy,
-        enablePointInTime: undefined | boolean,
+        pointInTimeRecovery: undefined | boolean,
     ): dynamodb.Table {
         const table: dynamodb.Table = new dynamodb.Table(this, depositTableId, {
             tableName: depositTableName,
@@ -129,7 +132,7 @@ export class EmilyStack extends cdk.Stack {
             },
             removalPolicy: removalPolicy,
             billingMode: dynamodb.BillingMode.PAY_PER_REQUEST, // On-demand provisioning
-            pointInTimeRecovery: enablePointInTime,
+            pointInTimeRecovery: pointInTimeRecovery,
         });
 
         const indexName: string = "DepositStatus";
@@ -171,7 +174,7 @@ export class EmilyStack extends cdk.Stack {
         tableId: string,
         tableName: string,
         removalPolicy: cdk.RemovalPolicy,
-        enablePointInTime: undefined | boolean,
+        pointInTimeRecovery: undefined | boolean,
     ): dynamodb.Table {
         // Create DynamoDB table to store the messages. Encrypted by default.
         const table: dynamodb.Table = new dynamodb.Table(this, tableId, {
@@ -186,7 +189,7 @@ export class EmilyStack extends cdk.Stack {
             },
             removalPolicy: removalPolicy,
             billingMode: dynamodb.BillingMode.PAY_PER_REQUEST, // On-demand provisioning
-            pointInTimeRecovery: enablePointInTime,
+            pointInTimeRecovery: pointInTimeRecovery,
         });
 
         const indexName: string = "WithdrawalStatus";
@@ -226,7 +229,7 @@ export class EmilyStack extends cdk.Stack {
         tableId: string,
         tableName: string,
         removalPolicy: cdk.RemovalPolicy,
-        enablePointInTime: undefined | boolean,
+        pointInTimeRecovery: undefined | boolean,
     ): dynamodb.Table {
         // Create DynamoDB table to store the messages. Encrypted by default.
         return new dynamodb.Table(this, tableId, {
@@ -241,7 +244,7 @@ export class EmilyStack extends cdk.Stack {
             },
             removalPolicy: removalPolicy,
             billingMode: dynamodb.BillingMode.PAY_PER_REQUEST, // On-demand provisioning
-            pointInTimeRecovery: enablePointInTime,
+            pointInTimeRecovery: pointInTimeRecovery,
         });
     }
 
@@ -256,7 +259,7 @@ export class EmilyStack extends cdk.Stack {
         tableId: string,
         tableName: string,
         removalPolicy: cdk.RemovalPolicy,
-        enablePointInTime: undefined | boolean,
+        pointInTimeRecovery: undefined | boolean,
     ): dynamodb.Table {
         // Create DynamoDB table to store the messages. Encrypted by default.
         return new dynamodb.Table(this, tableId, {
@@ -271,7 +274,7 @@ export class EmilyStack extends cdk.Stack {
             },
             removalPolicy: removalPolicy,
             billingMode: dynamodb.BillingMode.PAY_PER_REQUEST, // On-demand provisioning
-            pointInTimeRecovery: enablePointInTime,
+            pointInTimeRecovery: pointInTimeRecovery,
         });
     }
 

--- a/emily/cdk/lib/emily-stack.ts
+++ b/emily/cdk/lib/emily-stack.ts
@@ -123,7 +123,7 @@ export class EmilyStack extends cdk.Stack {
             },
             removalPolicy: removalPolicy,
             billingMode: dynamodb.BillingMode.PAY_PER_REQUEST, // On-demand provisioning
-            pointInTimeRecovery: false,
+            pointInTimeRecovery: EmilyStackUtils.isDevelopmentStack() ? undefined : true,
         });
 
         const indexName: string = "DepositStatus";
@@ -179,7 +179,7 @@ export class EmilyStack extends cdk.Stack {
             },
             removalPolicy: removalPolicy,
             billingMode: dynamodb.BillingMode.PAY_PER_REQUEST, // On-demand provisioning
-            pointInTimeRecovery: false,
+            pointInTimeRecovery: EmilyStackUtils.isDevelopmentStack() ? undefined : true,
         });
 
         const indexName: string = "WithdrawalStatus";
@@ -233,7 +233,7 @@ export class EmilyStack extends cdk.Stack {
             },
             removalPolicy: removalPolicy,
             billingMode: dynamodb.BillingMode.PAY_PER_REQUEST, // On-demand provisioning
-            pointInTimeRecovery: false,
+            pointInTimeRecovery: EmilyStackUtils.isDevelopmentStack() ? undefined : true,
         });
     }
 
@@ -262,7 +262,7 @@ export class EmilyStack extends cdk.Stack {
             },
             removalPolicy: removalPolicy,
             billingMode: dynamodb.BillingMode.PAY_PER_REQUEST, // On-demand provisioning
-            pointInTimeRecovery: false,
+            pointInTimeRecovery: EmilyStackUtils.isDevelopmentStack() ? undefined : true,
         });
     }
 


### PR DESCRIPTION
## Description

Enable Point in Time Backup for the production and test environments, and disable it for local and dev environments. 
The local env is not supported so the variable is configured to undefined to omit the parameter in the Cloudformation template.

Closes: https://github.com/bitcoinl2labs/sbtc.testnet/issues/12

## Changes

- Add DynamoDB Point in Time Backup

## Testing Information

Deployed in Dev

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
