### PR TITLE
fix: validate network recipient stacks address

### DIFF
--- a/sbtc/src/deposits.rs
+++ b/sbtc/src/deposits.rs
@@ -125,6 +125,8 @@ impl CreateDepositRequest {
     ///   the expected formats for deposit transactions.
     /// * That deposit script and the reclaim script are part of the UTXO
     ///   ScriptPubKey.
+    /// * That the Stacks network for the recipient address matches the one
+    ///   given as input to this function.
     pub fn validate_tx(&self, tx: &Transaction, is_mainnet: bool) -> Result<DepositInfo, Error> {
         if tx.compute_txid() != self.outpoint.txid {
             // The expectation is that the transaction was fetched from the

--- a/sbtc/src/deposits.rs
+++ b/sbtc/src/deposits.rs
@@ -15,7 +15,9 @@ use bitcoin::ScriptBuf;
 use bitcoin::Transaction;
 use bitcoin::XOnlyPublicKey;
 use clarity::codec::StacksMessageCodec;
+use clarity::types::chainstate::StacksAddress;
 use clarity::vm::types::PrincipalData;
+use clarity::vm::types::QualifiedContractIdentifier;
 use secp256k1::SECP256K1;
 use stacks_common::types::chainstate::STACKS_ADDRESS_ENCODED_SIZE;
 
@@ -123,7 +125,7 @@ impl CreateDepositRequest {
     ///   the expected formats for deposit transactions.
     /// * That deposit script and the reclaim script are part of the UTXO
     ///   ScriptPubKey.
-    pub fn validate_tx(&self, tx: &Transaction) -> Result<DepositInfo, Error> {
+    pub fn validate_tx(&self, tx: &Transaction, is_mainnet: bool) -> Result<DepositInfo, Error> {
         if tx.compute_txid() != self.outpoint.txid {
             // The expectation is that the transaction was fetched from the
             // blockchain using the txid, so in practice this should never
@@ -158,6 +160,11 @@ impl CreateDepositRequest {
             return Err(Error::UtxoScriptPubKeyMismatch(self.outpoint));
         }
 
+        // Check that the recipient network matches what we expect
+        if principal_is_mainnet(deposit.recipient.clone()) != is_mainnet {
+            return Err(Error::RecipientNetworkMismatch(deposit.recipient));
+        }
+
         Ok(DepositInfo {
             max_fee: deposit.max_fee,
             deposit_script,
@@ -169,6 +176,15 @@ impl CreateDepositRequest {
             outpoint: self.outpoint,
         })
     }
+}
+
+/// Return whether the given principal address is a mainnet address.
+fn principal_is_mainnet(principal: PrincipalData) -> bool {
+    let standard_address = match principal {
+        PrincipalData::Contract(QualifiedContractIdentifier { issuer, .. }) => issuer,
+        PrincipalData::Standard(issuer) => issuer,
+    };
+    StacksAddress::from(standard_address).is_mainnet()
 }
 
 /// Construct the expected taproot info for a deposit UTXO on the given
@@ -335,14 +351,14 @@ impl DepositScriptInputs {
         let Some((max_fee_bytes, mut address)) = deposit_data.split_first_chunk::<8>() else {
             return Err(Error::InvalidDepositScript);
         };
-        let stacks_address = PrincipalData::consensus_deserialize(&mut address)
+        let recipient = PrincipalData::consensus_deserialize(&mut address)
             .map_err(Error::ParseStacksAddress)?;
 
         Ok(DepositScriptInputs {
             signers_public_key: XOnlyPublicKey::from_slice(public_key)
                 .map_err(Error::InvalidXOnlyPublicKey)?,
             max_fee: u64::from_be_bytes(*max_fee_bytes),
-            recipient: stacks_address,
+            recipient,
         })
     }
 }
@@ -822,7 +838,7 @@ mod tests {
             deposit_script: setup.deposit.deposit_script(),
         };
 
-        let parsed = request.validate_tx(&setup.tx).unwrap();
+        let parsed = request.validate_tx(&setup.tx, false).unwrap();
 
         assert_eq!(parsed.outpoint, request.outpoint);
         assert_eq!(parsed.deposit_script, request.deposit_script);
@@ -831,6 +847,23 @@ mod tests {
         assert_eq!(parsed.signers_public_key, setup.deposit.signers_public_key);
         assert_eq!(parsed.lock_time, LockTime::from_height(lock_time as u16));
         assert_eq!(parsed.recipient, setup.deposit.recipient);
+    }
+
+    #[test_case(true ; "is mainnet address")]
+    #[test_case(false ; "is testnet address")]
+    fn tx_validation_network(is_mainnet: bool) {
+        let recipient = StacksAddress::burn_address(is_mainnet);
+        let setup: TxSetup =
+            testing::deposits::tx_setup_with_recipient(150, 2500, 35000, recipient);
+
+        let request = CreateDepositRequest {
+            outpoint: OutPoint::new(setup.tx.compute_txid(), 0),
+            reclaim_script: setup.reclaim.reclaim_script(),
+            deposit_script: setup.deposit.deposit_script(),
+        };
+
+        assert!(request.validate_tx(&setup.tx, is_mainnet).is_ok());
+        assert!(request.validate_tx(&setup.tx, !is_mainnet).is_err());
     }
 
     #[test]
@@ -851,7 +884,7 @@ mod tests {
             reclaim_script: setup.reclaim.reclaim_script(),
         };
 
-        let error = request.validate_tx(&setup.tx).unwrap_err();
+        let error = request.validate_tx(&setup.tx, false).unwrap_err();
         assert!(matches!(error, Error::UtxoScriptPubKeyMismatch(_)));
     }
 
@@ -873,7 +906,7 @@ mod tests {
             reclaim_script: setup.reclaim.reclaim_script(),
         };
 
-        let error = request.validate_tx(&setup.tx).unwrap_err();
+        let error = request.validate_tx(&setup.tx, false).unwrap_err();
         assert!(matches!(error, Error::UtxoScriptPubKeyMismatch(_)));
     }
 
@@ -892,7 +925,7 @@ mod tests {
             reclaim_script: setup.reclaim.reclaim_script(),
         };
 
-        let error = request.validate_tx(&setup.tx).unwrap_err();
+        let error = request.validate_tx(&setup.tx, false).unwrap_err();
         assert!(matches!(error, Error::OutpointIndex(_, _)));
 
         let request = CreateDepositRequest {
@@ -902,7 +935,7 @@ mod tests {
             reclaim_script: setup.reclaim.reclaim_script(),
         };
 
-        let error = request.validate_tx(&setup.tx).unwrap_err();
+        let error = request.validate_tx(&setup.tx, false).unwrap_err();
         assert!(matches!(error, Error::TxidMismatch { .. }));
     }
 
@@ -923,7 +956,7 @@ mod tests {
             reclaim_script: setup.reclaim.reclaim_script(),
         };
 
-        let error = request.validate_tx(&setup.tx).unwrap_err();
+        let error = request.validate_tx(&setup.tx, false).unwrap_err();
         assert!(matches!(error, Error::InvalidDepositScriptLength));
 
         let request = CreateDepositRequest {
@@ -935,7 +968,7 @@ mod tests {
             reclaim_script: ScriptBuf::new(),
         };
 
-        let error = request.validate_tx(&setup.tx).unwrap_err();
+        let error = request.validate_tx(&setup.tx, false).unwrap_err();
         assert!(matches!(error, Error::InvalidReclaimScript));
     }
 

--- a/sbtc/src/error.rs
+++ b/sbtc/src/error.rs
@@ -42,6 +42,10 @@ pub enum Error {
     /// Could not parse the Stacks principal address.
     #[error("could not parse the stacks principal address: {0}")]
     ParseStacksAddress(#[source] stacks_common::codec::Error),
+    /// The network of the recipient address does not match the expected
+    /// network.
+    #[error("incorrect network of the recipient address: {0}")]
+    RecipientNetworkMismatch(clarity::vm::types::PrincipalData),
     /// This happens when the lock-time is given in time units instead of
     /// block units.
     #[error("lock-time given in time units, but only block units are supported: {0}")]

--- a/sbtc/tests/integration/validation.rs
+++ b/sbtc/tests/integration/validation.rs
@@ -77,7 +77,7 @@ fn tx_validation_from_mempool() {
     regtest::p2tr_sign_transaction(&mut setup.tx, 0, &utxos, &depositor.keypair);
     rpc.send_raw_transaction(&setup.tx).unwrap();
 
-    let parsed = request.validate_tx(&setup.tx).unwrap();
+    let parsed = request.validate_tx(&setup.tx, false).unwrap();
 
     assert_eq!(parsed.outpoint, request.outpoint);
     assert_eq!(parsed.deposit_script, request.deposit_script);
@@ -492,7 +492,7 @@ fn reclaiming_rejected_deposits() {
         deposit_script: deposit_script.clone(),
     };
 
-    let _ = request.validate_tx(&deposit_tx).unwrap();
+    let _ = request.validate_tx(&deposit_tx, false).unwrap();
 
     // Alright now we know the signers haven't moved our funds, so we
     // reclaim it. We construct a transaction spending the funds back to

--- a/signer/tests/integration/utxo_construction.rs
+++ b/signer/tests/integration/utxo_construction.rs
@@ -109,7 +109,7 @@ where
         reclaim_script,
     };
 
-    let dep = create_req.validate_tx(&deposit_tx).unwrap();
+    let dep = create_req.validate_tx(&deposit_tx, false).unwrap();
 
     let req = DepositRequest {
         outpoint: dep.outpoint,


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/1228

## Changes

* Validate the network of the Stacks recipient address during deposit validation.

## Testing Information

Two unit tests were added into the sbtc crate, which should be sufficient.

## Checklist:

- [x] I have performed a self-review of my code
