### PR TITLE
feat: add bitcoin block start height to the signers

### DIFF
--- a/docker/sbtc/signer/signer-config.toml
+++ b/docker/sbtc/signer/signer-config.toml
@@ -148,7 +148,7 @@ dkg_begin_pause = 2
 # node if not present.
 #
 # Required: false
-# Environment: SIGNER_SIGNER__sbtc_bitcoin_start_height
+# Environment: SIGNER_SIGNER__SBTC_BITCOIN_START_HEIGHT
 # sbtc_bitcoin_start_height = 231
 
 # When defined, this field sets the scrape endpoint as an IPv4 or IPv6

--- a/docker/sbtc/signer/signer-config.toml
+++ b/docker/sbtc/signer/signer-config.toml
@@ -104,12 +104,6 @@ network = "regtest"
 # TODO(715): Add default delay (15 seconds? see #701)
 bitcoin_processing_delay = 3
 
-# The number of blocks back the block observer should look for unprocessed
-# blocks before proceeding.
-# Required: true
-# Environment: SIGNER_SIGNER__BITCOIN_BLOCK_HORIZON
-bitcoin_block_horizon = 1500
-
 # How many bitcoin blocks back from the chain tip the signer will look for
 # requests. Must be strictly positive.
 #

--- a/docker/sbtc/signer/signer-config.toml
+++ b/docker/sbtc/signer/signer-config.toml
@@ -148,8 +148,8 @@ dkg_begin_pause = 2
 # node if not present.
 #
 # Required: false
-# Environment: SIGNER_SIGNER__SBTC_START_HEIGHT
-# sbtc_start_height = 231
+# Environment: SIGNER_SIGNER__sbtc_bitcoin_start_height
+# sbtc_bitcoin_start_height = 231
 
 # When defined, this field sets the scrape endpoint as an IPv4 or IPv6
 # socket address for exporting metrics for Prometheus.

--- a/docker/sbtc/signer/signer-config.toml
+++ b/docker/sbtc/signer/signer-config.toml
@@ -142,6 +142,22 @@ bitcoin_processing_delay = 3
 # Environment: SIGNER_SIGNER__DKG_BEGIN_PAUSE
 dkg_begin_pause = 2
 
+# The minimum bitcoin block height for which the sbtc signers will backfill
+# bitcoin blocks to. The signers may not work if operated before this
+# height. Defaults to the Nakamoto start height returned from the stacks
+# node if not present.
+#
+# Required: false
+# Environment: SIGNER_SIGNER__SBTC_START_HEIGHT
+# sbtc_start_height = 231
+
+# When defined, this field sets the scrape endpoint as an IPv4 or IPv6
+# socket address for exporting metrics for Prometheus.
+#
+# Required: false
+# Environment: SIGNER_SIGNER__PROMETHEUS_EXPORTER_ENDPOINT
+# prometheus_exporter_endpoint = "[::]:9184"
+
 # The address that deployed the sbtc smart contracts.
 #
 # Required: true

