### PR TITLE
fix: add default '200' handler for signer api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -732,7 +732,7 @@ dependencies = [
  "rustversion",
  "serde 1.0.203",
  "sync_wrapper 0.1.2",
- "tower",
+ "tower 0.4.13",
  "tower-layer",
  "tower-service",
 ]
@@ -764,7 +764,7 @@ dependencies = [
  "serde_path_to_error",
  "sync_wrapper 1.0.1",
  "tokio",
- "tower",
+ "tower 0.4.13",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3207,7 +3207,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
- "tower",
+ "tower 0.4.13",
  "tracing",
 ]
 
@@ -6238,6 +6238,7 @@ dependencies = [
  "toml_edit 0.22.22",
  "tonic",
  "tonic-build",
+ "tower 0.5.2",
  "tower-http",
  "tracing",
  "tracing-attributes",
@@ -7182,7 +7183,7 @@ dependencies = [
  "prost",
  "tokio",
  "tokio-stream",
- "tower",
+ "tower 0.4.13",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -7236,6 +7237,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper 1.0.1",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "tower-http"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7260,9 +7275,9 @@ checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -7622,7 +7637,7 @@ dependencies = [
  "mime",
  "once_cell",
  "thiserror",
- "tower",
+ "tower 0.4.13",
  "tracing",
  "url",
  "warp",

--- a/signer/Cargo.toml
+++ b/signer/Cargo.toml
@@ -80,6 +80,7 @@ test-case = "3.1"
 test-log = { version = "0.2.16", default-features = false, features = ["trace"] }
 toml_edit = "0.22.22"
 tempfile = "3.6"
+tower = { version = "0.5.2", features = ["util"] }
 
 [build-dependencies]
 tonic-build.workspace = true

--- a/signer/src/api/default.rs
+++ b/signer/src/api/default.rs
@@ -1,0 +1,62 @@
+//! Default/fallback route for the API.
+
+use axum::http::StatusCode;
+
+/// Default/fallback route for the API.
+pub async fn default_handler() -> StatusCode {
+    StatusCode::OK
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Method, Request, StatusCode},
+        Router,
+    };
+    use tower::ServiceExt;
+
+    use crate::{api::ApiState, testing::context::TestContext};
+
+    #[tokio::test]
+    async fn test_unknown_routes_return_ok() {
+        let context = TestContext::default_mocked();
+
+        // Test that we get 404 when the fallback handler isn't set.
+        let state = ApiState { ctx: context.clone() };
+        let app: Router = Router::new()
+            .route("/", axum::routing::get(crate::api::status_handler))
+            .route(
+                "/new_block",
+                axum::routing::post(crate::api::new_block_handler),
+            )
+            .with_state(state);
+        let request = Request::builder()
+            .uri("/asdf")
+            .method(Method::GET)
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+        // Now test that we get 200 OK when the fallback handler is set.
+        let state = ApiState { ctx: context.clone() };
+        let app: Router = Router::new()
+            .route("/", axum::routing::get(crate::api::status_handler))
+            .route(
+                "/new_block",
+                axum::routing::post(crate::api::new_block_handler),
+            )
+            .fallback(crate::api::default_handler)
+            .with_state(state);
+        let request = Request::builder()
+            .uri("/asdf")
+            .method(Method::GET)
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+}

--- a/signer/src/api/mod.rs
+++ b/signer/src/api/mod.rs
@@ -1,9 +1,11 @@
 //! This module contains functions and structs for the Signer API.
 //!
 
+pub mod default;
 pub mod new_block;
 pub mod status;
 
+pub use default::default_handler;
 pub use new_block::new_block_handler;
 pub use status::status_handler;
 

--- a/signer/src/main.rs
+++ b/signer/src/main.rs
@@ -267,6 +267,7 @@ async fn run_api(ctx: impl Context + 'static) -> Result<(), Error> {
                     tracing::trace!(duration_ms = duration.as_millis(), "request completed");
                 }),
         )
+        .fallback(api::default::default_handler)
         .with_state(state);
 
     // Bind to the configured address and port


### PR DESCRIPTION
## Description

The sBTC signers stalled their Stacks nodes in prod when the nodes emitted "attachment" events (which is a known bug on the node-side), and the sBTC signers couldn't handle it.

## Changes

This adds a default handler to the axum server which will simply return 200 OK for unknown routes. I don't necessarily think that we should keep this around long-term, or rather that stacks events maybe should be behind a `/stacks/..` path where we have a default handler. But this change in particular is intended to be a band-aid until the event-filtering for `attachment` events are properly handled in stacks-core.

## Testing Information

New test added which checks before/after these changes to ensure that the correct status code is returned.

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
