### PR TITLE
fix: add pagination to deposit fetching 

### DIFF
--- a/docker/sbtc/signer/signer-config.toml
+++ b/docker/sbtc/signer/signer-config.toml
@@ -29,6 +29,14 @@ endpoints = [
     "http://testApiKey@emily-server:3031",
 ]
 
+# The pagination timeout, in seconds used to fetch deposits and withdrawals
+# requests from Emily.
+#
+# Format: <seconds>
+# Default: 30
+# Required: false
+pagination_timeout = 30
+
 # !! ==============================================================================
 # !! Bitcoin Core Configuration
 # !! ==============================================================================
@@ -152,12 +160,12 @@ dkg_begin_pause = 2
 # sbtc_bitcoin_start_height = 231
 
 # The maximum number of deposit inputs that will be included in a single
-# bitcoin transaction. 
-# 
+# bitcoin transaction.
+#
 # Transactions must be constructed within a tenure of a bitcoin block, and
 # higher values here imply lower likelihood of signing all inputs before
 # the next bitcoin block arrives.
-# 
+#
 # Required: false
 # Environment: SIGNER_SIGNER__MAX_DEPOSITS_PER_BITCOIN_TX
 # max_deposits_per_bitcoin_tx = 25

--- a/signer/src/config/default.toml
+++ b/signer/src/config/default.toml
@@ -32,6 +32,16 @@ endpoints = [
     "http://testApiKey@localhost:3031",
 ]
 
+# The pagination timeout, in seconds used to fetch deposits and withdrawals
+# requests from Emily.
+#
+# Format: <seconds>
+# Default: <none>
+# Required: true
+# Environment: SIGNER_EMILY__PAGINATION_TIMEOUT
+# Environment Example: 30
+pagination_timeout = 30
+
 # !! ==============================================================================
 # !! Bitcoin Core Configuration
 # !! ==============================================================================
