### PR TITLE
refactor: better integration test db instantiation

### DIFF
--- a/docker/docker-compose.ci.yml
+++ b/docker/docker-compose.ci.yml
@@ -29,7 +29,6 @@ services:
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
-      POSTGRES_DB: signer
       POSTGRES_HOST_AUTH_METHOD: trust
     ports:
       - "5432:5432"

--- a/docker/docker-compose.ci.yml
+++ b/docker/docker-compose.ci.yml
@@ -53,4 +53,3 @@ services:
       - emily-dynamodb
     environment:
       - DYNAMODB_ENDPOINT=http://emily-dynamodb:8000
- 

--- a/docker/docker-compose.ci.yml
+++ b/docker/docker-compose.ci.yml
@@ -53,3 +53,4 @@ services:
       - emily-dynamodb
     environment:
       - DYNAMODB_ENDPOINT=http://emily-dynamodb:8000
+ 

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -31,7 +31,6 @@ services:
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
-      POSTGRES_DB: signer
       POSTGRES_HOST_AUTH_METHOD: trust
     ports:
       - "5432:5432"
@@ -40,23 +39,6 @@ services:
       interval: 2s
       timeout: 1s
       retries: 5
-
-  flyway:
-    image: flyway/flyway:10.13.0
-    command: >-
-      -url=jdbc:postgresql://postgres:5432/signer
-      -user=postgres
-      -password=postgres
-      -sqlMigrationPrefix=""
-      -connectRetries=60
-      migrate
-    volumes:
-      - ../signer/migrations:/flyway/sql
-    depends_on:
-      postgres:
-        condition: service_healthy
-    profiles:
-      - manual_start
 
   # DynamoDB Tables for the Emily API.
   emily-dynamodb:
@@ -94,3 +76,20 @@ services:
       - PORT=3031
     ports:
       - "3031:3031"
+
+  flyway:
+    image: flyway/flyway:10.13.0
+    command: >-
+      -url=jdbc:postgresql://postgres:5432/signer
+      -user=postgres
+      -password=postgres
+      -sqlMigrationPrefix=""
+      -connectRetries=60
+      migrate
+    volumes:
+      - ../signer/migrations:/flyway/sql
+    depends_on:
+      postgres:
+        condition: service_healthy
+    profiles:
+      - manual_start

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -80,7 +80,7 @@ services:
   flyway:
     image: flyway/flyway:10.13.0
     command: >-
-      -url=jdbc:postgresql://postgres:5432/signer
+      -url=jdbc:postgresql://postgres:5432/postgres
       -user=postgres
       -password=postgres
       -sqlMigrationPrefix=""

