### PR TITLE
fix: exit early if no requests during presign request creation

### DIFF
--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -412,7 +412,8 @@ where
         transaction_package: &[utxo::UnsignedTransaction<'_>],
     ) -> Result<(), Error> {
         // Constructing a pre-sign request with empty request IDs is
-        // invalid. The other signers should reject an attempt to do so.
+        // invalid. The other signers should reject the message if we send
+        // one, so let's not create it.
         if transaction_package.is_empty() {
             tracing::debug!("no requests to handle this tenure, exiting");
             return Ok(());

--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -411,6 +411,12 @@ where
         signer_btc_state: &utxo::SignerBtcState,
         transaction_package: &[utxo::UnsignedTransaction<'_>],
     ) -> Result<(), Error> {
+        // Constructing a pre-sign request with empty request IDs is
+        // invalid. The other signers should reject an attempt to do so.
+        if transaction_package.is_empty() {
+            tracing::debug!("no requests to handle this tenure, exiting");
+            return Ok(());
+        }
         // Create the BitcoinPreSignRequest from the transaction package
         let sbtc_requests = BitcoinPreSignRequest {
             request_package: transaction_package


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/1214

## Changes

* Return early in `TxCoordinatorEventLoop::construct_and_send_bitcoin_presign_request` if there are no transactions to handle.

## Testing Information

I did not add a test because it would take quite a while to setup. Perhaps I should create a ticket to add a test at some later date.

## Checklist:

- [x] I have performed a self-review of my code

