### PR TITLE
fix: reject empty pre-sign requests

### DIFF
--- a/signer/src/bitcoin/utxo.rs
+++ b/signer/src/bitcoin/utxo.rs
@@ -1809,10 +1809,9 @@ mod tests {
         assert_eq!(new_utxo.public_key, requests.signer_state.public_key);
     }
 
-    /// Transactions that do not service requests do not have the OP_RETURN
-    /// output.
+    /// You cannot create sweep transactions that do not service requests.
     #[test]
-    fn no_requests_no_op_return() {
+    fn no_requests_no_sweep() {
         let public_key = XOnlyPublicKey::from_str(X_ONLY_PUBLIC_KEY1).unwrap();
         let signer_state = SignerBtcState {
             utxo: SignerUtxo {
@@ -1826,14 +1825,9 @@ mod tests {
             magic_bytes: [0; 2],
         };
 
-        // No requests so the first output should be the signers UTXO and
-        // that's it. No OP_RETURN output.
         let requests = Requests::new(Vec::new());
-        let unsigned = UnsignedTransaction::new(requests, &signer_state).unwrap();
-        assert_eq!(unsigned.tx.output.len(), 1);
-
-        // There is only one output and it's a P2TR output
-        assert!(unsigned.tx.output[0].script_pubkey.is_p2tr());
+        let sweep = UnsignedTransaction::new(requests, &signer_state);
+        assert!(sweep.is_err());
     }
 
     /// We aggregate the bitmaps to form a single one at the end. Check

--- a/signer/src/bitcoin/utxo.rs
+++ b/signer/src/bitcoin/utxo.rs
@@ -798,7 +798,7 @@ impl<'a> UnsignedTransaction<'a> {
     /// Construct an unsigned transaction.
     ///
     /// This function can fail if the output amounts are greater than the
-    /// input amounts.
+    /// input amounts or if the [`Requests`] object is empty.
     ///
     /// The returned BTC transaction has the following properties:
     ///   1. The amounts for each output has taken fees into consideration.
@@ -822,7 +822,7 @@ impl<'a> UnsignedTransaction<'a> {
     /// Construct a transaction with stub witness data.
     ///
     /// This function can fail if the output amounts are greater than the
-    /// input amounts.
+    /// input amounts or if the [`Requests`] object is empty.
     ///
     /// The returned BTC transaction has the following properties:
     ///   1. The amounts for each output has taken fees into consideration.
@@ -833,6 +833,9 @@ impl<'a> UnsignedTransaction<'a> {
     ///   5. All witness data is correctly set, except for the fake
     ///      signatures from (4).
     pub fn new_stub(requests: Requests<'a>, state: &SignerBtcState) -> Result<Self, Error> {
+        if requests.is_empty() {
+            return Err(Error::BitcoinNoRequests);
+        }
         // Construct a transaction base. This transaction's inputs have
         // witness data with dummy signatures so that our virtual size
         // estimates are accurate. Later we will update the fees.

--- a/signer/src/bitcoin/validation.rs
+++ b/signer/src/bitcoin/validation.rs
@@ -454,6 +454,13 @@ impl BitcoinTxValidationData {
     /// not a part of the signing set locking one or more deposits. In such
     /// a case, it will just sign for the deposits that it can.
     pub fn is_valid_tx(&self) -> bool {
+        // A transaction is invalid if it is not servicing any deposit or
+        // withdrawal requests. Doing so costs fees and the signers do not
+        // gain anything by permitting such a transaction.
+        if self.reports.deposits.is_empty() && self.reports.withdrawals.is_empty() {
+            return false;
+        }
+
         let deposit_validation_results = self.reports.deposits.iter().all(|(_, report)| {
             matches!(
                 report.validate(

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -530,6 +530,16 @@ pub enum Error {
     #[error("The request packages contain duplicate deposit or withdrawal entries.")]
     DuplicateRequests,
 
+    /// Indicates that the BitcoinPreSignRequest object does not contain
+    /// any deposit or withdrawal requests.
+    #[error("The BitcoinPreSignRequest object does not contain deposit or withdrawal requests")]
+    PreSignContainsNoRequests,
+
+    /// Indicates that the BitcoinPreSignRequest object contains a fee rate
+    /// that is less than or equal to zero.
+    #[error("The fee rate in the BitcoinPreSignRequest object is not greater than zero: {0}")]
+    PreSignInvalidFeeRate(f64),
+
     /// Error when deposit requests would exceed sBTC supply cap
     #[error("Total deposit amount ({total_amount} sats) would exceed sBTC supply cap (current max mintable is {max_mintable} sats)")]
     ExceedsSbtcSupplyCap {

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -535,6 +535,11 @@ pub enum Error {
     #[error("The BitcoinPreSignRequest object does not contain deposit or withdrawal requests")]
     PreSignContainsNoRequests,
 
+    /// Indicates that we tried to create an UnsignedTransaction object
+    /// without any deposit or withdrawal requests.
+    #[error("The UnsignedTransaction must contain deposit or withdrawal requests")]
+    BitcoinNoRequests,
+
     /// Indicates that the BitcoinPreSignRequest object contains a fee rate
     /// that is less than or equal to zero.
     #[error("The fee rate in the BitcoinPreSignRequest object is not greater than zero: {0}")]


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/1189.

## Changes

* Reject a `BitcoinPreSignRequest` if it does not contain any deposit or withdrawal requests.
* Reject fee rates that are not strictly positive.
* Make sure pre-validation checks run before everything else during bitcoin validation.

## Testing Information

I tested that the changes here solve the issue on local devnet.

## Checklist:

- [x] I have performed a self-review of my code
