### PR TITLE
chore: change sidecar port 5000->20540

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -138,7 +138,7 @@ services:
       target: emily-sidecar
     restart: on-failure
     ports:
-      - "5000:5000"
+      - "20540:20540"
     environment:
       EMILY_API_KEY: testApiKey
       EMILY_CHAINSTATE_URL: http://emily-server:3031/chainstate

--- a/docker/sbtc/docker-compose.yml
+++ b/docker/sbtc/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       target: emily-sidecar
     restart: on-failure
     ports:
-      - "5000:5000"
+      - "20540:20540"
     environment:
       EMILY_API_KEY: testApiKey
       EMILY_CHAINSTATE_URL: http://emily-server:3031/chainstate

--- a/docker/sbtc/emily-sidecar/Dockerfile
+++ b/docker/sbtc/emily-sidecar/Dockerfile
@@ -6,7 +6,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Set environment variables
 ENV FLASK_APP=app.py
 # Expose the Flask port
-EXPOSE 5000
+EXPOSE 20540
 ENV EMILY_API_KEY=testApiKey
 ENV EMILY_CHAINSTATE_URL=http://emily-server:3031/chainstate
 ENV DEPLOYER_ADDRESS=SN3R84XZYA63QS28932XQF3G1J8R9PC3W76P9CSQS

--- a/docker/stacks/stacks-regtest-miner.toml
+++ b/docker/stacks/stacks-regtest-miner.toml
@@ -63,7 +63,7 @@ events_keys = ["*"]
 
 # Add emily-sidecar as an event observer
 [[events_observer]]
-endpoint = "host.docker.internal:5000"
+endpoint = "host.docker.internal:20540"
 events_keys = [
     "SN3R84XZYA63QS28932XQF3G1J8R9PC3W76P9CSQS.sbtc-registry::print",
 ]

--- a/emily_sidecar/app.py
+++ b/emily_sidecar/app.py
@@ -73,4 +73,4 @@ def handle_new_block():
 
 
 if __name__ == "__main__":
-    app.run(host="127.0.0.1", port=5000)
+    app.run(host="127.0.0.1", port=20540)

--- a/emily_sidecar/gunicorn_config.py
+++ b/emily_sidecar/gunicorn_config.py
@@ -1,5 +1,5 @@
 # Server socket
-bind = "0.0.0.0:5000"
+bind = "0.0.0.0:20540"
 
 # Worker processes
 workers = 1


### PR DESCRIPTION
## Description

Update the port used by the emily-sidecar from 5000 to 20540. The reason for this change is that port 5000 is commonly used by various other applications and services, which can lead to conflicts during deployment or local development. Switching to a less commonly used port (20540) reduces the risk of such conflicts and ensures smoother operation.


## Testing Information
- tested that the sidecar was still receiving update from the stacks-node and forwarding chainstate updates to emily in devenv
