### PR TITLE
fix: ensure mint amount is greater than the dust limit

### DIFF
--- a/signer/src/bitcoin/utxo.rs
+++ b/signer/src/bitcoin/utxo.rs
@@ -173,7 +173,7 @@ impl SbtcRequests {
             })
             .map(RequestRef::Withdrawal);
 
-        // Filter deposit requests based on two constraints:
+        // Filter deposit requests based on four constraints:
         // 1. The user's max fee must be >= our minimum required fee for
         //     deposits (based on fixed deposit tx size)
         // 2. The deposit amount must be less than the per-deposit limit
@@ -2878,7 +2878,9 @@ mod tests {
         // filtering done here uses a heuristic where we take the maximum
         // fee that the user could pay, and subtract that amount from the
         // deposit amount. The maximum fee that a user could pay is the
-        // SOLO_DEPOSIT_TX_VSIZE times the fee rate.
+        // SOLO_DEPOSIT_TX_VSIZE times the fee rate so with a fee rate of 1
+        // we should filter the request if the deposit amount is less than
+        // SOLO_DEPOSIT_TX_VSIZE + DEPOSIT_DUST_LIMIT.
         let requests = SbtcRequests {
             deposits: vec![create_deposit(2500000, 100000, 0), req],
             withdrawals: vec![],

--- a/signer/src/bitcoin/utxo.rs
+++ b/signer/src/bitcoin/utxo.rs
@@ -51,6 +51,7 @@ use crate::storage::model::TxOutput;
 use crate::storage::model::TxOutputType;
 use crate::storage::model::TxPrevout;
 use crate::storage::model::TxPrevoutType;
+use crate::DEPOSIT_DUST_LIMIT;
 
 /// The minimum incremental fee rate in sats per virtual byte for RBF
 /// transactions.
@@ -173,10 +174,13 @@ impl SbtcRequests {
             .map(RequestRef::Withdrawal);
 
         // Filter deposit requests based on two constraints:
-        // 1. The user's max fee must be >= our minimum required fee for deposits
-        //     (based on fixed deposit tx size)
+        // 1. The user's max fee must be >= our minimum required fee for
+        //     deposits (based on fixed deposit tx size)
         // 2. The deposit amount must be less than the per-deposit limit
-        // 3. The total amount being minted must stay under the maximum allowed mintable amount
+        // 3. The total amount being minted must stay under the maximum
+        //    allowed mintable amount
+        // 4. The mint amount is above the deposit dust limit in the smart
+        //    contract.
         let minimum_deposit_fee = self.compute_minimum_fee(SOLO_DEPOSIT_TX_VSIZE);
         let max_mintable_cap = self.sbtc_limits.max_mintable_cap().to_sat();
         let per_deposit_cap = self.sbtc_limits.per_deposit_cap().to_sat();
@@ -191,6 +195,9 @@ impl SbtcRequests {
                 } else {
                     false
                 };
+            if req.amount.saturating_sub(minimum_deposit_fee) < DEPOSIT_DUST_LIMIT {
+                return None;
+            }
             if is_fee_valid && is_within_per_deposit_cap && is_within_max_mintable_cap {
                 amount_to_mint += req.amount;
                 Some(RequestRef::Deposit(req))
@@ -2847,6 +2854,61 @@ mod tests {
             .sum();
         assert_eq!(nr_requests, num_accepted_requests);
         assert_eq!(total_amount, accepted_amount);
+    }
+
+    #[test_case(
+        create_deposit(
+            DEPOSIT_DUST_LIMIT + SOLO_DEPOSIT_TX_VSIZE as u64,
+            10_000,
+            0
+        ),
+        true; "deposit amounts over the dust limit accepted")]
+    #[test_case(
+        create_deposit(
+            DEPOSIT_DUST_LIMIT + SOLO_DEPOSIT_TX_VSIZE as u64 - 1,
+            10_000,
+            0
+        ),
+        false; "deposit amounts under the dust limit rejected")]
+    fn deposit_requests_respect_dust_limits(req: DepositRequest, is_included: bool) {
+        let outpoint = req.outpoint;
+        let public_key = XOnlyPublicKey::from_str(X_ONLY_PUBLIC_KEY1).unwrap();
+
+        // We use a fee rate of 1 to simplify the computation. The
+        // filtering done here uses a heuristic where we take the maximum
+        // fee that the user could pay, and subtract that amount from the
+        // deposit amount. The maximum fee that a user could pay is the
+        // SOLO_DEPOSIT_TX_VSIZE times the fee rate.
+        let requests = SbtcRequests {
+            deposits: vec![create_deposit(2500000, 100000, 0), req],
+            withdrawals: vec![],
+            signer_state: SignerBtcState {
+                utxo: SignerUtxo {
+                    outpoint: generate_outpoint(300_000, 0),
+                    amount: 300_000_000,
+                    public_key,
+                },
+                fee_rate: 1.0,
+                public_key,
+                last_fees: None,
+                magic_bytes: [0; 2],
+            },
+            num_signers: 11,
+            accept_threshold: 6,
+            sbtc_limits: SbtcLimits::default(),
+        };
+
+        // Let's construct the unsigned transaction and check to see if we
+        // include it in the deposit requests in the transaction.
+        let tx = requests.construct_transactions().unwrap().pop().unwrap();
+        let request_is_included = tx
+            .requests
+            .iter()
+            .filter_map(RequestRef::as_deposit)
+            .find(|req| req.outpoint == outpoint)
+            .is_some();
+
+        assert_eq!(request_is_included, is_included);
     }
 
     #[test]

