### PR TITLE
feat: Add Artifact attestation for CI builds

### DIFF
--- a/.github/workflows/image-build.yaml
+++ b/.github/workflows/image-build.yaml
@@ -108,6 +108,6 @@ jobs:
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2
         with:
-          subject-name: ${{ steps.docker_metadata.outputs.tags }}
+          subject-name: docker.io/${{ env.docker-org }}/sbtc
           subject-digest: ${{ steps.docker_build.outputs.digest }}
           push-to-registry: true

--- a/.github/workflows/image-build.yaml
+++ b/.github/workflows/image-build.yaml
@@ -10,6 +10,12 @@ on:
     tags:
       - '*'
 
+permissions:
+  id-token: write
+  contents: read
+  attestations: write
+  packages: write
+
 ## Define which docker arch to build for
 env:
   docker_platforms: "linux/amd64"
@@ -98,3 +104,10 @@ jobs:
           push: true
           build-args: |
             GIT_COMMIT=${{ github.ref_name }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.docker-org }}/sbtc
+          subject-digest: ${{ steps.docker_build.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/image-build.yaml
+++ b/.github/workflows/image-build.yaml
@@ -108,6 +108,6 @@ jobs:
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2
         with:
-          subject-name: docker.io/${{ env.docker-org }}/sbtc
+          subject-name: index.docker.io/${{ env.docker-org }}/sbtc
           subject-digest: ${{ steps.docker_build.outputs.digest }}
           push-to-registry: true

--- a/.github/workflows/image-build.yaml
+++ b/.github/workflows/image-build.yaml
@@ -108,6 +108,6 @@ jobs:
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2
         with:
-          subject-name: ${{ env.docker-org }}/sbtc
+          subject-name: ${{ steps.docker_metadata.outputs.tags }}
           subject-digest: ${{ steps.docker_build.outputs.digest }}
           push-to-registry: true


### PR DESCRIPTION
## Description

Add Artifact attestation for CI

Closes: https://github.com/stacks-network/sbtc/issues/1233

Ref: https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds#generating-artifact-attestations-for-your-builds

## Changes

- Add Github Artifact Attestation in the docker build workflow

## Testing Information

https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds#generating-artifact-attestations-for-your-builds

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
