### PR TITLE
Swap custom domain prefix to support beta environment dns limitation

### DIFF
--- a/emily/cdk/lib/emily-stack.ts
+++ b/emily/cdk/lib/emily-stack.ts
@@ -459,7 +459,8 @@ export class EmilyStack extends cdk.Stack {
                 ? ""
                 : `${EmilyStackUtils.getStageName()}.`;
             const purposePrefix = apiPurpose != "public" ? `${apiPurpose}.` : "";
-            const customDomainName = `${stagePrefix}${purposePrefix}${customRootDomainNameRoot}`;
+            // const customDomainName = `${stagePrefix}${purposePrefix}${customRootDomainNameRoot}`;
+            const customDomainName = `${purposePrefix}${stagePrefix}${customRootDomainNameRoot}`;
 
             // Get zone.
             const hostedZoneResourceId = `HostedZone${apiPurposeResourceIdSuffix}`;

--- a/emily/cdk/lib/emily-stack.ts
+++ b/emily/cdk/lib/emily-stack.ts
@@ -459,7 +459,6 @@ export class EmilyStack extends cdk.Stack {
                 ? ""
                 : `${EmilyStackUtils.getStageName()}.`;
             const purposePrefix = apiPurpose != "public" ? `${apiPurpose}.` : "";
-            // const customDomainName = `${stagePrefix}${purposePrefix}${customRootDomainNameRoot}`;
             const customDomainName = `${purposePrefix}${stagePrefix}${customRootDomainNameRoot}`;
 
             // Get zone.


### PR DESCRIPTION
## Description

This PR fixes a problem in the beta environment where we use the DNS delegation with the prod account.  This account is not able to create an alias beta.private.* but only private.beta.*

## Changes

- Swap stage and prefix

## Testing Information

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
