### PR TITLE
add per_deposit_minimum validation

### DIFF
--- a/signer/src/bitcoin/utxo.rs
+++ b/signer/src/bitcoin/utxo.rs
@@ -175,15 +175,18 @@ impl SbtcRequests {
         // Filter deposit requests based on two constraints:
         // 1. The user's max fee must be >= our minimum required fee for deposits
         //     (based on fixed deposit tx size)
-        // 2. The deposit amount must be less than the per-deposit limit
-        // 3. The total amount being minted must stay under the maximum allowed mintable amount
+        // 2. The deposit amount must be greater than or equal to the per-deposit minimum
+        // 3. The deposit amount must be less than or equal to the per-deposit cap
+        // 4. The total amount being minted must stay under the maximum allowed mintable amount
         let minimum_deposit_fee = self.compute_minimum_fee(SOLO_DEPOSIT_TX_VSIZE);
         let max_mintable_cap = self.sbtc_limits.max_mintable_cap().to_sat();
         let per_deposit_cap = self.sbtc_limits.per_deposit_cap().to_sat();
+        let per_deposit_minimum = self.sbtc_limits.per_deposit_minimum().to_sat();
 
         let mut amount_to_mint: u64 = 0;
         let deposits = self.deposits.iter().filter_map(|req| {
             let is_fee_valid = req.max_fee.min(req.amount) >= minimum_deposit_fee;
+            let is_above_per_deposit_minimum = req.amount >= per_deposit_minimum;
             let is_within_per_deposit_cap = req.amount <= per_deposit_cap;
             let is_within_max_mintable_cap =
                 if let Some(new_amount) = amount_to_mint.checked_add(req.amount) {
@@ -191,7 +194,11 @@ impl SbtcRequests {
                 } else {
                     false
                 };
-            if is_fee_valid && is_within_per_deposit_cap && is_within_max_mintable_cap {
+            if is_fee_valid
+                && is_above_per_deposit_minimum
+                && is_within_per_deposit_cap
+                && is_within_max_mintable_cap
+            {
                 amount_to_mint += req.amount;
                 Some(RequestRef::Deposit(req))
             } else {
@@ -2782,30 +2789,42 @@ mod tests {
         create_deposit(10_000, 10_000, 0),
         create_deposit(10_000, 10_000, 0),
         create_deposit(10_000, 10_000, 0),
-    ], 3, 30_000, 10_000, 30_000; "should_accept_deposits_until_max_mintable_reached")]
+    ], 3, 30_000, 0, 10_000, 30_000; "should_accept_deposits_until_max_mintable_reached")]
     #[test_case(vec![
         create_deposit(10_000, 10_000, 0),
         create_deposit(10_000, 10_000, 0),
-    ], 1, 10_000, 10_000, 15_000; "should_accept_all_deposits_when_under_max_mintable")]
+    ], 1, 10_000, 0, 10_000, 15_000; "should_accept_all_deposits_when_under_max_mintable")]
     #[test_case(vec![
         create_deposit(10_000, 10_000, 0),
-    ], 0, 0, 0, 0; "should_handle_empty_deposit_list")]
+    ], 0, 0, 0, 0, 0; "should_handle_empty_deposit_list")]
     #[test_case(vec![
         create_deposit(10_000, 0, 0),
         create_deposit(11_000, 10_000, 0),
         create_deposit(9_000, 10_000, 0),
-    ], 1, 9_000, 10_000, 10_000; "should_skip_invalid_fee_and_accept_valid_deposits")]
+    ], 1, 9_000, 0, 10_000, 10_000; "should_skip_invalid_fee_and_accept_valid_deposits")]
     #[test_case(vec![
         create_deposit(10_001, 10_000, 0),
-    ], 0, 0, 10_001, 10_000; "should_reject_single_deposit_exceeding_max_mintable")]
+    ], 0, 0, 0, 10_001, 10_000; "should_reject_single_deposit_exceeding_max_mintable")]
     #[test_case(vec![
         create_deposit(10_000, 10_000, 0),
