### PR TITLE
chore: bump wsts revision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8048,7 +8048,7 @@ dependencies = [
 [[package]]
 name = "wsts"
 version = "10.0.0"
-source = "git+https://github.com/Trust-Machines/wsts.git?rev=b7c009e4903bcf03351847a9341c25a26d36c042#b7c009e4903bcf03351847a9341c25a26d36c042"
+source = "git+https://github.com/Trust-Machines/wsts.git?rev=53ae23f5f35def420877ccc8c0fe3662e64e38a1#53ae23f5f35def420877ccc8c0fe3662e64e38a1"
 dependencies = [
  "aes-gcm",
  "bs58 0.5.1",

--- a/protobufs/crypto/wsts/wsts.proto
+++ b/protobufs/crypto/wsts/wsts.proto
@@ -229,7 +229,7 @@ message DkgStatus {
     // DKG private shares were bad from these signer_ids
     BadPrivateShares bad_private_shares = 6;
     // The DKG threshold was not met
-    Threshold Threshold = 7;
+    Threshold threshold = 7;
   }
 }
 

--- a/protobufs/crypto/wsts/wsts.proto
+++ b/protobufs/crypto/wsts/wsts.proto
@@ -228,6 +228,8 @@ message DkgStatus {
     MissingPrivateShares missing_private_shares = 5;
     // DKG private shares were bad from these signer_ids
     BadPrivateShares bad_private_shares = 6;
+    // The DKG threshold was not met
+    Threshold Threshold = 7;
   }
 }
 
@@ -318,3 +320,6 @@ message SignatureShare {
   // The key IDs of the party
   repeated uint32 key_ids = 3;
 }
+
+// The DKG threshold has not been upheld by the coordinator.
+message Threshold {}

--- a/signer/Cargo.toml
+++ b/signer/Cargo.toml
@@ -53,7 +53,7 @@ tracing-attributes.workspace = true
 tracing-subscriber = { workspace = true }
 url.workspace = true
 # wsts.workspace = true
-wsts = { git = "https://github.com/Trust-Machines/wsts.git", rev = "b7c009e4903bcf03351847a9341c25a26d36c042" }
+wsts = { git = "https://github.com/Trust-Machines/wsts.git", rev = "53ae23f5f35def420877ccc8c0fe3662e64e38a1" }
 hex.workspace = true
 cfg-if = "1.0"
 include_dir = "0.7.4"

--- a/signer/src/proto/convert.rs
+++ b/signer/src/proto/convert.rs
@@ -804,6 +804,7 @@ impl From<DkgStatus> for proto::DkgStatus {
                 DkgFailure::BadPrivateShares(inner) => {
                     proto::dkg_status::Mode::BadPrivateShares(inner.into())
                 }
+                DkgFailure::Threshold => proto::dkg_status::Mode::Threshold(proto::Threshold {}),
             },
         };
         proto::DkgStatus { mode: Some(mode) }
@@ -828,6 +829,7 @@ impl TryFrom<proto::DkgStatus> for DkgStatus {
             proto::dkg_status::Mode::BadPrivateShares(inner) => {
                 DkgStatus::Failure(DkgFailure::BadPrivateShares(inner.try_into()?))
             }
+            proto::dkg_status::Mode::Threshold(_) => DkgStatus::Failure(DkgFailure::Threshold),
         })
     }
 }

--- a/signer/src/proto/generated/crypto.wsts.rs
+++ b/signer/src/proto/generated/crypto.wsts.rs
@@ -373,7 +373,7 @@ pub struct ProofIdentifier {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DkgStatus {
-    #[prost(oneof = "dkg_status::Mode", tags = "1, 2, 3, 4, 5, 6")]
+    #[prost(oneof = "dkg_status::Mode", tags = "1, 2, 3, 4, 5, 6, 7")]
     pub mode: ::core::option::Option<dkg_status::Mode>,
 }
 /// Nested message and enum types in `DkgStatus`.
@@ -399,6 +399,9 @@ pub mod dkg_status {
         /// DKG private shares were bad from these signer_ids
         #[prost(message, tag = "6")]
         BadPrivateShares(super::BadPrivateShares),
+        /// The DKG threshold was not met
+        #[prost(message, tag = "7")]
+        Threshold(super::Threshold),
     }
 }
 /// DKG completed successfully
@@ -514,3 +517,7 @@ pub struct SignatureShare {
     #[prost(uint32, repeated, tag = "3")]
     pub key_ids: ::prost::alloc::vec::Vec<u32>,
 }
+/// The DKG threshold has not been upheld by the coordinator.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Threshold {}


### PR DESCRIPTION
## Description

WSTS signer state machines now take a parameter for the DKG key threshold. This PR uses that commit and we make changes after their API changed.

## Changes

* Update the version of WSTS
* Update the protobufs after the new change
* Update our use of WSTS signer state machines after the API change.

## Testing Information

This is a dependency update, where the dependency, WSTS, is more strict. If tests pass then we should be good to go.

## Checklist:

- [x] I have performed a self-review of my code
