### PR TITLE
feat: Make emily api able to migrate

### DIFF
--- a/emily/cdk/lib/constants.ts
+++ b/emily/cdk/lib/constants.ts
@@ -21,6 +21,11 @@ export class Constants {
     static DEV_STAGE_NAME: string = "dev";
 
     /**
+     * Stage name used for temporary stacks.
+     */
+    static TEMP_STAGE_NAME: string = "temp";
+
+    /**
      * Default stage name used when no stage name is provided.
      */
     static DEFAULT_STAGE_NAME: string = "dev";

--- a/emily/cdk/lib/emily-stack-utils.ts
+++ b/emily/cdk/lib/emily-stack-utils.ts
@@ -147,7 +147,8 @@ export class EmilyStackUtils {
     public static isDevelopmentStack(): boolean {
         return this.getStageName() === Constants.DEV_STAGE_NAME
             || this.getStageName() === Constants.LOCAL_STAGE_NAME
-            || this.getStageName() === Constants.UNIT_TEST_STAGE_NAME;
+            || this.getStageName() === Constants.UNIT_TEST_STAGE_NAME
+            || this.getStageName() === Constants.TEMP_STAGE_NAME;
     }
 
     /*


### PR DESCRIPTION
## Description

Closes: #N/A

## Changes

Changes various resource names so that api keys won't be overwritten, and so that nothing needs to changed manually to deploy on mainnet without issues.

The public api will now have no suffixes, but the others will.

Also created a new standard stage name for even more dev like environments `temp`.

## Testing Information

Tested by deploying onto a real development environment

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