-    ], 0, 0, 8_000, 10_000; "should_reject_single_deposit_exceeding_per_deposit_cap")]
+    ], 0, 0, 0, 8_000, 10_000; "should_reject_single_deposit_exceeding_per_deposit_cap")]
+    #[test_case(vec![
+        create_deposit(5_000, 10_000, 0),
+        create_deposit(15_000, 10_000, 0),
+    ], 1, 15_000, 10_000, 20_000, 30_000; "should_reject_deposits_below_per_deposit_minimum")]
+    #[test_case(vec![
+        create_deposit(10_000, 10_000, 0), // accepted
+        create_deposit(9_000, 10_000, 0),  // rejected (below per_deposit_minimum)
+        create_deposit(21_000, 10_000, 0), // rejected (above per_deposit_cap)
+        create_deposit(20_000, 10_000, 0), // accepted
+        create_deposit(20_000, 10_000, 0), // rejected (above max_mintable)
+    ], 2, 30_000, 10_000, 20_000, 40_000; "should_respect_all_limits")]
     #[tokio::test]
     async fn test_construct_transactions_filters_deposits_over_max_mintable(
         deposits: Vec<DepositRequest>,
         num_accepted_requests: usize,
         accepted_amount: u64,
+        per_deposit_minimum: u64,
         per_deposit_cap: u64,
         max_mintable: u64,
     ) {
@@ -2829,7 +2848,9 @@ mod tests {
             accept_threshold: 8,
             sbtc_limits: SbtcLimits::new(
                 None,
+                Some(Amount::from_sat(per_deposit_minimum)),
                 Some(Amount::from_sat(per_deposit_cap)),
+                None,
                 None,
                 Some(Amount::from_sat(max_mintable)),
             ),

--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -557,7 +557,9 @@ impl<C: Context, B> BlockObserver<C, B> {
 
         let limits = SbtcLimits::new(
             Some(limits.total_cap()),
+            Some(limits.per_deposit_minimum()),
             Some(limits.per_deposit_cap()),
+            Some(limits.per_withdrawal_minimum()),
             Some(limits.per_withdrawal_cap()),
             Some(max_mintable),
         );

--- a/signer/src/context/signer_state.rs
+++ b/signer/src/context/signer_state.rs
@@ -82,8 +82,12 @@ impl SignerState {
 pub struct SbtcLimits {
     /// Represents the total cap for all pegged-in BTC/sBTC.
     total_cap: Option<Amount>,
+    /// Represents the minimum amount of BTC allowed to be pegged-in per transaction.
+    per_deposit_minimum: Option<Amount>,
     /// Represents the maximum amount of BTC allowed to be pegged-in per transaction.
     per_deposit_cap: Option<Amount>,
+    /// Represents the minimum amount of sBTC allowed to be pegged-out per transaction.
+    per_withdrawal_minimum: Option<Amount>,
     /// Represents the maximum amount of sBTC allowed to be pegged-out per transaction.
     per_withdrawal_cap: Option<Amount>,
     /// Represents the maximum amount of sBTC that can currently be minted.
@@ -94,8 +98,8 @@ impl std::fmt::Display for SbtcLimits {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "[total cap: {:?}, per-deposit cap: {:?}, per-withdrawal cap: {:?}, max-mintable cap: {:?}]",
-            self.total_cap, self.per_deposit_cap, self.per_withdrawal_cap, self.max_mintable_cap
+            "[total cap: {:?}, per-deposit min: {:?}, per-deposit cap: {:?}, per-withdrawal min: {:?}, per-withdrawal cap: {:?}, max-mintable cap: {:?}]",
+            self.total_cap, self.per_deposit_minimum, self.per_deposit_cap, self.per_withdrawal_minimum, self.per_withdrawal_cap, self.max_mintable_cap
         )
     }
 }
@@ -104,13 +108,17 @@ impl SbtcLimits {
     /// Create a new `SbtcLimits` object.
     pub fn new(
         total_cap: Option<Amount>,
+        per_deposit_minimum: Option<Amount>,
         per_deposit_cap: Option<Amount>,
+        per_withdrawal_minimum: Option<Amount>,
         per_withdrawal_cap: Option<Amount>,
         max_mintable_cap: Option<Amount>,
     ) -> Self {
         Self {
             total_cap,
+            per_deposit_minimum,
             per_deposit_cap,
+            per_withdrawal_minimum,
             per_withdrawal_cap,
             max_mintable_cap,
         }
@@ -126,9 +134,19 @@ impl SbtcLimits {
         self.total_cap.is_some()
     }
 
+    /// Get the minimum amount of BTC allowed to be pegged-in per transaction.
+    pub fn per_deposit_minimum(&self) -> Amount {
+        self.per_deposit_minimum.unwrap_or(Amount::ZERO)
+    }
+
     /// Get the maximum amount of BTC allowed to be pegged-in per transaction.
     pub fn per_deposit_cap(&self) -> Amount {
         self.per_deposit_cap.unwrap_or(Amount::MAX_MONEY)
+    }
+
+    /// Get the minimum amount of sBTC allowed to be pegged-out per transaction.
+    pub fn per_withdrawal_minimum(&self) -> Amount {
+        self.per_withdrawal_minimum.unwrap_or(Amount::ZERO)
     }
 
     /// Get the maximum amount of sBTC allowed to be pegged-out per transaction.

--- a/signer/src/emily_client.rs
+++ b/signer/src/emily_client.rs
@@ -336,16 +336,24 @@ impl EmilyInteract for EmilyClient {
             .map_err(Error::EmilyApi)?;
 
         let total_cap = limits.peg_cap.and_then(|cap| cap.map(Amount::from_sat));
+        let per_deposit_minimum: Option<Amount> = limits
+            .per_deposit_minimum
+            .and_then(|min| min.map(Amount::from_sat));
         let per_deposit_cap = limits
             .per_deposit_cap
             .and_then(|cap| cap.map(Amount::from_sat));
+        let per_withdrawal_minimum: Option<Amount> = limits
+            .per_withdrawal_minimum
+            .and_then(|min| min.map(Amount::from_sat));
         let per_withdrawal_cap = limits
             .per_withdrawal_cap
             .and_then(|cap| cap.map(Amount::from_sat));
 
         Ok(SbtcLimits::new(
             total_cap,
+            per_deposit_minimum,
             per_deposit_cap,
+            per_withdrawal_minimum,
             per_withdrawal_cap,
             None,
         ))

--- a/signer/tests/integration/block_observer.rs
+++ b/signer/tests/integration/block_observer.rs
@@ -661,9 +661,9 @@ async fn block_observer_stores_donation_and_sbtc_utxos() {
 
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[test_case::test_case(false, SbtcLimits::default(); "no contracts, default limits")]
-#[test_case::test_case(false, SbtcLimits::new(Some(bitcoin::Amount::from_sat(1_000)), None, None, None); "no contracts, total cap limit")]
+#[test_case::test_case(false, SbtcLimits::new(Some(bitcoin::Amount::from_sat(1_000)), None, None, None, None, None); "no contracts, total cap limit")]
 #[test_case::test_case(true, SbtcLimits::default(); "deployed contracts, default limits")]
-#[test_case::test_case(true, SbtcLimits::new(Some(bitcoin::Amount::from_sat(1_000)), None, None, None); "deployed contracts, total cap limit")]
+#[test_case::test_case(true, SbtcLimits::new(Some(bitcoin::Amount::from_sat(1_000)), None, None, None, None, None); "deployed contracts, total cap limit")]
 #[tokio::test]
 async fn block_observer_handles_update_limits(deployed: bool, sbtc_limits: SbtcLimits) {
     // We start with the typical setup with a fresh database and context


### PR DESCRIPTION
## Description

Add support for the `per_deposit_minimum` limit from Emily

## Changes

- Retrieve the new values from Emily
- Validate both in the coordinator and the signers that the amount is above the minimum

## Testing Information
- Add unit tests

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