--- a/signer/src/bitcoin/validation.rs
+++ b/signer/src/bitcoin/validation.rs
@@ -265,7 +265,7 @@ impl BitcoinPreSignRequest {
                 .deposit_reports
                 .get(&key)
                 // This should never happen because we have already validated that we have all the reports.
-                .ok_or(InputValidationResult::Unknown.into_error(btc_ctx))?;
+                .ok_or_else(|| InputValidationResult::Unknown.into_error(btc_ctx))?;
             deposits.push((report.to_deposit_request(votes), report.clone()));
         }
 
@@ -274,7 +274,7 @@ impl BitcoinPreSignRequest {
                 .withdrawal_reports
                 .get(id)
                 // This should never happen because we have already validated that we have all the reports.
-                .ok_or(WithdrawalValidationResult::Unknown.into_error(btc_ctx))?;
+                .ok_or_else(|| WithdrawalValidationResult::Unknown.into_error(btc_ctx))?;
             withdrawals.push((report.to_withdrawal_request(votes), report.clone()));
         }
 

--- a/signer/src/bitcoin/validation.rs
+++ b/signer/src/bitcoin/validation.rs
@@ -23,6 +23,7 @@ use crate::storage::model::BitcoinWithdrawalOutput;
 use crate::storage::model::QualifiedRequestId;
 use crate::storage::model::SignerVotes;
 use crate::storage::DbRead;
+use crate::DEPOSIT_DUST_LIMIT;
 use crate::DEPOSIT_LOCKTIME_BLOCK_BUFFER;
 
 use super::utxo::DepositRequest;
