### PR TITLE
fix: add handler for new attachments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -732,7 +732,7 @@ dependencies = [
  "rustversion",
  "serde 1.0.203",
  "sync_wrapper 0.1.2",
- "tower",
+ "tower 0.4.13",
  "tower-layer",
  "tower-service",
 ]
@@ -764,7 +764,7 @@ dependencies = [
  "serde_path_to_error",
  "sync_wrapper 1.0.1",
  "tokio",
- "tower",
+ "tower 0.4.13",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3207,7 +3207,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
- "tower",
+ "tower 0.4.13",
  "tracing",
 ]
 
@@ -6238,6 +6238,7 @@ dependencies = [
  "toml_edit 0.22.22",
  "tonic",
  "tonic-build",
+ "tower 0.5.2",
  "tower-http",
  "tracing",
  "tracing-attributes",
@@ -7182,7 +7183,7 @@ dependencies = [
  "prost",
  "tokio",
  "tokio-stream",
- "tower",
+ "tower 0.4.13",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -7236,6 +7237,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper 1.0.1",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "tower-http"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7260,9 +7275,9 @@ checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -7622,7 +7637,7 @@ dependencies = [
  "mime",
  "once_cell",
  "thiserror",
- "tower",
+ "tower 0.4.13",
  "tracing",
  "url",
  "warp",

--- a/signer/Cargo.toml
+++ b/signer/Cargo.toml
@@ -80,6 +80,7 @@ test-case = "3.1"
 test-log = { version = "0.2.16", default-features = false, features = ["trace"] }
 toml_edit = "0.22.22"
 tempfile = "3.6"
+tower = { version = "0.5.2", features = ["util"] }
 
 [build-dependencies]
 tonic-build.workspace = true

--- a/signer/src/api/mod.rs
+++ b/signer/src/api/mod.rs
@@ -1,11 +1,12 @@
 //! This module contains functions and structs for the Signer API.
 //!
 
-pub mod new_block;
-pub mod status;
+mod new_block;
+mod router;
+mod status;
 
 pub use new_block::new_block_handler;
-pub use status::status_handler;
+pub use router::get_router;
 
 /// A struct with state data necessary for runtime operation.
 #[derive(Debug, Clone)]

--- a/signer/src/api/router.rs
+++ b/signer/src/api/router.rs
@@ -1,0 +1,59 @@
+//! This module contains the default router for the signers api
+//!
+
+use axum::{
+    routing::{get, post},
+    Router,
+};
+
+use crate::context::Context;
+
+use axum::http::StatusCode;
+
+use super::{new_block, status, ApiState};
+
+async fn new_attachment_handler() -> StatusCode {
+    StatusCode::OK
+}
+
+/// Return the default router
+pub fn get_router<C: Context + 'static>() -> Router<ApiState<C>> {
+    Router::new()
+        .route("/", get(status::status_handler))
+        .route("/new_block", post(new_block::new_block_handler))
+        // TODO: remove this once https://github.com/stacks-network/stacks-core/issues/5558
+        // is addressed
+        .route("/attachments/new", post(new_attachment_handler))
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Method, Request, StatusCode},
+        Router,
+    };
+    use tower::ServiceExt;
+
+    use crate::{
+        api::{router::get_router, ApiState},
+        testing::context::TestContext,
+    };
+
+    #[tokio::test]
+    async fn test_new_attachment() {
+        let context = TestContext::default_mocked();
+
+        let state = ApiState { ctx: context.clone() };
+        let app: Router = get_router().with_state(state);
+
+        let request = Request::builder()
+            .uri("/attachments/new")
+            .method(Method::POST)
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+}

--- a/signer/src/main.rs
+++ b/signer/src/main.rs
@@ -7,9 +7,6 @@ use std::time::Duration;
 
 use axum::http::Request;
 use axum::http::Response;
-use axum::routing::get;
-use axum::routing::post;
-use axum::Router;
 use cfg_if::cfg_if;
 use clap::Parser;
 use clap::ValueEnum;
@@ -247,9 +244,7 @@ async fn run_api(ctx: impl Context + 'static) -> Result<(), Error> {
     let request_id = Arc::new(AtomicU64::new(0));
 
     // Build the signer API application
-    let app = Router::new()
-        .route("/", get(api::status_handler))
-        .route("/new_block", post(api::new_block_handler))
+    let app = api::get_router()
         .layer(
             TraceLayer::new_for_http()
                 .make_span_with(|request: &Request<_>| {


### PR DESCRIPTION
## Description

The sBTC signers stalled their Stacks nodes in prod when the nodes emitted "attachment" events (which is a known bug on the node-side), and the sBTC signers couldn't handle it.

## Changes

This adds a dummy endpoint responding with 200 OK.

## Testing Information

Add simple test, and tested that everything else still works via devenv demo script.

## Checklist:

- [X] I have performed a self-review of my code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
