### PR TITLE
chore: remove unused `nakamoto_start_height` config

### DIFF
--- a/docker/prodlike/config/signer-config.toml
+++ b/docker/prodlike/config/signer-config.toml
@@ -85,10 +85,6 @@ block_hash_stream_endpoints = [
 # making requests.
 endpoints = []
 
-# This is the start height of the first EPOCH 3.0 block on the stacks
-# blockchain.
-nakamoto_start_height = 867867
-
 # !! ==============================================================================
 # !! Signer Configuration
 # !! ==============================================================================

--- a/docker/sbtc/signer/signer-config.toml
+++ b/docker/sbtc/signer/signer-config.toml
@@ -71,10 +71,6 @@ block_hash_stream_endpoints = [
 # making requests.
 endpoints = ["http://stacks-node:20443"]
 
-# This is the start height of the first EPOCH 3.0 block on the stacks
-# blockchain.
-nakamoto_start_height = 31
-
 # !! ==============================================================================
 # !! Signer Configuration
 # !! ==============================================================================

--- a/signer/src/config/default.toml
+++ b/signer/src/config/default.toml
@@ -74,11 +74,6 @@ block_hash_stream_endpoints = [
 # making requests.
 endpoints = ["http://localhost:20443"]
 
-# This is the start height of the first EPOCH 3.0 block on the stacks
-# blockchain.
-# TODO(715): Update to 867867
-nakamoto_start_height = 31
-
 # !! ==============================================================================
 # !! Signer Configuration
 # !! ==============================================================================

--- a/signer/src/config/mod.rs
+++ b/signer/src/config/mod.rs
@@ -405,9 +405,6 @@ pub struct StacksConfig {
     /// The endpoint to use when making requests to a stacks node.
     #[serde(deserialize_with = "url_deserializer_vec")]
     pub endpoints: Vec<url::Url>,
-    /// This is the start height of the first EPOCH 3.0 block on the Stacks
-    /// blockchain.
-    pub nakamoto_start_height: u64,
 }
 
 impl Validatable for StacksConfig {
@@ -415,12 +412,6 @@ impl Validatable for StacksConfig {
         if self.endpoints.is_empty() {
             return Err(ConfigError::Message(
                 "[stacks] Endpoints cannot be empty".to_string(),
-            ));
-        }
-
-        if self.nakamoto_start_height == 0 {
-            return Err(ConfigError::Message(
-                "[stacks] Nakamoto start height must be greater than zero".to_string(),
             ));
         }
 

--- a/signer/tests/integration/block_observer.rs
+++ b/signer/tests/integration/block_observer.rs
@@ -251,12 +251,7 @@ async fn link_blocks() {
     let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
     let db = testing::storage::new_test_database(db_num, true).await;
 
-    let nakamoto_start_height = 30;
-    let stacks_client = StacksClient::new(
-        Url::parse("http://localhost:20443").unwrap(),
-        nakamoto_start_height,
-    )
-    .unwrap();
+    let stacks_client = StacksClient::new(Url::parse("http://localhost:20443").unwrap()).unwrap();
 
     let mut ctx = TestContext::builder()
         .with_storage(db.clone())


### PR DESCRIPTION
## Description

Closes: #?

## Changes

Remove unused `nakamoto_start_height` config -- we already use pox info for this, the config was probably a leftover. This is *not* a breaking-local since extra entries in toml are simply ignored.

## Testing Information

Devenv demo script run okay.

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