@@ -508,6 +509,9 @@ impl SbtcReports {
 pub enum InputValidationResult {
     /// The deposit request passed validation
     Ok,
+    /// The deposit request amount, less the fees, would be rejected from
+    /// the smart contract during the complete-deposit contract call.
+    MintAmountBelowDustLimit,
     /// The deposit request amount exceeds the allowed per-deposit cap.
     AmountTooHigh,
     /// The assessed fee exceeds the max-fee in the deposit request.
@@ -728,6 +732,10 @@ impl DepositRequestReport {
 
         if assessed_fee.to_sat() > self.max_fee.min(self.amount) {
             return InputValidationResult::FeeTooHigh;
+        }
+
+        if self.amount.saturating_sub(assessed_fee.to_sat()) < DEPOSIT_DUST_LIMIT {
+            return InputValidationResult::MintAmountBelowDustLimit;
         }
 
         // Let's check whether we rejected this deposit.
@@ -1063,6 +1071,38 @@ mod tests {
         status: InputValidationResult::FeeTooHigh,
         chain_tip_height: 2,
     } ; "one-sat-too-high-fee-amount")]
+    #[test_case(DepositReportErrorMapping {
+        report: DepositRequestReport {
+            status: DepositConfirmationStatus::Confirmed(0, BitcoinBlockHash::from([0; 32])),
+            can_sign: Some(true),
+            can_accept: Some(true),
+            amount: TX_FEE.to_sat() + DEPOSIT_DUST_LIMIT - 1,
+            max_fee: TX_FEE.to_sat(),
+            lock_time: LockTime::from_height(DEPOSIT_LOCKTIME_BLOCK_BUFFER + 3),
+            outpoint: OutPoint::null(),
+            deposit_script: ScriptBuf::new(),
+            reclaim_script: ScriptBuf::new(),
+            signers_public_key: *sbtc::UNSPENDABLE_TAPROOT_KEY,
+        },
+        status: InputValidationResult::MintAmountBelowDustLimit,
+        chain_tip_height: 2,
+    } ; "one-sat-under-dust-amount")]
+    #[test_case(DepositReportErrorMapping {
+        report: DepositRequestReport {
+            status: DepositConfirmationStatus::Confirmed(0, BitcoinBlockHash::from([0; 32])),
+            can_sign: Some(true),
+            can_accept: Some(true),
+            amount: TX_FEE.to_sat() + DEPOSIT_DUST_LIMIT,
+            max_fee: TX_FEE.to_sat(),
+            lock_time: LockTime::from_height(DEPOSIT_LOCKTIME_BLOCK_BUFFER + 3),
+            outpoint: OutPoint::null(),
+            deposit_script: ScriptBuf::new(),
+            reclaim_script: ScriptBuf::new(),
+            signers_public_key: *sbtc::UNSPENDABLE_TAPROOT_KEY,
+        },
+        status: InputValidationResult::Ok,
+        chain_tip_height: 2,
+    } ; "at-dust-amount")]
     #[test_case(DepositReportErrorMapping {
         report: DepositRequestReport {
             status: DepositConfirmationStatus::Confirmed(0, BitcoinBlockHash::from([0; 32])),

--- a/signer/src/lib.rs
+++ b/signer/src/lib.rs
@@ -78,6 +78,11 @@ pub const MAX_REORG_BLOCK_COUNT: i64 = 10;
 /// per block.
 pub const MAX_TX_PER_BITCOIN_BLOCK: i64 = 25;
 
+/// This is the dust limit for deposits in the sBTC smart contracts. A
+/// deposit amount that is less than this amount will be rejected by the
+/// smart contract, so let's not try.
+pub const DEPOSIT_DUST_LIMIT: u64 = 546;
+
 /// These are all build info variables. Many of them are set in build.rs.
 
 /// The name of the binary that is being run,

--- a/signer/src/lib.rs
+++ b/signer/src/lib.rs
@@ -78,9 +78,9 @@ pub const MAX_REORG_BLOCK_COUNT: i64 = 10;
 /// per block.
 pub const MAX_TX_PER_BITCOIN_BLOCK: i64 = 25;
 
-/// This is the dust limit for deposits in the sBTC smart contracts. A
-/// deposit amount that is less than this amount will be rejected by the
-/// smart contract, so let's not try.
+/// This is the dust limit for deposits in the sBTC smart contracts.
+/// Deposit amounts that is less than this amount will be rejected by the
+/// smart contract.
 pub const DEPOSIT_DUST_LIMIT: u64 = 546;
 
 /// These are all build info variables. Many of them are set in build.rs.

--- a/signer/src/testing/block_observer.rs
+++ b/signer/src/testing/block_observer.rs
@@ -103,7 +103,7 @@ impl TestHarness {
             vout: Vec::new(),
             block_hash: response
                 .block_hash
-                .unwrap_or(bitcoin::BlockHash::all_zeros()),
+                .unwrap_or_else(bitcoin::BlockHash::all_zeros),
             confirmations: 0,
             block_time: 0,
         };

--- a/signer/tests/integration/complete_deposit.rs
+++ b/signer/tests/integration/complete_deposit.rs
@@ -18,7 +18,10 @@ use signer::testing::context::*;
 use fake::Fake;
 
 use crate::setup::backfill_bitcoin_blocks;
+use crate::setup::DepositAmounts;
+use crate::setup::TestSignerSet;
 use crate::setup::TestSweepSetup;
+use crate::setup::TestSweepSetup2;
 use crate::DATABASE_NUM;
 
 /// Create a "proper" [`CompleteDepositV1`] object and context with the
@@ -71,6 +74,66 @@ pub fn make_complete_deposit(data: &TestSweepSetup) -> (CompleteDepositV1, ReqCo
         // accepted. During validation, a signer won't sign a transaction
         // if it is not considered accepted but the collection of signers.
         signatures_required: 2,
+        // This is who the current signer thinks deployed the sBTC
+        // contracts.
+        deployer: StacksAddress::burn_address(false),
+    };
+
+    (complete_deposit_tx, req_ctx)
+}
+
+/// Create a "proper" [`CompleteDepositV1`] object and context with the
+/// given information. If the information here is correct then the returned
+/// [`CompleteDepositV1`] object will pass validation with the given
+/// context.
+pub fn make_complete_deposit2(data: &TestSweepSetup2) -> (CompleteDepositV1, ReqContext) {
+    let deposit = &data.deposits[0];
+    let sweep_tx_info = data.sweep_tx_info.clone().unwrap();
+    // The fee assessed for a deposit is subtracted from the minted amount.
+    let fee = sweep_tx_info
+        .tx_info
+        .assess_input_fee(&deposit.1.outpoint)
+        .unwrap()
+        .to_sat();
+    let complete_deposit_tx = CompleteDepositV1 {
+        // This OutPoint points to the deposit UTXO.
+        outpoint: deposit.1.outpoint,
+        // This amount must not exceed the amount in the deposit request.
+        amount: deposit.1.amount - fee,
+        // The recipient must match what was indicated in the deposit
+        // request.
+        recipient: deposit.0.recipient.clone(),
+        // The deployer must match what is in the signers' context.
+        deployer: StacksAddress::burn_address(false),
+        // The sweep transaction ID must point to a transaction on
+        // the canonical bitcoin blockchain.
+        sweep_txid: sweep_tx_info.tx_info.txid.into(),
+        // The block hash of the block that includes the above sweep
+        // transaction. It must be on the canonical bitcoin blockchain.
+        sweep_block_hash: sweep_tx_info.block_hash,
+        // This must be the height of the above block.
+        sweep_block_height: sweep_tx_info.block_height,
+    };
+
+    // This is what the current signer thinks is the state of things.
+    let req_ctx = ReqContext {
+        chain_tip: BitcoinBlockRef {
+            block_hash: sweep_tx_info.block_hash,
+            block_height: sweep_tx_info.block_height,
+        },
+        // This value means that the signer will go back 10 blocks when
+        // looking for pending and accepted deposit requests.
+        context_window: 10,
+        // The value here doesn't matter.
+        origin: fake::Faker.fake_with_rng(&mut OsRng),
+        // When checking whether the transaction is from the signer, we
+        // check that the first "prevout" has a `scriptPubKey` that the
+        // signers control.
+        aggregate_key: data.signers.aggregate_key(),
+        // This value affects how many deposit transactions are consider
+        // accepted. During validation, a signer won't sign a transaction
+        // if it is not considered accepted but the collection of signers.
+        signatures_required: data.signatures_required,
         // This is who the current signer thinks deployed the sBTC
         // contracts.
         deployer: StacksAddress::burn_address(false),
@@ -339,25 +402,42 @@ async fn complete_deposit_validation_recipient_mismatch() {
 }
 
 /// For this test we check that the `CompleteDepositV1::validate` function
-/// returns a deposit validation error with a InvalidMintAmount message
-/// when the amount of sBTC to mint exceeds the amount in the signer's
-/// deposit request record.
+/// returns a deposit validation error with a AmountBelowDustLimit message
+/// when the sweep transaction does not have a prevout with a scriptPubKey
+/// that the signers control.
+///
+/// Unfortunately, this test is a bit opaque and complex. We try to set
+/// things so that the mint amount is less than the dust amount, but for
+/// that we need to take into consideration fees. The fee rate for these
+/// tests are 10 sats per vbyte, and this test constructs a sweep
+/// transaction that is 235 bytes. Adding more deposits, including
+/// withdrawals outputs, and changing the fee rate would change the
+/// calulation specified in this test, so that's why we use the magic
+/// deposit amount here.
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
-async fn complete_deposit_validation_invalid_mint_amount() {
+async fn complete_deposit_validation_fee_too_low() {
     // Normal: this generates the blockchain as well as deposit request
     // transactions and a transaction sweeping in the deposited funds.
     let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
     let db = testing::storage::new_test_database(db_num, true).await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
     let (rpc, faucet) = regtest::initialize_blockchain();
-    let setup = TestSweepSetup::new_setup(&rpc, &faucet, 1_000_000, &mut rng);
+
+    let signers = TestSignerSet::new(&mut rng);
+    // We are trying to trigger the fee too low mint amount. Specifically,
+    // we want to choose a deposit amount that is still positive after fees
+    // but below the dust limit. The fee rate in this test is fixed at 10.0
+    // sats per vbyte and the tx size is 235 bytes so we lose 2350 sats to
+    // fees.
+    let amounts = DepositAmounts { amount: 2850, max_fee: 80_000 };
+    let mut setup = TestSweepSetup2::new_setup(signers, faucet, &[amounts]);
 
     // Normal: the signers' block observer should be getting new block
     // events from bitcoin-core. We haven't hooked up our block observer,
     // so we need to manually update the database with new bitcoin block
     // headers and at least one stacks block.
-    backfill_bitcoin_blocks(&db, rpc, &setup.sweep_block_hash).await;
+    backfill_bitcoin_blocks(&db, rpc, &setup.deposit_block_hash).await;
     // Normal: This stores a genesis stacks block anchored to the bitcoin
     // blockchain identified by setup.sweep_block_hash.
     setup.store_stacks_genesis_block(&db).await;
@@ -365,8 +445,15 @@ async fn complete_deposit_validation_invalid_mint_amount() {
     // Normal: we take the deposit transaction as is from the test setup
     // and store it in the database. This is necessary for when we fetch
     // outstanding unfulfilled deposit requests.
-    setup.store_deposit_tx(&db).await;
+    setup.store_deposit_txs(&db).await;
 
+    // Normal: we submit the transaction sweeping the funds. It gets
+    // confirmed; this generates a new bitcoin block behind the scene.
+    setup.submit_sweep_tx(rpc, faucet, false);
+
+    // Normal: When a new bitcoin block is generated, we need to update the
+    // signer's database with blockchain data.
+    backfill_bitcoin_blocks(&db, rpc, &setup.sweep_block_hash().unwrap()).await;
     // Normal: we take the sweep transaction as is from the test setup and
     // store it in the database.
     setup.store_sweep_tx(&db).await;
@@ -383,10 +470,7 @@ async fn complete_deposit_validation_invalid_mint_amount() {
 
     // Normal: create a properly formed complete-deposit transaction object
     // and the corresponding request context.
-    let (mut complete_deposit_tx, req_ctx) = make_complete_deposit(&setup);
-    // Different: The amount cannot exceed the amount in the deposit
-    // request.
-    complete_deposit_tx.amount = setup.deposit_request.amount + 1;
+    let (complete_deposit_tx, req_ctx) = make_complete_deposit2(&setup);
 
     let ctx = TestContext::builder()
         .with_storage(db.clone())
@@ -395,10 +479,10 @@ async fn complete_deposit_validation_invalid_mint_amount() {
         .with_mocked_emily_client()
         .build();
 
-    let validate_future = complete_deposit_tx.validate(&ctx, &req_ctx);
-    match validate_future.await.unwrap_err() {
+    let validation_result = complete_deposit_tx.validate(&ctx, &req_ctx).await;
+    match validation_result.unwrap_err() {
         Error::DepositValidation(ref err) => {
-            assert_eq!(err.error, DepositErrorMsg::InvalidMintAmount)
+            assert_eq!(err.error, DepositErrorMsg::AmountBelowDustLimit)
         }
         err => panic!("unexpected error during validation {err}"),
     }

--- a/signer/tests/integration/complete_deposit.rs
+++ b/signer/tests/integration/complete_deposit.rs
@@ -133,7 +133,7 @@ pub fn make_complete_deposit2(data: &TestSweepSetup2) -> (CompleteDepositV1, Req
         aggregate_key: data.signers.aggregate_key(),
         // This value affects how many deposit transactions are consider
         // accepted. During validation, a signer won't sign a transaction
-        // if it is not considered accepted but the collection of signers.
+        // if it is not considered accepted by enough signers.
         signatures_required: data.signatures_required,
         // This is who the current signer thinks deployed the sBTC
         // contracts.
@@ -430,16 +430,16 @@ async fn complete_deposit_validation_fee_too_low() {
     let (rpc, faucet) = regtest::initialize_blockchain();
 
     let signers = TestSignerSet::new(&mut rng);
-    // We are trying to trigger the fee too low mint amount. Specifically,
-    // we want to choose a deposit amount that is still positive after fees
-    // but below the dust limit. But our test code goes through the
-    // production code that refuses to construct transactions where we
-    // could hit the dust limit. So we construct a deposit with a certain
-    // high amount, and then modify the database to store an amount that
-    // would trigger the limit. This is tricky because we reach out to
-    // bitcoin core for something and rely on the database for others.
-    // Hopefully this test becomes an issue down the line becuase of a
-    // refactor.
+    // We are trying to trigger the AmountBelowDustLimit error.
+    // Specifically, we want to choose a deposit amount that is still
+    // positive after fees but below the dust limit. But our test code goes
+    // through the production code that refuses to construct transactions
+    // where we could hit the dust limit. So we construct a deposit with a
+    // certain high amount, and then modify the database to store an amount
+    // that would trigger the limit. This is tricky because we reach out to
+    // bitcoin core for somethings and rely on the database for others.
+    // Hopefully this test does not becomes an issue down the line becuase
+    // of a refactor.
     let amounts = DepositAmounts { amount: 50000, max_fee: 80_000 };
     let mut setup = TestSweepSetup2::new_setup(signers, faucet, &[amounts]);
 

--- a/signer/tests/integration/complete_deposit.rs
+++ b/signer/tests/integration/complete_deposit.rs
@@ -413,11 +413,11 @@ async fn complete_deposit_validation_recipient_mismatch() {
 /// tests are 10 sats per vbyte, and this test constructs a sweep
 /// transaction that is 235 bytes. Adding more deposits, including
 /// withdrawals outputs, and changing the fee rate would change the
-/// calulation specified in this test, so that's why we use the magic
+/// calculation specified in this test, so that's why we use the magic
 /// deposit amount here.
 ///
 /// Moreover, our testing apparatus goes through code that filters deposits
-/// based off of the the DUST amount so we need custom code to trigger this
+/// based off of the DUST amount, so we need custom code to trigger this
 /// error.
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
@@ -437,9 +437,9 @@ async fn complete_deposit_validation_fee_too_low() {
     // where we could hit the dust limit. So we construct a deposit with a
     // certain high amount, and then modify the database to store an amount
     // that would trigger the limit. This is tricky because we reach out to
-    // bitcoin core for somethings and rely on the database for others.
-    // Hopefully this test does not becomes an issue down the line becuase
-    // of a refactor.
+    // bitcoin core for some things and rely on the database for others.
+    // Hopefully this test does not become an issue down the line due to a
+    // refactor.
     let amounts = DepositAmounts { amount: 50000, max_fee: 80_000 };
     let mut setup = TestSweepSetup2::new_setup(signers, faucet, &[amounts]);
 
@@ -482,7 +482,7 @@ async fn complete_deposit_validation_fee_too_low() {
     // validation would reject. To do that we update our database.
     //
     // The fee rate in this test is fixed at 10.0 sats per vbyte and the tx
-    // size is 235 bytes so we lose 2350 sats to fees. The amount here is
+    // size is 235 bytes, so we lose 2350 sats to fees. The amount here is
     // chosen so that 2350 + 546 is greater than it.
     let deposit_amount = 2895;
     sqlx::query(


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/1135 and closes https://github.com/stacks-network/sbtc/issues/1174.

This is technically protocol breaking, because now signers may reject requests for inclusion into a bitcoin transaction when before they wouldn't. Practically speaking, this has no effect since the current sBTC limits filter out these deposit requests as already.

## Changes

* Only consider deposits where the mint amount is above the dust limit.
* Check for the mint amount during bitcoin validation.
* Check for the mint amount during stacks validation.
* Don't be so wasteful during the happy path.
* Do less work during the happy path when unwrapping stuff.

## Testing Information

This PR adds an integration test that is crappier than our other integration tests. It's not flaky, just complex.

## Checklist:

- [x] I have performed a self-review of my code

