### PR TITLE
feat: add attachments handler to the sidecar

### DIFF
--- a/emily_sidecar/app.py
+++ b/emily_sidecar/app.py
@@ -72,5 +72,13 @@ def handle_new_block():
     return jsonify({}), 200
 
 
+# stacks-node will seldomly send a POST request to /attachments/new
+# if the request is not handled, the node will loop and keep retrying
+# https://github.com/stacks-network/stacks-core/issues/5558
+@app.route("/attachments/new", methods=["POST"])
+def handle_attachments():
+    return jsonify({}), 200
+
+
 if __name__ == "__main__":
     app.run(host="127.0.0.1", port=5000)

--- a/emily_sidecar/test.py
+++ b/emily_sidecar/test.py
@@ -66,5 +66,26 @@ class NewBlockTestCase(unittest.TestCase):
         self.assertIn("Failed to send chainstate", response.get_json()["error"])
 
 
+class AttachmentsTestCase(unittest.TestCase):
+    def setUp(self):
+        self.app = app.test_client()
+        self.app.testing = True
+
+    def test_handle_attachments_with_any_json(self):
+        test_json = {"key": "value"}
+        response = self.app.post('/attachments/new', json=test_json)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual({}, response.get_json())
+
+    def test_handle_attachments_with_empty_json(self):
+        response = self.app.post('/attachments/new', json={})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual({}, response.get_json())
+
+    def test_handle_attachments_with_no_json(self):
+        response = self.app.post('/attachments/new')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual({}, response.get_json())
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Description
As detailed in [stacks-core issue #5558](https://github.com/stacks-network/stacks-core/issues/5558), we discovered that when connected to a syncing stacks-node, the node rarely sends POST requests to the configured event observers at the `/attachments/new` endpoint - even if the events observer is configured to filter only specific events. 

This issue was observed during a sync starting from the genesis block, though it is unclear whether it also occurs with more recent messages.

## Changes
- added dummy handler for `/attachments/new`

## Testing Information
- add unit tests to confirm that the enpoint always returns 200 whatever the input

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
