### PR TITLE
fix: length bug in rotate-keys-wrapper contract call

### DIFF
--- a/contracts/contracts/sbtc-bootstrap-signers.clar
+++ b/contracts/contracts/sbtc-bootstrap-signers.clar
@@ -114,15 +114,15 @@
 )
 
 ;; Concatenate a pubkey buffer with a length prefix.
-;; The max size of the iterator is 4239 bytes, which is (33 * 128) 4224 bytes
-;; for the public keys and 15 bytes for the length prefixes.
-(define-read-only (concat-pubkeys-fold (pubkey (buff 33)) (iterator (buff 510)))
+;; The max size of the iterator is 4352 bytes, which is (33 * 128) 4224 bytes
+;; for the public keys and 128 bytes for the length prefixes.
+(define-read-only (concat-pubkeys-fold (pubkey (buff 33)) (iterator (buff 4352)))
   (let
     (
       (pubkey-with-len (concat (bytes-len pubkey) pubkey))
       (next (concat iterator pubkey-with-len))
     )
-    (unwrap-panic (as-max-len? next u510))
+    (unwrap-panic (as-max-len? next u4352))
   )
 )
 

--- a/contracts/contracts/sbtc-deposit.clar
+++ b/contracts/contracts/sbtc-deposit.clar
@@ -76,10 +76,10 @@
 ;; Note that this function can only be called by the current
 ;; bootstrap signer set address - it cannot be called by users directly.
 ;; 
-;; This function handles the validation & minting of sBTC by handling multiple (up to 1000) deposits at a time, 
+;; This function handles the validation & minting of sBTC by handling multiple (up to 500) deposits at a time, 
 ;; it then calls into the sbtc-registry contract to update the state of the protocol. 
 (define-public (complete-deposits-wrapper 
-        (deposits (list 650 {txid: (buff 32), vout-index: uint, amount: uint, recipient: principal, burn-hash: (buff 32), burn-height: uint, sweep-txid: (buff 32)}))
+        (deposits (list 500 {txid: (buff 32), vout-index: uint, amount: uint, recipient: principal, burn-hash: (buff 32), burn-height: uint, sweep-txid: (buff 32)}))
     )
     (begin
         ;; Check that the caller is the current signer principal

--- a/contracts/contracts/sbtc-token.clar
+++ b/contracts/contracts/sbtc-token.clar
@@ -110,6 +110,7 @@
 	(fold complete-individual-transfer recipients (ok u0))
 )
 
+;; #[allow(unchecked_data)]
 (define-private (complete-individual-transfer 
 					(individual-transfer { 
 						amount: uint, 

--- a/contracts/docs/sbtc-bootstrap-signers.md
+++ b/contracts/docs/sbtc-bootstrap-signers.md
@@ -129,7 +129,7 @@ Checks that the length of each key is exactly 33 bytes #[allow(unchecked_data)]
 
 [View in file](../contracts/sbtc-bootstrap-signers.clar#L81)
 
-`(define-read-only (pubkeys-to-spend-script ((pubkeys (list 128 (buff 33))) (m uint)) (buff 513))`
+`(define-read-only (pubkeys-to-spend-script ((pubkeys (list 128 (buff 33))) (m uint)) (buff 4355))`
 
 Generate the p2sh redeem script for a multisig
 
@@ -223,7 +223,7 @@ Given a set of pubkeys and an m-of-n, generate a principal
 
 [View in file](../contracts/sbtc-bootstrap-signers.clar#L112)
 
-`(define-read-only (pubkeys-to-bytes ((pubkeys (list 128 (buff 33)))) (buff 510))`
+`(define-read-only (pubkeys-to-bytes ((pubkeys (list 128 (buff 33)))) (buff 4352))`
 
 Concat a list of pubkeys into a buffer with length prefixes
 
@@ -248,23 +248,23 @@ Concat a list of pubkeys into a buffer with length prefixes
 
 [View in file](../contracts/sbtc-bootstrap-signers.clar#L119)
 
-`(define-read-only (concat-pubkeys-fold ((pubkey (buff 33)) (iterator (buff 510))) (buff 510))`
+`(define-read-only (concat-pubkeys-fold ((pubkey (buff 33)) (iterator (buff 4352))) (buff 4352))`
 
 Concatenate a pubkey buffer with a length prefix.
-The max size of the iterator is 4239 bytes, which is (33 \* 128) 4224 bytes
-for the public keys and 15 bytes for the length prefixes.
+The max size of the iterator is 4352 bytes, which is (33 \* 128) 4224 bytes
+for the public keys and 128 bytes for the length prefixes.
 
 <details>
   <summary>Source code:</summary>
 
 ```clarity
-(define-read-only (concat-pubkeys-fold (pubkey (buff 33)) (iterator (buff 510)))
+(define-read-only (concat-pubkeys-fold (pubkey (buff 33)) (iterator (buff 4352)))
   (let
     (
       (pubkey-with-len (concat (bytes-len pubkey) pubkey))
       (next (concat iterator pubkey-with-len))
     )
-    (unwrap-panic (as-max-len? next u510))
+    (unwrap-panic (as-max-len? next u4352))
   )
 )
 ```
@@ -273,10 +273,10 @@ for the public keys and 15 bytes for the length prefixes.
 
 **Parameters:**
 
-| Name     | Type       |
-| -------- | ---------- |
-| pubkey   | (buff 33)  |
-| iterator | (buff 510) |
+| Name     | Type        |
+| -------- | ----------- |
+| pubkey   | (buff 33)   |
+| iterator | (buff 4352) |
 
 ### bytes-len
 

--- a/contracts/tests/clarigen-types.ts
+++ b/contracts/tests/clarigen-types.ts
@@ -67,9 +67,9 @@ export const contracts = {
         access: "read_only",
         args: [
           { name: "pubkey", type: { buffer: { length: 33 } } },
-          { name: "iterator", type: { buffer: { length: 510 } } },
+          { name: "iterator", type: { buffer: { length: 4352 } } },
         ],
-        outputs: { type: { buffer: { length: 510 } } },
+        outputs: { type: { buffer: { length: 4352 } } },
       } as TypedAbiFunction<
         [
           pubkey: TypedAbiArg<Uint8Array, "pubkey">,
@@ -86,7 +86,7 @@ export const contracts = {
             type: { list: { type: { buffer: { length: 33 } }, length: 128 } },
           },
         ],
-        outputs: { type: { buffer: { length: 510 } } },
+        outputs: { type: { buffer: { length: 4352 } } },
       } as TypedAbiFunction<
         [pubkeys: TypedAbiArg<Uint8Array[], "pubkeys">],
         Uint8Array
@@ -137,7 +137,7 @@ export const contracts = {
           },
           { name: "m", type: "uint128" },
         ],
-        outputs: { type: { buffer: { length: 513 } } },
+        outputs: { type: { buffer: { length: 4355 } } },
       } as TypedAbiFunction<
         [
           pubkeys: TypedAbiArg<Uint8Array[], "pubkeys">,
@@ -580,7 +580,7 @@ export const contracts = {
                     { name: "vout-index", type: "uint128" },
                   ],
                 },
-                length: 650,
+                length: 500,
               },
             },
           },

--- a/contracts/tests/sbtc-bootstrap-signers.test.ts
+++ b/contracts/tests/sbtc-bootstrap-signers.test.ts
@@ -86,6 +86,18 @@ describe("sBTC bootstrap signers contract", () => {
       expect(receipt.value).toEqual(true);
     });
 
+    test("Rotate keys wrapper 90-of-128", () => {
+      const receipt = txOk(
+        signers.rotateKeysWrapper({
+          newKeys: randomPublicKeys(128),
+          newAggregatePubkey: new Uint8Array(33).fill(0),
+          newSignatureThreshold: 90n,
+        }),
+        deployer
+      );
+      expect(receipt.value).toEqual(true);
+    });
+
     test("Rotate keys wrapper incorrect signer key size", () => {
       const newSignatureThreshold = 2n;
       const receipt = txErr(

--- a/contracts/tests/sbtc-deposit.test.ts
+++ b/contracts/tests/sbtc-deposit.test.ts
@@ -321,7 +321,7 @@ describe("optimization tests", () => {
     const { burnHeight, burnHash } = getCurrentBurnInfo();
 
     const totalAmount = 1000000n;
-    const runs = 650;
+    const runs = 500;
     const txids = randomPublicKeys(runs).map((pk) => pk.slice(0, 32));
     txOk(
       deposit.completeDepositsWrapper({


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/504 and closes https://github.com/stacks-network/sbtc/issues/1096.

## Changes

* Made sure the highlighted code comments were accurate
* Fixed a lingering bug in the number of keys that are acceptable in `rotate-keys-wrapper` contract calls.
* Reduce the number of acceptable deposits in one `complete-deposits-wrapper` contract call down to 500. `pnpm test:report` complete successfully with this change.

## Testing Information

This adds a test against the actual limit, that was missing when some of the function signatures were changed to accept 128 keys as opposed to 15.

## Checklist:

- [x] I have performed a self-review of my code
