### PR TITLE
Backwards compatible api keys

### DIFF
--- a/emily/cdk/lib/emily-stack.ts
+++ b/emily/cdk/lib/emily-stack.ts
@@ -420,11 +420,12 @@ export class EmilyStack extends cdk.Stack {
             ]
         });
 
-        let num_api_keys = EmilyStackUtils.getNumSignerApiKeys();
         let api_keys = [];
-        for (let i = 0; i < num_api_keys; i++) {
+        for (let i = 0; i < numApiKeys; i++) {
             // Create an API Key
-            const apiKeyId: string = `ApiKey-${apiUsagePlan}-${i}`;
+            const apiKeyId: string = apiPurpose === "public"
+                ? `ApiKey-${apiUsagePlan}-${i}`
+                : `ApiKey-${apiPurposeTitleCase}-${i}`;
             const apiKey = api.addApiKey(apiKeyId, {
                 apiKeyName: EmilyStackUtils.getResourceName(apiKeyId, props),
             });

--- a/emily/cdk/lib/emily-stack.ts
+++ b/emily/cdk/lib/emily-stack.ts
@@ -424,7 +424,7 @@ export class EmilyStack extends cdk.Stack {
         for (let i = 0; i < numApiKeys; i++) {
             // Create an API Key
             const apiKeyId: string = apiPurpose === "public"
-                ? `ApiKey-${apiUsagePlan}-${i}`
+                ? `ApiKey-${i}`
                 : `ApiKey-${apiPurposeTitleCase}-${i}`;
             const apiKey = api.addApiKey(apiKeyId, {
                 apiKeyName: EmilyStackUtils.getResourceName(apiKeyId, props),


### PR DESCRIPTION
## Description

Closes: #N/A

## Changes

- Fixes odd API key naming scheme I accidentally introduced in #897 
- Uses the right number of api keys per api
- Makes the api key names backwards compatible for the public endpoint

## Testing Information

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
