### PR TITLE
fix: use the same sorting key for in memory impl of stacks chain tip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1577,9 +1577,9 @@ checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
 
 [[package]]
 name = "dummy"
-version = "0.7.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e57e12b69e57fad516e01e2b3960f122696fdb13420e1a88ed8e210316f2876"
+checksum = "b3ee4e39146145f7dd28e6c85ffdce489d93c0d9c88121063b8aacabbd9858d2"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1744,9 +1744,9 @@ dependencies = [
 
 [[package]]
 name = "fake"
-version = "2.9.2"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c25829bde82205da46e1823b2259db6273379f626fc211f126f65654a2669be"
+checksum = "aef603df4ba9adbca6a332db7da6f614f21eafefbaf8e087844e452fdec152d0"
 dependencies = [
  "deunicode",
  "dummy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ axum = { version = "0.8.1", default-features = false, features = ["http1", "json
 tracing-subscriber = { version = "0.3.19", default-features = false, features = ["env-filter", "fmt", "json", "time", "ansi"] }
 
 # Crates used only for testing
-fake = { version = "2.9.2", default-features = false, features = ["derive", "time"] }
+fake = { version = "3.1.0", default-features = false, features = ["derive", "time"] }
 mockall = { version = "0.13.1", default-features = false }
 mockito = { version = "1.6.1", default-features = false }
 more-asserts = { version = "0.3.1", default-features = false }

--- a/signer/src/storage/in_memory.rs
+++ b/signer/src/storage/in_memory.rs
@@ -226,7 +226,7 @@ impl Store {
         .filter_map(|block| self.bitcoin_anchor_to_stacks_blocks.get(&block.block_hash))
         .flatten()
         .filter_map(|stacks_block_hash| self.stacks_blocks.get(stacks_block_hash))
-        .max_by_key(|block| (block.block_height, &block.block_hash))
+        .max_by_key(|block| (block.block_height, block.block_hash.to_bytes()))
         .cloned()
     }
 

--- a/signers.sh
+++ b/signers.sh
@@ -27,8 +27,6 @@ LOG_SETTINGS="$LOG_SETTINGS,netlink_proto=info,libp2p_autonat=info,libp2p_gossip
 
 # Run the specified number of signers
 exec_run() {
-  echo "here!"
-
   if [ "$1" -eq 1 ]; then
     printf "${RED}ERROR:${NC} At least 2 signers are required\n"
     exit 1

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -571,7 +571,7 @@ version = "1.0.9"
 criteria = "safe-to-deploy"
 
 [[exemptions.dummy]]
-version = "0.7.0"
+version = "0.9.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.ed25519]]
@@ -615,7 +615,7 @@ version = "0.5.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.fake]]
-version = "2.9.2"
+version = "3.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.fallible-iterator]]


### PR DESCRIPTION
## Description

Fix a difference between the in memory and pg implementation of `get_stacks_chain_tip`, follow up for the broken test after the `fake` (non) bump in https://github.com/stacks-network/sbtc/pull/1271.

## Changes

Bump `fake` and fix the in memory implementation of `get_stacks_chain_tip` to align it to the pg implementation, by changing the endianness of the stacks block hash used for tie breaking.

## Testing Information

The "broken" test now passes, and add two test to compare the get chain tip between the pg and in memory stores.

## Checklist:

- [X] I have performed a self-review of my code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