@@ -130,7 +140,7 @@ bootstrap_signing_set = [
 # The number of signatures required for signing Stacks transactions when
 # using the multi-sig wallet formed from the public keys in the
 # `bootstrap_signing_set`. Must be strictly positive.
-# 
+#
 # Required: true Environment: SIGNER_SIGNER__BOOTSTRAP_SIGNATURES_REQUIRED
 # TODO(715): Change as specified by sBTC SIP.
 bootstrap_signatures_required = 2
@@ -188,12 +198,12 @@ sbtc_bitcoin_start_height = 101
 # dkg_begin_pause = 10
 
 # The maximum number of deposit inputs that will be included in a single
-# bitcoin transaction. 
-# 
+# bitcoin transaction.
+#
 # Transactions must be constructed within a tenure of a bitcoin block, and
 # higher values here imply lower likelihood of signing all inputs before
 # the next bitcoin block arrives.
-# 
+#
 # Required: false
 # Environment: SIGNER_SIGNER__MAX_DEPOSITS_PER_BITCOIN_TX
 # max_deposits_per_bitcoin_tx = 25
@@ -224,16 +234,16 @@ sbtc_bitcoin_start_height = 101
 # !! ==============================================================================
 # !! Stacks Event Observer Configuration
 # !!
-# !! The event observer listens for events on the Stacks blockchain. The listen 
-# !! address must be reachable by your Stacks node, and must be configured in the 
+# !! The event observer listens for events on the Stacks blockchain. The listen
+# !! address must be reachable by your Stacks node, and must be configured in the
 # !! node's `event_observer` configuration section.
 # !!
-# !! Note that the event observer endpoint _does not_ support TLS and is served 
+# !! Note that the event observer endpoint _does not_ support TLS and is served
 # !! over HTTP.
 # !! ==============================================================================
 [signer.event_observer]
 # The network interface (ip address) and port to bind the event observer server to.
-# 
+#
 # Format: "<ip>:<port>"
 # Required: true
 # Environment: SIGNER_SIGNER__EVENT_OBSERVER__BIND
@@ -259,14 +269,14 @@ bind = "0.0.0.0:8801"
 # TODO(715): Add well-known seed nodes
 seeds = []
 
-# The local network interface(s) and port(s) to listen on. 
+# The local network interface(s) and port(s) to listen on.
 #
-# You may specify multiple interfaces and ports by adding additional entries to 
-# the list. Entries can be addressed by any of IPv4 address, IPv6 address or 
-# hostname. Note that not all networks have IPv6 enabled, so it is recommended 
+# You may specify multiple interfaces and ports by adding additional entries to
+# the list. Entries can be addressed by any of IPv4 address, IPv6 address or
+# hostname. Note that not all networks have IPv6 enabled, so it is recommended
 # to provide an IPv4 address as well.
 #
-# Specifying a port of `0` will cause the server to bind to a random port, 
+# Specifying a port of `0` will cause the server to bind to a random port,
 # and an IP of `0.0.0.0` will cause the server to listen on all available
 # interfaces.
 #
@@ -288,7 +298,7 @@ listen_on = ["tcp://0.0.0.0:4122", "quic-v1://0.0.0.0:4122"]
 
 # The publicly accessible network endpoint to advertise to other nodes.
 #
-# If this is not specified then the node will attempt to use other peers on the 
+# If this is not specified then the node will attempt to use other peers on the
 # network to determine its public endpoint. This is the recommended
 # configuration for most users.
 #

--- a/signer/src/config/mod.rs
+++ b/signer/src/config/mod.rs
@@ -11,6 +11,7 @@ use std::num::NonZeroU16;
 use std::num::NonZeroU32;
 use std::num::NonZeroU64;
 use std::path::Path;
+use std::time::Duration;
 use url::Url;
 
 use crate::config::error::SignerConfigError;
@@ -165,6 +166,9 @@ pub struct EmilyClientConfig {
     /// Emily API endpoints.
     #[serde(deserialize_with = "url_deserializer_vec")]
     pub endpoints: Vec<Url>,
+    /// Pagination timeout in seconds.
+    #[serde(deserialize_with = "duration_seconds_deserializer")]
+    pub pagination_timeout: Duration,
 }
 
 impl Validatable for EmilyClientConfig {

--- a/signer/tests/integration/block_observer.rs
+++ b/signer/tests/integration/block_observer.rs
@@ -382,8 +382,11 @@ async fn block_observer_stores_donation_and_sbtc_utxos() {
     // signer::logging::setup_logging("info,signer=debug", false);
 
     // We need to populate our databases, so let's fetch the data.
-    let emily_client =
-        EmilyClient::try_from(&Url::parse("http://testApiKey@localhost:3031").unwrap()).unwrap();
+    let emily_client = EmilyClient::try_from_url_and_duration(
+        &Url::parse("http://testApiKey@localhost:3031").unwrap(),
+        Duration::from_secs(1),
+    )
+    .unwrap();
 
     testing_api::wipe_databases(emily_client.config())
         .await

--- a/signer/tests/integration/emily.rs
+++ b/signer/tests/integration/emily.rs
@@ -147,8 +147,11 @@ async fn deposit_flow() {
     let network = network::in_memory::InMemoryNetwork::new();
     let signer_info = testing::wsts::generate_signer_info(&mut rng, num_signers);
 
-    let emily_client =
-        EmilyClient::try_from(&Url::parse("http://testApiKey@localhost:3031").unwrap()).unwrap();
+    let emily_client = EmilyClient::try_from_url_and_duration(
+        &Url::parse("http://testApiKey@localhost:3031").unwrap(),
+        Duration::from_secs(1),
+    )
+    .unwrap();
     let stacks_client = WrappedMock::default();
 
     // Wipe the Emily database to start fresh
@@ -565,8 +568,11 @@ async fn get_deposit_request_works() {
     let amount_sats = 49_900_000;
     let lock_time = 150;
 
-    let emily_client =
-        EmilyClient::try_from(&Url::parse("http://testApiKey@localhost:3031").unwrap()).unwrap();
+    let emily_client = EmilyClient::try_from_url_and_duration(
+        &Url::parse("http://testApiKey@localhost:3031").unwrap(),
+        Duration::from_secs(1),
+    )
+    .unwrap();
 
     wipe_databases(&emily_client.config())
         .await

--- a/signer/tests/integration/request_decider.rs
+++ b/signer/tests/integration/request_decider.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use emily_client::apis::deposit_api;
 use emily_client::apis::testing_api;
 use emily_client::models::CreateDepositRequestBody;
@@ -299,8 +301,11 @@ async fn persist_received_deposit_decision_fetches_missing_deposit_requests() {
 
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
 
-    let emily_client =
-        EmilyClient::try_from(&Url::parse("http://testApiKey@localhost:3031").unwrap()).unwrap();
+    let emily_client = EmilyClient::try_from_url_and_duration(
+        &Url::parse("http://testApiKey@localhost:3031").unwrap(),
+        Duration::from_secs(1),
+    )
+    .unwrap();
 
     testing_api::wipe_databases(emily_client.config())
         .await

--- a/signer/tests/integration/stacks_events_observer.rs
+++ b/signer/tests/integration/stacks_events_observer.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use axum::extract::State;
 use axum::http::StatusCode;
@@ -43,8 +44,11 @@ async fn test_context() -> TestContext<
     WrappedMock<MockStacksInteract>,
     EmilyClient,
 > {
-    let emily_client =
-        EmilyClient::try_from(&Url::parse("http://testApiKey@localhost:3031").unwrap()).unwrap();
+    let emily_client = EmilyClient::try_from_url_and_duration(
+        &Url::parse("http://testApiKey@localhost:3031").unwrap(),
+        Duration::from_secs(1),
+    )
+    .unwrap();
     let stacks_client = WrappedMock::default();
 
     TestContext::builder()

--- a/signer/tests/integration/transaction_coordinator.rs
+++ b/signer/tests/integration/transaction_coordinator.rs
@@ -1396,8 +1396,11 @@ async fn sign_bitcoin_transaction() {
     let (rpc, faucet) = regtest::initialize_blockchain();
 
     // We need to populate our databases, so let's fetch the data.
-    let emily_client =
-        EmilyClient::try_from(&Url::parse("http://testApiKey@localhost:3031").unwrap()).unwrap();
+    let emily_client = EmilyClient::try_from_url_and_duration(
+        &Url::parse("http://testApiKey@localhost:3031").unwrap(),
+        Duration::from_secs(1),
+    )
+    .unwrap();
 
     testing_api::wipe_databases(emily_client.config())
         .await
@@ -1826,8 +1829,11 @@ async fn sign_bitcoin_transaction_multiple_locking_keys() {
     signer::logging::setup_logging("info,signer=debug", false);
 
     // We need to populate our databases, so let's fetch the data.
-    let emily_client =
-        EmilyClient::try_from(&Url::parse("http://testApiKey@localhost:3031").unwrap()).unwrap();
+    let emily_client = EmilyClient::try_from_url_and_duration(
+        &Url::parse("http://testApiKey@localhost:3031").unwrap(),
+        Duration::from_secs(1),
+    )
+    .unwrap();
 
     testing_api::wipe_databases(emily_client.config())
         .await
@@ -2442,8 +2448,11 @@ async fn skip_smart_contract_deployment_and_key_rotation_if_up_to_date() {
     let (rpc, faucet) = regtest::initialize_blockchain();
 
     // We need to populate our databases, so let's fetch the data.
-    let emily_client =
-        EmilyClient::try_from(&Url::parse("http://testApiKey@localhost:3031").unwrap()).unwrap();
+    let emily_client: EmilyClient = EmilyClient::try_from_url_and_duration(
+        &Url::parse("http://testApiKey@localhost:3031").unwrap(),
+        Duration::from_secs(1),
+    )
+    .unwrap();
 
     testing_api::wipe_databases(emily_client.config())
         .await


### PR DESCRIPTION
## Description

Closes: #1148 

## Changes
- add pagination handling to get_deposits
- add pagination_timeout to EmilyClient - it causes the client to stop fetching deposits - but still return the ones alrealdy fetched - when the time passed > timeout.
- added pagination_timeout to the configs - currently set to 30
- NOTE: currently, Emily doesn't enforce an order to the deposits returned by get_deposits. The handler uses [query_with_partition_key](https://github.com/stacks-network/sbtc/blob/main/emily/handler/src/database/entries/mod.rs#L259) , using the deposit status as `partition_key`. If we want to enforce a mechanism that will make the signer ignore deposits  created after a certain BlockHeight, we'll have to modify also Emily.

## Testing Information

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
