### PR TITLE
feat: additional logging for `new_block` handler

### DIFF
--- a/signer/src/api/new_block.rs
+++ b/signer/src/api/new_block.rs
@@ -118,13 +118,11 @@ pub async fn new_block_handler(state: State<ApiState<impl Context>>, body: Strin
     };
     let block_id = new_block_event.index_block_hash;
 
-    {
-        let span = tracing::span::Span::current();
-        span.record("block_hash", stacks_chaintip.block_hash.to_hex());
-        span.record("block_height", stacks_chaintip.block_height);
-        span.record("parent_hash", stacks_chaintip.parent_hash.to_hex());
-        span.record("bitcoin_anchor", stacks_chaintip.bitcoin_anchor.to_string());
-    }
+    let span = tracing::span::Span::current();
+    span.record("block_hash", stacks_chaintip.block_hash.to_hex());
+    span.record("block_height", stacks_chaintip.block_height);
+    span.record("parent_hash", stacks_chaintip.parent_hash.to_hex());
+    span.record("bitcoin_anchor", stacks_chaintip.bitcoin_anchor.to_string());
 
     tracing::debug!("received a new block event from stacks-core");
 

--- a/signer/src/api/new_block.rs
+++ b/signer/src/api/new_block.rs
@@ -143,7 +143,7 @@ pub async fn new_block_handler(state: State<ApiState<impl Context>>, body: Strin
         return StatusCode::OK;
     }
 
-    tracing::debug!(count = %events.len(), "processing events for new stack block");
+    tracing::debug!(count = %events.len(), "processing events for new stacks block");
 
     // Create vectors to store the processed events for Emily.
     let mut completed_deposits = Vec::new();

--- a/signer/src/api/new_block.rs
+++ b/signer/src/api/new_block.rs
@@ -262,8 +262,7 @@ pub async fn new_block_handler(state: State<ApiState<impl Context>>, body: Strin
 ///   information on the completed deposit to be sent to Emily.
 ///   In case of a database error, returns an `Error`
 #[tracing::instrument(skip_all, fields(
-    bitcoin_txid = %event.outpoint.txid,
-    bitcoin_vout = event.outpoint.vout,
+    bitcoin_outpoint = %event.outpoint,
     stacks_txid = %event.txid
 ))]
 async fn handle_completed_deposit(

--- a/signer/src/api/new_block.rs
+++ b/signer/src/api/new_block.rs
@@ -257,7 +257,7 @@ pub async fn new_block_handler(state: State<ApiState<impl Context>>, body: Strin
 ///   information on the completed deposit to be sent to Emily.
 ///   In case of a database error, returns an `Error`
 #[tracing::instrument(skip_all, fields(
-    bitcoin_txid = %event.outpoint.txid, 
+    bitcoin_txid = %event.outpoint.txid,
     bitcoin_vout = event.outpoint.vout,
     stacks_txid = %event.txid
 ))]
@@ -422,7 +422,7 @@ async fn handle_withdrawal_reject(
 }
 
 #[tracing::instrument(skip_all, fields(
-    %stacks_txid, 
+    %stacks_txid,
     address = %event.new_address.to_string(),
     aggregate_key = %event.new_aggregate_pubkey
 ))]

--- a/signer/src/api/new_block.rs
+++ b/signer/src/api/new_block.rs
@@ -275,7 +275,7 @@ async fn handle_completed_deposit(
         .write_completed_deposit_event(&event)
         .await?;
 
-    tracing::info!("handled completed deposit event");
+    tracing::debug!(topic = "completed-deposit", "handled stacks event");
 
     // If the deposit request is not found, we don't want to update Emily about it because
     // we don't have the necessary information to compute the fee.
@@ -334,7 +334,7 @@ async fn handle_withdrawal_accept(
         .write_withdrawal_accept_event(&event)
         .await?;
 
-    tracing::info!("handled withdrawal accept event");
+    tracing::debug!(topic = "withdrawal-accept", "handled stacks event");
 
     Ok(WithdrawalUpdate {
         request_id: event.request_id,
@@ -377,7 +377,7 @@ async fn handle_withdrawal_create(
         .write_withdrawal_create_event(&event)
         .await?;
 
-    tracing::debug!("handled withdrawal creation event");
+    tracing::debug!(topic = "withdrawal-create", "handled stacks event");
 
     Ok(CreateWithdrawalRequestBody {
         amount: event.amount,
@@ -414,7 +414,7 @@ async fn handle_withdrawal_reject(
         .write_withdrawal_reject_event(&event)
         .await?;
 
-    tracing::info!("handled withdrawal rejection event");
+    tracing::debug!(topic = "withdrawal-reject", "handled stacks event");
 
     Ok(WithdrawalUpdate {
         fulfillment: None,
@@ -448,7 +448,7 @@ async fn handle_key_rotation(
         .write_rotate_keys_transaction(&key_rotation_tx)
         .await?;
 
-    tracing::info!("handled rotate-keys event");
+    tracing::debug!(topic = "key-rotation", "handled stacks event");
 
     Ok(())
 }


### PR DESCRIPTION
## Description

Adds a little additional logging to the `new_block` event observer handler to help with healthchecks of partner signers. This will now record the block hash, height, parent and bitcoin anchor for log events within the handler.

## Changes

- Additional logging and tracing spans
- Minor refactors to help optimize how/when the log lines are written and so they include the relevant fields

## Testing Information

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
