### PR TITLE
feat: index to help get_last_key_rotation

### DIFF
--- a/signer/migrations/0011__add_stacks_blocks_block_height_index.sql
+++ b/signer/migrations/0011__add_stacks_blocks_block_height_index.sql
@@ -1,1 +1,0 @@
-CREATE INDEX ix_stacks_blocks_block_height_block_hash ON sbtc_signer.stacks_blocks(block_height DESC, block_hash DESC);

--- a/signer/migrations/0011__add_stacks_blocks_block_height_index.sql
+++ b/signer/migrations/0011__add_stacks_blocks_block_height_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX ix_stacks_blocks_block_height_block_hash ON sbtc_signer.stacks_blocks(block_height DESC, block_hash DESC);

--- a/signer/migrations/0011__add_stacks_blocks_indexes.sql
+++ b/signer/migrations/0011__add_stacks_blocks_indexes.sql
@@ -1,0 +1,2 @@
+CREATE INDEX ix_stacks_blocks_block_height ON sbtc_signer.stacks_blocks(block_height DESC);
+CREATE INDEX ix_stacks_blocks_block_hash ON sbtc_signer.stacks_transactions(block_hash DESC);


### PR DESCRIPTION
## Description

Pulled this out of #1158 (and modified) as it's only indexes.

`get_last_key_rotation()` has the following in its query:

```sql
JOIN sbtc_signer.stacks_transactions st ON st.txid = rkt.txid
JOIN stacks_blocks sb on st.block_hash = sb.block_hash
ORDER BY sb.block_height DESC, sb.block_hash DESC, rkt.txid DESC
```

I would like to think that postgres would use `stacks_transactions` as the anchor table in both `st.block_hash = sb.block_hash` and `st.block_hash = sb.block_hash` since its result set should be the smaller of the two due to `st.txid = rkt.txid`, but I can't be certain how the query optimizer is using them.

Keeping this as draft for now and will bench them a little against a db dump from one of the devnet signers.