--- a/docker/testnet/config/signer-config.toml.sample
+++ b/docker/testnet/config/signer-config.toml.sample
@@ -56,7 +56,6 @@ bootstrap_signing_set = [
 bootstrap_signatures_required = 11
 
 bitcoin_processing_delay = 30
-bitcoin_block_horizon = 3000
 
 [signer.event_observer]
 bind = "0.0.0.0:8801"

--- a/signer/src/bitcoin/client.rs
+++ b/signer/src/bitcoin/client.rs
@@ -21,6 +21,7 @@ use url::Url;
 
 use crate::{error::Error, util::ApiFallbackClient};
 
+use super::rpc::BitcoinBlockHeader;
 use super::rpc::BitcoinCoreClient;
 use super::rpc::BitcoinTxInfo;
 use super::rpc::GetTxResponse;
@@ -53,7 +54,7 @@ impl BitcoinInteract for ApiFallbackClient<BitcoinCoreClient> {
     async fn get_block_header(
         &self,
         block_hash: &BlockHash,
-    ) -> Result<Option<bitcoin::block::Header>, Error> {
+    ) -> Result<Option<BitcoinBlockHeader>, Error> {
         self.exec(|client, _| BitcoinInteract::get_block_header(client, block_hash))
             .await
     }

--- a/signer/src/bitcoin/client.rs
+++ b/signer/src/bitcoin/client.rs
@@ -50,6 +50,14 @@ impl BitcoinInteract for ApiFallbackClient<BitcoinCoreClient> {
             .await
     }
 
+    async fn get_block_header(
+        &self,
+        block_hash: &BlockHash,
+    ) -> Result<Option<bitcoin::block::Header>, Error> {
+        self.exec(|client, _| BitcoinInteract::get_block_header(client, block_hash))
+            .await
+    }
+
     async fn get_tx(&self, txid: &Txid) -> Result<Option<GetTxResponse>, Error> {
         self.exec(|client, _| BitcoinInteract::get_tx(client, txid))
             .await

--- a/signer/src/bitcoin/mod.rs
+++ b/signer/src/bitcoin/mod.rs
@@ -2,12 +2,12 @@
 
 use std::future::Future;
 
-use bitcoin::block::Header;
 use bitcoin::BlockHash;
 use bitcoin::Txid;
 
 use bitcoincore_rpc_json::GetMempoolEntryResult;
 use bitcoincore_rpc_json::GetTxOutResult;
+use rpc::BitcoinBlockHeader;
 use rpc::BitcoinTxInfo;
 use rpc::GetTxResponse;
 
@@ -57,7 +57,7 @@ pub trait BitcoinInteract: Sync + Send {
     fn get_block_header(
         &self,
         block_hash: &BlockHash,
-    ) -> impl Future<Output = Result<Option<Header>, Error>> + Send;
+    ) -> impl Future<Output = Result<Option<BitcoinBlockHeader>, Error>> + Send;
 
     /// get tx
     fn get_tx(

--- a/signer/src/bitcoin/mod.rs
+++ b/signer/src/bitcoin/mod.rs
@@ -2,6 +2,7 @@
 
 use std::future::Future;
 
+use bitcoin::block::Header;
 use bitcoin::BlockHash;
 use bitcoin::Txid;
 
@@ -51,6 +52,12 @@ pub trait BitcoinInteract: Sync + Send {
         &self,
         block_hash: &BlockHash,
     ) -> impl Future<Output = Result<Option<bitcoin::Block>, Error>> + Send;
+
+    /// Fer the header of the block identified by the given block hash.
+    fn get_block_header(
+        &self,
+        block_hash: &BlockHash,
+    ) -> impl Future<Output = Result<Option<Header>, Error>> + Send;
 
     /// get tx
     fn get_tx(

--- a/signer/src/bitcoin/mod.rs
+++ b/signer/src/bitcoin/mod.rs
@@ -53,7 +53,7 @@ pub trait BitcoinInteract: Sync + Send {
         block_hash: &BlockHash,
     ) -> impl Future<Output = Result<Option<bitcoin::Block>, Error>> + Send;
 
-    /// Fer the header of the block identified by the given block hash.
+    /// Get the header of the block identified by the given block hash.
     fn get_block_header(
         &self,
         block_hash: &BlockHash,

--- a/signer/src/bitcoin/rpc.rs
+++ b/signer/src/bitcoin/rpc.rs
@@ -231,7 +231,8 @@ pub struct PrevoutScriptPubKey {
     pub script: ScriptBuf,
 }
 
-/// The response for a getblockheader RPC call to bitcoin-core.
+/// The response for a `getblockheader` RPC call to bitcoin-core with
+/// verbose set to `true`.
 ///
 /// Some fields from the actual response have been omitted because they
 /// were unneeded at the time.
@@ -244,7 +245,7 @@ pub struct BitcoinBlockHeader {
     pub height: u64,
     /// The time value in the block header.
     pub time: u64,
-    /// The block hash of this blocks parent block/
+    /// The block hash of this blocks parent block.
     #[serde(rename = "previousblockhash")]
     pub previous_block_hash: BlockHash,
 }

--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -273,7 +273,7 @@ impl<C: Context, B> BlockObserver<C, B> {
     /// This function does two things:
     /// 1. Set the `sbtc_start_height` if it has not been set already. If
     ///    it is not set, then we fetch the stacks nakamoto start height
-    ///    from stacks-core and use that value. 
+    ///    from stacks-core and use that value.
     /// 2. Continually fetches block headers from bitcoin-core until it
     ///    encounters a known block header or if the height of the block is
     ///    less than or equal to the `sbtc_start_height`.

--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -264,9 +264,9 @@ impl<C: Context, B> BlockObserver<C, B> {
 
     /// Find the parent blocks from the given block that are also missing
     /// from our database.
-    /// 
+    ///
     /// # Notes
-    /// 
+    ///
     /// This function will continually fetch block headers from
     /// bitcoin-core until it encounters a known block hash or if the
     /// height of the block associated with the header is less than or
@@ -512,7 +512,7 @@ impl<C: Context, B> BlockObserver<C, B> {
             .get_bitcoin_client()
             .get_block(&block_header.hash)
             .await?
-            .ok_or(Error::BitcoinCoreMissingBlock(block_header.hash.into()))?;
+            .ok_or(Error::BitcoinCoreMissingBlock(block_header.hash))?;
         let db_block = model::BitcoinBlock::from(&block);
 
         self.context

--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -612,11 +612,13 @@ mod tests {
         let mut rng = rand::rngs::StdRng::seed_from_u64(46);
         let storage = storage::in_memory::Store::new_shared();
         let test_harness = TestHarness::generate(&mut rng, 20, 0..5);
+        let min_height = test_harness.min_block_height();
         let ctx = TestContext::builder()
             .with_storage(storage.clone())
             .with_stacks_client(test_harness.clone())
             .with_emily_client(test_harness.clone())
             .with_bitcoin_client(test_harness.clone())
+            .modify_settings(|settings| settings.signer.sbtc_bitcoin_start_height = min_height)
             .build();
 
         // There must be at least one signal receiver alive when the block observer
@@ -745,6 +747,7 @@ mod tests {
         // Add the deposit requests to the pending deposits which
         // would be returned by Emily.
         test_harness.add_pending_deposits(&[deposit_request0, deposit_request1, deposit_request2]);
+        let min_height = test_harness.min_block_height();
 
         // Now we finish setting up the block observer.
         let storage = storage::in_memory::Store::new_shared();
@@ -753,6 +756,7 @@ mod tests {
             .with_stacks_client(test_harness.clone())
             .with_emily_client(test_harness.clone())
             .with_bitcoin_client(test_harness.clone())
+            .modify_settings(|settings| settings.signer.sbtc_bitcoin_start_height = min_height)
             .build();
 
         let block_observer = BlockObserver {
@@ -829,6 +833,7 @@ mod tests {
         // would be returned by Emily.
         test_harness.add_pending_deposit(deposit_request0);
 
+        let min_height = test_harness.min_block_height();
         // Now we finish setting up the block observer.
         let storage = storage::in_memory::Store::new_shared();
         let ctx = TestContext::builder()
@@ -836,6 +841,7 @@ mod tests {
             .with_stacks_client(test_harness.clone())
             .with_emily_client(test_harness.clone())
             .with_bitcoin_client(test_harness.clone())
+            .modify_settings(|settings| settings.signer.sbtc_bitcoin_start_height = min_height)
             .build();
 
         let block_observer = BlockObserver {

--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -56,8 +56,6 @@ pub struct BlockObserver<Context, BlockHashStream> {
     pub context: Context,
     /// Stream of blocks from the block notifier
     pub bitcoin_blocks: BlockHashStream,
-    /// How far back in time the observer should look
-    pub horizon: u32,
 }
 
 /// A full "deposit", containing the bitcoin transaction and a fully
@@ -606,7 +604,6 @@ mod tests {
         let block_observer = BlockObserver {
             context: ctx.clone(),
             bitcoin_blocks: block_hash_stream,
-            horizon: 1,
         };
 
         let handle = tokio::spawn(block_observer.run());
@@ -738,7 +735,6 @@ mod tests {
         let block_observer = BlockObserver {
             context: ctx,
             bitcoin_blocks: (),
-            horizon: 1,
         };
 
         {
@@ -822,7 +818,6 @@ mod tests {
         let block_observer = BlockObserver {
             context: ctx,
             bitcoin_blocks: (),
-            horizon: 1,
         };
 
         block_observer.load_latest_deposit_requests().await.unwrap();
@@ -924,7 +919,6 @@ mod tests {
         let block_observer = BlockObserver {
             context: ctx,
             bitcoin_blocks: (),
-            horizon: 1,
         };
 
         // First we try extracting the transactions from a block that does

--- a/signer/src/config/default.toml
+++ b/signer/src/config/default.toml
@@ -177,8 +177,8 @@ dkg_max_duration = 120
 # node if not present.
 #
 # Required: false
-# Environment: SIGNER_SIGNER__SBTC_START_HEIGHT
-sbtc_start_height = 101
+# Environment: SIGNER_SIGNER__sbtc_bitcoin_start_height
+sbtc_bitcoin_start_height = 101
 
 # The amount of time, in seconds, the signer should pause for after
 # receiving a DKG begin message before relaying to give the other signers.

--- a/signer/src/config/default.toml
+++ b/signer/src/config/default.toml
@@ -177,7 +177,7 @@ dkg_max_duration = 120
 # node if not present.
 #
 # Required: false
-# Environment: SIGNER_SIGNER__sbtc_bitcoin_start_height
+# Environment: SIGNER_SIGNER__SBTC_BITCOIN_START_HEIGHT
 sbtc_bitcoin_start_height = 101
 
 # The amount of time, in seconds, the signer should pause for after

--- a/signer/src/config/default.toml
+++ b/signer/src/config/default.toml
@@ -140,12 +140,6 @@ bootstrap_signatures_required = 2
 # TODO(715): Add default delay (15 seconds? see #701)
 bitcoin_processing_delay = 0
 
-# The number of blocks back the block observer should look for unprocessed
-# blocks before proceeding.
-# Required: true
-# Environment: SIGNER_SIGNER__BITCOIN_BLOCK_HORIZON
-bitcoin_block_horizon = 1500
-
 # How many bitcoin blocks back from the chain tip the signer will look for
 # requests. Must be strictly positive.
 #

--- a/signer/src/config/default.toml
+++ b/signer/src/config/default.toml
@@ -184,7 +184,7 @@ dkg_max_duration = 120
 #
 # Required: false
 # Environment: SIGNER_SIGNER__SBTC_START_HEIGHT
-# sbtc_start_height = 232
+sbtc_start_height = 101
 
 # The amount of time, in seconds, the signer should pause for after
 # receiving a DKG begin message before relaying to give the other signers.

--- a/signer/src/config/default.toml
+++ b/signer/src/config/default.toml
@@ -177,6 +177,15 @@ bitcoin_presign_request_max_duration = 30
 # Environment: SIGNER_SIGNER__DKG_MAX_DURATION
 dkg_max_duration = 120
 
+# The minimum bitcoin block height for which the sbtc signers will backfill
+# bitcoin blocks to. The signers may not work if operated before this
+# height. Defaults to the Nakamoto start height returned from the stacks
+# node if not present.
+#
+# Required: false
+# Environment: SIGNER_SIGNER__SBTC_START_HEIGHT
+# sbtc_start_height = 232
+
 # The amount of time, in seconds, the signer should pause for after
 # receiving a DKG begin message before relaying to give the other signers.
 #

--- a/signer/src/config/mod.rs
+++ b/signer/src/config/mod.rs
@@ -243,7 +243,7 @@ pub struct SignerConfig {
     pub dkg_begin_pause: Option<u64>,
     /// The minimum bitcoin block height for which the sbtc signers will
     /// backfill bitcoin blocks to.
-    pub sbtc_start_height: Option<u64>,
+    pub sbtc_bitcoin_start_height: Option<u64>,
 }
 
 impl Validatable for SignerConfig {
@@ -491,7 +491,7 @@ mod tests {
         );
         assert!(!settings.signer.bootstrap_signing_set.is_empty());
         assert!(settings.signer.dkg_begin_pause.is_none());
-        assert_eq!(settings.signer.sbtc_start_height, Some(101));
+        assert_eq!(settings.signer.sbtc_bitcoin_start_height, Some(101));
         assert_eq!(settings.signer.bootstrap_signatures_required, 2);
         assert_eq!(settings.signer.context_window, 1000);
         assert!(settings.signer.prometheus_exporter_endpoint.is_none());
@@ -627,13 +627,13 @@ mod tests {
     }
 
     #[test]
-    fn sbtc_start_height() {
+    fn sbtc_bitcoin_start_height() {
         clear_env();
 
-        std::env::set_var("SIGNER_SIGNER__SBTC_START_HEIGHT", "12345");
+        std::env::set_var("SIGNER_SIGNER__SBTC_BITCOIN_START_HEIGHT", "12345");
 
         let settings = Settings::new_from_default_config().unwrap();
-        let height = settings.signer.sbtc_start_height.unwrap();
+        let height = settings.signer.sbtc_bitcoin_start_height.unwrap();
 
         assert_eq!(height, 12345);
     }

--- a/signer/src/config/mod.rs
+++ b/signer/src/config/mod.rs
@@ -491,7 +491,7 @@ mod tests {
         );
         assert!(!settings.signer.bootstrap_signing_set.is_empty());
         assert!(settings.signer.dkg_begin_pause.is_none());
-        assert!(settings.signer.sbtc_start_height.is_none());
+        assert_eq!(settings.signer.sbtc_start_height, Some(101));
         assert_eq!(settings.signer.bootstrap_signatures_required, 2);
         assert_eq!(settings.signer.context_window, 1000);
         assert!(settings.signer.prometheus_exporter_endpoint.is_none());

--- a/signer/src/config/mod.rs
+++ b/signer/src/config/mod.rs
@@ -237,9 +237,6 @@ pub struct SignerConfig {
     /// coordinator will time out and return an error.
     #[serde(deserialize_with = "duration_seconds_deserializer")]
     pub dkg_max_duration: std::time::Duration,
-    /// The number of blocks back the block observer should look for
-    /// unprocessed blocks before proceeding.
-    pub bitcoin_block_horizon: u32,
     /// The amount of time, in seconds, the signer should pause for after
     /// receiving a DKG begin message before relaying to give the other
     /// signers time to catch up.
@@ -496,7 +493,6 @@ mod tests {
         assert!(settings.signer.dkg_begin_pause.is_none());
         assert!(settings.signer.sbtc_start_height.is_none());
         assert_eq!(settings.signer.bootstrap_signatures_required, 2);
-        assert_eq!(settings.signer.bitcoin_block_horizon, 1500);
         assert_eq!(settings.signer.context_window, 1000);
         assert!(settings.signer.prometheus_exporter_endpoint.is_none());
         assert_eq!(
@@ -860,15 +856,6 @@ mod tests {
             settings.unwrap_err(),
             ConfigError::Message(msg) if msg == Error::DecodeHexBytes(hex_err).to_string()
         ));
-    }
-
-    #[test]
-    fn horizon_parameter_works() {
-        clear_env();
-
-        std::env::set_var("SIGNER_SIGNER__BITCOIN_BLOCK_HORIZON", "1234");
-        let config = Settings::new_from_default_config().unwrap();
-        assert_eq!(config.signer.bitcoin_block_horizon, 1234);
     }
 
     #[test]

--- a/signer/src/config/mod.rs
+++ b/signer/src/config/mod.rs
@@ -244,6 +244,9 @@ pub struct SignerConfig {
     /// receiving a DKG begin message before relaying to give the other
     /// signers time to catch up.
     pub dkg_begin_pause: Option<u64>,
+    /// The minimum bitcoin block height for which the sbtc signers will
+    /// backfill bitcoin blocks to.
+    pub sbtc_start_height: Option<u64>,
 }
 
 impl Validatable for SignerConfig {
@@ -491,6 +494,7 @@ mod tests {
         );
         assert!(!settings.signer.bootstrap_signing_set.is_empty());
         assert!(settings.signer.dkg_begin_pause.is_none());
+        assert!(settings.signer.sbtc_start_height.is_none());
         assert_eq!(settings.signer.bootstrap_signatures_required, 2);
         assert_eq!(settings.signer.bitcoin_block_horizon, 1500);
         assert_eq!(settings.signer.context_window, 1000);
@@ -624,6 +628,18 @@ mod tests {
 
         let settings = Settings::new_from_default_config().unwrap();
         assert_eq!(settings.signer.network, NetworkKind::Regtest);
+    }
+
+    #[test]
+    fn sbtc_start_height() {
+        clear_env();
+
+        std::env::set_var("SIGNER_SIGNER__SBTC_START_HEIGHT", "12345");
+
+        let settings = Settings::new_from_default_config().unwrap();
+        let height = settings.signer.sbtc_start_height.unwrap();
+
+        assert_eq!(height, 12345);
     }
 
     #[test]

--- a/signer/src/context/signer_context.rs
+++ b/signer/src/context/signer_context.rs
@@ -86,10 +86,14 @@ where
         // messages into a local VecDequeue and process them in their own time.
         let (signal_tx, _) = tokio::sync::broadcast::channel(SIGNER_CHANNEL_CAPACITY);
         let (term_tx, _) = tokio::sync::watch::channel(false);
+        let state = SignerState::default();
+        if let Some(height) = config.signer.sbtc_start_height {
+            state.set_sbtc_start_height(height);
+        }
 
         Self {
             config,
-            state: Default::default(),
+            state: Arc::new(state),
             signal_tx,
             term_tx,
             storage: db,

--- a/signer/src/context/signer_context.rs
+++ b/signer/src/context/signer_context.rs
@@ -87,8 +87,8 @@ where
         let (signal_tx, _) = tokio::sync::broadcast::channel(SIGNER_CHANNEL_CAPACITY);
         let (term_tx, _) = tokio::sync::watch::channel(false);
         let state = SignerState::default();
-        if let Some(height) = config.signer.sbtc_start_height {
-            state.set_sbtc_start_height(height);
+        if let Some(height) = config.signer.sbtc_bitcoin_start_height {
+            state.set_sbtc_bitcoin_start_height(height);
         }
 
         Self {

--- a/signer/src/context/signer_state.rs
+++ b/signer/src/context/signer_state.rs
@@ -19,8 +19,8 @@ pub struct SignerState {
     current_signer_set: SignerSet,
     current_limits: RwLock<SbtcLimits>,
     sbtc_contracts_deployed: AtomicBool,
-    sbtc_start_height: AtomicU64,
-    is_sbtc_start_height_set: AtomicBool,
+    sbtc_bitcoin_start_height: AtomicU64,
+    is_sbtc_bitcoin_start_height_set: AtomicBool,
 }
 
 impl SignerState {
@@ -59,19 +59,19 @@ impl SignerState {
     }
 
     /// Get the sbtc start height
-    pub fn get_sbtc_start_height(&self) -> u64 {
-        self.sbtc_start_height.load(Ordering::SeqCst)
+    pub fn get_sbtc_bitcoin_start_height(&self) -> u64 {
+        self.sbtc_bitcoin_start_height.load(Ordering::SeqCst)
     }
 
     /// Set the sbtc start height
-    pub fn set_sbtc_start_height(&self, height: u64) {
-        self.is_sbtc_start_height_set.store(true, Ordering::SeqCst);
-        self.sbtc_start_height.store(height, Ordering::SeqCst);
+    pub fn set_sbtc_bitcoin_start_height(&self, height: u64) {
+        self.is_sbtc_bitcoin_start_height_set.store(true, Ordering::SeqCst);
+        self.sbtc_bitcoin_start_height.store(height, Ordering::SeqCst);
     }
 
     /// Return whether the sbtc start height has been set.
-    pub fn is_sbtc_start_height_set(&self) -> bool {
-        self.is_sbtc_start_height_set.load(Ordering::SeqCst)
+    pub fn is_sbtc_bitcoin_start_height_set(&self) -> bool {
+        self.is_sbtc_bitcoin_start_height_set.load(Ordering::SeqCst)
     }
 }
 

--- a/signer/src/context/signer_state.rs
+++ b/signer/src/context/signer_state.rs
@@ -20,6 +20,7 @@ pub struct SignerState {
     current_limits: RwLock<SbtcLimits>,
     sbtc_contracts_deployed: AtomicBool,
     sbtc_start_height: AtomicU64,
+    is_sbtc_start_height_set: AtomicBool,
 }
 
 impl SignerState {
@@ -64,7 +65,13 @@ impl SignerState {
 
     /// Set the sbtc start height
     pub fn set_sbtc_start_height(&self, height: u64) {
+        self.is_sbtc_start_height_set.store(true, Ordering::SeqCst);
         self.sbtc_start_height.store(height, Ordering::SeqCst);
+    }
+
+    /// Return whether the sbtc start height has been set.
+    pub fn is_sbtc_start_height_set(&self) -> bool {
+        self.is_sbtc_start_height_set.load(Ordering::SeqCst)
     }
 }
 

--- a/signer/src/context/signer_state.rs
+++ b/signer/src/context/signer_state.rs
@@ -65,8 +65,10 @@ impl SignerState {
 
     /// Set the sbtc start height
     pub fn set_sbtc_bitcoin_start_height(&self, height: u64) {
-        self.is_sbtc_bitcoin_start_height_set.store(true, Ordering::SeqCst);
-        self.sbtc_bitcoin_start_height.store(height, Ordering::SeqCst);
+        self.is_sbtc_bitcoin_start_height_set
+            .store(true, Ordering::SeqCst);
+        self.sbtc_bitcoin_start_height
+            .store(height, Ordering::SeqCst);
     }
 
     /// Return whether the sbtc start height has been set.

--- a/signer/src/context/signer_state.rs
+++ b/signer/src/context/signer_state.rs
@@ -1,7 +1,7 @@
 //! Module for signer state
 
 use std::sync::{
-    atomic::{AtomicBool, Ordering},
+    atomic::{AtomicBool, AtomicU64, Ordering},
     RwLock,
 };
 
@@ -19,6 +19,7 @@ pub struct SignerState {
     current_signer_set: SignerSet,
     current_limits: RwLock<SbtcLimits>,
     sbtc_contracts_deployed: AtomicBool,
+    sbtc_start_height: AtomicU64,
 }
 
 impl SignerState {
@@ -54,6 +55,16 @@ impl SignerState {
     /// Set the sbtc smart contracts deployed flag
     pub fn set_sbtc_contracts_deployed(&self) {
         self.sbtc_contracts_deployed.store(true, Ordering::SeqCst);
+    }
+
+    /// Get the sbtc start height
+    pub fn get_sbtc_start_height(&self) -> u64 {
+        self.sbtc_start_height.load(Ordering::SeqCst)
+    }
+
+    /// Set the sbtc start height
+    pub fn set_sbtc_start_height(&self, height: u64) {
+        self.sbtc_start_height.store(height, Ordering::SeqCst);
     }
 }
 

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -66,6 +66,19 @@ pub enum Error {
     #[error("bitcoin-core getblock RPC error for hash {1}: {0}")]
     BitcoinCoreGetBlock(#[source] bitcoincore_rpc::Error, bitcoin::BlockHash),
 
+    /// Attempt to fetch a bitcoin block header resulted in an unexpected
+    /// error. This is not triggered if the block header is missing.
+    #[error("bitcoin-core getblockheader RPC error for hash {1}: {0}")]
+    BitcoinCoreGetBlockHeader(#[source] bitcoincore_rpc::Error, bitcoin::BlockHash),
+
+    /// Attempt to decode a bitcoin block header from hex resulted in an
+    /// unexpected error.
+    #[error("could not decode getblockheader response from bitcoin-core {1}: {0}")]
+    BitcoinCoreDecodeHeaderHex(
+        #[source] bitcoin::consensus::encode::FromHexError,
+        bitcoin::BlockHash,
+    ),
+
     /// Received an error in response to getrawtransaction RPC call
     #[error("failed to retrieve the raw transaction for txid {1} from bitcoin-core. {0}")]
     BitcoinCoreGetTransaction(#[source] bitcoincore_rpc::Error, bitcoin::Txid),

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -71,6 +71,11 @@ pub enum Error {
     #[error("bitcoin-core getblockheader RPC error for hash {1}: {0}")]
     BitcoinCoreGetBlockHeader(#[source] bitcoincore_rpc::Error, bitcoin::BlockHash),
 
+    /// Bitcoin block header is unknown to bitcoin-core. This is only
+    /// triggered if bitcoin-core does not know about the block hash.
+    #[error("Unknown block hash response from bitcoin-core getblockheader RPC call: {0}")]
+    BitcoinCoreUnknownBlockHeader(bitcoin::BlockHash),
+
     /// Received an error in response to getrawtransaction RPC call
     #[error("failed to retrieve the raw transaction for txid {1} from bitcoin-core. {0}")]
     BitcoinCoreGetTransaction(#[source] bitcoincore_rpc::Error, bitcoin::Txid),

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -71,14 +71,6 @@ pub enum Error {
     #[error("bitcoin-core getblockheader RPC error for hash {1}: {0}")]
     BitcoinCoreGetBlockHeader(#[source] bitcoincore_rpc::Error, bitcoin::BlockHash),
 
-    /// Attempt to decode a bitcoin block header from hex resulted in an
-    /// unexpected error.
-    #[error("could not decode getblockheader response from bitcoin-core {1}: {0}")]
-    BitcoinCoreDecodeHeaderHex(
-        #[source] bitcoin::consensus::encode::FromHexError,
-        bitcoin::BlockHash,
-    ),
-
     /// Received an error in response to getrawtransaction RPC call
     #[error("failed to retrieve the raw transaction for txid {1} from bitcoin-core. {0}")]
     BitcoinCoreGetTransaction(#[source] bitcoincore_rpc::Error, bitcoin::Txid),
@@ -375,6 +367,10 @@ pub enum Error {
     /// Key error
     #[error("key error: {0}")]
     KeyError(#[from] p256k1::keys::Error),
+
+    /// Missing bitcoin block
+    #[error("bitcoin-core is missing bitcoin block {0}")]
+    BitcoinCoreMissingBlock(bitcoin::BlockHash),
 
     /// Missing bitcoin block
     #[error("the database is missing bitcoin block {0}")]

--- a/signer/src/main.rs
+++ b/signer/src/main.rs
@@ -310,7 +310,6 @@ async fn run_block_observer(ctx: impl Context) -> Result<(), Error> {
     let block_observer = block_observer::BlockObserver {
         context: ctx,
         bitcoin_blocks: stream.to_block_hash_stream(),
-        horizon: config.signer.bitcoin_block_horizon,
     };
 
     block_observer.run().await

--- a/signer/src/request_decider.rs
+++ b/signer/src/request_decider.rs
@@ -368,7 +368,6 @@ where
             tracing::debug!("no record of the deposit request, fetching from emily");
             let processor = BlockObserver {
                 context: self.context.clone(),
-                horizon: 20,
                 bitcoin_blocks: (),
             };
             let deposit_request = self

--- a/signer/src/storage/in_memory.rs
+++ b/signer/src/storage/in_memory.rs
@@ -773,6 +773,13 @@ impl super::DbRead for SharedStore {
         }
     }
 
+    async fn is_known_bitcoin_block_hash(
+        &self,
+        block_hash: &model::BitcoinBlockHash,
+    ) -> Result<bool, Error> {
+        Ok(self.lock().await.bitcoin_blocks.contains_key(block_hash))
+    }
+
     async fn in_canonical_bitcoin_blockchain(
         &self,
         chain_tip: &model::BitcoinBlockRef,

--- a/signer/src/storage/mod.rs
+++ b/signer/src/storage/mod.rs
@@ -270,9 +270,7 @@ pub trait DbRead {
         aggregate_key: &PublicKey,
     ) -> impl Future<Output = Result<model::SignerVotes, Error>> + Send;
 
-    /// Check that the given block hash is included in the canonical
-    /// bitcoin blockchain, where the canonical blockchain is identified by
-    /// the given `chain_tip`.
+    /// Check for whether  the given block hash is in the database.
     fn is_known_bitcoin_block_hash(
         &self,
         block_hash: &model::BitcoinBlockHash,

--- a/signer/src/storage/mod.rs
+++ b/signer/src/storage/mod.rs
@@ -273,6 +273,14 @@ pub trait DbRead {
     /// Check that the given block hash is included in the canonical
     /// bitcoin blockchain, where the canonical blockchain is identified by
     /// the given `chain_tip`.
+    fn is_known_bitcoin_block_hash(
+        &self,
+        block_hash: &model::BitcoinBlockHash,
+    ) -> impl Future<Output = Result<bool, Error>> + Send;
+
+    /// Check that the given block hash is included in the canonical
+    /// bitcoin blockchain, where the canonical blockchain is identified by
+    /// the given `chain_tip`.
     fn in_canonical_bitcoin_blockchain(
         &self,
         chain_tip: &model::BitcoinBlockRef,

--- a/signer/src/storage/model.rs
+++ b/signer/src/storage/model.rs
@@ -10,6 +10,7 @@ use clarity::vm::types::PrincipalData;
 use stacks_common::types::chainstate::BurnchainHeaderHash;
 use stacks_common::types::chainstate::StacksBlockId;
 
+use crate::bitcoin::rpc::BitcoinBlockHeader;
 use crate::bitcoin::validation::InputValidationResult;
 use crate::bitcoin::validation::WithdrawalValidationResult;
 use crate::block_observer::Deposit;
@@ -94,6 +95,16 @@ impl From<&bitcoin::Block> for BitcoinBlock {
                 .bip34_block_height()
                 .expect("Failed to get block height"),
             parent_hash: block.header.prev_blockhash.into(),
+        }
+    }
+}
+
+impl From<BitcoinBlockHeader> for BitcoinBlock {
+    fn from(header: BitcoinBlockHeader) -> Self {
+        BitcoinBlock {
+            block_hash: header.hash.into(),
+            block_height: header.height,
+            parent_hash: header.previous_block_hash.into(),
         }
     }
 }

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -1655,6 +1655,25 @@ impl super::DbRead for PgStore {
         }
     }
 
+    async fn is_known_bitcoin_block_hash(
+        &self,
+        block_hash: &model::BitcoinBlockHash,
+    ) -> Result<bool, Error> {
+        sqlx::query_scalar::<_, bool>(
+            r#"
+            SELECT EXISTS (
+                SELECT TRUE
+                FROM sbtc_signer.bitcoin_blocks AS bb
+                WHERE bb.block_hash = $1
+            );
+        "#,
+        )
+        .bind(block_hash)
+        .fetch_one(&self.0)
+        .await
+        .map_err(Error::SqlxQuery)
+    }
+
     async fn in_canonical_bitcoin_blockchain(
         &self,
         chain_tip: &model::BitcoinBlockRef,

--- a/signer/src/testing/block_observer.rs
+++ b/signer/src/testing/block_observer.rs
@@ -208,6 +208,17 @@ impl BitcoinInteract for TestHarness {
         Ok(self.deposits.get(txid).cloned().map(|(resp, _)| resp))
     }
 
+    async fn get_block_header(
+        &self,
+        block_hash: &BlockHash,
+    ) -> Result<Option<bitcoin::block::Header>, Error> {
+        Ok(self
+            .bitcoin_blocks
+            .iter()
+            .find(|block| &block.block_hash() == block_hash)
+            .map(|block| block.header))
+    }
+
     async fn get_tx_info(
         &self,
         txid: &Txid,

--- a/signer/src/testing/block_observer.rs
+++ b/signer/src/testing/block_observer.rs
@@ -71,6 +71,14 @@ impl TestHarness {
         &self.bitcoin_blocks
     }
 
+    /// The minimum block height amount blocks in this blockchain
+    pub fn min_block_height(&self) -> Option<u64> {
+        self.bitcoin_blocks
+            .iter()
+            .map(|block| block.bip34_block_height().unwrap())
+            .min()
+    }
+
     /// Get the Stacks blocks in the test harness.
     pub fn stacks_blocks(&self) -> &[(StacksBlockId, NakamotoBlock, BlockHash)] {
         &self.stacks_blocks
@@ -130,7 +138,10 @@ impl TestHarness {
         num_bitcoin_blocks: usize,
         num_stacks_blocks_per_bitcoin_block: std::ops::Range<usize>,
     ) -> Self {
-        let mut bitcoin_blocks: Vec<_> = std::iter::repeat_with(|| dummy::block(&fake::Faker, rng))
+        // There is some issue with using heights less than 17, probably
+        // minimal pushes or something.
+        let mut bitcoin_blocks: Vec<_> = std::iter::successors(Some(17), |height| Some(height + 1))
+            .map(|height| dummy::block(&fake::Faker, rng, height))
             .take(num_bitcoin_blocks)
             .collect();
 

--- a/signer/src/testing/context.rs
+++ b/signer/src/testing/context.rs
@@ -17,6 +17,7 @@ use clarity::types::chainstate::{StacksAddress, StacksBlockId};
 use tokio::sync::{broadcast, Mutex};
 use tokio::time::error::Elapsed;
 
+use crate::bitcoin::rpc::BitcoinBlockHeader;
 use crate::bitcoin::GetTransactionFeeResult;
 use crate::context::SbtcLimits;
 use crate::stacks::api::TenureBlocks;
@@ -307,7 +308,7 @@ impl BitcoinInteract for WrappedMock<MockBitcoinInteract> {
     async fn get_block_header(
         &self,
         block_hash: &bitcoin::BlockHash,
-    ) -> Result<Option<bitcoin::block::Header>, Error> {
+    ) -> Result<Option<BitcoinBlockHeader>, Error> {
         self.inner.lock().await.get_block_header(block_hash).await
     }
 

--- a/signer/src/testing/context.rs
+++ b/signer/src/testing/context.rs
@@ -304,6 +304,13 @@ impl BitcoinInteract for WrappedMock<MockBitcoinInteract> {
         self.inner.lock().await.get_block(block_hash).await
     }
 
+    async fn get_block_header(
+        &self,
+        block_hash: &bitcoin::BlockHash,
+    ) -> Result<Option<bitcoin::block::Header>, Error> {
+        self.inner.lock().await.get_block_header(block_hash).await
+    }
+
     async fn get_tx(&self, txid: &Txid) -> Result<Option<GetTxResponse>, Error> {
         self.inner.lock().await.get_tx(txid).await
     }

--- a/signer/tests/integration/bitcoin_rpc.rs
+++ b/signer/tests/integration/bitcoin_rpc.rs
@@ -84,7 +84,10 @@ fn btc_client_getblockheader() {
 
     let block = rpc.get_block(&block_hash).unwrap();
 
-    assert_eq!(header, block.header);
+    assert_eq!(header.hash, block.block_hash());
+    assert_eq!(header.previous_block_hash, block.header.prev_blockhash);
+    assert_eq!(header.height, block.bip34_block_height().unwrap());
+    assert_eq!(header.time, block.header.time as u64);
 
     let random_hash = bitcoin::BlockHash::from_byte_array([13; 32]);
     assert!(client.get_block_header(&random_hash).unwrap().is_none());

--- a/signer/tests/integration/bitcoin_rpc.rs
+++ b/signer/tests/integration/bitcoin_rpc.rs
@@ -10,6 +10,7 @@ use bitcoin::ScriptBuf;
 use bitcoin::Sequence;
 use bitcoin::Txid;
 use bitcoin::Witness;
+use bitcoincore_rpc::RpcApi;
 use bitcoincore_rpc_json::Utxo;
 use fake::{Fake, Faker};
 use rand::rngs::OsRng;
@@ -64,6 +65,29 @@ fn btc_client_getstransaction() {
     assert!(response.block_hash.is_some());
     assert!(response.block_time.is_some());
     assert_eq!(response.confirmations, Some(1));
+}
+
+#[cfg_attr(not(feature = "integration-tests"), ignore)]
+#[test]
+fn btc_client_getblockheader() {
+    let client = BitcoinCoreClient::new(
+        "http://localhost:18443",
+        regtest::BITCOIN_CORE_RPC_USERNAME.to_string(),
+        regtest::BITCOIN_CORE_RPC_PASSWORD.to_string(),
+    )
+    .unwrap();
+    let (rpc, _) = regtest::initialize_blockchain();
+
+    // Let's get the chain-tip
+    let block_hash = rpc.get_best_block_hash().unwrap();
+    let header = client.get_block_header(&block_hash).unwrap().unwrap();
+
+    let block = rpc.get_block(&block_hash).unwrap();
+
+    assert_eq!(header, block.header);
+
+    let random_hash = bitcoin::BlockHash::from_byte_array([13; 32]);
+    assert!(client.get_block_header(&random_hash).unwrap().is_none());
 }
 
 #[cfg_attr(not(feature = "integration-tests"), ignore)]

--- a/signer/tests/integration/block_observer.rs
+++ b/signer/tests/integration/block_observer.rs
@@ -67,10 +67,10 @@ pub const GET_POX_INFO_JSON: &str =
 /// supposed to fetch all deposit requests from Emily and persist the ones
 /// that pass validation, regardless of when they were confirmed.
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
-#[test_case::test_case(1, 10; "one block ago")]
-#[test_case::test_case(5, 10; "five blocks ago")]
+#[test_case::test_case(1; "one block ago")]
+#[test_case::test_case(5; "five blocks ago")]
 #[tokio::test]
-async fn load_latest_deposit_requests_persists_requests_from_past(blocks_ago: u64, horizon: u32) {
+async fn load_latest_deposit_requests_persists_requests_from_past(blocks_ago: u64) {
     // We start with the typical setup with a fresh database and context
     // with a real bitcoin core client and a real connection to our
     // database.
@@ -166,7 +166,6 @@ async fn load_latest_deposit_requests_persists_requests_from_past(blocks_ago: u6
     let block_observer = BlockObserver {
         context: ctx.clone(),
         bitcoin_blocks: ReceiverStream::new(receiver),
-        horizon,
     };
 
     // We need at least one receiver
@@ -284,7 +283,6 @@ async fn link_blocks() {
     let block_observer = BlockObserver {
         context: ctx.clone(),
         bitcoin_blocks: ReceiverStream::new(receiver),
-        horizon: 10,
     };
 
     let mut signal_rx = ctx.get_signal_receiver();
@@ -456,7 +454,6 @@ async fn block_observer_stores_donation_and_sbtc_utxos() {
     let block_observer = BlockObserver {
         context: ctx.clone(),
         bitcoin_blocks: ReceiverStream::new(receiver),
-        horizon: 2,
     };
 
     tokio::spawn(async move {
@@ -775,7 +772,6 @@ async fn block_observer_handles_update_limits(deployed: bool, sbtc_limits: SbtcL
     let block_observer = BlockObserver {
         context: ctx.clone(),
         bitcoin_blocks: ReceiverStream::new(receiver),
-        horizon: 10,
     };
 
     let mut signal_receiver = ctx.get_signal_receiver();

--- a/signer/tests/integration/emily.rs
+++ b/signer/tests/integration/emily.rs
@@ -26,7 +26,6 @@ use signer::bitcoin::rpc::GetTxResponse;
 use signer::block_observer;
 use signer::context::Context;
 use signer::context::RequestDeciderEvent;
-use signer::context::SbtcLimits;
 use signer::emily_client::EmilyClient;
 use signer::emily_client::EmilyInteract;
 use signer::error::Error;
@@ -601,34 +600,4 @@ async fn get_deposit_request_works() {
     // This one doesn't exist
     let request = emily_client.get_deposit(&txid, 50).await.unwrap();
     assert!(request.is_none());
-}
-
-#[ignore = "Test tries to use an emily api call it cannot access."]
-// #[cfg_attr(not(feature = "integration-tests"), ignore)]
-// #[tokio::test]
-async fn get_limits_works() {
-    let url = Url::parse("http://testApiKey@localhost:3031").unwrap();
-    let emily_client = EmilyClient::try_from(&url).unwrap();
-    // emily_client::apis::limits_api::set_limits(
-    //     &emily_client.config(),
-    //     Limits {
-    //         peg_cap: Some(Some(100)),
-    //         per_deposit_cap: Some(Some(90)),
-    //         per_withdrawal_cap: Some(Some(80)),
-    //         ..Default::default()
-    //     },
-    // )
-    // .await
-    // .unwrap();
-
-    let limits = emily_client.get_limits().await.unwrap();
-
-    let expected = SbtcLimits::new(
-        Some(Amount::from_sat(100)),
-        Some(Amount::from_sat(90)),
-        Some(Amount::from_sat(80)),
-        None,
-    );
-
-    assert_eq!(limits, expected);
 }

--- a/signer/tests/integration/emily.rs
+++ b/signer/tests/integration/emily.rs
@@ -398,7 +398,6 @@ async fn deposit_flow() {
     let block_observer = block_observer::BlockObserver {
         context: context.clone(),
         bitcoin_blocks: block_stream,
-        horizon: 1,
     };
 
     let block_observer_handle = tokio::spawn(async move { block_observer.run().await });

--- a/signer/tests/integration/setup.rs
+++ b/signer/tests/integration/setup.rs
@@ -712,11 +712,7 @@ impl TestSweepSetup2 {
             .get_tx(&self.donation.txid)
             .unwrap()
             .unwrap();
-        let block_observer = BlockObserver {
-            context,
-            bitcoin_blocks: (),
-            horizon: 3,
-        };
+        let block_observer = BlockObserver { context, bitcoin_blocks: () };
 
         block_observer
             .extract_sbtc_transactions(block_hash.unwrap(), &[tx])

--- a/signer/tests/integration/transaction_coordinator.rs
+++ b/signer/tests/integration/transaction_coordinator.rs
@@ -1370,7 +1370,6 @@ async fn sign_bitcoin_transaction() {
         let block_observer = BlockObserver {
             context: ctx.clone(),
             bitcoin_blocks: ReceiverStream::new(receiver),
-            horizon: 10,
         };
         let counter = start_count.clone();
         tokio::spawn(async move {
@@ -1760,7 +1759,6 @@ async fn skip_smart_contract_deployment_and_key_rotation_if_up_to_date() {
         let block_observer = BlockObserver {
             context: ctx.clone(),
             bitcoin_blocks: ReceiverStream::new(receiver),
-            horizon: 10,
         };
         let counter = start_count.clone();
         tokio::spawn(async move {


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/685 as well.

This PR focuses on the bitcoin side of things. The OOM possibility applies much less to Stacks blocks.

## Changes

* Add an optional config parameter that defines the minimum bitcoin block height for the signers. This means that the signers will have blocks for heights at least as high as the block set here. If the above parameter is unset, we use the nakamoto start height as the fallback value.
* Fetch bitcoin blocks all the way back to the last known block in the database. If there are no blocks in the database, then stop at the minimum block height defined above.
* Fetch historical bitcoin blocks by first fetching (slimmed down) block headers and then, once all block headers are known, fetch the bitcoin blocks one at a time. This limits memory usage of the previous approach.
* Remove the now unused horizon parameter.
* Add a function for calling the `getblockhash` RPC from bitcoin-core.
* Add a new query for checking whether a block is in the database.

## Testing Information

This needs more local testing.

## Checklist:

- [x] I have performed a self-review of my code
