### PR TITLE
feat: #1200 feature signers allow second dkg after specific block height

### DIFF
--- a/signer/src/config/mod.rs
+++ b/signer/src/config/mod.rs
@@ -8,6 +8,7 @@ use serde::Deserialize;
 use stacks_common::types::chainstate::StacksAddress;
 use std::collections::BTreeSet;
 use std::num::NonZeroU16;
+use std::num::NonZeroU32;
 use std::num::NonZeroU64;
 use std::path::Path;
 use url::Url;
@@ -260,6 +261,12 @@ pub struct SignerConfig {
     /// this block height at most once. If DKG has never been run, this
     /// configuration has no effect.
     pub dkg_rerun_bitcoin_height: Option<NonZeroU64>,
+
+    /// Configures a target number of DKG rounds to run/accept. If this is set
+    /// and the number of DKG shares is less than this number, the coordinator
+    /// will continue to run DKG rounds until this number of rounds is reached,
+    /// assuming the conditions for `dkg_rerun_bitcoin_height` are also met.
+    pub dkg_rounds_target: NonZeroU32,
 }
 
 impl Validatable for SignerConfig {
@@ -398,6 +405,7 @@ impl Settings {
             "signer.max_deposits_per_bitcoin_tx",
             DEFAULT_MAX_DEPOSITS_PER_BITCOIN_TX,
         )?;
+        cfg_builder = cfg_builder.set_default("signer.dkg_rounds_target", 1)?;
 
         if let Some(path) = config_path {
             cfg_builder = cfg_builder.add_source(File::from(path.as_ref()));

--- a/signer/src/config/mod.rs
+++ b/signer/src/config/mod.rs
@@ -255,13 +255,11 @@ pub struct SignerConfig {
     /// arrives. The default here is controlled by the
     /// [`MAX_DEPOSITS_PER_BITCOIN_TX`] constant
     pub max_deposits_per_bitcoin_tx: NonZeroU16,
-
     /// Configures a DKG re-run Bitcoin block height. If this is set and DKG has
     /// already been run, the coordinator will attempt to re-run DKG after this
     /// block height is met if `dkg_target_rounds` has not been reached. If DKG
     /// has never been run, this configuration has no effect.
     pub dkg_min_bitcoin_block_height: Option<NonZeroU64>,
-
     /// Configures a target number of DKG rounds to run/accept. If this is set
     /// and the number of DKG shares is less than this number, the coordinator
     /// will continue to run DKG rounds until this number of rounds is reached,

--- a/signer/src/config/mod.rs
+++ b/signer/src/config/mod.rs
@@ -8,6 +8,7 @@ use serde::Deserialize;
 use stacks_common::types::chainstate::StacksAddress;
 use std::collections::BTreeSet;
 use std::num::NonZeroU16;
+use std::num::NonZeroU64;
 use std::path::Path;
 use url::Url;
 
@@ -253,6 +254,12 @@ pub struct SignerConfig {
     /// arrives. The default here is controlled by the
     /// [`MAX_DEPOSITS_PER_BITCOIN_TX`] constant
     pub max_deposits_per_bitcoin_tx: NonZeroU16,
+
+    /// Configures a DKG re-run Bitcoin block height. If this is set and DKG
+    /// has already been run, the coordinator will attempt to re-run DKG after
+    /// this block height at most once. If DKG has never been run, this
+    /// configuration has no effect.
+    pub dkg_rerun_bitcoin_height: Option<NonZeroU64>,
 }
 
 impl Validatable for SignerConfig {

--- a/signer/src/config/mod.rs
+++ b/signer/src/config/mod.rs
@@ -256,17 +256,18 @@ pub struct SignerConfig {
     /// [`MAX_DEPOSITS_PER_BITCOIN_TX`] constant
     pub max_deposits_per_bitcoin_tx: NonZeroU16,
 
-    /// Configures a DKG re-run Bitcoin block height. If this is set and DKG
-    /// has already been run, the coordinator will attempt to re-run DKG after
-    /// this block height at most once. If DKG has never been run, this
-    /// configuration has no effect.
-    pub dkg_rerun_bitcoin_height: Option<NonZeroU64>,
+    /// Configures a DKG re-run Bitcoin block height. If this is set and DKG has
+    /// already been run, the coordinator will attempt to re-run DKG after this
+    /// block height is met if `dkg_target_rounds` has not been reached. If DKG
+    /// has never been run, this configuration has no effect.
+    pub dkg_min_bitcoin_block_height: Option<NonZeroU64>,
 
     /// Configures a target number of DKG rounds to run/accept. If this is set
     /// and the number of DKG shares is less than this number, the coordinator
     /// will continue to run DKG rounds until this number of rounds is reached,
-    /// assuming the conditions for `dkg_rerun_bitcoin_height` are also met.
-    pub dkg_rounds_target: NonZeroU32,
+    /// assuming the conditions for `dkg_rerun_bitcoin_height` are also met. If
+    /// DKG has never been run, this configuration has no effect.
+    pub dkg_target_rounds: NonZeroU32,
 }
 
 impl Validatable for SignerConfig {
@@ -405,7 +406,7 @@ impl Settings {
             "signer.max_deposits_per_bitcoin_tx",
             DEFAULT_MAX_DEPOSITS_PER_BITCOIN_TX,
         )?;
-        cfg_builder = cfg_builder.set_default("signer.dkg_rounds_target", 1)?;
+        cfg_builder = cfg_builder.set_default("signer.dkg_target_rounds", 2)?;
 
         if let Some(path) = config_path {
             cfg_builder = cfg_builder.add_source(File::from(path.as_ref()));

--- a/signer/src/storage/in_memory.rs
+++ b/signer/src/storage/in_memory.rs
@@ -601,7 +601,7 @@ impl super::DbRead for SharedStore {
             .map(|(_, shares)| shares.clone()))
     }
 
-    async fn get_encrypted_dkg_share_count(&self) -> Result<u32, Error> {
+    async fn get_encrypted_dkg_shares_count(&self) -> Result<u32, Error> {
         Ok(self.lock().await.encrypted_dkg_shares.len() as u32)
     }
 

--- a/signer/src/storage/in_memory.rs
+++ b/signer/src/storage/in_memory.rs
@@ -601,6 +601,10 @@ impl super::DbRead for SharedStore {
             .map(|(_, shares)| shares.clone()))
     }
 
+    async fn get_encrypted_dkg_share_count(&self) -> Result<u32, Error> {
+        Ok(self.lock().await.encrypted_dkg_shares.len() as u32)
+    }
+
     async fn get_last_key_rotation(
         &self,
         chain_tip: &model::BitcoinBlockHash,

--- a/signer/src/storage/mod.rs
+++ b/signer/src/storage/mod.rs
@@ -218,6 +218,9 @@ pub trait DbRead {
         &self,
     ) -> impl Future<Output = Result<Option<model::EncryptedDkgShares>, Error>> + Send;
 
+    /// Returns the number of DKG share entries in the database.
+    fn get_encrypted_dkg_share_count(&self) -> impl Future<Output = Result<u32, Error>> + Send;
+
     /// Return the latest rotate-keys transaction confirmed by the given `chain-tip`.
     fn get_last_key_rotation(
         &self,

--- a/signer/src/storage/mod.rs
+++ b/signer/src/storage/mod.rs
@@ -218,8 +218,8 @@ pub trait DbRead {
         &self,
     ) -> impl Future<Output = Result<Option<model::EncryptedDkgShares>, Error>> + Send;
 
-    /// Returns the number of DKG share entries in the database.
-    fn get_encrypted_dkg_share_count(&self) -> impl Future<Output = Result<u32, Error>> + Send;
+    /// Returns the number of DKG shares entries in the database.
+    fn get_encrypted_dkg_shares_count(&self) -> impl Future<Output = Result<u32, Error>> + Send;
 
     /// Return the latest rotate-keys transaction confirmed by the given `chain-tip`.
     fn get_last_key_rotation(

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -1507,6 +1507,16 @@ impl super::DbRead for PgStore {
         .map_err(Error::SqlxQuery)
     }
 
+    /// Returns the number of rows in the `dkg_shares` table.
+    async fn get_encrypted_dkg_share_count(&self) -> Result<u32, Error> {
+        let count: i32 = sqlx::query_scalar("SELECT COUNT(*) FROM sbtc_signer.dkg_shares;")
+            .fetch_one(&self.0)
+            .await
+            .map_err(Error::SqlxQuery)?;
+
+        Ok(count as u32)
+    }
+
     /// Find the last key rotation by iterating backwards from the stacks
     /// chain tip scanning all transactions until we encounter a key
     /// rotation transactions.

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -1509,12 +1509,14 @@ impl super::DbRead for PgStore {
 
     /// Returns the number of rows in the `dkg_shares` table.
     async fn get_encrypted_dkg_share_count(&self) -> Result<u32, Error> {
-        let count: i32 = sqlx::query_scalar("SELECT COUNT(*) FROM sbtc_signer.dkg_shares;")
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM sbtc_signer.dkg_shares;")
             .fetch_one(&self.0)
             .await
             .map_err(Error::SqlxQuery)?;
 
-        Ok(count as u32)
+        Ok(
+            u32::try_from(count).map_err(Error::ConversionDatabaseInt)?
+        )
     }
 
     /// Find the last key rotation by iterating backwards from the stacks

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -1514,7 +1514,7 @@ impl super::DbRead for PgStore {
             .await
             .map_err(Error::SqlxQuery)?;
 
-        Ok(u32::try_from(count).map_err(Error::ConversionDatabaseInt)?)
+        u32::try_from(count).map_err(Error::ConversionDatabaseInt)
     }
 
     /// Find the last key rotation by iterating backwards from the stacks

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -1514,9 +1514,7 @@ impl super::DbRead for PgStore {
             .await
             .map_err(Error::SqlxQuery)?;
 
-        Ok(
-            u32::try_from(count).map_err(Error::ConversionDatabaseInt)?
-        )
+        Ok(u32::try_from(count).map_err(Error::ConversionDatabaseInt)?)
     }
 
     /// Find the last key rotation by iterating backwards from the stacks

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -1508,7 +1508,7 @@ impl super::DbRead for PgStore {
     }
 
     /// Returns the number of rows in the `dkg_shares` table.
-    async fn get_encrypted_dkg_share_count(&self) -> Result<u32, Error> {
+    async fn get_encrypted_dkg_shares_count(&self) -> Result<u32, Error> {
         let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM sbtc_signer.dkg_shares;")
             .fetch_one(&self.0)
             .await

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -900,21 +900,13 @@ async fn assert_allow_dkg_begin(
                 "DKG rerun height has been met and we are below the target number of rounds; proceeding with DKG"
             );
         }
-        (current, _, None) if current >= 1 => {
+        // Note that we account for all (0, _, _) cases above (i.e. first DKG round)
+        (_, _, None) => {
             tracing::warn!(
                 ?dkg_min_bitcoin_block_height,
                 %dkg_target_rounds,
                 dkg_current_rounds = %dkg_shares_entry_count,
                 "attempt to run multiple DKGs without a configured re-run height; aborting"
-            );
-            return Err(Error::DkgHasAlreadyRun);
-        }
-        _ => {
-            tracing::warn!(
-                ?dkg_min_bitcoin_block_height,
-                %dkg_target_rounds,
-                dkg_current_rounds = %dkg_shares_entry_count,
-                "multiple DKG shares already exist; aborting"
             );
             return Err(Error::DkgHasAlreadyRun);
         }

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -879,6 +879,7 @@ async fn assert_allow_dkg_begin(
                 tracing::warn!(
                     ?dkg_min_bitcoin_block_height,
                     %dkg_target_rounds,
+                    dkg_current_rounds = %dkg_share_entry_count,
                     "The target number of DKG shares has been reached; aborting"
                 );
                 return Err(Error::DkgHasAlreadyRun);
@@ -887,6 +888,7 @@ async fn assert_allow_dkg_begin(
                 tracing::warn!(
                     ?dkg_min_bitcoin_block_height,
                     %dkg_target_rounds,
+                    dkg_current_rounds = %dkg_share_entry_count,
                     "bitcoin chain tip is below the minimum height for DKG rerun; aborting"
                 );
                 return Err(Error::DkgHasAlreadyRun);
@@ -894,6 +896,7 @@ async fn assert_allow_dkg_begin(
             tracing::info!(
                 ?dkg_min_bitcoin_block_height,
                 %dkg_target_rounds,
+                dkg_current_rounds = %dkg_share_entry_count,
                 "DKG rerun height has been met and we are below the target number of rounds; proceeding with DKG"
             );
         }
@@ -901,6 +904,7 @@ async fn assert_allow_dkg_begin(
             tracing::warn!(
                 ?dkg_min_bitcoin_block_height,
                 %dkg_target_rounds,
+                dkg_current_rounds = %dkg_share_entry_count,
                 "attempt to run multiple DKGs without a configured re-run height; aborting"
             );
             return Err(Error::DkgHasAlreadyRun);
@@ -909,6 +913,7 @@ async fn assert_allow_dkg_begin(
             tracing::warn!(
                 ?dkg_min_bitcoin_block_height,
                 %dkg_target_rounds,
+                dkg_current_rounds = %dkg_share_entry_count,
                 "multiple DKG shares already exist; aborting"
             );
             return Err(Error::DkgHasAlreadyRun);

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -900,7 +900,7 @@ async fn assert_allow_dkg_begin(
                 "DKG rerun height has been met and we are below the target number of rounds; proceeding with DKG"
             );
         }
-        (1, _, None) => {
+        (current, _, None) if current >= 1 => {
             tracing::warn!(
                 ?dkg_min_bitcoin_block_height,
                 %dkg_target_rounds,

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -861,7 +861,7 @@ async fn assert_allow_dkg_begin(
     let dkg_min_bitcoin_block_height = config.signer.dkg_min_bitcoin_block_height;
     let dkg_target_rounds = config.signer.dkg_target_rounds;
 
-    // Determine the action based on the DKG share count and the rerun height (if configured)
+    // Determine the action based on the DKG shares count and the rerun height (if configured)
     match (
         dkg_shares_entry_count,
         dkg_target_rounds,
@@ -1074,7 +1074,7 @@ mod tests {
         let storage = context.get_storage_mut();
         let network = InMemoryNetwork::new();
 
-        // Write 1 DKG share entry to the database, simulating that DKG has
+        // Write 1 DKG shares entry to the database, simulating that DKG has
         // successfully run once.
         storage
             .write_encrypted_dkg_shares(&Faker.fake())

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -855,7 +855,7 @@ async fn assert_allow_dkg_begin(
         .ok_or(Error::NoChainTip)?;
 
     // Get the number of DKG shares that have been stored
-    let dkg_share_entry_count = storage.get_encrypted_dkg_share_count().await?;
+    let dkg_shares_entry_count = storage.get_encrypted_dkg_shares_count().await?;
 
     // Get DKG configuration parameters
     let dkg_min_bitcoin_block_height = config.signer.dkg_min_bitcoin_block_height;
@@ -863,7 +863,7 @@ async fn assert_allow_dkg_begin(
 
     // Determine the action based on the DKG share count and the rerun height (if configured)
     match (
-        dkg_share_entry_count,
+        dkg_shares_entry_count,
         dkg_target_rounds,
         dkg_min_bitcoin_block_height,
     ) {
@@ -879,7 +879,7 @@ async fn assert_allow_dkg_begin(
                 tracing::warn!(
                     ?dkg_min_bitcoin_block_height,
                     %dkg_target_rounds,
-                    dkg_current_rounds = %dkg_share_entry_count,
+                    dkg_current_rounds = %dkg_shares_entry_count,
                     "The target number of DKG shares has been reached; aborting"
                 );
                 return Err(Error::DkgHasAlreadyRun);
@@ -888,7 +888,7 @@ async fn assert_allow_dkg_begin(
                 tracing::warn!(
                     ?dkg_min_bitcoin_block_height,
                     %dkg_target_rounds,
-                    dkg_current_rounds = %dkg_share_entry_count,
+                    dkg_current_rounds = %dkg_shares_entry_count,
                     "bitcoin chain tip is below the minimum height for DKG rerun; aborting"
                 );
                 return Err(Error::DkgHasAlreadyRun);
@@ -896,7 +896,7 @@ async fn assert_allow_dkg_begin(
             tracing::info!(
                 ?dkg_min_bitcoin_block_height,
                 %dkg_target_rounds,
-                dkg_current_rounds = %dkg_share_entry_count,
+                dkg_current_rounds = %dkg_shares_entry_count,
                 "DKG rerun height has been met and we are below the target number of rounds; proceeding with DKG"
             );
         }
@@ -904,7 +904,7 @@ async fn assert_allow_dkg_begin(
             tracing::warn!(
                 ?dkg_min_bitcoin_block_height,
                 %dkg_target_rounds,
-                dkg_current_rounds = %dkg_share_entry_count,
+                dkg_current_rounds = %dkg_shares_entry_count,
                 "attempt to run multiple DKGs without a configured re-run height; aborting"
             );
             return Err(Error::DkgHasAlreadyRun);
@@ -913,7 +913,7 @@ async fn assert_allow_dkg_begin(
             tracing::warn!(
                 ?dkg_min_bitcoin_block_height,
                 %dkg_target_rounds,
-                dkg_current_rounds = %dkg_share_entry_count,
+                dkg_current_rounds = %dkg_shares_entry_count,
                 "multiple DKG shares already exist; aborting"
             );
             return Err(Error::DkgHasAlreadyRun);

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -1056,6 +1056,9 @@ mod tests {
         let result = assert_allow_dkg_begin(&context, &bitcoin_chain_tip).await;
 
         // Assert the result
-        assert_eq!(result.is_ok(), should_allow);
+        match should_allow {
+            true => assert!(result.is_ok()),
+            false => assert!(matches!(result, Err(Error::DkgHasAlreadyRun))),
+        }
     }
 }


### PR DESCRIPTION
## Description

Closes: #1200 

## Changes

Changes the check in the `handle_wsts_message` method for `DkgBegin` messages in the transaction signer to conditionally allow a second DKG run if:

- There has not been a DKG run yet (i.e. no entries in the signer's `dkg_shares` db table), **OR**
- If DKG has been run exactly once (one entry in the signer's `dkg_shares` db table) **AND** a DKG re-run height is configured **AND** the current bitcoin chain tip height is >= the configured re-run height

This copies a snippet of the config code in #1201 to be able to retrieve the config value for the DKG re-run height.

## Testing Information

This currently lacks additional tests because my integration env is borked for some reason; looking into that now.

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
