### PR TITLE
feat: add sql-side of a pseudo-materialized-view for the blockchains

### DIFF
--- a/signer/migrations/0011__materialized_chains.sql
+++ b/signer/migrations/0011__materialized_chains.sql
@@ -1,0 +1,112 @@
+-- This table holds the canonical chain information for Bitcoin and Stacks
+-- chains keyed by the bitcoin chain tip.
+CREATE TABLE sbtc_signer.canonical_chains (
+    run_id INT,
+    bitcoin_chain_tip BYTEA,
+    bitcoin_block_hash BYTEA,
+    bitcoin_block_height BIGINT,
+    stacks_block_hash BYTEA,
+    stacks_block_height BIGINT
+);
+
+-- Indexes to support common queries on the canonical chains table.
+CREATE INDEX ix_canonical_chains_run_id ON sbtc_signer.canonical_chains(run_id);
+CREATE INDEX ix_canonical_chains_bitcoin_chain_tip ON sbtc_signer.canonical_chains(bitcoin_chain_tip);
+CREATE INDEX ix_canonical_chains_bitcoin_block_hash ON sbtc_signer.canonical_chains(bitcoin_block_hash);
+CREATE INDEX ix_canonical_chains_bitcoin_block_height ON sbtc_signer.canonical_chains(bitcoin_block_height);
+CREATE INDEX ix_canonical_chains_stacks_block_hash ON sbtc_signer.canonical_chains(stacks_block_hash);
+CREATE INDEX ix_canonical_chains_stacks_block_height ON sbtc_signer.canonical_chains(stacks_block_height);
+
+-- New sequence which will be used to generate the run_id for each materialized
+-- view canonical chain.
+CREATE SEQUENCE sbtc_signer.canonical_chains_run_id_seq;
+
+-- Function to materialize the canonical chains for a given bitcoin chain tip
+-- and the maximum depth of the bitcoin blockchain to consider.
+CREATE OR REPLACE FUNCTION sbtc_signer.materialize_canonical_chains(chain_tip BYTEA, max_depth INT)
+RETURNS INTEGER AS $$
+DECLARE
+    rows_written INTEGER;
+	existing_rows INTEGER;
+	new_run_id BIGINT;
+BEGIN
+	-- Get the next value for the run_id
+    new_run_id := nextval('sbtc_signer.canonical_chains_run_id_seq');
+
+	-- Check if rows exist with the given chain_tip
+    SELECT COUNT(*) INTO existing_rows
+    FROM sbtc_signer.canonical_chains
+    WHERE bitcoin_chain_tip = chain_tip;
+
+    -- If rows exist, return an error code
+    IF existing_rows > 0 THEN
+        RETURN -1; -- Error code indicating rows already exist
+    END IF;
+
+	-- Materialize the canonical chains from the given bitcoin chain tip.
+    WITH RECURSIVE 
+    bitcoin AS (
+        SELECT 
+            block_hash,
+            parent_hash,
+            block_height,
+			1 as depth
+        FROM sbtc_signer.bitcoin_blocks
+        WHERE block_hash = chain_tip
+
+        UNION ALL
+
+        SELECT 
+            parent.block_hash,
+            parent.parent_hash,
+            parent.block_height,
+			last.depth + 1
+        FROM sbtc_signer.bitcoin_blocks parent
+        JOIN bitcoin last ON parent.block_hash = last.parent_hash
+		WHERE last.depth < max_depth
+    ),
+    stacks AS (
+        (SELECT 
+            blocks.block_hash,
+            blocks.parent_hash,
+            blocks.block_height,
+            blocks.bitcoin_anchor
+        FROM sbtc_signer.stacks_blocks blocks
+        JOIN bitcoin ON blocks.bitcoin_anchor = bitcoin.block_hash
+        ORDER BY bitcoin.block_height DESC, bitcoin.block_hash DESC, blocks.block_height DESC, blocks.block_hash DESC
+        LIMIT 1)
+
+        UNION ALL
+
+        SELECT 
+            parent.block_hash,
+            parent.parent_hash,
+            parent.block_height,
+            parent.bitcoin_anchor
+        FROM sbtc_signer.stacks_blocks parent
+        JOIN stacks last ON parent.block_hash = last.parent_hash
+        JOIN bitcoin ON bitcoin.block_hash = parent.bitcoin_anchor
+    )
+    INSERT INTO sbtc_signer.canonical_chains (
+		run_id,
+        bitcoin_chain_tip,
+        bitcoin_block_hash,
+        bitcoin_block_height,
+        stacks_block_hash,
+        stacks_block_height
+    )
+    SELECT 
+		new_run_id,
+        chain_tip,
+        bb.block_hash AS bitcoin_block_hash,
+        bb.block_height AS bitcoin_block_height,
+        sb.block_hash AS stacks_block_hash,
+        sb.block_height AS stacks_block_height
+    FROM bitcoin bb
+    LEFT JOIN stacks sb ON sb.bitcoin_anchor = bb.block_hash
+    ORDER BY bb.block_height DESC, sb.block_height DESC;
+
+    GET DIAGNOSTICS rows_written = ROW_COUNT;
+    RETURN rows_written;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Description

Closes: #1170

## Changes

Adds the SQL-side of pseudo-materialized views for the canonical blockchains, keyed on the bitcoin chain tip. It's intended that the `materialize_canonical_chains` function is called after each Bitcoin block has been processed (but that's not included here).

## Testing Information

The added script has been run and tested against a local copy of the signer database from testnet using the `get_last_key_rotation()` query. The updated query I used (below) reduced the execution time on my local machine from 0.2 seconds to 0.002:

```sql
select 
	rkt.txid,
	rkt.address,
	rkt.aggregate_key,
	rkt.signer_set,
	rkt.signatures_required
from rotate_keys_transactions rkt 
inner join stacks_transactions st on st.txid = rkt.txid
inner join canonical_chains cc 
	on cc.stacks_block_hash = st.block_hash 
	and cc.bitcoin_chain_tip = '\x9F654F6D199EB6691B560A2CE2511F600D21E2F350549855488A75CC7FAF7D59'
order by 
	cc.stacks_block_height desc, 
	cc.stacks_block_hash desc, 
	rkt.created_at desc
limit 1
```