### PR TITLE
feat: api key is optional in all api headers

### DIFF
--- a/emily/handler/src/api/handlers/deposit.rs
+++ b/emily/handler/src/api/handlers/deposit.rs
@@ -318,14 +318,14 @@ fn scripts_to_resource_parameters(
 #[instrument(skip(context))]
 pub async fn update_deposits(
     context: EmilyContext,
-    api_key: String,
+    maybe_api_key: Option<String>,
     body: UpdateDepositsRequestBody,
 ) -> impl warp::reply::Reply {
     debug!("In update deposits");
     // Internal handler so `?` can be used correctly while still returning a reply.
     async fn handler(
         context: EmilyContext,
-        api_key: String,
+        maybe_api_key: Option<String>,
         body: UpdateDepositsRequestBody,
     ) -> Result<impl warp::reply::Reply, Error> {
         // Get the api state and error if the api state is claimed by a reorg.
@@ -341,7 +341,12 @@ pub async fn update_deposits(
         // Infer the new chainstates that would come from these deposit updates and then
         // attempt to update the chainstates.
         let inferred_chainstates = validated_request.inferred_chainstates()?;
-        let can_reorg = context.settings.trusted_reorg_api_key == api_key;
+
+        // Get whether the API key is provided and allowed to initiate a reorg.
+        let can_reorg = maybe_api_key
+            .map(|api_key| context.settings.trusted_reorg_api_key == api_key)
+            .unwrap_or(false);
+
         for chainstate in inferred_chainstates {
             // TODO(TBD): Determine what happens if this occurs in multiple lambda
             // instances at once.
@@ -373,7 +378,7 @@ pub async fn update_deposits(
         Ok(with_status(json(&response), StatusCode::CREATED))
     }
     // Handle and respond.
-    handler(context, api_key, body)
+    handler(context, maybe_api_key, body)
         .await
         .map_or_else(Reply::into_response, Reply::into_response)
 }

--- a/emily/handler/src/api/routes/chainstate.rs
+++ b/emily/handler/src/api/routes/chainstate.rs
@@ -46,7 +46,7 @@ fn set_chainstate(
         .map(move || context.clone())
         .and(warp::path!("chainstate"))
         .and(warp::post())
-        .and(warp::header::<String>("x-api-key"))
+        .and(warp::header::optional::<String>("x-api-key"))
         .and(warp::body::json())
         .then(handlers::chainstate::set_chainstate)
 }
@@ -59,7 +59,7 @@ fn update_chainstate(
         .map(move || context.clone())
         .and(warp::path!("chainstate"))
         .and(warp::put())
-        .and(warp::header::<String>("x-api-key"))
+        .and(warp::header::optional::<String>("x-api-key"))
         .and(warp::body::json())
         .then(handlers::chainstate::update_chainstate)
 }

--- a/emily/handler/src/api/routes/deposit.rs
+++ b/emily/handler/src/api/routes/deposit.rs
@@ -71,7 +71,7 @@ fn update_deposits(
         .map(move || context.clone())
         .and(warp::path!("deposit"))
         .and(warp::put())
-        .and(warp::header::<String>("x-api-key"))
+        .and(warp::header::optional::<String>("x-api-key"))
         .and(warp::body::json())
         .then(handlers::deposit::update_deposits)
 }

--- a/emily/handler/src/api/routes/withdrawal.rs
+++ b/emily/handler/src/api/routes/withdrawal.rs
@@ -58,7 +58,7 @@ fn update_withdrawals(
         .map(move || context.clone())
         .and(warp::path("withdrawal"))
         .and(warp::put())
-        .and(warp::header::<String>("x-api-key"))
+        .and(warp::header::optional::<String>("x-api-key"))
         .and(warp::body::json())
         .then(handlers::withdrawal::update_withdrawals)
 }


### PR DESCRIPTION
## Description

Closes: #N/A

## Changes

Makes the api key an optional header value in endpoints that require the api key to be a specific value in order to initiate a reorg.

## Testing Information

## Checklist:

- [x] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
