### PR TITLE
feat: Use --locked flag for release builds

### DIFF
--- a/.github/actions/dockerfiles/Dockerfile.blocklist-client.debian
+++ b/.github/actions/dockerfiles/Dockerfile.blocklist-client.debian
@@ -1,6 +1,6 @@
 FROM rust:1.81.0-slim-bookworm AS build
 
-ARG CARGO_BUILD_ARGS="--release"
+ARG CARGO_BUILD_ARGS="--release --locked"
 
 # Install dependencies.
 RUN apt-get update

--- a/.github/actions/dockerfiles/Dockerfile.signer.debian
+++ b/.github/actions/dockerfiles/Dockerfile.signer.debian
@@ -3,7 +3,7 @@ FROM rust:1.81.0-slim-bookworm AS build
 ARG GIT_COMMIT
 RUN test -n "$GIT_COMMIT" || (echo "GIT_COMMIT not set" && false)
 
-ARG CARGO_BUILD_ARGS="--release"
+ARG CARGO_BUILD_ARGS="--release --locked"
 
 # Install dependencies.
 RUN apt-get update


### PR DESCRIPTION
## Description

Use --locked flag for release builds

Closes: https://github.com/stacks-network/sbtc/issues/1225

## Changes

- Add locked option in the docker build

## Testing Information

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