--- a/signer/src/stacks/api.rs
+++ b/signer/src/stacks/api.rs
@@ -1418,7 +1418,6 @@ mod tests {
     use crate::stacks::wallet::get_full_tx_size;
     use crate::storage::in_memory::Store;
     use crate::storage::DbWrite;
-    use crate::testing::storage::DATABASE_NUM;
 
     use clarity::types::Address;
     use clarity::vm::types::{
@@ -1432,7 +1431,6 @@ mod tests {
 
     use super::*;
     use std::io::Read;
-    use std::sync::atomic::Ordering;
 
     fn generate_wallet(num_keys: u16, signatures_required: u16) -> SignerWallet {
         let network_kind = NetworkKind::Regtest;
@@ -1448,8 +1446,7 @@ mod tests {
     #[ignore = "This is an integration test that hasn't been setup for CI yet"]
     #[test(tokio::test)]
     async fn fetch_unknown_ancestors_works() {
-        let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-        let db = crate::testing::storage::new_test_database(db_num, true).await;
+        let db = crate::testing::storage::new_test_database().await;
 
         let settings = Settings::new_from_default_config().unwrap();
         // This is an integration test that will read from the config, which provides

--- a/signer/tests/integration/bitcoin_validation.rs
+++ b/signer/tests/integration/bitcoin_validation.rs
@@ -1,6 +1,5 @@
 use std::collections::HashSet;
 use std::ops::Deref;
-use std::sync::atomic::Ordering;
 
 use bitcoin::hashes::Hash as _;
 use rand::rngs::OsRng;
@@ -25,7 +24,6 @@ use signer::testing::context::*;
 
 use crate::setup::{backfill_bitcoin_blocks, TestSignerSet};
 use crate::setup::{DepositAmounts, TestSweepSetup2};
-use crate::DATABASE_NUM;
 
 const TEST_FEE_RATE: f64 = 10.0;
 const TEST_CONTEXT_WINDOW: u16 = 1000;
@@ -92,8 +90,7 @@ impl AssertConstantInvariants for Vec<BitcoinTxValidationData> {
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn one_tx_per_request_set() {
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
     let (rpc, faucet) = regtest::initialize_blockchain();
 
@@ -188,8 +185,7 @@ async fn one_tx_per_request_set() {
 async fn one_invalid_deposit_invalidates_tx() {
     let low_fee = 10;
 
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
     let (rpc, faucet) = regtest::initialize_blockchain();
 
@@ -304,8 +300,7 @@ async fn one_invalid_deposit_invalidates_tx() {
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn one_withdrawal_errors_validation() {
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
     let (rpc, faucet) = regtest::initialize_blockchain();
 
@@ -375,8 +370,7 @@ async fn one_withdrawal_errors_validation() {
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn cannot_sign_deposit_is_ok() {
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
     let (rpc, faucet) = regtest::initialize_blockchain();
 
@@ -541,8 +535,7 @@ async fn cannot_sign_deposit_is_ok() {
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn sighashes_match_from_sbtc_requests_object() {
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
     let (rpc, faucet) = regtest::initialize_blockchain();
 
@@ -674,8 +667,7 @@ async fn sighashes_match_from_sbtc_requests_object() {
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn outcome_is_independent_of_input_order() {
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
     let mut rng = OsRng;
     let (rpc, faucet) = regtest::initialize_blockchain();
 

--- a/signer/tests/integration/block_observer.rs
+++ b/signer/tests/integration/block_observer.rs
@@ -59,7 +59,6 @@ use crate::setup::TestSweepSetup;
 use crate::transaction_coordinator::mock_reqwests_status_code_error;
 use crate::utxo_construction::make_deposit_request;
 use crate::zmq::BITCOIN_CORE_ZMQ_ENDPOINT;
-use crate::DATABASE_NUM;
 
 pub const GET_POX_INFO_JSON: &str =
     include_str!("../../tests/fixtures/stacksapi-get-pox-info-test-data.json");
@@ -77,8 +76,7 @@ async fn load_latest_deposit_requests_persists_requests_from_past(blocks_ago: u6
     // database.
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
     let (rpc, faucet) = regtest::initialize_blockchain();
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
     let mut ctx = TestContext::builder()
         .with_storage(db.clone())
         .with_first_bitcoin_core_client()
@@ -250,8 +248,7 @@ async fn load_latest_deposit_requests_persists_requests_from_past(blocks_ago: u6
 async fn link_blocks() {
     setup_logging("info", true);
 
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
 
     let stacks_client = StacksClient::new(Url::parse("http://localhost:20443").unwrap()).unwrap();
 
@@ -396,8 +393,7 @@ async fn block_observer_stores_donation_and_sbtc_utxos() {
 
     // 1. Create a database, an associated context for the block observer.
 
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
     let mut ctx = TestContext::builder()
         .with_storage(db.clone())
         .with_first_bitcoin_core_client()
@@ -673,8 +669,7 @@ async fn block_observer_handles_update_limits(deployed: bool, sbtc_limits: SbtcL
     // with a real bitcoin core client and a real connection to our
     // database.
     let (_, faucet) = regtest::initialize_blockchain();
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
     let mut ctx = TestContext::builder()
         .with_storage(db.clone())
         .with_first_bitcoin_core_client()
@@ -825,8 +820,7 @@ async fn next_headers_to_process_gets_all_headers() {
     const START_HEIGHT: u64 = 103;
 
     let (_, faucet) = regtest::initialize_blockchain();
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
 
     let ctx = TestContext::builder()
         .with_storage(db.clone())
@@ -885,8 +879,7 @@ async fn next_headers_to_process_ignores_known_headers() {
     // with a real bitcoin core client and a real connection to our
     // database.
     let (rpc, _) = regtest::initialize_blockchain();
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
     let context = TestContext::builder()
         .with_storage(db.clone())
         .with_first_bitcoin_core_client()

--- a/signer/tests/integration/complete_deposit.rs
+++ b/signer/tests/integration/complete_deposit.rs
@@ -1,5 +1,3 @@
-use std::sync::atomic::Ordering;
-
 use blockstack_lib::types::chainstate::StacksAddress;
 use rand::rngs::OsRng;
 use rand::SeedableRng;
@@ -23,7 +21,6 @@ use crate::setup::DepositAmounts;
 use crate::setup::TestSignerSet;
 use crate::setup::TestSweepSetup;
 use crate::setup::TestSweepSetup2;
-use crate::DATABASE_NUM;
 
 /// Create a "proper" [`CompleteDepositV1`] object and context with the
 /// given information. If the information here is correct then the returned
@@ -149,8 +146,7 @@ async fn complete_deposit_validation_happy_path() {
     // Normal: this generates the blockchain as well as deposit request
     // transactions and a transaction sweeping in the deposited funds.
     // This is just setup and should be essentially the same between tests.
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
     let (rpc, faucet) = regtest::initialize_blockchain();
     let setup = TestSweepSetup::new_setup(&rpc, &faucet, 1_000_000, &mut rng);
@@ -212,8 +208,7 @@ async fn complete_deposit_validation_happy_path() {
 async fn complete_deposit_validation_deployer_mismatch() {
     // Normal: this generates the blockchain as well as deposit request
     // transactions and a transaction sweeping in the deposited funds.
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
     let (rpc, faucet) = regtest::initialize_blockchain();
     let setup = TestSweepSetup::new_setup(&rpc, &faucet, 1_000_000, &mut rng);
@@ -280,8 +275,7 @@ async fn complete_deposit_validation_deployer_mismatch() {
 async fn complete_deposit_validation_missing_deposit_request() {
     // Normal: this generates the blockchain as well as deposit request
     // transactions and a transaction sweeping in the deposited funds.
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
     let (rpc, faucet) = regtest::initialize_blockchain();
     let setup = TestSweepSetup::new_setup(&rpc, &faucet, 1_000_000, &mut rng);
@@ -342,8 +336,7 @@ async fn complete_deposit_validation_missing_deposit_request() {
 async fn complete_deposit_validation_recipient_mismatch() {
     // Normal: this generates the blockchain as well as deposit request
     // transactions and a transaction sweeping in the deposited funds.
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
     let (rpc, faucet) = regtest::initialize_blockchain();
     let setup = TestSweepSetup::new_setup(&rpc, &faucet, 1_000_000, &mut rng);
@@ -424,8 +417,7 @@ async fn complete_deposit_validation_recipient_mismatch() {
 async fn complete_deposit_validation_fee_too_low() {
     // Normal: this generates the blockchain as well as deposit request
     // transactions and a transaction sweeping in the deposited funds.
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
     let (rpc, faucet) = regtest::initialize_blockchain();
 
@@ -555,8 +547,7 @@ async fn complete_deposit_validation_fee_too_low() {
 async fn complete_deposit_validation_fee_too_high() {
     // Normal: this generates the blockchain as well as deposit request
     // transactions and a transaction sweeping in the deposited funds.
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
     let (rpc, faucet) = regtest::initialize_blockchain();
     let mut setup = TestSweepSetup::new_setup(&rpc, &faucet, 1_000_000, &mut rng);
@@ -628,8 +619,7 @@ async fn complete_deposit_validation_fee_too_high() {
 async fn complete_deposit_validation_sweep_tx_missing() {
     // Normal: this generates the blockchain as well as deposit request
     // transactions and a transaction sweeping in the deposited funds.
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
     let (rpc, faucet) = regtest::initialize_blockchain();
     let setup = TestSweepSetup::new_setup(&rpc, &faucet, 1_000_000, &mut rng);
@@ -698,8 +688,7 @@ async fn complete_deposit_validation_sweep_tx_missing() {
 async fn complete_deposit_validation_sweep_reorged() {
     // Normal: this generates the blockchain as well as deposit request
     // transactions and a transaction sweeping in the deposited funds.
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
     let (rpc, faucet) = regtest::initialize_blockchain();
     let setup = TestSweepSetup::new_setup(&rpc, &faucet, 1_000_000, &mut rng);
@@ -778,8 +767,7 @@ async fn complete_deposit_validation_sweep_reorged() {
 async fn complete_deposit_validation_deposit_not_in_sweep() {
     // Normal: this generates the blockchain as well as deposit request
     // transactions and a transaction sweeping in the deposited funds.
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
     let (rpc, faucet) = regtest::initialize_blockchain();
     let setup = TestSweepSetup::new_setup(&rpc, &faucet, 1_000_000, &mut rng);
@@ -850,8 +838,7 @@ async fn complete_deposit_validation_deposit_not_in_sweep() {
 async fn complete_deposit_validation_deposit_incorrect_fee() {
     // Normal: this generates the blockchain as well as deposit request
     // transactions and a transaction sweeping in the deposited funds.
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
     let (rpc, faucet) = regtest::initialize_blockchain();
     let setup = TestSweepSetup::new_setup(&rpc, &faucet, 1_000_000, &mut rng);
@@ -919,8 +906,7 @@ async fn complete_deposit_validation_deposit_incorrect_fee() {
 async fn complete_deposit_validation_deposit_invalid_sweep() {
     // Normal: this generates the blockchain as well as deposit request
     // transactions and a transaction sweeping in the deposited funds.
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
     let (rpc, faucet) = regtest::initialize_blockchain();
     let setup = TestSweepSetup::new_setup(&rpc, &faucet, 1_000_000, &mut rng);

--- a/signer/tests/integration/emily.rs
+++ b/signer/tests/integration/emily.rs
@@ -1,4 +1,3 @@
-use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use bitcoin::block::Header;
@@ -62,7 +61,6 @@ use test_log::test;
 use url::Url;
 
 use crate::utxo_construction::make_deposit_request;
-use crate::DATABASE_NUM;
 
 async fn run_dkg<Rng, C>(
     ctx: &C,
@@ -144,8 +142,7 @@ async fn deposit_flow() {
     let signing_threshold = 5;
     let context_window = 10;
 
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(46);
     let network = network::in_memory::InMemoryNetwork::new();
     let signer_info = testing::wsts::generate_signer_info(&mut rng, num_signers);

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeMap;
 use std::collections::HashSet;
 use std::io::Read;
-use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use bitcoin::hashes::Hash as _;
@@ -70,13 +69,11 @@ use crate::setup::DepositAmounts;
 use crate::setup::TestSignerSet;
 use crate::setup::TestSweepSetup;
 use crate::setup::TestSweepSetup2;
-use crate::DATABASE_NUM;
 
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn should_be_able_to_query_bitcoin_blocks() {
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let mut store = testing::storage::new_test_database(db_num, true).await;
+    let mut store = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(42);
 
     let test_model_params = testing::storage::model::Params {
@@ -186,8 +183,7 @@ impl AsContractCall for InitiateWithdrawalRequest {
 )); "rotate-keys")]
 #[tokio::test]
 async fn writing_stacks_blocks_works<T: AsContractCall>(contract: ContractCallWrapper<T>) {
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let store = testing::storage::new_test_database(db_num, true).await;
+    let store = testing::storage::new_test_database().await;
 
     let path = "tests/fixtures/tenure-blocks-0-e5fdeb1a51ba6eb297797a1c473e715c27dc81a58ba82c698f6a32eeccee9a5b.bin";
     let mut file = std::fs::File::open(path).unwrap();
@@ -280,8 +276,7 @@ async fn writing_stacks_blocks_works<T: AsContractCall>(contract: ContractCallWr
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn checking_stacks_blocks_exists_works() {
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let store = testing::storage::new_test_database(db_num, true).await;
+    let store = testing::storage::new_test_database().await;
 
     let path = "tests/fixtures/tenure-blocks-0-e5fdeb1a51ba6eb297797a1c473e715c27dc81a58ba82c698f6a32eeccee9a5b.bin";
     let mut file = std::fs::File::open(path).unwrap();
@@ -322,8 +317,7 @@ async fn checking_stacks_blocks_exists_works() {
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn should_return_the_same_pending_deposit_requests_as_in_memory_store() {
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let mut pg_store = testing::storage::new_test_database(db_num, true).await;
+    let mut pg_store = testing::storage::new_test_database().await;
     let mut in_memory_store = storage::in_memory::Store::new_shared();
 
     let mut rng = rand::rngs::StdRng::seed_from_u64(42);
@@ -385,8 +379,7 @@ async fn should_return_the_same_pending_deposit_requests_as_in_memory_store() {
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn get_pending_deposit_requests_only_pending() {
-    let db_num = testing::storage::DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
 
     let (rpc, faucet) = sbtc::testing::regtest::initialize_blockchain();
 
@@ -439,8 +432,7 @@ async fn get_pending_deposit_requests_only_pending() {
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn get_pending_withdrawal_requests_only_pending() {
-    let db_num = testing::storage::DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
 
     let (rpc, faucet) = sbtc::testing::regtest::initialize_blockchain();
 
@@ -492,8 +484,7 @@ async fn get_pending_withdrawal_requests_only_pending() {
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn should_return_the_same_pending_withdraw_requests_as_in_memory_store() {
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let mut pg_store = testing::storage::new_test_database(db_num, true).await;
+    let mut pg_store = testing::storage::new_test_database().await;
     let mut in_memory_store = storage::in_memory::Store::new_shared();
 
     let mut rng = rand::rngs::StdRng::seed_from_u64(42);
@@ -570,8 +561,7 @@ async fn should_return_the_same_pending_withdraw_requests_as_in_memory_store() {
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn should_return_the_same_pending_accepted_deposit_requests_as_in_memory_store() {
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let mut pg_store = testing::storage::new_test_database(db_num, true).await;
+    let mut pg_store = testing::storage::new_test_database().await;
     let mut in_memory_store = storage::in_memory::Store::new_shared();
 
     let mut rng = rand::rngs::StdRng::seed_from_u64(42);
@@ -636,8 +626,7 @@ async fn should_return_the_same_pending_accepted_deposit_requests_as_in_memory_s
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn should_return_the_same_pending_accepted_withdraw_requests_as_in_memory_store() {
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let mut pg_store = testing::storage::new_test_database(db_num, true).await;
+    let mut pg_store = testing::storage::new_test_database().await;
     let mut in_memory_store = storage::in_memory::Store::new_shared();
 
     let mut rng = rand::rngs::StdRng::seed_from_u64(42);
@@ -704,8 +693,7 @@ async fn should_return_the_same_pending_accepted_withdraw_requests_as_in_memory_
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn should_not_return_swept_deposits_as_pending_accepted() {
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
 
     // This query doesn't *need* bitcoind (it's just a query), we just need
@@ -781,8 +769,7 @@ async fn should_not_return_swept_deposits_as_pending_accepted() {
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn should_return_only_accepted_pending_deposits_that_are_within_reclaim_bounds() {
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let mut pg_store = testing::storage::new_test_database(db_num, true).await;
+    let mut pg_store = testing::storage::new_test_database().await;
     let mut in_memory_store = storage::in_memory::Store::new_shared();
 
     let mut rng = rand::rngs::StdRng::seed_from_u64(42);
@@ -929,7 +916,7 @@ async fn should_return_only_accepted_pending_deposits_that_are_within_reclaim_bo
     // This time some of the deposit requests are outside of the reclaim bounds.
     // We should only get the ones that are within the reclaim bounds.
     signer::testing::storage::drop_db(pg_store).await;
-    pg_store = testing::storage::new_test_database(db_num, true).await;
+    pg_store = testing::storage::new_test_database().await;
     in_memory_store = storage::in_memory::Store::new_shared();
 
     // Initialize the data.
@@ -969,8 +956,7 @@ async fn should_return_only_accepted_pending_deposits_that_are_within_reclaim_bo
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn should_return_the_same_last_key_rotation_as_in_memory_store() {
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let mut pg_store = testing::storage::new_test_database(db_num, true).await;
+    let mut pg_store = testing::storage::new_test_database().await;
     let mut in_memory_store = storage::in_memory::Store::new_shared();
 
     let mut rng = rand::rngs::StdRng::seed_from_u64(42);
@@ -1043,8 +1029,7 @@ async fn should_return_the_same_last_key_rotation_as_in_memory_store() {
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn writing_deposit_requests_postgres() {
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let store = testing::storage::new_test_database(db_num, true).await;
+    let store = testing::storage::new_test_database().await;
     let num_rows = 15;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
     let deposit_requests: Vec<model::DepositRequest> =
@@ -1088,8 +1073,7 @@ async fn writing_deposit_requests_postgres() {
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn writing_transactions_postgres() {
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let store = testing::storage::new_test_database(db_num, true).await;
+    let store = testing::storage::new_test_database().await;
     let num_rows = 12;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
     let mut txs: Vec<model::Transaction> =
@@ -1158,8 +1142,7 @@ async fn writing_transactions_postgres() {
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn writing_completed_deposit_requests_postgres() {
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let store = testing::storage::new_test_database(db_num, true).await;
+    let store = testing::storage::new_test_database().await;
 
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
     let event: CompletedDepositEvent = fake::Faker.fake_with_rng(&mut rng);
@@ -1196,8 +1179,7 @@ async fn writing_completed_deposit_requests_postgres() {
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn writing_withdrawal_create_requests_postgres() {
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let store = testing::storage::new_test_database(db_num, true).await;
+    let store = testing::storage::new_test_database().await;
 
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
     let event: WithdrawalCreateEvent = fake::Faker.fake_with_rng(&mut rng);
@@ -1245,8 +1227,7 @@ async fn writing_withdrawal_create_requests_postgres() {
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn writing_withdrawal_accept_requests_postgres() {
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let store = testing::storage::new_test_database(db_num, true).await;
+    let store = testing::storage::new_test_database().await;
 
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
     let event: WithdrawalAcceptEvent = fake::Faker.fake_with_rng(&mut rng);
@@ -1288,8 +1269,7 @@ async fn writing_withdrawal_accept_requests_postgres() {
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn writing_withdrawal_reject_requests_postgres() {
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let store = testing::storage::new_test_database(db_num, true).await;
+    let store = testing::storage::new_test_database().await;
 
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
     let event: WithdrawalRejectEvent = fake::Faker.fake_with_rng(&mut rng);
@@ -1331,8 +1311,7 @@ async fn fetching_deposit_request_votes() {
     // So we have 7 signers, but we will only receive votes from 4 of them.
     // Three of the votes will be to accept and one explicit reject. The
     // others will be counted as rejections in the query.
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let store = testing::storage::new_test_database(db_num, true).await;
+    let store = testing::storage::new_test_database().await;
 
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
     let signer_set_config = SignerSetConfig {
@@ -1432,8 +1411,7 @@ async fn fetching_withdrawal_request_votes() {
     // So we have 7 signers, but we will only receive votes from 4 of them.
     // Three of the votes will be to accept and one explicit reject. The
     // others will be counted as rejections in the query.
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let store = testing::storage::new_test_database(db_num, true).await;
+    let store = testing::storage::new_test_database().await;
 
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
     let signer_set_config = SignerSetConfig {
@@ -1539,8 +1517,7 @@ async fn fetching_withdrawal_request_votes() {
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn block_in_canonical_bitcoin_blockchain_in_other_block_chain() {
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let pg_store = testing::storage::new_test_database(db_num, true).await;
+    let pg_store = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
 
     // This is just a sql test, where we use the `TestData` struct to help
@@ -1614,8 +1591,7 @@ async fn block_in_canonical_bitcoin_blockchain_in_other_block_chain() {
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn we_can_fetch_bitcoin_txs_from_db() {
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let pg_store = testing::storage::new_test_database(db_num, true).await;
+    let pg_store = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
 
     // This is just a sql test, where we use the `TestData` struct to help
@@ -1672,8 +1648,7 @@ async fn we_can_fetch_bitcoin_txs_from_db() {
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn is_signer_script_pub_key_checks_dkg_shares_for_script_pubkeys() {
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
     let mem = storage::in_memory::Store::new_shared();
 
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
@@ -1717,8 +1692,7 @@ async fn is_signer_script_pub_key_checks_dkg_shares_for_script_pubkeys() {
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn get_signers_script_pubkeys_returns_non_empty_vec_old_rows() {
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
 
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
 
@@ -1761,8 +1735,7 @@ async fn get_signers_script_pubkeys_returns_non_empty_vec_old_rows() {
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn get_last_encrypted_dkg_shares_gets_most_recent_shares() {
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
 
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
 
@@ -1810,8 +1783,7 @@ async fn get_last_encrypted_dkg_shares_gets_most_recent_shares() {
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn deposit_request_exists_works() {
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
 
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
 
@@ -1837,8 +1809,7 @@ async fn deposit_request_exists_works() {
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn is_known_bitcoin_block_hash_works() {
-    let db_num = testing::storage::DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(71);
 
     // We only want the blockchain to be generated
@@ -1885,8 +1856,7 @@ async fn is_known_bitcoin_block_hash_works() {
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn get_swept_deposit_requests_returns_swept_deposit_requests() {
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
 
     // This query doesn't *need* bitcoind (it's just a query), we just need
@@ -1947,8 +1917,7 @@ async fn get_swept_deposit_requests_returns_swept_deposit_requests() {
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn get_swept_deposit_requests_does_not_return_unswept_deposit_requests() {
-    let db_num = testing::storage::DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
 
     // This query doesn't *need* bitcoind (it's just a query), we just need
@@ -1999,8 +1968,7 @@ async fn get_swept_deposit_requests_does_not_return_unswept_deposit_requests() {
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn get_swept_deposit_requests_does_not_return_deposit_requests_with_responses() {
-    let db_num = testing::storage::DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
 
     // This query doesn't *need* bitcoind (it's just a query), we just need
@@ -2146,8 +2114,7 @@ async fn get_swept_deposit_requests_does_not_return_deposit_requests_with_respon
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn can_sign_deposit_tx_rejects_not_in_signer_set() {
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
 
     // Let's create any old aggregate key
@@ -2208,8 +2175,7 @@ async fn can_sign_deposit_tx_rejects_not_in_signer_set() {
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn get_swept_deposit_requests_response_tx_reorged() {
-    let db_num = testing::storage::DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
 
     // This query doesn't *need* bitcoind (it's just a query), we just need
@@ -2334,8 +2300,7 @@ async fn transaction_coordinator_test_environment(
 #[test(tokio::test)]
 /// Tests that TxCoordinatorEventLoop::get_pending_requests ignores withdrawals
 async fn should_ignore_withdrawals() {
-    let db_num = testing::storage::DATABASE_NUM.fetch_add(1, core::sync::atomic::Ordering::SeqCst);
-    let store = testing::storage::new_test_database(db_num, true).await;
+    let store = testing::storage::new_test_database().await;
 
     transaction_coordinator_test_environment(store.clone())
         .await
@@ -2348,8 +2313,7 @@ async fn should_ignore_withdrawals() {
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn should_get_signer_utxo_simple() {
-    let db_num = testing::storage::DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let store = testing::storage::new_test_database(db_num, true).await;
+    let store = testing::storage::new_test_database().await;
 
     transaction_coordinator_test_environment(store.clone())
         .await
@@ -2362,8 +2326,7 @@ async fn should_get_signer_utxo_simple() {
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn should_get_signer_utxo_fork() {
-    let db_num = testing::storage::DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let store = testing::storage::new_test_database(db_num, true).await;
+    let store = testing::storage::new_test_database().await;
 
     transaction_coordinator_test_environment(store.clone())
         .await
@@ -2376,8 +2339,7 @@ async fn should_get_signer_utxo_fork() {
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn should_get_signer_utxo_unspent() {
-    let db_num = testing::storage::DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let store = testing::storage::new_test_database(db_num, true).await;
+    let store = testing::storage::new_test_database().await;
 
     transaction_coordinator_test_environment(store.clone())
         .await
@@ -2390,8 +2352,7 @@ async fn should_get_signer_utxo_unspent() {
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn should_get_signer_utxo_donations() {
-    let db_num = testing::storage::DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let store = testing::storage::new_test_database(db_num, true).await;
+    let store = testing::storage::new_test_database().await;
 
     transaction_coordinator_test_environment(store.clone())
         .await
@@ -2420,8 +2381,7 @@ async fn should_get_signer_utxo_donations() {
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn deposit_report_with_only_deposit_request() {
-    let db_num = testing::storage::DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(20);
 
     // We only want the blockchain to be generated
@@ -2521,8 +2481,7 @@ async fn deposit_report_with_only_deposit_request() {
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn deposit_report_with_deposit_request_reorged() {
-    let db_num = testing::storage::DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(21);
 
     // We only want the blockchain to be generated
@@ -2597,8 +2556,7 @@ async fn deposit_report_with_deposit_request_reorged() {
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn deposit_report_with_deposit_request_spent() {
-    let db_num = testing::storage::DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(22);
 
     // We only want the blockchain to be generated
@@ -2696,8 +2654,7 @@ async fn deposit_report_with_deposit_request_spent() {
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn deposit_report_with_deposit_request_swept_but_swept_reorged() {
-    let db_num = testing::storage::DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(23);
 
     // We only want the blockchain to be generated
@@ -2828,8 +2785,7 @@ async fn deposit_report_with_deposit_request_swept_but_swept_reorged() {
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn deposit_report_with_deposit_request_confirmed() {
-    let db_num = testing::storage::DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(24);
 
     // We only want the blockchain to be generated
@@ -2905,8 +2861,7 @@ async fn deposit_report_with_deposit_request_confirmed() {
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn can_write_and_get_multiple_bitcoin_txs_sighashes() {
-    let db_num = testing::storage::DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
 
     let sighashes: Vec<BitcoinTxSigHash> = (0..5).map(|_| fake::Faker.fake()).collect();
 
@@ -2928,8 +2883,7 @@ async fn can_write_and_get_multiple_bitcoin_txs_sighashes() {
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn can_write_multiple_bitcoin_withdrawal_outputs() {
-    let db_num = testing::storage::DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
 
     let outputs: Vec<BitcoinWithdrawalOutput> = (0..5).map(|_| fake::Faker.fake()).collect();
 
@@ -2943,8 +2897,7 @@ async fn can_write_multiple_bitcoin_withdrawal_outputs() {
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn get_deposit_request_returns_none_for_missing_deposit() {
-    let db_num = testing::storage::DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
 
     // Create a random txid
@@ -2962,8 +2915,7 @@ async fn get_deposit_request_returns_none_for_missing_deposit() {
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn get_deposit_request_returns_returns_inserted_deposit_request() {
-    let db_num = testing::storage::DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
 
     // Create multiple deposit requests
@@ -3073,8 +3025,7 @@ impl<const N: usize> ReorgDescription<N> {
 }; "busy-bridge-with-reorg")]
 #[tokio::test]
 async fn signer_utxo_reorg_suite<const N: usize>(desc: ReorgDescription<N>) {
-    let db_num = testing::storage::DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
 
     // We just need some basic data in the database. The only value that

--- a/signer/tests/integration/request_decider.rs
+++ b/signer/tests/integration/request_decider.rs
@@ -1,5 +1,3 @@
-use std::sync::atomic::Ordering;
-
 use emily_client::apis::deposit_api;
 use emily_client::apis::testing_api;
 use emily_client::models::CreateDepositRequestBody;
@@ -28,7 +26,6 @@ use url::Url;
 
 use crate::setup::backfill_bitcoin_blocks;
 use crate::setup::TestSweepSetup;
-use crate::DATABASE_NUM;
 
 fn test_environment(
     db: PgStore,
@@ -67,8 +64,7 @@ fn test_environment(
 }
 
 async fn create_signer_database() -> PgStore {
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    signer::testing::storage::new_test_database(db_num, true).await
+    signer::testing::storage::new_test_database().await
 }
 
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
@@ -128,8 +124,7 @@ async fn should_store_decisions_received_from_other_signers() {
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn handle_pending_deposit_request_address_script_pub_key() {
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
 
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
 
@@ -214,8 +209,7 @@ async fn handle_pending_deposit_request_address_script_pub_key() {
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn handle_pending_deposit_request_not_in_signing_set() {
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
 
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
 
@@ -301,8 +295,7 @@ async fn handle_pending_deposit_request_not_in_signing_set() {
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn persist_received_deposit_decision_fetches_missing_deposit_requests() {
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
 
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
 

--- a/signer/tests/integration/rotate_keys.rs
+++ b/signer/tests/integration/rotate_keys.rs
@@ -1,5 +1,3 @@
-use std::sync::atomic::Ordering;
-
 use blockstack_lib::types::chainstate::StacksAddress;
 use rand::rngs::OsRng;
 use rand::SeedableRng;
@@ -27,8 +25,6 @@ use signer::testing::context::*;
 
 use fake::Fake;
 use signer::testing::storage::model::TestData;
-
-use crate::DATABASE_NUM;
 
 struct TestRotateKeySetup {
     /// The signer object. It's public key represents the group of signers'
@@ -170,8 +166,7 @@ fn make_rotate_key(setup: &TestRotateKeySetup) -> (RotateKeysV1, ReqContext) {
 #[tokio::test]
 async fn rotate_key_validation_happy_path() {
     // Normal: preamble
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let mut db = testing::storage::new_test_database(db_num, true).await;
+    let mut db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
 
     let test_model_params = testing::storage::model::Params {
@@ -221,8 +216,7 @@ async fn rotate_key_validation_happy_path() {
 #[tokio::test]
 async fn rotate_key_validation_no_dkg() {
     // Normal: preamble
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let mut db = testing::storage::new_test_database(db_num, true).await;
+    let mut db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
 
     let test_model_params = testing::storage::model::Params {
@@ -260,8 +254,7 @@ async fn rotate_key_validation_no_dkg() {
 #[tokio::test]
 async fn rotate_key_validation_wrong_deployer() {
     // Normal: preamble
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let mut db = testing::storage::new_test_database(db_num, true).await;
+    let mut db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
 
     let test_model_params = testing::storage::model::Params {
@@ -305,8 +298,7 @@ async fn rotate_key_validation_wrong_deployer() {
 #[tokio::test]
 async fn rotate_key_validation_wrong_signing_set() {
     // Normal: preamble
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let mut db = testing::storage::new_test_database(db_num, true).await;
+    let mut db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
 
     let test_model_params = testing::storage::model::Params {
@@ -356,8 +348,7 @@ async fn rotate_key_validation_wrong_signing_set() {
 #[tokio::test]
 async fn rotate_key_validation_wrong_aggregate_key() {
     // Normal: preamble
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let mut db = testing::storage::new_test_database(db_num, true).await;
+    let mut db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
 
     let test_model_params = testing::storage::model::Params {
@@ -407,8 +398,7 @@ async fn rotate_key_validation_wrong_aggregate_key() {
 #[tokio::test]
 async fn rotate_key_validation_wrong_signatures_required() {
     // Normal: preamble
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let mut db = testing::storage::new_test_database(db_num, true).await;
+    let mut db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
 
     let test_model_params = testing::storage::model::Params {
@@ -463,8 +453,7 @@ async fn rotate_key_validation_wrong_signatures_required() {
 #[tokio::test]
 async fn rotate_key_validation_replay() {
     // Normal: preamble
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let mut db = testing::storage::new_test_database(db_num, true).await;
+    let mut db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
 
     let test_model_params = testing::storage::model::Params {

--- a/signer/tests/integration/transaction_coordinator.rs
+++ b/signer/tests/integration/transaction_coordinator.rs
@@ -100,7 +100,6 @@ use crate::setup::backfill_bitcoin_blocks;
 use crate::setup::TestSweepSetup;
 use crate::utxo_construction::make_deposit_request;
 use crate::zmq::BITCOIN_CORE_ZMQ_ENDPOINT;
-use crate::DATABASE_NUM;
 
 type IntegrationTestContext =
     TestContext<PgStore, BitcoinCoreClient, WrappedMock<MockStacksInteract>, EmilyClient>;
@@ -410,8 +409,7 @@ fn mock_recover_and_deploy_all_contracts_after_failure(
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[test(tokio::test)]
 async fn process_complete_deposit() {
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
     let (rpc, faucet) = regtest::initialize_blockchain();
     let setup = TestSweepSetup::new_setup(&rpc, &faucet, 1_000_000, &mut rng);
@@ -614,8 +612,7 @@ async fn deploy_smart_contracts_coordinator<F>(
     F: FnOnce(u64, Sender<StacksTransaction>) -> Box<dyn FnOnce(&mut MockStacksInteract)>,
 {
     signer::logging::setup_logging("info", false);
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
 
     let num_messages = smart_contracts.len();
@@ -778,8 +775,7 @@ async fn deploy_smart_contracts_coordinator<F>(
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn get_signer_public_keys_and_aggregate_key_falls_back() {
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
 
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
 
@@ -940,8 +936,7 @@ async fn run_dkg_from_scratch() {
 
     for (kp, data) in iter {
         let broadcast_stacks_tx = broadcast_stacks_tx.clone();
-        let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-        let db = testing::storage::new_test_database(db_num, true).await;
+        let db = testing::storage::new_test_database().await;
         let mut ctx = TestContext::builder()
             .with_storage(db.clone())
             .with_mocked_clients()
@@ -1176,8 +1171,7 @@ async fn sign_bitcoin_transaction() {
     // =========================================================================
     let mut signers = Vec::new();
     for kp in signer_key_pairs.iter() {
-        let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-        let db = testing::storage::new_test_database(db_num, true).await;
+        let db = testing::storage::new_test_database().await;
         let ctx = TestContext::builder()
             .with_storage(db.clone())
             .with_first_bitcoin_core_client()
@@ -1579,8 +1573,7 @@ async fn skip_smart_contract_deployment_and_key_rotation_if_up_to_date() {
     // =========================================================================
     let mut signers = Vec::new();
     for kp in signer_key_pairs.iter() {
-        let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-        let db = testing::storage::new_test_database(db_num, true).await;
+        let db = testing::storage::new_test_database().await;
         let ctx = TestContext::builder()
             .with_storage(db.clone())
             .with_first_bitcoin_core_client()
@@ -1874,8 +1867,7 @@ async fn wait_for_signers(signers: &[(IntegrationTestContext, PgStore, &Keypair,
 async fn test_get_btc_state_with_no_available_sweep_transactions() {
     let mut rng = rand::rngs::StdRng::seed_from_u64(46);
 
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
 
     let mut context = TestContext::builder()
         .with_storage(db.clone())
@@ -2010,8 +2002,7 @@ async fn test_get_btc_state_with_no_available_sweep_transactions() {
 async fn test_get_btc_state_with_available_sweep_transactions_and_rbf() {
     let mut rng = rand::rngs::StdRng::seed_from_u64(46);
 
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
 
     let client = BitcoinCoreClient::new(
         "http://localhost:18443",

--- a/signer/tests/integration/transaction_signer.rs
+++ b/signer/tests/integration/transaction_signer.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use fake::Fake as _;
@@ -34,7 +33,6 @@ use signer::transaction_signer::TxSignerEventLoop;
 use crate::setup::backfill_bitcoin_blocks;
 use crate::setup::fill_signers_utxo;
 use crate::setup::TestSweepSetup;
-use crate::DATABASE_NUM;
 
 /// Test that [`TxSignerEventLoop::get_signer_public_keys`] falls back to
 /// the bootstrap config if there is no rotate-keys transaction in the
@@ -42,8 +40,7 @@ use crate::DATABASE_NUM;
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn get_signer_public_keys_and_aggregate_key_falls_back() {
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
 
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
 
@@ -136,8 +133,7 @@ async fn get_signer_public_keys_and_aggregate_key_falls_back() {
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 async fn signing_set_validation_check_for_stacks_transactions() {
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
 
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
 
@@ -215,8 +211,7 @@ async fn signing_set_validation_check_for_stacks_transactions() {
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 #[tokio::test]
 pub async fn assert_should_be_able_to_handle_sbtc_requests() {
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
 
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
     let fee_rate = 1.3;

--- a/signer/tests/integration/withdrawal_accept.rs
+++ b/signer/tests/integration/withdrawal_accept.rs
@@ -1,5 +1,3 @@
-use std::sync::atomic::Ordering;
-
 use bitcoin::OutPoint;
 use blockstack_lib::types::chainstate::StacksAddress;
 use rand::rngs::OsRng;
@@ -19,7 +17,6 @@ use signer::testing::context::*;
 
 use crate::setup::backfill_bitcoin_blocks;
 use crate::setup::TestSweepSetup;
-use crate::DATABASE_NUM;
 
 /// Create a "proper" [`AcceptWithdrawalV1`] object and context with the
 /// given information. If the information here is correct then the returned
@@ -91,8 +88,7 @@ async fn accept_withdrawal_validation_happy_path() {
     // Normal: this generates the blockchain as well as a transaction
     // sweeping out the funds for a withdrawal request. This is just setup
     // and should be essentially the same between tests.
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
     let (rpc, faucet) = regtest::initialize_blockchain();
     let setup = TestSweepSetup::new_setup(&rpc, &faucet, 1_000_000, &mut rng);
@@ -141,8 +137,7 @@ async fn accept_withdrawal_validation_happy_path() {
 async fn accept_withdrawal_validation_deployer_mismatch() {
     // Normal: this generates the blockchain as well as a transaction
     // sweeping out the funds for a withdrawal request.
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
     let (rpc, faucet) = regtest::initialize_blockchain();
     let setup = TestSweepSetup::new_setup(&rpc, &faucet, 1_000_000, &mut rng);
@@ -200,8 +195,7 @@ async fn accept_withdrawal_validation_deployer_mismatch() {
 async fn accept_withdrawal_validation_missing_withdrawal_request() {
     // Normal: this generates the blockchain as well as a transaction
     // sweeping out the funds for a withdrawal request.
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
     let (rpc, faucet) = regtest::initialize_blockchain();
     let setup = TestSweepSetup::new_setup(&rpc, &faucet, 1_000_000, &mut rng);
@@ -260,8 +254,7 @@ async fn accept_withdrawal_validation_missing_withdrawal_request() {
 async fn accept_withdrawal_validation_recipient_mismatch() {
     // Normal: this generates the blockchain as well as a transaction
     // sweeping out the funds for a withdrawal request.
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
     let (rpc, faucet) = regtest::initialize_blockchain();
     let mut setup = TestSweepSetup::new_setup(&rpc, &faucet, 1_000_000, &mut rng);
@@ -320,8 +313,7 @@ async fn accept_withdrawal_validation_recipient_mismatch() {
 async fn accept_withdrawal_validation_invalid_amount() {
     // Normal: this generates the blockchain as well as a transaction
     // sweeping out the funds for a withdrawal request.
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
     let (rpc, faucet) = regtest::initialize_blockchain();
     let mut setup = TestSweepSetup::new_setup(&rpc, &faucet, 1_000_000, &mut rng);
@@ -378,8 +370,7 @@ async fn accept_withdrawal_validation_invalid_amount() {
 async fn accept_withdrawal_validation_invalid_fee() {
     // Normal: this generates the blockchain as well as a transaction
     // sweeping out the funds for a withdrawal request.
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
     let (rpc, faucet) = regtest::initialize_blockchain();
     let mut setup = TestSweepSetup::new_setup(&rpc, &faucet, 1_000_000, &mut rng);
@@ -438,8 +429,7 @@ async fn accept_withdrawal_validation_invalid_fee() {
 async fn accept_withdrawal_validation_sweep_tx_missing() {
     // Normal: this generates the blockchain as well as a transaction
     // sweeping out the funds for a withdrawal request.
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
     let (rpc, faucet) = regtest::initialize_blockchain();
     let setup = TestSweepSetup::new_setup(&rpc, &faucet, 1_000_000, &mut rng);
@@ -500,8 +490,7 @@ async fn accept_withdrawal_validation_sweep_tx_missing() {
 async fn accept_withdrawal_validation_sweep_reorged() {
     // Normal: this generates the blockchain as well as a transaction
     // sweeping out the funds for a withdrawal request.
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
     let (rpc, faucet) = regtest::initialize_blockchain();
     let setup = TestSweepSetup::new_setup(&rpc, &faucet, 1_000_000, &mut rng);
@@ -571,8 +560,7 @@ async fn accept_withdrawal_validation_sweep_reorged() {
 async fn accept_withdrawal_validation_withdrawal_not_in_sweep() {
     // Normal: this generates the blockchain as well as a transaction
     // sweeping out the funds for a withdrawal request.
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
     let (rpc, faucet) = regtest::initialize_blockchain();
     let setup = TestSweepSetup::new_setup(&rpc, &faucet, 1_000_000, &mut rng);
@@ -633,8 +621,7 @@ async fn accept_withdrawal_validation_withdrawal_not_in_sweep() {
 async fn accept_withdrawal_validation_bitmap_mismatch() {
     // Normal: this generates the blockchain as well as a transaction
     // sweeping out the funds for a withdrawal request.
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
     let (rpc, faucet) = regtest::initialize_blockchain();
     let setup = TestSweepSetup::new_setup(&rpc, &faucet, 1_000_000, &mut rng);
@@ -694,8 +681,7 @@ async fn accept_withdrawal_validation_bitmap_mismatch() {
 async fn accept_withdrawal_validation_withdrawal_incorrect_fee() {
     // Normal: this generates the blockchain as well as a transaction
     // sweeping out the funds for a withdrawal request.
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
     let (rpc, faucet) = regtest::initialize_blockchain();
     let setup = TestSweepSetup::new_setup(&rpc, &faucet, 1_000_000, &mut rng);
@@ -753,8 +739,7 @@ async fn accept_withdrawal_validation_withdrawal_incorrect_fee() {
 async fn accept_withdrawal_validation_withdrawal_invalid_sweep() {
     // Normal: this generates the blockchain as well as a transaction
     // sweeping out the funds for a withdrawal request.
-    let db_num = DATABASE_NUM.fetch_add(1, Ordering::SeqCst);
-    let db = testing::storage::new_test_database(db_num, true).await;
+    let db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
     let (rpc, faucet) = regtest::initialize_blockchain();
     let setup = TestSweepSetup::new_setup(&rpc, &faucet, 1_000_000, &mut rng);


### PR DESCRIPTION
## Description

The integration-env completely broke for me causing me to be unable to run integration tests locally and I'm not sure what the root cause actually was, but I kept getting a lot of failures with errors that looked like concurrency issues (despite that we're using single-threaded). It seemed to be related to creating databases using a template 🤷 

This refactor fixed the issues for me anyway and simplifies the code a bit.

## Changes

- Now uses a sequence in the database for `db_num`.
- The `new_test_database()` method is now a bit more streamlined -- I removed the parameters since we never use them, and it's now much simpler/smaller.

## Testing Information

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
