### PR TITLE
chore: Change Reprocessing state  to Pending

### DIFF
--- a/emily/handler/src/database/entries/deposit.rs
+++ b/emily/handler/src/database/entries/deposit.rs
@@ -171,10 +171,11 @@ impl DepositEntry {
                 || ((chainstate.stacks_block_height == event.stacks_block_height)
                     && (chainstate.stacks_block_hash == event.stacks_block_hash))
         });
-        // If the history is empty add a reprocessing event.
+        // If the history is empty, just say that the deposit is pending again where its
+        // latest update is the point at which the reorg happened.
         if self.history.is_empty() {
             self.history = vec![DepositEvent {
-                status: StatusEntry::Reprocessing,
+                status: StatusEntry::Pending,
                 message: "Reprocessing deposit status after reorg.".to_string(),
                 stacks_block_height: chainstate.stacks_block_height,
                 stacks_block_hash: chainstate.stacks_block_hash.clone(),

--- a/emily/handler/src/database/entries/withdrawal.rs
+++ b/emily/handler/src/database/entries/withdrawal.rs
@@ -129,10 +129,11 @@ impl WithdrawalEntry {
                 || ((chainstate.stacks_block_height == event.stacks_block_height)
                     && (chainstate.stacks_block_hash == event.stacks_block_hash))
         });
-        // If the history is empty add a reprocessing event.
+        // If the history is empty, just say that the withdrawal is pending again where its
+        // latest update is the point at which the reorg happened.
         if self.history.is_empty() {
             self.history = vec![WithdrawalEvent {
-                status: StatusEntry::Reprocessing,
+                status: StatusEntry::Pending,
                 message: "Reprocessing withdrawal status after reorg.".to_string(),
                 stacks_block_height: chainstate.stacks_block_height,
                 stacks_block_hash: chainstate.stacks_block_hash.clone(),


### PR DESCRIPTION
## Description

Closes: #1073

## Changes

To simplify the design of what happens during a reorg, this PR is to put operations into the pending status instead of the reprocessing status when a reorg causes a deposit to have been created during a non-canonical fork.

Please note that I've left in the reprocessing status so that if any tables have it there aren't any errors, but this PR means that there won't be any more deposits with this status created.

## Testing Information

Integration tests.

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
