### PR TITLE
feat: cache key-rotation data block observer

### DIFF
--- a/signer/src/bitcoin/validation.rs
+++ b/signer/src/bitcoin/validation.rs
@@ -322,7 +322,6 @@ impl BitcoinPreSignRequest {
             tx_fee: Amount::from_sat(tx.tx_fee),
             reports,
             chain_tip_height: btc_ctx.chain_tip_height,
-            // If the cap is None, then we assume that it is unlimited.
             sbtc_limits: ctx.state().get_current_limits(),
         };
 

--- a/signer/src/bitcoin/zmq.rs
+++ b/signer/src/bitcoin/zmq.rs
@@ -50,7 +50,7 @@ pub struct BitcoinCoreMessageStream {
 }
 
 impl BitcoinCoreMessageStream {
-    /// Create a new one using the endpoint(s) in the config.
+    /// Create a new one using the given endpoint.
     pub async fn new_from_endpoint(endpoint: &str) -> Result<Self, Error> {
         let inner_stream = tokio::time::timeout(Duration::from_secs(10), async {
             bitcoincore_zmq::subscribe_async_monitor(&[endpoint])

--- a/signer/src/bitcoin/zmq.rs
+++ b/signer/src/bitcoin/zmq.rs
@@ -51,10 +51,7 @@ pub struct BitcoinCoreMessageStream {
 
 impl BitcoinCoreMessageStream {
     /// Create a new one using the endpoint(s) in the config.
-    pub async fn new_from_endpoint<T>(endpoint: &str, _subscriptions: &[T]) -> Result<Self, Error>
-    where
-        T: AsRef<str>,
-    {
+    pub async fn new_from_endpoint(endpoint: &str) -> Result<Self, Error> {
         let inner_stream = tokio::time::timeout(Duration::from_secs(10), async {
             bitcoincore_zmq::subscribe_async_monitor(&[endpoint])
         })

--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -588,7 +588,9 @@ impl<C: Context, B> BlockObserver<C, B> {
         tracing::info!("Updating the signer state with the current signer set");
         let (aggregate_key, public_keys) = self.get_signer_set_and_aggregate_key(chain_tip).await?;
         if let Some(aggregate_key) = aggregate_key {
-            self.context.state().set_current_aggregate_key(aggregate_key);
+            self.context
+                .state()
+                .set_current_aggregate_key(aggregate_key);
         }
 
         self.context.state().update_current_signer_set(public_keys);

--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -581,6 +581,23 @@ impl<C: Context, B> BlockObserver<C, B> {
         Ok(())
     }
 
+    /// Update the `SignerState` object with current signer set and
+    /// aggregate key data.
+    ///
+    /// # Notes
+    ///
+    /// The function updates the following:
+    /// * The current signer set. We get this information from the last
+    ///   successful key-rotation contract call, if that does not exist we
+    ///   use the latest DKG shares, and if that doesn't exist we use the
+    ///   bootstrap signing set from the configuration.
+    /// * The current aggregate key. We get this information from the last
+    ///   successful key-rotation contract call, if that does not exist we
+    ///   use the latest DKG shares.
+    ///
+    /// We cache this information in memory because the query that fetches
+    /// the last key rotation can take quite a lot of some time to
+    /// complete.
     async fn set_signer_set_and_aggregate_key(&self, chain_tip: BlockHash) -> Result<(), Error> {
         let (aggregate_key, public_keys) =
             get_signer_set_and_aggregate_key(&self.context, chain_tip).await?;
@@ -595,6 +612,15 @@ impl<C: Context, B> BlockObserver<C, B> {
         Ok(())
     }
 
+    /// Update the `SignerState` object with data that is unlikely to
+    /// change until the arrival of the next bitcoin block.
+    ///
+    /// # Notes
+    ///
+    /// The function updates the following:
+    /// * sBTC limits from Emily.
+    /// * The current signer set.
+    /// * The current aggregate key.
     async fn update_signer_state(&self, chain_tip: BlockHash) -> Result<(), Error> {
         tracing::info!("loading sbtc limits from Emily");
         self.update_sbtc_limits().await?;

--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -159,7 +159,7 @@ where
                         tracing::warn!(%error, "could not process stacks blocks");
                     }
 
-                    tracing::debug!("Updating the signer state");
+                    tracing::debug!("updating the signer state");
                     if let Err(error) = self.update_signer_state(block_hash).await {
                         tracing::warn!(%error, "could not update the signer state");
                         continue;
@@ -625,7 +625,7 @@ impl<C: Context, B> BlockObserver<C, B> {
         tracing::info!("loading sbtc limits from Emily");
         self.update_sbtc_limits().await?;
 
-        tracing::info!("Updating the signer state with the current signer set");
+        tracing::info!("updating the signer state with the current signer set");
         self.set_signer_set_and_aggregate_key(chain_tip).await
     }
 }

--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -17,6 +17,7 @@
 //! - Update signer set transactions
 //! - Set aggregate key transactions
 
+use std::collections::BTreeSet;
 use std::future::Future;
 use std::time::Duration;
 
@@ -29,6 +30,7 @@ use crate::context::SbtcLimits;
 use crate::context::SignerEvent;
 use crate::emily_client::EmilyInteract;
 use crate::error::Error;
+use crate::keys::PublicKey;
 use crate::metrics::Metrics;
 use crate::metrics::BITCOIN_BLOCKCHAIN;
 use crate::stacks::api::GetNakamotoStartHeight as _;
@@ -157,8 +159,9 @@ where
                         tracing::warn!(%error, "could not process stacks blocks");
                     }
 
-                    if let Err(error) = self.update_sbtc_limits().await {
-                        tracing::warn!(%error, "could not update sBTC limits");
+                    tracing::debug!("Updating the signer state");
+                    if let Err(error) = self.update_signer_state(block_hash).await {
+                        tracing::warn!(%error, "could not update the signer state");
                         continue;
                     }
 
@@ -576,6 +579,65 @@ impl<C: Context, B> BlockObserver<C, B> {
             signer_state.update_current_limits(limits);
         }
         Ok(())
+    }
+
+    async fn update_signer_state(&self, chain_tip: BlockHash) -> Result<(), Error> {
+        tracing::info!("loading sbtc limits from Emily");
+        self.update_sbtc_limits().await?;
+
+        tracing::info!("Updating the signer state with the current signer set");
+        let (aggregate_key, public_keys) = self.get_signer_set_and_aggregate_key(chain_tip).await?;
+        if let Some(aggregate_key) = aggregate_key {
+            self.context.state().set_current_aggregate_key(aggregate_key);
+        }
+
+        self.context.state().update_current_signer_set(public_keys);
+        Ok(())
+    }
+
+    /// Return the signing set that can make sBTC related contract calls
+    /// along with the current aggregate key to use for locking UTXOs on
+    /// bitcoin.
+    ///
+    /// The aggregate key fetched here is the one confirmed on the
+    /// canonical Stacks blockchain as part of a `rotate-keys` contract
+    /// call. It will be the public key that is the result of a DKG run. If
+    /// there are no rotate-keys transactions on the canonical stacks
+    /// blockchain, then we fall back on the last known DKG shares row in
+    /// our database, and return None as the aggregate key if no DKG shares
+    /// can be found, implying that this signer has not participated in
+    /// DKG.
+    #[tracing::instrument(skip_all)]
+    pub async fn get_signer_set_and_aggregate_key(
+        &self,
+        chain_tip: BlockHash,
+    ) -> Result<(Option<PublicKey>, BTreeSet<PublicKey>), Error> {
+        let db = self.context.get_storage();
+        let chain_tip = model::BitcoinBlockHash::from(chain_tip);
+
+        // We are supposed to submit a rotate-keys transaction after
+        // running DKG, but that transaction may not have been submitted
+        // yet (if we have just run DKG) or it may not have been confirmed
+        // on the canonical Stacks blockchain.
+        //
+        // If the signers have already run DKG, then we know that all
+        // participating signers should have the same view of the latest
+        // aggregate key, so we can fall back on the stored DKG shares for
+        // getting the current aggregate key and associated signing set.
+        match db.get_last_key_rotation(&chain_tip).await? {
+            Some(last_key) => {
+                let aggregate_key = last_key.aggregate_key;
+                let signer_set = last_key.signer_set.into_iter().collect();
+                Ok((Some(aggregate_key), signer_set))
+            }
+            None => match db.get_latest_encrypted_dkg_shares().await? {
+                Some(shares) => {
+                    let signer_set = shares.signer_set_public_keys.into_iter().collect();
+                    Ok((Some(shares.aggregate_key), signer_set))
+                }
+                None => Ok((None, self.context.config().signer.bootstrap_signing_set())),
+            },
+        }
     }
 }
 

--- a/signer/src/context/signer_state.rs
+++ b/signer/src/context/signer_state.rs
@@ -46,11 +46,13 @@ impl SignerState {
     }
 
     /// Get the current aggregate key for the signers.
+    #[allow(clippy::unwrap_in_result)]
     pub fn current_aggregate_key(&self) -> Option<PublicKey> {
         self.current_aggregate_key
             .read()
             .expect("BUG: Failed to acquire read lock")
-            .clone()
+            .as_ref()
+            .copied()
     }
 
     /// Set the current aggregate key to the given value

--- a/signer/src/context/signer_state.rs
+++ b/signer/src/context/signer_state.rs
@@ -41,8 +41,8 @@ impl SignerState {
     }
 
     /// Set the public keys of the current signer set, remove the old set.
-    pub fn update_current_signer_set(&self, new_public_keys: BTreeSet<PublicKey>) {
-        self.current_signer_set.replace_signers(new_public_keys);
+    pub fn update_current_signer_set(&self, public_keys: BTreeSet<PublicKey>) {
+        self.current_signer_set.replace_signers(public_keys);
     }
 
     /// Get the current aggregate key for the signers.
@@ -300,7 +300,7 @@ impl SignerSet {
     }
 
     /// Add a signer (public key) to the known active signer set.
-    pub fn replace_signers(&self, new_public_keys: BTreeSet<PublicKey>) {
+    pub fn replace_signers(&self, public_keys: BTreeSet<PublicKey>) {
         let inner_signer_set = self.get_signers();
 
         // Get a guard for the peer IDs.
@@ -324,7 +324,7 @@ impl SignerSet {
         }
 
         // Add the new signer set
-        for public_key in new_public_keys {
+        for public_key in public_keys {
             let signer = Signer::new(public_key);
             inner_peer_ids.insert(signer.peer_id);
             inner_public_keys.insert(signer);

--- a/signer/src/context/signer_state.rs
+++ b/signer/src/context/signer_state.rs
@@ -1,5 +1,6 @@
 //! Module for signer state
 
+use std::collections::BTreeSet;
 use std::sync::{
     atomic::{AtomicBool, AtomicU64, Ordering},
     RwLock,
@@ -18,6 +19,7 @@ use crate::keys::PublicKey;
 pub struct SignerState {
     current_signer_set: SignerSet,
     current_limits: RwLock<SbtcLimits>,
+    current_aggregate_key: RwLock<Option<PublicKey>>,
     sbtc_contracts_deployed: AtomicBool,
     sbtc_bitcoin_start_height: AtomicU64,
     is_sbtc_bitcoin_start_height_set: AtomicBool,
@@ -27,6 +29,36 @@ impl SignerState {
     /// Get the current signer set.
     pub fn current_signer_set(&self) -> &SignerSet {
         &self.current_signer_set
+    }
+
+    /// Return the public keys of the current signer set.
+    pub fn current_signer_public_keys(&self) -> BTreeSet<PublicKey> {
+        self.current_signer_set
+            .get_signers()
+            .into_iter()
+            .map(|signer| signer.public_key)
+            .collect()
+    }
+
+    /// Set the public keys of the current signer set, remove the old set.
+    pub fn update_current_signer_set(&self, new_public_keys: BTreeSet<PublicKey>) {
+        self.current_signer_set.replace_signers(new_public_keys);
+    }
+
+    /// Get the current aggregate key for the signers.
+    pub fn current_aggregate_key(&self) -> Option<PublicKey> {
+        self.current_aggregate_key
+            .read()
+            .expect("BUG: Failed to acquire read lock")
+            .clone()
+    }
+
+    /// Set the current aggregate key to the given value
+    pub fn set_current_aggregate_key(&self, aggregate_key: PublicKey) {
+        self.current_aggregate_key
+            .write()
+            .expect("BUG: Failed to acquire write lock")
+            .replace(aggregate_key);
     }
 
     /// Get the current sBTC limits.
@@ -82,6 +114,7 @@ impl Default for SignerState {
         Self {
             current_signer_set: Default::default(),
             current_limits: RwLock::new(SbtcLimits::zero()),
+            current_aggregate_key: RwLock::new(None),
             sbtc_contracts_deployed: Default::default(),
             sbtc_bitcoin_start_height: Default::default(),
             is_sbtc_bitcoin_start_height_set: Default::default(),
@@ -264,6 +297,38 @@ impl SignerSet {
             .write()
             .expect("BUG: Failed to acquire write lock")
             .insert(signer);
+    }
+
+    /// Add a signer (public key) to the known active signer set.
+    pub fn replace_signers(&self, new_public_keys: BTreeSet<PublicKey>) {
+        let inner_signer_set = self.get_signers();
+
+        // Get a guard for the peer IDs.
+        #[allow(clippy::expect_used)]
+        let mut inner_peer_ids = self
+            .peer_ids
+            .write()
+            .expect("BUG: Failed to acquire write lock");
+
+        // Get a guard for the Signer objects the signer into the set.
+        #[allow(clippy::expect_used)]
+        let mut inner_public_keys = self
+            .signers
+            .write()
+            .expect("BUG: Failed to acquire write lock");
+
+        // Remove the old signer set
+        for signer in inner_signer_set {
+            inner_peer_ids.remove(signer.peer_id());
+            inner_public_keys.remove(signer.public_key());
+        }
+
+        // Add the new signer set
+        for public_key in new_public_keys {
+            let signer = Signer::new(public_key);
+            inner_peer_ids.insert(signer.peer_id);
+            inner_public_keys.insert(signer);
+        }
     }
 
     /// Remove a signer (public key) from the known active signer set.

--- a/signer/src/main.rs
+++ b/signer/src/main.rs
@@ -299,12 +299,10 @@ async fn run_block_observer(ctx: impl Context) -> Result<(), Error> {
 
     // TODO: Need to handle multiple endpoints, so some sort of
     // failover-stream-wrapper.
-    let stream = BitcoinCoreMessageStream::new_from_endpoint(
-        config.bitcoin.block_hash_stream_endpoints[0].as_str(),
-        &["hashblock"],
-    )
-    .await
-    .unwrap();
+    let endpoint = config.bitcoin.block_hash_stream_endpoints[0].as_str();
+    let stream = BitcoinCoreMessageStream::new_from_endpoint(endpoint)
+        .await
+        .unwrap();
 
     // TODO: We should have a new() method that builds from the context
     let block_observer = block_observer::BlockObserver {

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -5,7 +5,6 @@
 //!
 //! For more details, see the [`TxSignerEventLoop`] documentation.
 
-use std::collections::BTreeSet;
 use std::time::Duration;
 
 use crate::bitcoin::validation::BitcoinTxContext;
@@ -318,7 +317,7 @@ where
             .is_some();
         let is_canonical = msg_bitcoin_chain_tip == &chain_tip;
 
-        let signer_set = self.get_signer_public_keys(&chain_tip).await?;
+        let signer_set = self.context.state().current_signer_public_keys();
         let sender_is_coordinator = crate::transaction_coordinator::given_key_is_coordinator(
             msg_sender,
             &chain_tip,
@@ -357,9 +356,7 @@ where
             .map_err(|_| Error::NoChainTip)?
             .ok_or_else(|| Error::NoChainTip)?;
 
-        let (maybe_aggregate_key, _signer_set) = self
-            .get_signer_set_and_aggregate_key(bitcoin_chain_tip)
-            .await?;
+        let maybe_aggregate_key = self.context.state().current_aggregate_key();
 
         let btc_ctx = BitcoinTxContext {
             chain_tip: *bitcoin_chain_tip,
@@ -524,7 +521,7 @@ where
                 // and configuration.
                 assert_allow_dkg_begin(&self.context, bitcoin_chain_tip).await?;
 
-                let signer_public_keys = self.get_signer_public_keys(bitcoin_chain_tip).await?;
+                let signer_public_keys = self.context.state().current_signer_public_keys();
 
                 let state_machine = SignerStateMachine::new(
                     signer_public_keys,
@@ -813,73 +810,6 @@ where
             .signal(TxSignerEvent::MessageGenerated(msg).into())?;
 
         Ok(())
-    }
-
-    /// Return the signing set that can make sBTC related contract calls
-    /// along with the current aggregate key to use for locking UTXOs on
-    /// bitcoin.
-    ///
-    /// The aggregate key fetched here is the one confirmed on the
-    /// canonical Stacks blockchain as part of a `rotate-keys` contract
-    /// call. It will be the public key that is the result of a DKG run. If
-    /// there are no rotate-keys transactions on the canonical stacks
-    /// blockchain, then we fall back on the last known DKG shares row in
-    /// our database, and return None as the aggregate key if no DKG shares
-    /// can be found, implying that this signer has not participated in
-    /// DKG.
-    #[tracing::instrument(skip_all)]
-    pub async fn get_signer_set_and_aggregate_key(
-        &self,
-        bitcoin_chain_tip: &model::BitcoinBlockHash,
-    ) -> Result<(Option<PublicKey>, BTreeSet<PublicKey>), Error> {
-        let db = self.context.get_storage();
-
-        // We are supposed to submit a rotate-keys transaction after
-        // running DKG, but that transaction may not have been submitted
-        // yet (if we have just run DKG) or it may not have been confirmed
-        // on the canonical Stacks blockchain.
-        //
-        // If the signers have already run DKG, then we know that all
-        // participating signers should have the same view of the latest
-        // aggregate key, so we can fall back on the stored DKG shares for
-        // getting the current aggregate key and associated signing set.
-        match db.get_last_key_rotation(bitcoin_chain_tip).await? {
-            Some(last_key) => {
-                let aggregate_key = last_key.aggregate_key;
-                let signer_set = last_key.signer_set.into_iter().collect();
-                Ok((Some(aggregate_key), signer_set))
-            }
-            None => match db.get_latest_encrypted_dkg_shares().await? {
-                Some(shares) => {
-                    let signer_set = shares.signer_set_public_keys.into_iter().collect();
-                    Ok((Some(shares.aggregate_key), signer_set))
-                }
-                None => Ok((None, self.context.config().signer.bootstrap_signing_set())),
-            },
-        }
-    }
-
-    /// Get the set of public keys for the current signing set.
-    ///
-    /// If there is a successful `rotate-keys` transaction in the database
-    /// then we should use that as the source of truth for the current
-    /// signing set, otherwise we fall back to the bootstrap keys in our
-    /// config.
-    #[tracing::instrument(skip_all)]
-    pub async fn get_signer_public_keys(
-        &self,
-        chain_tip: &model::BitcoinBlockHash,
-    ) -> Result<BTreeSet<PublicKey>, Error> {
-        let db = self.context.get_storage();
-
-        // Get the last rotate-keys transaction from the database on the
-        // canonical Stacks blockchain (which we identify using the
-        // canonical bitcoin blockchain). If we don't have such a
-        // transaction then get the bootstrap keys from our config.
-        match db.get_last_key_rotation(chain_tip).await? {
-            Some(last_key) => Ok(last_key.signer_set.into_iter().collect()),
-            None => Ok(self.context.config().signer.bootstrap_signing_set()),
-        }
     }
 
     fn signer_public_key(&self) -> PublicKey {

--- a/signer/tests/integration/block_observer.rs
+++ b/signer/tests/integration/block_observer.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::collections::HashSet;
 use std::ops::Deref;
 use std::sync::atomic::AtomicBool;
@@ -24,14 +25,17 @@ use sbtc::testing::regtest;
 use sbtc::testing::regtest::Recipient;
 use signer::bitcoin::utxo::SbtcRequests;
 use signer::bitcoin::utxo::SignerBtcState;
+use signer::block_observer::get_signer_set_and_aggregate_key;
 use signer::context::SbtcLimits;
 use signer::emily_client::EmilyClient;
 use signer::error::Error;
+use signer::keys::PublicKey;
 use signer::keys::SignerScriptPubKey as _;
 use signer::stacks::api::TenureBlocks;
 use signer::storage::model;
 use signer::storage::model::BitcoinBlockHash;
 use signer::storage::model::EncryptedDkgShares;
+use signer::storage::model::RotateKeysTransaction;
 use signer::storage::model::TxOutput;
 use signer::storage::model::TxOutputType;
 use signer::storage::model::TxPrevout;
@@ -51,6 +55,7 @@ use signer::storage::DbRead as _;
 use signer::testing;
 use signer::testing::context::TestContext;
 use signer::testing::context::*;
+use signer::testing::storage::model::TestData;
 use tokio_stream::wrappers::ReceiverStream;
 use url::Url;
 
@@ -903,6 +908,104 @@ async fn next_headers_to_process_ignores_known_headers() {
         .await
         .unwrap();
     assert!(headers.is_empty());
+
+    testing::storage::drop_db(db).await;
+}
+
+/// The [`TxCoordinatorEventLoop::get_signer_set_and_aggregate_key`]
+/// function is supposed to fetch the "current" signing set and the
+/// aggregate key to use for bitcoin transactions. It attempts to get the
+/// latest rotate-keys contract call transaction confirmed on the canonical
+/// Stacks blockchain and falls back to the DKG shares table if no such
+/// transaction can be found.
+///
+/// This tests that we prefer rotate keys transactions if it's available
+/// but will use the DKG shares behavior is indeed the case.
+#[tokio::test]
+async fn get_signer_public_keys_and_aggregate_key_falls_back() {
+    let db = testing::storage::new_test_database().await;
+
+    let mut rng = rand::rngs::StdRng::seed_from_u64(51);
+
+    let ctx = TestContext::builder()
+        .with_storage(db.clone())
+        .with_mocked_clients()
+        .build();
+
+    // We need stacks blocks for the rotate-keys transactions.
+    let test_params = testing::storage::model::Params {
+        num_bitcoin_blocks: 10,
+        num_stacks_blocks_per_bitcoin_block: 1,
+        num_deposit_requests_per_block: 0,
+        num_withdraw_requests_per_block: 0,
+        num_signers_per_request: 0,
+        consecutive_blocks: false,
+    };
+    let test_data = TestData::generate(&mut rng, &[], &test_params);
+    test_data.write_to(&db).await;
+
+    // We always need the chain tip.
+    let chain_tip = db.get_bitcoin_canonical_chain_tip().await.unwrap().unwrap();
+
+    // We have no rows in the DKG shares table and no rotate-keys
+    // transactions, so there should be no aggregate key, since that only
+    // happens after DKG, but we should always know the current signer set.
+    let (maybe_aggregate_key, signer_set) = get_signer_set_and_aggregate_key(&ctx, chain_tip)
+        .await
+        .unwrap();
+    assert!(maybe_aggregate_key.is_none());
+    assert!(!signer_set.is_empty());
+
+    // Alright, lets write some DKG shares into the database. When we do
+    // that the signer set should be considered whatever the signer set is
+    // from our DKG shares.
+    let shares: EncryptedDkgShares = Faker.fake_with_rng(&mut rng);
+    db.write_encrypted_dkg_shares(&shares).await.unwrap();
+
+    let (aggregate_key, signer_set) = get_signer_set_and_aggregate_key(&ctx, chain_tip)
+        .await
+        .unwrap();
+
+    let shares_signer_set: BTreeSet<PublicKey> =
+        shares.signer_set_public_keys.iter().copied().collect();
+
+    assert_eq!(shares.aggregate_key, aggregate_key.unwrap());
+    assert_eq!(shares_signer_set, signer_set);
+
+    // Okay not we write a rotate-keys transaction into the database. To do
+    // that we need the stacks chain tip, and a something in 3 different
+    // tables...
+    let stacks_chain_tip = db.get_stacks_chain_tip(&chain_tip).await.unwrap().unwrap();
+
+    let rotate_keys: RotateKeysTransaction = Faker.fake_with_rng(&mut rng);
+    let transaction = model::Transaction {
+        txid: rotate_keys.txid.into_bytes(),
+        tx: Vec::new(),
+        tx_type: model::TransactionType::RotateKeys,
+        block_hash: stacks_chain_tip.block_hash.into_bytes(),
+    };
+    let tx = model::StacksTransaction {
+        txid: rotate_keys.txid,
+        block_hash: stacks_chain_tip.block_hash,
+    };
+
+    db.write_transaction(&transaction).await.unwrap();
+    db.write_stacks_transaction(&tx).await.unwrap();
+    db.write_rotate_keys_transaction(&rotate_keys)
+        .await
+        .unwrap();
+
+    // Alright, now that we have a rotate-keys transaction, we can check if
+    // it is preferred over the DKG shares table.
+    let (aggregate_key, signer_set) = get_signer_set_and_aggregate_key(&ctx, chain_tip)
+        .await
+        .unwrap();
+
+    let rotate_keys_signer_set: BTreeSet<PublicKey> =
+        rotate_keys.signer_set.iter().copied().collect();
+
+    assert_eq!(rotate_keys.aggregate_key, aggregate_key.unwrap());
+    assert_eq!(rotate_keys_signer_set, signer_set);
 
     testing::storage::drop_db(db).await;
 }

--- a/signer/tests/integration/block_observer.rs
+++ b/signer/tests/integration/block_observer.rs
@@ -45,7 +45,6 @@ use signer::storage::DbWrite;
 use signer::testing::stacks::DUMMY_SORTITION_INFO;
 use signer::testing::stacks::DUMMY_TENURE_INFO;
 
-use signer::bitcoin::zmq::BitcoinCoreMessageStream;
 use signer::block_observer::BlockObserver;
 use signer::context::Context as _;
 use signer::context::SignerEvent;
@@ -150,15 +149,9 @@ async fn load_latest_deposit_requests_persists_requests_from_past(blocks_ago: u6
     let start_flag = Arc::new(AtomicBool::new(false));
     let flag = start_flag.clone();
 
-    let zmq_stream =
-        BitcoinCoreMessageStream::new_from_endpoint(BITCOIN_CORE_ZMQ_ENDPOINT, &["hashblock"])
-            .await
-            .unwrap()
-            .as_receiver_stream();
-
     let block_observer = BlockObserver {
         context: ctx.clone(),
-        bitcoin_blocks: zmq_stream,
+        bitcoin_blocks: testing::btc::new_zmq_block_hash_stream(BITCOIN_CORE_ZMQ_ENDPOINT).await,
     };
 
     // We need at least one receiver
@@ -259,15 +252,9 @@ async fn link_blocks() {
     })
     .await;
 
-    let zmq_stream =
-        BitcoinCoreMessageStream::new_from_endpoint(BITCOIN_CORE_ZMQ_ENDPOINT, &["hashblock"])
-            .await
-            .unwrap()
-            .as_receiver_stream();
-
     let block_observer = BlockObserver {
         context: ctx.clone(),
-        bitcoin_blocks: zmq_stream,
+        bitcoin_blocks: testing::btc::new_zmq_block_hash_stream(BITCOIN_CORE_ZMQ_ENDPOINT).await,
     };
 
     let mut signal_rx = ctx.get_signal_receiver();
@@ -418,15 +405,9 @@ async fn block_observer_stores_donation_and_sbtc_utxos() {
     let start_flag = Arc::new(AtomicBool::new(false));
     let flag = start_flag.clone();
 
-    let zmq_stream =
-        BitcoinCoreMessageStream::new_from_endpoint(BITCOIN_CORE_ZMQ_ENDPOINT, &["hashblock"])
-            .await
-            .unwrap()
-            .as_receiver_stream();
-
     let block_observer = BlockObserver {
         context: ctx.clone(),
-        bitcoin_blocks: zmq_stream,
+        bitcoin_blocks: testing::btc::new_zmq_block_hash_stream(BITCOIN_CORE_ZMQ_ENDPOINT).await,
     };
 
     tokio::spawn(async move {
@@ -726,15 +707,9 @@ async fn block_observer_handles_update_limits(deployed: bool, sbtc_limits: SbtcL
     let start_flag = Arc::new(AtomicBool::new(false));
     let flag = start_flag.clone();
 
-    let zmq_stream =
-        BitcoinCoreMessageStream::new_from_endpoint(BITCOIN_CORE_ZMQ_ENDPOINT, &["hashblock"])
-            .await
-            .unwrap()
-            .as_receiver_stream();
-
     let block_observer = BlockObserver {
         context: ctx.clone(),
-        bitcoin_blocks: zmq_stream,
+        bitcoin_blocks: testing::btc::new_zmq_block_hash_stream(BITCOIN_CORE_ZMQ_ENDPOINT).await,
     };
 
     let mut signal_receiver = ctx.get_signal_receiver();
@@ -1037,15 +1012,9 @@ async fn block_observer_updates_state_after_observing_bitcoin_block() {
     let start_flag = Arc::new(AtomicBool::new(false));
     let flag = start_flag.clone();
 
-    let zmq_stream =
-        BitcoinCoreMessageStream::new_from_endpoint(BITCOIN_CORE_ZMQ_ENDPOINT, &["hashblock"])
-            .await
-            .unwrap()
-            .as_receiver_stream();
-
     let block_observer = BlockObserver {
         context: ctx.clone(),
-        bitcoin_blocks: zmq_stream,
+        bitcoin_blocks: testing::btc::new_zmq_block_hash_stream(BITCOIN_CORE_ZMQ_ENDPOINT).await,
     };
 
     // In this test the signer set public keys start empty. When running

--- a/signer/tests/integration/block_observer.rs
+++ b/signer/tests/integration/block_observer.rs
@@ -912,7 +912,7 @@ async fn get_signer_public_keys_and_aggregate_key_falls_back() {
     assert_eq!(shares.aggregate_key, aggregate_key.unwrap());
     assert_eq!(shares_signer_set, signer_set);
 
-    // Okay not we write a rotate-keys transaction into the database. To do
+    // Okay now we write a rotate-keys transaction into the database. To do
     // that we need the stacks chain tip, and a something in 3 different
     // tables...
     let stacks_chain_tip = db.get_stacks_chain_tip(&chain_tip).await.unwrap().unwrap();

--- a/signer/tests/integration/block_observer.rs
+++ b/signer/tests/integration/block_observer.rs
@@ -1103,7 +1103,7 @@ async fn block_observer_updates_state_after_observing_bitcoin_block() {
     assert_eq!(db_chain_tip, Some(chain_tip));
 
     let dkg_aggregate_key = Some(dkg_shares.aggregate_key);
-assert_eq!(state.get_current_limits(), SbtcLimits::unlimited());
+    assert_eq!(state.get_current_limits(), SbtcLimits::unlimited());
     assert_eq!(state.current_aggregate_key(), dkg_aggregate_key);
     assert_eq!(state.current_signer_public_keys(), dkg_public_keys);
 

--- a/signer/tests/integration/block_observer.rs
+++ b/signer/tests/integration/block_observer.rs
@@ -852,12 +852,11 @@ async fn next_headers_to_process_ignores_known_headers() {
     testing::storage::drop_db(db).await;
 }
 
-/// The [`TxCoordinatorEventLoop::get_signer_set_and_aggregate_key`]
-/// function is supposed to fetch the "current" signing set and the
-/// aggregate key to use for bitcoin transactions. It attempts to get the
-/// latest rotate-keys contract call transaction confirmed on the canonical
-/// Stacks blockchain and falls back to the DKG shares table if no such
-/// transaction can be found.
+/// The [`get_signer_set_and_aggregate_key`] function is supposed to fetch
+/// the "current" signing set and the aggregate key to use for bitcoin
+/// transactions. It attempts to get the latest rotate-keys contract call
+/// transaction confirmed on the canonical Stacks blockchain and falls back
+/// to the DKG shares table if no such transaction can be found.
 ///
 /// This tests that we prefer rotate keys transactions if it's available
 /// but will use the DKG shares behavior is indeed the case.

--- a/signer/tests/integration/transaction_coordinator.rs
+++ b/signer/tests/integration/transaction_coordinator.rs
@@ -74,7 +74,6 @@ use test_log::test;
 use tokio_stream::wrappers::BroadcastStream;
 use url::Url;
 
-use signer::bitcoin::zmq::BitcoinCoreMessageStream;
 use signer::block_observer::BlockObserver;
 use signer::context::Context;
 use signer::emily_client::EmilyClient;
@@ -1514,15 +1513,10 @@ async fn sign_bitcoin_transaction() {
             ev.run().await
         });
 
-        let zmq_stream =
-            BitcoinCoreMessageStream::new_from_endpoint(BITCOIN_CORE_ZMQ_ENDPOINT, &["hashblock"])
-                .await
-                .unwrap()
-                .as_receiver_stream();
-
         let block_observer = BlockObserver {
             context: ctx.clone(),
-            bitcoin_blocks: zmq_stream,
+            bitcoin_blocks: testing::btc::new_zmq_block_hash_stream(BITCOIN_CORE_ZMQ_ENDPOINT)
+                .await,
         };
         let counter = start_count.clone();
         tokio::spawn(async move {
@@ -1948,15 +1942,10 @@ async fn sign_bitcoin_transaction_multiple_locking_keys() {
             ev.run().await
         });
 
-        let zmq_stream =
-            BitcoinCoreMessageStream::new_from_endpoint(BITCOIN_CORE_ZMQ_ENDPOINT, &["hashblock"])
-                .await
-                .unwrap()
-                .as_receiver_stream();
-
         let block_observer = BlockObserver {
             context: ctx.clone(),
-            bitcoin_blocks: zmq_stream,
+            bitcoin_blocks: testing::btc::new_zmq_block_hash_stream(BITCOIN_CORE_ZMQ_ENDPOINT)
+                .await,
         };
         let counter = start_count.clone();
         tokio::spawn(async move {
@@ -2531,15 +2520,10 @@ async fn skip_smart_contract_deployment_and_key_rotation_if_up_to_date() {
             ev.run().await
         });
 
-        let zmq_stream =
-            BitcoinCoreMessageStream::new_from_endpoint(BITCOIN_CORE_ZMQ_ENDPOINT, &["hashblock"])
-                .await
-                .unwrap()
-                .as_receiver_stream();
-
         let block_observer = BlockObserver {
             context: ctx.clone(),
-            bitcoin_blocks: zmq_stream,
+            bitcoin_blocks: testing::btc::new_zmq_block_hash_stream(BITCOIN_CORE_ZMQ_ENDPOINT)
+                .await,
         };
         let counter = start_count.clone();
         tokio::spawn(async move {
@@ -3323,15 +3307,10 @@ async fn test_conservative_initial_sbtc_limits() {
             ev.run().await
         });
 
-        let zmq_stream =
-            BitcoinCoreMessageStream::new_from_endpoint(BITCOIN_CORE_ZMQ_ENDPOINT, &["hashblock"])
-                .await
-                .unwrap()
-                .as_receiver_stream();
-
         let block_observer = BlockObserver {
             context: ctx.clone(),
-            bitcoin_blocks: zmq_stream,
+            bitcoin_blocks: testing::btc::new_zmq_block_hash_stream(BITCOIN_CORE_ZMQ_ENDPOINT)
+                .await,
         };
         let counter = start_count.clone();
         tokio::spawn(async move {

--- a/signer/tests/integration/transaction_coordinator.rs
+++ b/signer/tests/integration/transaction_coordinator.rs
@@ -92,7 +92,6 @@ use signer::stacks::contracts::CompleteDepositV1;
 use signer::stacks::contracts::SMART_CONTRACTS;
 use signer::storage::model;
 use signer::storage::model::EncryptedDkgShares;
-use signer::storage::model::RotateKeysTransaction;
 use signer::storage::DbRead as _;
 use signer::storage::DbWrite as _;
 use signer::testing;
@@ -772,122 +771,6 @@ async fn deploy_smart_contracts_coordinator<F>(
 
     // Stop event loops
     tx_coordinator_handle.abort();
-
-    testing::storage::drop_db(db).await;
-}
-
-/// The [`TxCoordinatorEventLoop::get_signer_set_and_aggregate_key`]
-/// function is supposed to fetch the "current" signing set and the
-/// aggregate key to use for bitcoin transactions. It attempts to get the
-/// latest rotate-keys contract call transaction confirmed on the canonical
-/// Stacks blockchain and falls back to the DKG shares table if no such
-/// transaction can be found.
-///
-/// This tests that we prefer rotate keys transactions if it's available
-/// but will use the DKG shares behavior is indeed the case.
-#[tokio::test]
-async fn get_signer_public_keys_and_aggregate_key_falls_back() {
-    let db = testing::storage::new_test_database().await;
-
-    let mut rng = rand::rngs::StdRng::seed_from_u64(51);
-
-    let ctx = TestContext::builder()
-        .with_storage(db.clone())
-        .with_mocked_clients()
-        .build();
-
-    let network = InMemoryNetwork::new();
-
-    ctx.state().set_sbtc_contracts_deployed(); // Skip contract deployment
-    let coord = TxCoordinatorEventLoop {
-        network: network.connect(),
-        context: ctx.clone(),
-        context_window: 10000,
-        private_key: ctx.config().signer.private_key,
-        signing_round_max_duration: Duration::from_secs(10),
-        bitcoin_presign_request_max_duration: Duration::from_secs(10),
-        threshold: 2,
-        dkg_max_duration: Duration::from_secs(10),
-        is_epoch3: true,
-    };
-
-    // We need stacks blocks for the rotate-keys transactions.
-    let test_params = testing::storage::model::Params {
-        num_bitcoin_blocks: 10,
-        num_stacks_blocks_per_bitcoin_block: 1,
-        num_deposit_requests_per_block: 0,
-        num_withdraw_requests_per_block: 0,
-        num_signers_per_request: 0,
-        consecutive_blocks: false,
-    };
-    let test_data = TestData::generate(&mut rng, &[], &test_params);
-    test_data.write_to(&db).await;
-
-    // We always need the chain tip.
-    let chain_tip = db.get_bitcoin_canonical_chain_tip().await.unwrap().unwrap();
-
-    // We have no rows in the DKG shares table and no rotate-keys
-    // transactions, so there should be no aggregate key, since that only
-    // happens after DKG, but we should always know the current signer set.
-    let (maybe_aggregate_key, signer_set) = coord
-        .get_signer_set_and_aggregate_key(&chain_tip)
-        .await
-        .unwrap();
-    assert!(maybe_aggregate_key.is_none());
-    assert!(!signer_set.is_empty());
-
-    // Alright, lets write some DKG shares into the database. When we do
-    // that the signer set should be considered whatever the signer set is
-    // from our DKG shares.
-    let shares: EncryptedDkgShares = Faker.fake_with_rng(&mut rng);
-    db.write_encrypted_dkg_shares(&shares).await.unwrap();
-
-    let (aggregate_key, signer_set) = coord
-        .get_signer_set_and_aggregate_key(&chain_tip)
-        .await
-        .unwrap();
-
-    let shares_signer_set: BTreeSet<PublicKey> =
-        shares.signer_set_public_keys.iter().copied().collect();
-
-    assert_eq!(shares.aggregate_key, aggregate_key.unwrap());
-    assert_eq!(shares_signer_set, signer_set);
-
-    // Okay not we write a rotate-keys transaction into the database. To do
-    // that we need the stacks chain tip, and a something in 3 different
-    // tables...
-    let stacks_chain_tip = db.get_stacks_chain_tip(&chain_tip).await.unwrap().unwrap();
-
-    let rotate_keys: RotateKeysTransaction = Faker.fake_with_rng(&mut rng);
-    let transaction = model::Transaction {
-        txid: rotate_keys.txid.into_bytes(),
-        tx: Vec::new(),
-        tx_type: model::TransactionType::RotateKeys,
-        block_hash: stacks_chain_tip.block_hash.into_bytes(),
-    };
-    let tx = model::StacksTransaction {
-        txid: rotate_keys.txid,
-        block_hash: stacks_chain_tip.block_hash,
-    };
-
-    db.write_transaction(&transaction).await.unwrap();
-    db.write_stacks_transaction(&tx).await.unwrap();
-    db.write_rotate_keys_transaction(&rotate_keys)
-        .await
-        .unwrap();
-
-    // Alright, now that we have a rotate-keys transaction, we can check if
-    // it is preferred over the DKG shares table.
-    let (aggregate_key, signer_set) = coord
-        .get_signer_set_and_aggregate_key(&chain_tip)
-        .await
-        .unwrap();
-
-    let rotate_keys_signer_set: BTreeSet<PublicKey> =
-        rotate_keys.signer_set.iter().copied().collect();
-
-    assert_eq!(rotate_keys.aggregate_key, aggregate_key.unwrap());
-    assert_eq!(rotate_keys_signer_set, signer_set);
 
     testing::storage::drop_db(db).await;
 }

--- a/signer/tests/integration/transaction_coordinator.rs
+++ b/signer/tests/integration/transaction_coordinator.rs
@@ -488,10 +488,9 @@ async fn process_complete_deposit() {
     // When the signer binary starts up in main(), it sets the current
     // signer set public keys in the context state using the values in the
     // bootstrap_signing_set configuration parameter. Later, the aggregate
-    // key gets set in the block observer. state gets updated in the block
-    // observer when with values from the last rotate keys transaction.
-    // We're not running a block observer in this test, nor are we going
-    // through main, so we manually update the state here.
+    // key gets set in the block observer. We're not running a block
+    // observer in this test, nor are we going through main, so we manually
+    // update the state here.
     let signer_set_public_keys = testing_signer_set.signer_keys().into_iter().collect();
     let state = context.state();
     state.update_current_signer_set(signer_set_public_keys);

--- a/signer/tests/integration/transaction_signer.rs
+++ b/signer/tests/integration/transaction_signer.rs
@@ -28,14 +28,12 @@ use signer::storage::model;
 use signer::storage::model::BitcoinBlockHash;
 use signer::storage::model::BitcoinTxId;
 use signer::storage::model::BitcoinTxSigHash;
-use signer::storage::model::RotateKeysTransaction;
 use signer::storage::model::SigHash;
 use signer::storage::model::StacksTxId;
 use signer::storage::DbRead as _;
 use signer::storage::DbWrite as _;
 use signer::testing;
 use signer::testing::context::*;
-use signer::testing::storage::model::TestData;
 use signer::transaction_signer::ChainTipStatus;
 use signer::transaction_signer::MsgChainTipReport;
 use signer::transaction_signer::TxSignerEventLoop;
@@ -48,100 +46,6 @@ use crate::setup::fill_signers_utxo;
 use crate::setup::TestSignerSet;
 use crate::setup::TestSweepSetup;
 use crate::setup::TestSweepSetup2;
-
-/// Test that [`TxSignerEventLoop::get_signer_public_keys`] falls back to
-/// the bootstrap config if there is no rotate-keys transaction in the
-/// database.
-#[tokio::test]
-async fn get_signer_public_keys_and_aggregate_key_falls_back() {
-    let db = testing::storage::new_test_database().await;
-
-    let mut rng = rand::rngs::StdRng::seed_from_u64(51);
-
-    let ctx = TestContext::builder()
-        .with_storage(db.clone())
-        .with_mocked_clients()
-        .build();
-
-    let network = InMemoryNetwork::new();
-
-    let coord = TxSignerEventLoop {
-        network: network.connect(),
-        context: ctx.clone(),
-        context_window: 10000,
-        wsts_state_machines: LruCache::new(NonZeroUsize::new(100).unwrap()),
-        signer_private_key: ctx.config().signer.private_key,
-        threshold: 2,
-        rng: rand::rngs::StdRng::seed_from_u64(51),
-        dkg_begin_pause: None,
-    };
-
-    // We need stacks blocks for the rotate-keys transactions.
-    let test_params = testing::storage::model::Params {
-        num_bitcoin_blocks: 10,
-        num_stacks_blocks_per_bitcoin_block: 1,
-        num_deposit_requests_per_block: 0,
-        num_withdraw_requests_per_block: 0,
-        num_signers_per_request: 0,
-        consecutive_blocks: false,
-    };
-    let test_data = TestData::generate(&mut rng, &[], &test_params);
-    test_data.write_to(&db).await;
-
-    // We always need the chain tip.
-    let chain_tip = db.get_bitcoin_canonical_chain_tip().await.unwrap().unwrap();
-
-    // We have no transactions in the database, just blocks header hashes
-    // and block heights. The `get_signer_public_keys` function falls back
-    // to the config for keys if no rotate-keys transaction can be found.
-    // So this function almost never errors.
-    let bootstrap_signer_set = coord.get_signer_public_keys(&chain_tip).await.unwrap();
-    // We check that the signer set can form a valid wallet when we load
-    // the config. In particular, the signing set should not be empty.
-    assert!(!bootstrap_signer_set.is_empty());
-
-    let config_signer_set = ctx.config().signer.bootstrap_signing_set();
-    assert_eq!(bootstrap_signer_set, config_signer_set);
-
-    // Okay now we write a rotate-keys transaction into the database. To do
-    // that we need the stacks chain tip, and a something in 3 different
-    // tables...
-    let stacks_chain_tip = db.get_stacks_chain_tip(&chain_tip).await.unwrap().unwrap();
-
-    let rotate_keys: RotateKeysTransaction = Faker.fake_with_rng(&mut rng);
-    let transaction = model::Transaction {
-        txid: rotate_keys.txid.into_bytes(),
-        tx: Vec::new(),
-        tx_type: model::TransactionType::RotateKeys,
-        block_hash: stacks_chain_tip.block_hash.into_bytes(),
-    };
-    let tx = model::StacksTransaction {
-        txid: rotate_keys.txid,
-        block_hash: stacks_chain_tip.block_hash,
-    };
-
-    db.write_transaction(&transaction).await.unwrap();
-    db.write_stacks_transaction(&tx).await.unwrap();
-    db.write_rotate_keys_transaction(&rotate_keys)
-        .await
-        .unwrap();
-
-    // Alright, now that we have a rotate-keys transaction, we can check if
-    // it is preferred over the config.
-    let signer_set: Vec<PublicKey> = coord
-        .get_signer_public_keys(&chain_tip)
-        .await
-        .unwrap()
-        .into_iter()
-        .collect();
-
-    let mut rotate_keys_signer_set = rotate_keys.signer_set.clone();
-    rotate_keys_signer_set.sort();
-
-    assert_eq!(rotate_keys_signer_set, signer_set);
-
-    testing::storage::drop_db(db).await;
-}
 
 /// Test that [`TxSignerEventLoop::assert_valid_stacks_tx_sign_request`]
 /// errors when the signer is not in the signer set.

--- a/signer/tests/integration/zmq.rs
+++ b/signer/tests/integration/zmq.rs
@@ -13,10 +13,9 @@ pub const BITCOIN_CORE_ZMQ_ENDPOINT: &str = "tcp://localhost:28332";
 async fn block_stream_streams_blocks() {
     let (_, faucet) = regtest::initialize_blockchain();
 
-    let stream =
-        BitcoinCoreMessageStream::new_from_endpoint(BITCOIN_CORE_ZMQ_ENDPOINT, &["rawblock"])
-            .await
-            .unwrap();
+    let stream = BitcoinCoreMessageStream::new_from_endpoint(BITCOIN_CORE_ZMQ_ENDPOINT)
+        .await
+        .unwrap();
 
     let mut block_stream = stream.to_block_stream();
 
@@ -66,10 +65,9 @@ async fn block_stream_streams_blocks() {
 async fn block_hash_stream_streams_block_hashes() {
     let (_, faucet) = regtest::initialize_blockchain();
 
-    let stream =
-        BitcoinCoreMessageStream::new_from_endpoint(BITCOIN_CORE_ZMQ_ENDPOINT, &["hashblock"])
-            .await
-            .unwrap();
+    let stream = BitcoinCoreMessageStream::new_from_endpoint(BITCOIN_CORE_ZMQ_ENDPOINT)
+        .await
+        .unwrap();
 
     let mut block_hash_stream = stream.to_block_hash_stream();
 


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/1295.

## Changes

1. Store the current signer set and aggregate key in the signer state at the end of the block observer.
2. Change the event loops to use the signer state when they need the current signer set or current aggregate key.
3. Changes in the current signer set now affect who the signers can communicate to. This is fine for now, since we do not support changing the current signing set from the bootstrap signer set.
4. Clean up the creation of a block hash stream, particularly in tests.

## Testing Information

This PR adds a new integration test for the expected behavior of the block observer. It also moves around another test, and removes a test that was duplicated. The existing integration tests should catch anything else that might be amiss, but I also tested this locally in our devenv and everything was fine, where I was able to smoothly mint sbtc.

## Checklist:

- [x] I have performed a self-review of my code

