### PR TITLE
fix: Update block hash along with reorg.

### DIFF
--- a/emily/handler/src/database/entries/deposit.rs
+++ b/emily/handler/src/database/entries/deposit.rs
@@ -202,13 +202,24 @@ impl DepositEntry {
     /// reflect the latest data in the history vector with the latest entry in the history vector.
     pub fn synchronize_with_history(&mut self) -> Result<(), Error> {
         // Get latest event.
-        let latest_event = self.latest_event()?;
+        let latest_event: DepositEvent = self.latest_event()?.clone();
         // Calculate the new values.
         let new_status: Status = (&latest_event.status).into();
         let new_last_update_height: u64 = latest_event.stacks_block_height;
+
         // Set variables.
+        if new_status == Status::Confirmed {
+            self.fulfillment = match &latest_event.status {
+                StatusEntry::Confirmed(fulfillment) => Some(fulfillment.clone()),
+                _ => None,
+            };
+        } else {
+            self.fulfillment = None;
+        }
         self.status = new_status;
         self.last_update_height = new_last_update_height;
+        self.last_update_block_hash = latest_event.stacks_block_hash;
+
         // Return.
         Ok(())
     }
@@ -557,6 +568,8 @@ impl DepositUpdatePackage {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use test_case::test_case;
+    use testing_emily_client::models::fulfillment;
 
     #[test]
     fn deposit_update_should_be_unnecessary_when_event_is_present() {
@@ -634,5 +647,87 @@ mod tests {
         };
 
         assert!(!update.is_unnecessary(&deposit));
+    }
+
+    #[test_case(0, "hash0", 0, "hash0", StatusEntry::Pending; "reorg around genesis sets status to pending at genesis")]
+    #[test_case(5, "hash5", 4, "hash4", StatusEntry::Accepted; "reorg goes to earliest canonical event 1")]
+    #[test_case(4, "hash4", 4, "hash4", StatusEntry::Accepted; "reorg setting a height consistent with an event keeps it")]
+    #[test_case(4, "hash4-1", 2, "hash2", StatusEntry::Pending; "reorg setting a height inconsistent with an event removes it")]
+    #[test_case(3, "hash3", 2, "hash2", StatusEntry::Pending; "reorg  goes to earliest canonical event 2")]
+    fn reorganizing_around_a_new_chainstate_results_in_valid_deposit(
+        reorg_height: u64,
+        reorg_hash: &str,
+        expected_height: u64,
+        expected_hash: &str,
+        expected_status: StatusEntry,
+    ) {
+        let pending = DepositEvent {
+            status: StatusEntry::Pending,
+            message: "initial test pending".to_string(),
+            stacks_block_height: 2,
+            stacks_block_hash: "hash2".to_string(),
+        };
+
+        let accepted = DepositEvent {
+            status: StatusEntry::Accepted,
+            message: "accepted".to_string(),
+            stacks_block_height: 4,
+            stacks_block_hash: "hash4".to_string(),
+        };
+
+        let fulfillment: Fulfillment = Default::default();
+        let confirmed = DepositEvent {
+            status: StatusEntry::Confirmed(fulfillment.clone()),
+            message: "confirmed".to_string(),
+            stacks_block_height: 6,
+            stacks_block_hash: "hash6".to_string(),
+        };
+
+        let mut deposit = DepositEntry {
+            key: Default::default(),
+            version: 3,
+            recipient: "test-recipient".to_string(),
+            amount: 100,
+            parameters: Default::default(),
+            status: (&confirmed.status).into(),
+            reclaim_script: "test-reclaim".to_string(),
+            deposit_script: "test-deposit".to_string(),
+            last_update_height: 6,
+            last_update_block_hash: "hash6".to_string(),
+            fulfillment: Some(fulfillment.clone()),
+            history: vec![pending.clone(), accepted.clone(), confirmed.clone()],
+        };
+
+        // Ensure the deposit is valid.
+        assert!(
+            deposit.validate().is_ok(),
+            "Test deposit must be valid before reorg.",
+        );
+
+        // Reorganize around a new chainstate.
+        let chainstate = Chainstate {
+            stacks_block_height: reorg_height,
+            stacks_block_hash: reorg_hash.to_string(),
+        };
+        deposit.reorganize_around(&chainstate).unwrap();
+
+        // Ensure the deposit is valid.
+        assert!(
+            deposit.validate().is_ok(),
+            "Deposit must be valid after reorg.",
+        );
+
+        // Check latest height.
+        assert_eq!(deposit.last_update_height, expected_height);
+        assert_eq!(deposit.last_update_block_hash, expected_hash);
+        assert_eq!(deposit.status, (&expected_status).into());
+
+        let latest_event = deposit
+            .latest_event()
+            .expect("must have latest event")
+            .clone();
+        assert_eq!(latest_event.stacks_block_height, expected_height);
+        assert_eq!(latest_event.stacks_block_hash, expected_hash);
+        assert_eq!(latest_event.status, expected_status);
     }
 }

--- a/emily/handler/src/database/entries/withdrawal.rs
+++ b/emily/handler/src/database/entries/withdrawal.rs
@@ -691,10 +691,10 @@ mod tests {
             history: vec![pending.clone(), accepted.clone(), confirmed.clone()],
         };
 
-        // Ensure the deposit is valid.
+        // Ensure the withdrawal is valid.
         assert!(
             withdrawal_entry.validate().is_ok(),
-            "Test deposit must be valid before reorg.",
+            "Test withdrawal must be valid before reorg.",
         );
 
         // Reorganize around a new chainstate.
@@ -704,10 +704,10 @@ mod tests {
         };
         withdrawal_entry.reorganize_around(&chainstate).unwrap();
 
-        // Ensure the deposit is valid.
+        // Ensure the withdrawal is valid.
         assert!(
             withdrawal_entry.validate().is_ok(),
-            "Deposit must be valid after reorg.",
+            "Withdrawal must be valid after reorg.",
         );
 
         // Check latest height.

--- a/emily/handler/src/database/entries/withdrawal.rs
+++ b/emily/handler/src/database/entries/withdrawal.rs
@@ -160,13 +160,14 @@ impl WithdrawalEntry {
     /// reflect the latest data in the history vector with the latest entry in the history vector.
     pub fn synchronize_with_history(&mut self) -> Result<(), Error> {
         // Get latest event.
-        let latest_event = self.latest_event()?;
+        let latest_event = self.latest_event()?.clone();
         // Calculate the new values.
         let new_status: Status = (&latest_event.status).into();
         let new_last_update_height: u64 = latest_event.stacks_block_height;
         // Set variables.
         self.status = new_status;
         self.last_update_height = new_last_update_height;
+        self.last_update_block_hash = latest_event.stacks_block_hash.clone();
         // Return.
         Ok(())
     }
@@ -544,6 +545,8 @@ impl WithdrawalUpdatePackage {
 
 #[cfg(test)]
 mod tests {
+    use crate::api::models::chainstate::Chainstate;
+    use crate::api::models::common::Fulfillment;
     use crate::database::entries::StatusEntry;
     use crate::{
         api::models::common::Status,
@@ -552,6 +555,7 @@ mod tests {
             WithdrawalParametersEntry,
         },
     };
+    use test_case::test_case;
 
     #[test]
     fn withdrawal_update_should_be_unnecessary_when_event_is_present() {
@@ -635,5 +639,88 @@ mod tests {
 
         // Assert
         assert!(!is_unnecessary);
+    }
+
+    #[test_case(0, "hash0", 0, "hash0", StatusEntry::Pending; "reorg around genesis sets status to pending at genesis")]
+    #[test_case(5, "hash5", 4, "hash4", StatusEntry::Accepted; "reorg goes to earliest canonical event 1")]
+    #[test_case(4, "hash4", 4, "hash4", StatusEntry::Accepted; "reorg setting a height consistent with an event keeps it")]
+    #[test_case(4, "hash4-1", 2, "hash2", StatusEntry::Pending; "reorg setting a height inconsistent with an event removes it")]
+    #[test_case(3, "hash3", 2, "hash2", StatusEntry::Pending; "reorg  goes to earliest canonical event 2")]
+    fn reorganizing_around_a_new_chainstate_results_in_valid_withdrawal(
+        reorg_height: u64,
+        reorg_hash: &str,
+        expected_height: u64,
+        expected_hash: &str,
+        expected_status: StatusEntry,
+    ) {
+        let pending = WithdrawalEvent {
+            status: StatusEntry::Pending,
+            message: "initial test pending".to_string(),
+            stacks_block_height: 2,
+            stacks_block_hash: "hash2".to_string(),
+        };
+
+        let accepted = WithdrawalEvent {
+            status: StatusEntry::Accepted,
+            message: "accepted".to_string(),
+            stacks_block_height: 4,
+            stacks_block_hash: "hash4".to_string(),
+        };
+
+        let fulfillment: Fulfillment = Default::default();
+        let confirmed = WithdrawalEvent {
+            status: StatusEntry::Confirmed(fulfillment.clone()),
+            message: "confirmed".to_string(),
+            stacks_block_height: 6,
+            stacks_block_hash: "hash6".to_string(),
+        };
+
+        let mut withdrawal_entry = WithdrawalEntry {
+            key: WithdrawalEntryKey {
+                request_id: 1,
+                stacks_block_hash: "hash".to_string(),
+            },
+            stacks_block_height: 1,
+            version: 1,
+            recipient: "test-recipient".to_string(),
+            amount: 1,
+            parameters: WithdrawalParametersEntry { max_fee: 1 },
+            status: Status::Confirmed,
+            last_update_height: 6,
+            last_update_block_hash: "hash6".to_string(),
+            history: vec![pending.clone(), accepted.clone(), confirmed.clone()],
+        };
+
+        // Ensure the deposit is valid.
+        assert!(
+            withdrawal_entry.validate().is_ok(),
+            "Test deposit must be valid before reorg.",
+        );
+
+        // Reorganize around a new chainstate.
+        let chainstate = Chainstate {
+            stacks_block_height: reorg_height,
+            stacks_block_hash: reorg_hash.to_string(),
+        };
+        withdrawal_entry.reorganize_around(&chainstate).unwrap();
+
+        // Ensure the deposit is valid.
+        assert!(
+            withdrawal_entry.validate().is_ok(),
+            "Deposit must be valid after reorg.",
+        );
+
+        // Check latest height.
+        assert_eq!(withdrawal_entry.last_update_height, expected_height);
+        assert_eq!(withdrawal_entry.last_update_block_hash, expected_hash);
+        assert_eq!(withdrawal_entry.status, (&expected_status).into());
+
+        let latest_event = withdrawal_entry
+            .latest_event()
+            .expect("must have latest event")
+            .clone();
+        assert_eq!(latest_event.stacks_block_height, expected_height);
+        assert_eq!(latest_event.stacks_block_hash, expected_hash);
+        assert_eq!(latest_event.status, expected_status);
     }
 }


### PR DESCRIPTION
## Description

Closes: #N/A

There's an issue with the reorg logic where the reorg updates the height, but it doesn't update the hash or fulfillment.

## Changes

Updates the reorganizing behavior to fix the bug.

## Testing Information

Added unit tests for the reorganizing.

> Note: This is currently failing due to the intermittent swatinem caching error, but the tests are passing: [link](https://github.com/stacks-network/sbtc/actions/runs/12315906307/job/34375058287?pr=1120)

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
