### PR TITLE
fix: sidecar hash prefix strip on chainstate

### DIFF
--- a/emily_sidecar/app.py
+++ b/emily_sidecar/app.py
@@ -62,7 +62,7 @@ def handle_new_block():
 
     chainstate = {
         "stacksBlockHeight": validated_data["block_height"],
-        "stacksBlockHash": validated_data["index_block_hash"].lstrip("0x"),
+        "stacksBlockHash": validated_data["index_block_hash"].removeprefix("0x"),
     }
 
     try:


### PR DESCRIPTION
## Description

Previously, when the sidecar stripped the 0x prefix from the index_block_hash, it inadvertently removed additional leading zeros that followed the prefix. For example, `0x0012abc` was transformed into `12abc` instead of the correct `0012abc`.

Currently, Emily is storing multiple chainstate hashes with missing leading zeros. This issue will be resolved with a database pass, prepending zeros to the start of any hashes with fewer than 64 characters.

## Changes
- substituted `lstrip` with `removeprefix`

## Testing Information
- added a unit test
 
