### PR TITLE
feat: use consistent hash endianness in contract calls

### DIFF
--- a/signer/src/stacks/contracts.rs
+++ b/signer/src/stacks/contracts.rs
@@ -51,8 +51,8 @@ use crate::keys::PublicKey;
 use crate::stacks::wallet::SignerWallet;
 use crate::storage::model::BitcoinBlockHash;
 use crate::storage::model::BitcoinBlockRef;
-use crate::storage::model::ToLittleEndianOrder as _;
 use crate::storage::model::BitcoinTxId;
+use crate::storage::model::ToLittleEndianOrder as _;
 use crate::storage::DbRead;
 
 use super::api::StacksInteract;

--- a/signer/src/stacks/contracts.rs
+++ b/signer/src/stacks/contracts.rs
@@ -21,7 +21,6 @@ use std::future::Future;
 use std::ops::Deref;
 use std::sync::OnceLock;
 
-use bitcoin::hashes::Hash as _;
 use bitcoin::Amount;
 use bitcoin::OutPoint;
 use bitcoin::TxOut;
@@ -43,7 +42,6 @@ use blockstack_lib::clarity::vm::ContractName;
 use blockstack_lib::clarity::vm::Value as ClarityValue;
 use blockstack_lib::types::chainstate::StacksAddress;
 use blockstack_lib::util_lib::strings::StacksString;
-use clarity::types::chainstate::BurnchainHeaderHash;
 use clarity::vm::ClarityVersion;
 
 use crate::bitcoin::BitcoinInteract;
@@ -53,6 +51,7 @@ use crate::keys::PublicKey;
 use crate::stacks::wallet::SignerWallet;
 use crate::storage::model::BitcoinBlockHash;
 use crate::storage::model::BitcoinBlockRef;
+use crate::storage::model::ToLittleEndianOrder as _;
 use crate::storage::model::BitcoinTxId;
 use crate::storage::DbRead;
 
