### PR TITLE
feat: add config params for dkg-rerun bitcoin block height and target rounds

### DIFF
--- a/docker/mainnet/sbtc-signer/signer-config.toml.in
+++ b/docker/mainnet/sbtc-signer/signer-config.toml.in
@@ -154,16 +154,16 @@ prometheus_exporter_endpoint = "0.0.0.0:9184"
 # the sBTC team.
 #
 # Required: false
-# Environment: SIGNER_SIGNER__DKG_RERUN_BITCOIN_HEIGHT
-dkg_rerun_bitcoin_height = 880088
+# Environment: SIGNER_SIGNER__DKG_MIN_BITCOIN_BLOCK_HEIGHT
+dkg_min_bitcoin_block_height = 880088
 
 # When defined, the signer will attempt/allow multiple rounds of DKG until the
 # specified number of rounds have been completed. Please only use this parameter
 # when instructed to by the sBTC team.
 #
 # Required: false
-# Environment: SIGNER_SIGNER__DKG_ROUNDS_TARGET
-dkg_rounds_target = 2
+# Environment: SIGNER_SIGNER__DKG_TARGET_ROUNDS
+dkg_target_rounds = 2
 
 # !! ==============================================================================
 # !! Stacks Event Observer Configuration

--- a/docker/mainnet/sbtc-signer/signer-config.toml.in
+++ b/docker/mainnet/sbtc-signer/signer-config.toml.in
@@ -157,6 +157,14 @@ prometheus_exporter_endpoint = "0.0.0.0:9184"
 # Environment: SIGNER_SIGNER__DKG_RERUN_BITCOIN_HEIGHT
 dkg_rerun_bitcoin_height = 880088
 
+# When defined, the signer will attempt/allow multiple rounds of DKG until the
+# specified number of rounds have been completed. Please only use this parameter
+# when instructed to by the sBTC team.
+#
+# Required: false
+# Environment: SIGNER_SIGNER__DKG_ROUNDS_TARGET
+dkg_rounds_target = 2
+
 # !! ==============================================================================
 # !! Stacks Event Observer Configuration
 # !!

--- a/docker/mainnet/sbtc-signer/signer-config.toml.in
+++ b/docker/mainnet/sbtc-signer/signer-config.toml.in
@@ -149,6 +149,14 @@ bitcoin_block_horizon = 3000
 # Environment: SIGNER_SIGNER__PROMETHEUS_EXPORTER_ENDPOINT
 prometheus_exporter_endpoint = "0.0.0.0:9184"
 
+# When defined, the signer will attempt to re-run DKG after the specified
+# Bitcoin block height. Please only use this parameter when instructed to by
+# the sBTC team.
+#
+# Required: false
+# Environment: SIGNER_SIGNER__DKG_RERUN_BITCOIN_HEIGHT
+dkg_rerun_bitcoin_height = 880088
+
 # !! ==============================================================================
 # !! Stacks Event Observer Configuration
 # !!

--- a/docker/sbtc/signer/signer-config.toml
+++ b/docker/sbtc/signer/signer-config.toml
@@ -202,8 +202,16 @@ bootstrap_signatures_required = 2
 # the sBTC team.
 #
 # Required: false
-# Environment: SIGNER_SIGNER__DKG_RERUN_BITCOIN_HEIGHT
-# dkg_rerun_bitcoin_height = 1234
+# Environment: SIGNER_SIGNER__DKG_MIN_BITCOIN_BLOCK_HEIGHT
+# dkg_min_bitcoin_block_height = 1234
+
+# When defined, the signer will attempt/allow multiple rounds of DKG until the
+# specified number of rounds have been completed. Please only use this parameter
+# when instructed to by the sBTC team.
+#
+# Required: false
+# Environment: SIGNER_SIGNER__DKG_TARGET_ROUNDS
+# dkg_target_rounds = 1
 
 # !! ==============================================================================
 # !! Stacks Event Observer Configuration

