### PR TITLE
feat: #1199 feature coordinator attempts subsequent DKG run according to configuration

### DIFF
--- a/signer/src/config/mod.rs
+++ b/signer/src/config/mod.rs
@@ -255,18 +255,17 @@ pub struct SignerConfig {
     /// arrives. The default here is controlled by the
     /// [`MAX_DEPOSITS_PER_BITCOIN_TX`] constant
     pub max_deposits_per_bitcoin_tx: NonZeroU16,
-
-    /// Configures a DKG re-run Bitcoin block height. If this is set and DKG
-    /// has already been run, the coordinator will attempt to re-run DKG after
-    /// this block height at most once. If DKG has never been run, this
-    /// configuration has no effect.
-    pub dkg_rerun_bitcoin_height: Option<NonZeroU64>,
-
+    /// Configures a DKG re-run Bitcoin block height. If this is set and DKG has
+    /// already been run, the coordinator will attempt to re-run DKG after this
+    /// block height is met if `dkg_target_rounds` has not been reached. If DKG
+    /// has never been run, this configuration has no effect.
+    pub dkg_min_bitcoin_block_height: Option<NonZeroU64>,
     /// Configures a target number of DKG rounds to run/accept. If this is set
     /// and the number of DKG shares is less than this number, the coordinator
     /// will continue to run DKG rounds until this number of rounds is reached,
-    /// assuming the conditions for `dkg_rerun_bitcoin_height` are also met.
-    pub dkg_rounds_target: NonZeroU32,
+    /// assuming the conditions for `dkg_rerun_bitcoin_height` are also met. If
+    /// DKG has never been run, this configuration has no effect.
+    pub dkg_target_rounds: NonZeroU32,
 }
 
 impl Validatable for SignerConfig {
@@ -405,7 +404,7 @@ impl Settings {
             "signer.max_deposits_per_bitcoin_tx",
             DEFAULT_MAX_DEPOSITS_PER_BITCOIN_TX,
         )?;
-        cfg_builder = cfg_builder.set_default("signer.dkg_rounds_target", 1)?;
+        cfg_builder = cfg_builder.set_default("signer.dkg_target_rounds", 1)?;
 
         if let Some(path) = config_path {
             cfg_builder = cfg_builder.add_source(File::from(path.as_ref()));

--- a/signer/src/config/mod.rs
+++ b/signer/src/config/mod.rs
@@ -8,6 +8,8 @@ use serde::Deserialize;
 use stacks_common::types::chainstate::StacksAddress;
 use std::collections::BTreeSet;
 use std::num::NonZeroU16;
+use std::num::NonZeroU32;
+use std::num::NonZeroU64;
 use std::path::Path;
 use url::Url;
 
@@ -253,6 +255,18 @@ pub struct SignerConfig {
     /// arrives. The default here is controlled by the
     /// [`MAX_DEPOSITS_PER_BITCOIN_TX`] constant
     pub max_deposits_per_bitcoin_tx: NonZeroU16,
+
+    /// Configures a DKG re-run Bitcoin block height. If this is set and DKG
+    /// has already been run, the coordinator will attempt to re-run DKG after
+    /// this block height at most once. If DKG has never been run, this
+    /// configuration has no effect.
+    pub dkg_rerun_bitcoin_height: Option<NonZeroU64>,
+
+    /// Configures a target number of DKG rounds to run/accept. If this is set
+    /// and the number of DKG shares is less than this number, the coordinator
+    /// will continue to run DKG rounds until this number of rounds is reached,
+    /// assuming the conditions for `dkg_rerun_bitcoin_height` are also met.
+    pub dkg_rounds_target: NonZeroU32,
 }
 
 impl Validatable for SignerConfig {
@@ -391,6 +405,7 @@ impl Settings {
             "signer.max_deposits_per_bitcoin_tx",
             DEFAULT_MAX_DEPOSITS_PER_BITCOIN_TX,
         )?;
+        cfg_builder = cfg_builder.set_default("signer.dkg_rounds_target", 1)?;
 
         if let Some(path) = config_path {
             cfg_builder = cfg_builder.add_source(File::from(path.as_ref()));

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -13,6 +13,10 @@ use crate::storage::model::SigHash;
 /// Top-level signer error
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
+    /// The aggregate key for the given block hash could not be determined.
+    #[error("the signer set aggregate key could not be determined for bitcoin block {0}")]
+    MissingAggregateKey(bitcoin::BlockHash),
+
     /// An error occurred while attempting to connect to the Bitcoin Core ZMQ socket.
     #[error("timed-out trying to connect to bitcoin-core ZMQ endpoint: {0}")]
     BitcoinCoreZmqConnectTimeout(String),

--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -1938,7 +1938,7 @@ mod tests {
             .with_mocked_clients()
             .modify_settings(|s| {
                 s.signer.dkg_min_bitcoin_block_height =
-                    dkg_min_bitcoin_block_height.map(NonZeroU64::new).flatten();
+                    dkg_min_bitcoin_block_height.and_then(NonZeroU64::new);
                 s.signer.dkg_target_rounds = NonZeroU32::new(dkg_target_rounds).unwrap();
             })
             .build();

--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -303,25 +303,24 @@ where
             return Ok(());
         }
 
-        tracing::debug!("we are the coordinator, we may need to coordinate DKG");
+        tracing::debug!("we are the coordinator");
         metrics::counter!(Metrics::CoordinatorTenuresTotal).increment(1);
-        // If Self::get_signer_set_and_aggregate_key did not return an
-        // aggregate key, then we know that we have not run DKG yet. Since
-        // we are the coordinator, we should coordinate DKG.
-        let aggregate_key = match maybe_aggregate_key {
-            Some(key) => key,
-            // This function returns the new DKG aggregate key.
-            None => {
-                let dkg_result = self.coordinate_dkg(&bitcoin_chain_tip).await?;
-                // TODO: in `run_dkg_from_scratch` test, `dkg_result` differs from
-                // value fetched from the db. Adding a temporary fix for the (probably)
-                // race condition, but we should address this properly.
-                self.get_signer_set_and_aggregate_key(&bitcoin_chain_tip)
-                    .await
-                    .ok()
-                    .and_then(|res| res.0)
-                    .unwrap_or(dkg_result)
-            }
+
+        tracing::debug!("determining if we need to coordinate DKG");
+        let should_coordinate_dkg =
+            should_coordinate_dkg(&self.context, &bitcoin_chain_tip).await?;
+        let aggregate_key = if should_coordinate_dkg {
+            let dkg_result = self.coordinate_dkg(&bitcoin_chain_tip).await?;
+            // TODO: in `run_dkg_from_scratch` test, `dkg_result` differs from
+            // value fetched from the db. Adding a temporary fix for the (probably)
+            // race condition, but we should address this properly.
+            self.get_signer_set_and_aggregate_key(&bitcoin_chain_tip)
+                .await
+                .ok()
+                .and_then(|res| res.0)
+                .unwrap_or(dkg_result)
+        } else {
+            maybe_aggregate_key.ok_or(Error::MissingAggregateKey(*bitcoin_chain_tip))?
         };
 
         self.deploy_smart_contracts(&bitcoin_chain_tip, &aggregate_key)
@@ -1748,17 +1747,77 @@ pub fn coordinator_public_key(
         .copied()
 }
 
+/// Determine, according to the current state of the signer and configuration,
+/// whether or not a new DKG round should be coordinated.
+pub async fn should_coordinate_dkg(
+    context: &impl Context,
+    bitcoin_chain_tip: &model::BitcoinBlockHash,
+) -> Result<bool, Error> {
+    let storage = context.get_storage();
+    let config = context.config();
+
+    // Get the bitcoin block at the chain tip so that we know the height
+    let bitcoin_chain_tip_block = storage
+        .get_bitcoin_block(bitcoin_chain_tip)
+        .await?
+        .ok_or(Error::NoChainTip)?;
+
+    // Get the number of DKG shares that have been stored
+    let dkg_shares_entry_count = storage.get_encrypted_dkg_shares_count().await?;
+
+    // Get DKG configuration parameters
+    let dkg_min_bitcoin_block_height = config.signer.dkg_min_bitcoin_block_height;
+    let dkg_target_rounds = config.signer.dkg_target_rounds;
+
+    // Determine the action based on the DKG shares count and the rerun height (if configured)
+    match (
+        dkg_shares_entry_count,
+        dkg_target_rounds,
+        dkg_min_bitcoin_block_height,
+    ) {
+        (0, _, _) => {
+            tracing::info!(
+                ?dkg_min_bitcoin_block_height,
+                %dkg_target_rounds,
+                "no DKG shares exist; proceeding with DKG"
+            );
+            Ok(true)
+        }
+        (current, target, Some(dkg_min_height))
+            if current < target.get()
+                && bitcoin_chain_tip_block.block_height >= dkg_min_height.get() =>
+        {
+            tracing::info!(
+                ?dkg_min_bitcoin_block_height,
+                %dkg_target_rounds,
+                dkg_current_rounds = %dkg_shares_entry_count,
+                "DKG rerun height has been met and we are below the target number of rounds; proceeding with DKG"
+            );
+            Ok(true)
+        }
+        _ => Ok(false),
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::num::{NonZeroU32, NonZeroU64};
+
     use crate::bitcoin::MockBitcoinInteract;
+    use crate::context::Context;
     use crate::emily_client::MockEmilyInteract;
     use crate::stacks::api::MockStacksInteract;
     use crate::storage::in_memory::SharedStore;
+    use crate::storage::{model, DbWrite};
     use crate::testing;
     use crate::testing::context::*;
     use crate::testing::transaction_coordinator::TestEnvironment;
 
+    use fake::{Fake, Faker};
+    use test_case::test_case;
     use test_log::test;
+
+    use super::should_coordinate_dkg;
 
     fn test_environment() -> TestEnvironment<
         TestContext<
@@ -1858,5 +1917,62 @@ mod tests {
     #[tokio::test]
     async fn should_ignore_withdrawals() {
         test_environment().assert_ignore_withdrawals().await;
+    }
+
+    #[test_case(0, None, 1, 100, true; "first DKG allowed without min height")]
+    #[test_case(0, Some(100), 1, 5, true; "first DKG allowed regardless of min height")]
+    #[test_case(1, None, 2, 100, false; "subsequent DKG not allowed without min height")]
+    #[test_case(1, Some(101), 1, 100, false; "subsequent DKG not allowed with current height lower than min height")]
+    #[test_case(1, Some(100), 1, 100, false; "subsequent DKG not allowed when target rounds reached")]
+    #[test_case(1, Some(100), 2, 100, true; "subsequent DKG allowed when target rounds not reached and min height met")]
+    #[test_log::test(tokio::test)]
+    async fn test_should_coordinate_dkg(
+        dkg_rounds_current: u32,
+        dkg_min_bitcoin_block_height: Option<u64>,
+        dkg_target_rounds: u32,
+        chain_tip_height: u64,
+        should_allow: bool,
+    ) {
+        let context = TestContext::builder()
+            .with_in_memory_storage()
+            .with_mocked_clients()
+            .modify_settings(|s| {
+                s.signer.dkg_min_bitcoin_block_height =
+                    dkg_min_bitcoin_block_height.map(NonZeroU64::new).flatten();
+                s.signer.dkg_target_rounds = NonZeroU32::new(dkg_target_rounds).unwrap();
+            })
+            .build();
+
+        let storage = context.get_storage_mut();
+
+        // Write `dkg_shares` entries for the `current` number of rounds, simulating
+        // the signer having participated in that many successful DKG rounds.
+        for _ in 0..dkg_rounds_current {
+            storage
+                .write_encrypted_dkg_shares(&Faker.fake())
+                .await
+                .unwrap();
+        }
+
+        // Dummy chain tip hash which will be used to fetch the block height
+        let bitcoin_chain_tip: model::BitcoinBlockHash = Faker.fake();
+
+        // Write a bitcoin block at the given height, simulating the chain tip.
+        storage
+            .write_bitcoin_block(&model::BitcoinBlock {
+                block_height: chain_tip_height,
+                parent_hash: Faker.fake(),
+                block_hash: bitcoin_chain_tip,
+            })
+            .await
+            .unwrap();
+
+        // Test the case
+        let result = should_coordinate_dkg(&context, &bitcoin_chain_tip)
+            .await
+            .expect("failed to check if DKG should be coordinated");
+
+        // Assert the result
+        assert_eq!(result, should_allow);
     }
 }

--- a/signer/tests/integration/transaction_coordinator.rs
+++ b/signer/tests/integration/transaction_coordinator.rs
@@ -1326,6 +1326,13 @@ async fn run_subsequent_dkg() {
     // 7. Check that they all have the same aggregate keys in the
     //    `dkg_shares` table.
     assert_eq!(all_aggregate_keys.len(), 2);
+    let new_aggregate_key = all_aggregate_keys
+        .iter()
+        .filter(|k| *k != &aggregate_key_1)
+        .next()
+        .unwrap()
+        .clone();
+    assert_ne!(aggregate_key_1, new_aggregate_key);
 
     // 8. Check that the coordinator broadcast a rotate key tx
     broadcast_stacks_txs.verify().unwrap();
@@ -1344,8 +1351,9 @@ async fn run_subsequent_dkg() {
     let rotate_keys = RotateKeysV1::new(
         &signer_wallet,
         signers.first().unwrap().0.config().signer.deployer,
-        all_aggregate_keys.iter().next().unwrap(),
+        &new_aggregate_key,
     );
+
     assert_eq!(contract_call.function_args, rotate_keys.as_contract_args());
 
     for (_ctx, db, _, _) in signers {

--- a/signer/tests/integration/transaction_coordinator.rs
+++ b/signer/tests/integration/transaction_coordinator.rs
@@ -1,5 +1,7 @@
 use std::collections::BTreeSet;
 use std::collections::HashMap;
+use std::num::NonZeroU32;
+use std::num::NonZeroU64;
 use std::sync::atomic::AtomicU8;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -1107,6 +1109,242 @@ async fn run_dkg_from_scratch() {
         &signer_wallet,
         signers.first().unwrap().0.config().signer.deployer,
         aggregate_keys.iter().next().unwrap(),
+    );
+    assert_eq!(contract_call.function_args, rotate_keys.as_contract_args());
+
+    for (_ctx, db, _, _) in signers {
+        testing::storage::drop_db(db).await;
+    }
+}
+
+/// Test that we can run multiple DKG rounds.
+/// This test is very similar to the `run_dkg_from_scratch` test, but it
+/// simulates that DKG has been run once before and uses a signer configuration
+/// that allows for multiple DKG rounds.
+#[cfg_attr(not(feature = "integration-tests"), ignore)]
+#[test(tokio::test)]
+async fn run_subsequent_dkg() {
+    let mut rng = rand::rngs::StdRng::seed_from_u64(51);
+    let (signer_wallet, signer_key_pairs): (_, [Keypair; 3]) =
+        testing::wallet::regtest_bootstrap_wallet();
+
+    // We need to populate our databases, so let's generate some data.
+    let test_params = testing::storage::model::Params {
+        num_bitcoin_blocks: 10,
+        num_stacks_blocks_per_bitcoin_block: 1,
+        num_deposit_requests_per_block: 0,
+        num_withdraw_requests_per_block: 0,
+        num_signers_per_request: 0,
+    };
+    let test_data = TestData::generate(&mut rng, &[], &test_params);
+
+    let (broadcast_stacks_tx, _rx) = tokio::sync::broadcast::channel(1);
+
+    let mut stacks_tx_receiver = broadcast_stacks_tx.subscribe();
+    let stacks_tx_receiver_task = tokio::spawn(async move { stacks_tx_receiver.recv().await });
+
+    let iter: Vec<(Keypair, TestData)> = signer_key_pairs
+        .iter()
+        .copied()
+        .zip(std::iter::repeat_with(|| test_data.clone()))
+        .collect();
+
+    // 1. Create a database, an associated context, and a Keypair for each of
+    //    the signers in the signing set.
+    let network = WanNetwork::default();
+    let mut signers: Vec<_> = Vec::new();
+
+    // The aggregate key we will use for the first DKG shares entry.
+    let aggregate_key_1: PublicKey = Faker.fake_with_rng(&mut rng);
+
+    for (kp, data) in iter {
+        let broadcast_stacks_tx = broadcast_stacks_tx.clone();
+        let db = testing::storage::new_test_database().await;
+        let mut ctx = TestContext::builder()
+            .with_storage(db.clone())
+            .with_mocked_clients()
+            .modify_settings(|settings| {
+                settings.signer.dkg_target_rounds = NonZeroU32::new(2).unwrap();
+                settings.signer.dkg_min_bitcoin_block_height = Some(NonZeroU64::new(10).unwrap());
+            })
+            .build();
+
+        // Write one DKG shares entry to the signer's database simulating that
+        // DKG has been successfully run once.
+        db.write_encrypted_dkg_shares(&EncryptedDkgShares {
+            aggregate_key: aggregate_key_1,
+            signer_set_public_keys: signer_key_pairs
+                .iter()
+                .map(|kp| kp.public_key().into())
+                .collect(),
+            ..Faker.fake()
+        })
+        .await
+        .expect("failed to write dkg shares");
+
+        ctx.with_stacks_client(|client| {
+            client
+                .expect_estimate_fees()
+                .returning(|_, _, _| Box::pin(async { Ok(123000) }));
+
+            client.expect_get_account().returning(|_| {
+                Box::pin(async {
+                    Ok(AccountInfo {
+                        balance: 1_000_000,
+                        locked: 0,
+                        unlock_height: 0,
+                        nonce: 1,
+                    })
+                })
+            });
+
+            client.expect_submit_tx().returning(move |tx| {
+                let tx = tx.clone();
+                let txid = tx.txid();
+                let broadcast_stacks_tx = broadcast_stacks_tx.clone();
+                Box::pin(async move {
+                    broadcast_stacks_tx.send(tx).expect("Failed to send result");
+                    Ok(SubmitTxResponse::Acceptance(txid))
+                })
+            });
+
+            client
+                .expect_get_current_signers_aggregate_key()
+                .returning(move |_| {
+                    // We want to test the tx submission
+                    Box::pin(std::future::ready(Ok(None)))
+                });
+        })
+        .await;
+
+        // 2. Populate each database with the same data, so that they
+        //    have the same view of the canonical bitcoin blockchain.
+        //    This ensures that they participate in DKG.
+        data.write_to(&db).await;
+
+        let network = network.connect(&ctx);
+
+        signers.push((ctx, db, kp, network));
+    }
+
+    // 4. Start the [`TxCoordinatorEventLoop`] and [`TxSignerEventLoop`]
+    //    processes for each signer.
+    let tx_coordinator_processes = signers.iter().map(|(ctx, _, kp, net)| {
+        ctx.state().set_sbtc_contracts_deployed(); // Skip contract deployment
+        TxCoordinatorEventLoop {
+            network: net.spawn(),
+            context: ctx.clone(),
+            context_window: 10000,
+            private_key: kp.secret_key().into(),
+            signing_round_max_duration: Duration::from_secs(10),
+            bitcoin_presign_request_max_duration: Duration::from_secs(10),
+            threshold: ctx.config().signer.bootstrap_signatures_required,
+            dkg_max_duration: Duration::from_secs(10),
+            is_epoch3: true,
+        }
+    });
+
+    let tx_signer_processes = signers
+        .iter()
+        .map(|(context, _, kp, net)| TxSignerEventLoop {
+            network: net.spawn(),
+            threshold: context.config().signer.bootstrap_signatures_required as u32,
+            context: context.clone(),
+            context_window: 10000,
+            wsts_state_machines: HashMap::new(),
+            signer_private_key: kp.secret_key().into(),
+            rng: rand::rngs::OsRng,
+            dkg_begin_pause: None,
+        });
+
+    // We only proceed with the test after all processes have started, and
+    // we use this counter to notify us when that happens.
+    let start_count = Arc::new(AtomicU8::new(0));
+
+    tx_coordinator_processes.for_each(|ev| {
+        let counter = start_count.clone();
+        tokio::spawn(async move {
+            counter.fetch_add(1, Ordering::Relaxed);
+            ev.run().await
+        });
+    });
+
+    tx_signer_processes.for_each(|ev| {
+        let counter = start_count.clone();
+        tokio::spawn(async move {
+            counter.fetch_add(1, Ordering::Relaxed);
+            ev.run().await
+        });
+    });
+
+    while start_count.load(Ordering::SeqCst) < 6 {
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
+    // 5. Once they are all running, signal that DKG should be run. We
+    //    signal them all because we do not know which one is the
+    //    coordinator.
+    signers.iter().for_each(|(ctx, _, _, _)| {
+        ctx.get_signal_sender()
+            .send(RequestDeciderEvent::NewRequestsHandled.into())
+            .unwrap();
+    });
+
+    // Await the `stacks_tx_receiver_task` to receive the first transaction broadcasted.
+    let broadcast_stacks_txs =
+        tokio::time::timeout(Duration::from_secs(10), stacks_tx_receiver_task)
+            .await
+            .unwrap()
+            .expect("failed to receive message")
+            .expect("no message received");
+
+    // A BTreeSet to uniquely hold all the aggregate keys we find in the database.
+    let mut all_aggregate_keys = BTreeSet::new();
+
+    for (_, db, _, _) in signers.iter() {
+        // Get the aggregate keys from this signer's database.
+        let mut aggregate_keys =
+            sqlx::query_as::<_, (PublicKey,)>("SELECT aggregate_key FROM sbtc_signer.dkg_shares")
+                .fetch_all(db.pool())
+                .await
+                .unwrap();
+
+        // 6. Check that we have exactly one row in the `dkg_shares` table.
+        assert_eq!(aggregate_keys.len(), 2);
+        for key in aggregate_keys.iter() {
+            all_aggregate_keys.insert(key.0.clone());
+        }
+
+        // An additional sanity check that the query in
+        // get_last_encrypted_dkg_shares gets the right thing (which is the
+        // only thing in this case).
+        let key = aggregate_keys.pop().unwrap().0;
+        let shares = db.get_latest_encrypted_dkg_shares().await.unwrap().unwrap();
+        assert_eq!(shares.aggregate_key, key);
+    }
+
+    // 7. Check that they all have the same aggregate keys in the
+    //    `dkg_shares` table.
+    assert_eq!(all_aggregate_keys.len(), 2);
+
+    // 8. Check that the coordinator broadcast a rotate key tx
+    broadcast_stacks_txs.verify().unwrap();
+
+    let TransactionPayload::ContractCall(contract_call) = broadcast_stacks_txs.payload else {
+        panic!("unexpected tx payload")
+    };
+    assert_eq!(
+        contract_call.contract_name.to_string(),
+        RotateKeysV1::CONTRACT_NAME
+    );
+    assert_eq!(
+        contract_call.function_name.to_string(),
+        RotateKeysV1::FUNCTION_NAME
+    );
+    let rotate_keys = RotateKeysV1::new(
+        &signer_wallet,
+        signers.first().unwrap().0.config().signer.deployer,
+        all_aggregate_keys.iter().next().unwrap(),
     );
     assert_eq!(contract_call.function_args, rotate_keys.as_contract_args());
 


### PR DESCRIPTION
## Description

Closes: #1199

## Changes

Introduces similar logic to #1200 for the transaction coordinator when determining if DKG should be run or not. If the current state of the signer and the configuration allow, the coordinator will attempt a new round of DKG.

## Testing Information

Added a new test `run_subsequent_dkg` which is very similar to the existing `run_dkg_from_scratch` test, but with its starting point that one DKG round has been completed successfully.

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