@@ -318,15 +317,11 @@ impl AsContractCall for CompleteDepositV1 {
     /// Construct the input arguments to the complete-deposit-wrapper
     /// contract call.
     fn as_contract_args(&self) -> Vec<ClarityValue> {
-        let txid_data = self.outpoint.txid.to_byte_array().to_vec();
+        let txid_data = self.outpoint.txid.to_le_bytes().to_vec();
         let txid = BuffData { data: txid_data };
-        let sweep_txid_data = self.sweep_txid.to_byte_array().to_vec();
+        let sweep_txid_data = self.sweep_txid.to_le_bytes().to_vec();
         let sweep_txid = BuffData { data: sweep_txid_data };
-        // We first convert it into this type because the BitcoinBlockHash
-        // has the underlying bytes in that type are reversed from what the
-        // stacks-node expects.
-        let burn_hash = BurnchainHeaderHash::from(self.sweep_block_hash);
-        let burn_hash_data = burn_hash.into_bytes().to_vec();
+        let burn_hash_data = self.sweep_block_hash.to_le_bytes().to_vec();
         let burn_hash_buff = BuffData { data: burn_hash_data };
 
         vec![
@@ -651,13 +646,9 @@ impl AsContractCall for AcceptWithdrawalV1 {
         self.deployer
     }
     fn as_contract_args(&self) -> Vec<ClarityValue> {
-        let txid_data = self.outpoint.txid.to_byte_array().to_vec();
+        let txid_data = self.outpoint.txid.to_le_bytes().to_vec();
         let txid = BuffData { data: txid_data };
-        // We first convert it into this type because the BitcoinBlockHash
-        // has the underlying bytes in that type are reversed from what the
-        // stacks-node expects.
-        let burn_hash = BurnchainHeaderHash::from(self.sweep_block_hash);
-        let burn_hash_data = burn_hash.into_bytes().to_vec();
+        let burn_hash_data = self.sweep_block_hash.to_le_bytes().to_vec();
         let burn_hash_buff = BuffData { data: burn_hash_data };
 
         vec![

--- a/signer/src/stacks/events.rs
+++ b/signer/src/stacks/events.rs
@@ -30,23 +30,26 @@ use clarity::vm::Value as ClarityValue;
 use secp256k1::PublicKey;
 use stacks_common::types::chainstate::StacksBlockId;
 
-/// This trait adds a function for converting bytes from little-endian
-/// order into a type. This is because the signers convert
+/// This trait adds a function for converting bytes from little-endian byte
+/// order into a bitcoin hash types. This is because the signers convert
 /// [`bitcoin::Txid`] and [`bitcoin::BlockHash`] bytes into little-endian
-/// order before submitting the contract call.
+/// order before submitting contract calls.
 ///
 /// Both [`bitcoin::BlockHash`] and [`bitcoin::Txid`] are hash types that
-/// store bytes internally in big-endian order, and bitcoin-core transmits
-/// hashes in big-endian byte order[1] through the RPC interface. Note that
-/// the wire and zeromq interfaces transmit things in little-endian
-/// order[2].
+/// store bytes as SHA256 output, which is in big-endian order. Stacks-core
+/// stores hashes in little-endian byte order[2], implying that clarity
+/// functions, like `get-burn-block-info?`, return bitcoin block hashes in
+/// little-endian byte order. Note that Bitcoin-core transmits hashes in
+/// big-endian byte order[1] through the RPC interface, but the wire and
+/// zeromq interfaces transmit hashes in little-endian order[3].
 ///
 /// [^1]: See the Note in
 ///     <https://github.com/bitcoin/bitcoin/blob/62bd61de110b057cbfd6e31e4d0b727d93119c72/doc/zmq.md>.
-/// [^2]: <https://developer.bitcoin.org/reference/block_chain.html#block-chain>
+/// [^2]: <https://github.com/stacks-network/stacks-core/blob/70d24ea179840763c2335870d0965b31b37685d6/stacks-common/src/types/chainstate.rs#L427-L432>
+/// [^3]: <https://developer.bitcoin.org/reference/block_chain.html#block-chain>
 ///       <https://developer.bitcoin.org/reference/p2p_networking.html>
 /// <https://learnmeabitcoin.com/technical/general/byte-order/>
-trait FromLittleEndianOrder: Sized {
+pub trait FromLittleEndianOrder: Sized {
     /// Convert bytes expressed in little-endian order to the type;
     fn from_le_bytes(bytes: [u8; 32]) -> Self;
 }

--- a/signer/src/stacks/events.rs
+++ b/signer/src/stacks/events.rs
@@ -36,15 +36,16 @@ use stacks_common::types::chainstate::StacksBlockId;
 /// order before submitting the contract call.
 ///
 /// Both [`bitcoin::BlockHash`] and [`bitcoin::Txid`] are hash types that
-/// expect bytes in big-endian order, because bitcoin-core transmits hashes
-/// in big endian byte order[1] through the RPC interface.
+/// store bytes internally in big-endian order, and bitcoin-core transmits
+/// hashes in big-endian byte order[1] through the RPC interface. Note that
+/// the wire and zeromq interfaces transmit things in little-endian
+/// order[2].
 ///
 /// [^1]: See the Note in
-/// <https://github.com/bitcoin/bitcoin/blob/62bd61de110b057cbfd6e31e4d0b727d93119c72/doc/zmq.md>.
-///
-/// <https://developer.bitcoin.org/reference/block_chain.html#block-chain>
+///     <https://github.com/bitcoin/bitcoin/blob/62bd61de110b057cbfd6e31e4d0b727d93119c72/doc/zmq.md>.
+/// [^2]: <https://developer.bitcoin.org/reference/block_chain.html#block-chain>
+///       <https://developer.bitcoin.org/reference/p2p_networking.html>
 /// <https://learnmeabitcoin.com/technical/general/byte-order/>
-/// <https://developer.bitcoin.org/reference/p2p_networking.html>
 trait FromLittleEndianOrder: Sized {
     /// Convert bytes expressed in little-endian order to the type;
     fn from_le_bytes(bytes: [u8; 32]) -> Self;

--- a/signer/src/stacks/events.rs
+++ b/signer/src/stacks/events.rs
@@ -30,6 +30,40 @@ use clarity::vm::Value as ClarityValue;
 use secp256k1::PublicKey;
 use stacks_common::types::chainstate::StacksBlockId;
 
+/// This trait adds a function for converting bytes from little-endian
+/// order into a type. This is because the signers convert
+/// [`bitcoin::Txid`] and [`bitcoin::BlockHash`] bytes into little-endian
+/// order before submitting the contract call.
+///
+/// Both [`bitcoin::BlockHash`] and [`bitcoin::Txid`] are hash types that
+/// expect bytes in big-endian order, because bitcoin-core transmits hashes
+/// in big endian byte order[1] through the RPC interface.
+///
+/// [^1]: See the Note in
+/// <https://github.com/bitcoin/bitcoin/blob/62bd61de110b057cbfd6e31e4d0b727d93119c72/doc/zmq.md>.
+///
+/// <https://developer.bitcoin.org/reference/block_chain.html#block-chain>
+/// <https://learnmeabitcoin.com/technical/general/byte-order/>
+/// <https://developer.bitcoin.org/reference/p2p_networking.html>
+trait FromLittleEndianOrder: Sized {
+    /// Convert bytes expressed in little-endian order to the type;
+    fn from_le_bytes(bytes: [u8; 32]) -> Self;
+}
+
+impl FromLittleEndianOrder for bitcoin::Txid {
+    fn from_le_bytes(mut bytes: [u8; 32]) -> Self {
+        bytes.reverse();
+        bitcoin::Txid::from_byte_array(bytes)
+    }
+}
+
+impl FromLittleEndianOrder for bitcoin::BlockHash {
+    fn from_le_bytes(mut bytes: [u8; 32]) -> Self {
+        bytes.reverse();
+        bitcoin::BlockHash::from_byte_array(bytes)
+    }
+}
+
 /// An error when trying to parse an sBTC event into a concrete type.
 #[derive(Debug, thiserror::Error)]
 pub enum EventError {
@@ -48,8 +82,8 @@ pub enum EventError {
     ClarityStringConversion(#[source] std::string::FromUtf8Error),
     /// This can only be thrown when the number of bytes for a txid or
     /// block hash field is not exactly equal to 32. This should never occur.
-    #[error("Could not convert a hash in clarity event into the expected hash {0}")]
-    ClarityHashConversion(#[source] bitcoin::hashes::FromSliceError),
+    #[error("unexpected improper hash byte length, received {0} bytes")]
+    ClarityHashByteLength(usize),
     /// This error is thrown when trying to convert a public key from a
     /// Clarity buffer into a proper public key. It should never be thrown.
     #[error("Could not convert a public key in clarity event into the expected public key {0}")]
@@ -325,14 +359,13 @@ impl RawTupleData {
     fn completed_deposit(mut self) -> Result<RegistryEvent, EventError> {
         let amount = self.remove_u128("amount")?;
         let vout = self.remove_u128("output-index")?;
-        let txid_bytes = self.remove_buff("bitcoin-txid")?;
-        let mut sweep_block_hash = self.remove_buff("burn-hash")?;
+        let txid_bytes = <[u8; 32]>::try_from(self.remove_buff("bitcoin-txid")?)
+            .map_err(|bytes| EventError::ClarityHashByteLength(bytes.len()))?;
+        let sweep_txid = <[u8; 32]>::try_from(self.remove_buff("sweep-txid")?)
+            .map_err(|bytes| EventError::ClarityHashByteLength(bytes.len()))?;
+        let sweep_block_hash = <[u8; 32]>::try_from(self.remove_buff("burn-hash")?)
+            .map_err(|bytes| EventError::ClarityHashByteLength(bytes.len()))?;
         let sweep_block_height = self.remove_u128("burn-height")?;
-        let sweep_txid = self.remove_buff("sweep-txid")?;
-
-        // The `sweep_block_hash` we receive is reversed, so we reverse it here
-        // so that we store it in an ordering consistent with the rest of our db.
-        sweep_block_hash.reverse();
 
         Ok(RegistryEvent::CompletedDeposit(CompletedDepositEvent {
             txid: self.tx_info.txid,
@@ -343,19 +376,17 @@ impl RawTupleData {
             outpoint: OutPoint {
                 // This shouldn't error, this is set from a proper [`Txid`]
                 // in a contract call.
-                txid: BitcoinTxid::from_slice(&txid_bytes)
-                    .map_err(EventError::ClarityHashConversion)?,
+                txid: BitcoinTxid::from_le_bytes(txid_bytes),
+                // .map_err(EventError::ClarityHashConversion)?,
                 // This shouldn't actually error, we cast u32s to u128s
                 // before making the contract call, and that is the value
                 // that gets emitted here.
                 vout: u32::try_from(vout).map_err(EventError::ClarityIntConversion)?,
             },
-            sweep_block_hash: BitcoinBlockHash::from_slice(&sweep_block_hash)
-                .map_err(EventError::ClarityHashConversion)?,
+            sweep_block_hash: BitcoinBlockHash::from_le_bytes(sweep_block_hash),
             sweep_block_height: u64::try_from(sweep_block_height)
                 .map_err(EventError::ClarityIntConversion)?,
-            sweep_txid: BitcoinTxid::from_slice(&sweep_txid)
-                .map_err(EventError::ClarityHashConversion)?,
+            sweep_txid: BitcoinTxid::from_le_bytes(sweep_txid),
         }))
     }
 
@@ -578,14 +609,13 @@ impl RawTupleData {
         let bitmap = self.remove_u128("signer-bitmap")?;
         let fee = self.remove_u128("fee")?;
         let vout = self.remove_u128("output-index")?;
-        let txid_bytes = self.remove_buff("bitcoin-txid")?;
-        let mut sweep_block_hash = self.remove_buff("burn-hash")?;
+        let txid_bytes = <[u8; 32]>::try_from(self.remove_buff("bitcoin-txid")?)
+            .map_err(|bytes| EventError::ClarityHashByteLength(bytes.len()))?;
+        let sweep_txid = <[u8; 32]>::try_from(self.remove_buff("sweep-txid")?)
+            .map_err(|bytes| EventError::ClarityHashByteLength(bytes.len()))?;
+        let sweep_block_hash = <[u8; 32]>::try_from(self.remove_buff("burn-hash")?)
+            .map_err(|bytes| EventError::ClarityHashByteLength(bytes.len()))?;
         let sweep_block_height = self.remove_u128("burn-height")?;
-        let sweep_txid = self.remove_buff("sweep-txid")?;
-
-        // The `sweep_block_hash` we receive is reversed, so we reverse it here
-        // so that we store it in an ordering consistent with the rest of our db.
-        sweep_block_hash.reverse();
 
         Ok(RegistryEvent::WithdrawalAccept(WithdrawalAcceptEvent {
             txid: self.tx_info.txid,
@@ -597,8 +627,7 @@ impl RawTupleData {
             outpoint: OutPoint {
                 // This shouldn't error, this is set from a proper [`Txid`] in
                 // a contract call.
-                txid: BitcoinTxid::from_slice(&txid_bytes)
-                    .map_err(EventError::ClarityHashConversion)?,
+                txid: BitcoinTxid::from_le_bytes(txid_bytes),
                 // This shouldn't actually error, we cast u32s to u128s before
                 // making the contract call, and that is the value that gets
                 // emitted here.
@@ -608,14 +637,12 @@ impl RawTupleData {
             // amount of sats by us.
             fee: u64::try_from(fee).map_err(EventError::ClarityIntConversion)?,
 
-            sweep_block_hash: BitcoinBlockHash::from_slice(&sweep_block_hash)
-                .map_err(EventError::ClarityHashConversion)?,
+            sweep_block_hash: BitcoinBlockHash::from_le_bytes(sweep_block_hash),
 
             sweep_block_height: u64::try_from(sweep_block_height)
                 .map_err(EventError::ClarityIntConversion)?,
 
-            sweep_txid: BitcoinTxid::from_slice(&sweep_txid)
-                .map_err(EventError::ClarityHashConversion)?,
+            sweep_txid: BitcoinTxid::from_le_bytes(sweep_txid),
         }))
     }
 

--- a/signer/src/stacks/events.rs
+++ b/signer/src/stacks/events.rs
@@ -381,7 +381,6 @@ impl RawTupleData {
                 // This shouldn't error, this is set from a proper [`Txid`]
                 // in a contract call.
                 txid: BitcoinTxid::from_le_bytes(txid_bytes),
-                // .map_err(EventError::ClarityHashConversion)?,
                 // This shouldn't actually error, we cast u32s to u128s
                 // before making the contract call, and that is the value
                 // that gets emitted here.

--- a/signer/src/storage/model.rs
+++ b/signer/src/storage/model.rs
@@ -623,15 +623,23 @@ pub struct QualifiedRequestId {
     pub block_hash: StacksBlockHash,
 }
 
-/// Bitcoin-core typically transmits hashes in internal bytes order[1],
-/// which I believe is little-endian byte order. However, when these bytes
-/// are displayed, they are reversed as big endian byte order. This trait
-/// adds a function for converting bytes to and from hash bytes in reverse
-/// order.
+
+/// This trait adds a function for converting bytes to little-endian order
+/// into a type. This is because the stacks core expects bitcoin block
+/// hashes to be in little-endian byte order when evaluating some clarity
+/// functions.
 ///
-/// [^1]: <https://developer.bitcoin.org/reference/block_chain.html#block-chain>
+/// Both [`bitcoin::BlockHash`] and [`bitcoin::Txid`] are hash types that
+/// store bytes internally in big-endian order, and bitcoin-core transmits
+/// hashes in big-endian byte order[1] through the RPC interface. Note that
+/// the wire and zeromq interfaces transmit things in little-endian
+/// order[2].
+///
+/// [^1]: See the Note in
+///     <https://github.com/bitcoin/bitcoin/blob/62bd61de110b057cbfd6e31e4d0b727d93119c72/doc/zmq.md>.
+/// [^2]: <https://developer.bitcoin.org/reference/block_chain.html#block-chain>
+///       <https://developer.bitcoin.org/reference/p2p_networking.html>
 /// <https://learnmeabitcoin.com/technical/general/byte-order/>
-/// <https://developer.bitcoin.org/reference/p2p_networking.html>
 pub trait ToLittleEndianOrder: Sized {
     /// Return the bytes in little-endian order.
     fn to_le_bytes(&self) -> [u8; 32];

--- a/signer/src/storage/model.rs
+++ b/signer/src/storage/model.rs
@@ -624,7 +624,7 @@ pub struct QualifiedRequestId {
 }
 
 /// This trait adds a function for converting a type into bytes to
-/// little-endian byyte order. This is because stacks-core expects
+/// little-endian byte order. This is because stacks-core expects
 /// bitcoin block hashes to be in little-endian byte order when evaluating
 /// some clarity functions.
 ///


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/1102

## Changes

* Add traits for converting to and from little-endian byte order. Implement them for bitcoin `Txid` and `BlockHash` types.
* Convert bitcoin txid and block hash types to little-endian byte order for all contract calls transactions.

## Testing Information

I tested this out on local devenv.

## Checklist:

- [x] I have performed a self-review of my code