--- a/docker/sbtc/signer/signer-config.toml
+++ b/docker/sbtc/signer/signer-config.toml
@@ -197,6 +197,14 @@ bootstrap_signing_set = [
 # Required: true
 bootstrap_signatures_required = 2
 
+# When defined, the signer will attempt to re-run DKG after the specified
+# Bitcoin block height. Please only use this parameter when instructed to by
+# the sBTC team.
+#
+# Required: false
+# Environment: SIGNER_SIGNER__DKG_RERUN_BITCOIN_HEIGHT
+# dkg_rerun_bitcoin_height = 1234
+
 # !! ==============================================================================
 # !! Stacks Event Observer Configuration
 # !!

--- a/signer/src/config/default.toml
+++ b/signer/src/config/default.toml
@@ -213,6 +213,14 @@ sbtc_bitcoin_start_height = 101
 # Environment: SIGNER_SIGNER__DKG_RERUN_BITCOIN_HEIGHT
 # dkg_rerun_bitcoin_height = 1234
 
+# When defined, the signer will attempt/allow multiple rounds of DKG until the
+# specified number of rounds have been completed. Please only use this parameter
+# when instructed to by the sBTC team.
+#
+# Required: false
+# Environment: SIGNER_SIGNER__DKG_ROUNDS_TARGET
+# dkg_rounds_target = 1
+
 # !! ==============================================================================
 # !! Stacks Event Observer Configuration
 # !!

--- a/signer/src/config/default.toml
+++ b/signer/src/config/default.toml
@@ -205,6 +205,14 @@ sbtc_bitcoin_start_height = 101
 # Environment: SIGNER_SIGNER__PROMETHEUS_EXPORTER_ENDPOINT
 # prometheus_exporter_endpoint = "[::]:9184"
 
+# When defined, the signer will attempt to re-run DKG after the specified
+# Bitcoin block height. Please only use this parameter when instructed to by
+# the sBTC team.
+#
+# Required: false
+# Environment: SIGNER_SIGNER__DKG_RERUN_BITCOIN_HEIGHT
+# dkg_rerun_bitcoin_height = 1234
+
 # !! ==============================================================================
 # !! Stacks Event Observer Configuration
 # !!

--- a/signer/src/config/default.toml
+++ b/signer/src/config/default.toml
@@ -210,16 +210,16 @@ sbtc_bitcoin_start_height = 101
 # the sBTC team.
 #
 # Required: false
-# Environment: SIGNER_SIGNER__DKG_RERUN_BITCOIN_HEIGHT
-# dkg_rerun_bitcoin_height = 1234
+# Environment: SIGNER_SIGNER__DKG_MIN_BITCOIN_BLOCK_HEIGHT
+# dkg_min_bitcoin_block_height = 1234
 
 # When defined, the signer will attempt/allow multiple rounds of DKG until the
 # specified number of rounds have been completed. Please only use this parameter
 # when instructed to by the sBTC team.
 #
 # Required: false
-# Environment: SIGNER_SIGNER__DKG_ROUNDS_TARGET
-# dkg_rounds_target = 1
+# Environment: SIGNER_SIGNER__DKG_TARGET_ROUNDS
+# dkg_target_rounds = 1
 
 # !! ==============================================================================
 # !! Stacks Event Observer Configuration

--- a/signer/src/config/mod.rs
+++ b/signer/src/config/mod.rs
@@ -8,6 +8,7 @@ use serde::Deserialize;
 use stacks_common::types::chainstate::StacksAddress;
 use std::collections::BTreeSet;
 use std::num::NonZeroU16;
+use std::num::NonZeroU32;
 use std::num::NonZeroU64;
 use std::path::Path;
 use url::Url;
@@ -265,7 +266,7 @@ pub struct SignerConfig {
     /// and the number of DKG shares is less than this number, the coordinator
     /// will continue to run DKG rounds until this number of rounds is reached,
     /// assuming the conditions for `dkg_rerun_bitcoin_height` are also met.
-    pub dkg_rounds_target: Option<NonZeroU16>,
+    pub dkg_rounds_target: Option<NonZeroU32>,
 }
 
 impl Validatable for SignerConfig {
@@ -537,7 +538,7 @@ mod tests {
         assert_eq!(settings.signer.dkg_max_duration, Duration::from_secs(120));
         assert_eq!(
             settings.signer.dkg_rounds_target,
-            Some(NonZeroU16::new(1).unwrap())
+            Some(NonZeroU32::new(1).unwrap())
         );
     }
 
@@ -686,14 +687,14 @@ mod tests {
         let settings = Settings::new_from_default_config().unwrap();
         assert_eq!(
             settings.signer.dkg_rounds_target,
-            Some(NonZeroU16::new(1).unwrap())
+            Some(NonZeroU32::new(1).unwrap())
         );
 
         std::env::set_var("SIGNER_SIGNER__DKG_ROUNDS_TARGET", "42");
         let settings = Settings::new_from_default_config().unwrap();
         assert_eq!(
             settings.signer.dkg_rounds_target,
-            Some(NonZeroU16::new(42).unwrap())
+            Some(NonZeroU32::new(42).unwrap())
         );
     }
 

--- a/signer/src/config/mod.rs
+++ b/signer/src/config/mod.rs
@@ -263,8 +263,8 @@ pub struct SignerConfig {
     /// Configures a target number of DKG rounds to run/accept. If this is set
     /// and the number of DKG shares is less than this number, the coordinator
     /// will continue to run DKG rounds until this number of rounds is reached,
-    /// assuming the conditions for `dkg_rerun_bitcoin_height` are also met. If
-    /// DKG has never been run, this configuration has no effect.
+    /// assuming the conditions for `dkg_min_bitcoin_block_height` are also met.
+    /// If DKG has never been run, this configuration has no effect.
     pub dkg_target_rounds: NonZeroU32,
 }
 
@@ -666,7 +666,7 @@ mod tests {
     }
 
     #[test]
-    fn default_config_toml_loads_dkg_rerun_bitcoin_height() {
+    fn default_config_toml_loads_dkg_min_bitcoin_block_height() {
         clear_env();
 
         let settings = Settings::new_from_default_config().unwrap();
@@ -681,7 +681,7 @@ mod tests {
     }
 
     #[test]
-    fn default_config_toml_loads_dkg_rounds_target() {
+    fn default_config_toml_loads_dkg_target_rounds() {
         clear_env();
 
         let settings = Settings::new_from_default_config().unwrap();

--- a/signer/src/config/mod.rs
+++ b/signer/src/config/mod.rs
@@ -8,6 +8,7 @@ use serde::Deserialize;
 use stacks_common::types::chainstate::StacksAddress;
 use std::collections::BTreeSet;
 use std::num::NonZeroU16;
+use std::num::NonZeroU64;
 use std::path::Path;
 use url::Url;
 
@@ -253,6 +254,12 @@ pub struct SignerConfig {
     /// arrives. The default here is controlled by the
     /// [`MAX_DEPOSITS_PER_BITCOIN_TX`] constant
     pub max_deposits_per_bitcoin_tx: NonZeroU16,
+
+    /// Configures a DKG re-run Bitcoin block height. If this is set and DKG
+    /// has already been run, the coordinator will attempt to re-run DKG after
+    /// this block height at most once. If DKG has never been run, this
+    /// configuration has no effect.
+    pub dkg_rerun_bitcoin_height: Option<NonZeroU64>,
 }
 
 impl Validatable for SignerConfig {
@@ -644,6 +651,21 @@ mod tests {
 
         std::env::set_var("SIGNER_SIGNER__MAX_DEPOSITS_PER_BITCOIN_TX", "0");
         assert!(Settings::new_from_default_config().is_err());
+    }
+
+    #[test]
+    fn default_config_toml_loads_dkg_rerun_bitcoin_height() {
+        clear_env();
+
+        let settings = Settings::new_from_default_config().unwrap();
+        assert_eq!(settings.signer.dkg_rerun_bitcoin_height, None);
+
+        std::env::set_var("SIGNER_SIGNER__DKG_RERUN_BITCOIN_HEIGHT", "42");
+        let settings = Settings::new_from_default_config().unwrap();
+        assert_eq!(
+            settings.signer.dkg_rerun_bitcoin_height,
+            Some(NonZeroU64::new(42).unwrap())
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description

Closes: #1201 
Closes: #1207 

## Changes

Adds the configuration parameter `dkg_rerun_bitcoin_height` (don't love the name) and `dkg_rounds_target` in preparation for #1199 and #1200.

I made this optional for now (contrary to #1201 requesting required) because I'm not sure how we want this to behave when it comes to devenv etc. -- required would mean that devenv needs to run two DKG's, maybe we don't want that? So I can change it to required after we discuss the implications if we want.

## Testing Information

- Adds one new test for each of the config parameters for testing reading the default configuration and env var.

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
