### PR TITLE
feat: validate rotate keys contract calls with validated shares

### DIFF
--- a/signer/migrations/0012__dkg_verification_extensions.sql
+++ b/signer/migrations/0012__dkg_verification_extensions.sql
@@ -1,75 +1,52 @@
--- Enum table for DKG shares status
-CREATE TABLE sbtc_signer.dkg_shares_status (
-    -- The id of the status, not auto-incremented as we want to control the values.
-    id INTEGER PRIMARY KEY,
-    -- The name of the status.
-    key TEXT NOT NULL,
-    -- Brief description of what the status means.
-    description TEXT NOT NULL
-);
 
--- Insert the initial entries.
-INSERT INTO sbtc_signer.dkg_shares_status (id, key, description) VALUES
-    (0, 'PENDING', 'DKG round successful, pending verification via signing round'),
-    (1, 'VERIFIED', 'Successfully verified via signing round'),
-    (2, 'KEY_REVOKED', 'The DKG key has been revoked and should not be used');
+CREATE TYPE sbtc_signer.dkg_shares_status AS ENUM (
+    'unverified',
+    'verified',
+    'failed'
+);
 
 -- Add the new columns to the `dkg_shares` table. We're not adding indexes for
 -- now because the table is so small that the overhead likely outweighs the
 -- benefits.
 ALTER TABLE sbtc_signer.dkg_shares
-    -- Contains the current 
-    ADD COLUMN dkg_shares_status_id INTEGER DEFAULT 0 REFERENCES sbtc_signer.dkg_shares_status (id),
-    ADD COLUMN verified_at_bitcoin_block_hash BYTEA DEFAULT NULL,
-    ADD COLUMN verified_at_bitcoin_block_height BIGINT DEFAULT NULL,
-    ADD CONSTRAINT fk_dkg_shares_bitcoin_block_hash
-        FOREIGN KEY (verified_at_bitcoin_block_hash)
-        REFERENCES sbtc_signer.bitcoin_blocks (block_hash),
-    ADD CONSTRAINT chk_verified_at
-        CHECK (
-            (dkg_shares_status_id = 1 AND verified_at_bitcoin_block_hash IS NOT NULL AND verified_at_bitcoin_block_height IS NOT NULL) 
-            OR (dkg_shares_status_id <> 1 AND verified_at_bitcoin_block_hash IS NULL AND verified_at_bitcoin_block_height IS NULL)
-        );
+    ADD COLUMN dkg_shares_status sbtc_signer.dkg_shares_status,
+    ADD COLUMN started_at_bitcoin_block_hash BYTEA,
+    ADD COLUMN started_at_bitcoin_block_height BIGINT;
 
--- Set all of the current `dkg_shares` to `3` (revoked) to start with. Confirmed
--- DKG shares will be updated to `1` (verified) in the next step.
+
 UPDATE sbtc_signer.dkg_shares
-SET dkg_shares_status_id = 3;
+SET dkg_shares_status_id = 'unverified';
 
--- Update the `dkg_shares` which have been included in a
--- `rotate_keys_transactions` which can also be tied to a bitcoin block to `1`
--- (verified) and set the `verified_at_*` fields to the bitcoin block
--- hash/height corresponding to the block where these were anchored.
---
--- This update is not fork aware, but at the time of writing there is no forks
--- that should be problematic (i.e. we shouldn't have any rotate-keys events
--- that have been orphaned).
-WITH updated_shares AS (
+-- These are all DKG shares associated scriptPubKeys that have been successfully spent
+UPDATE sbtc_signer.dkg_shares
+SET dkg_shares_status = 'verified'
+FROM sbtc_signer.bitcoin_tx_inputs
+WHERE sbtc_signer.dkg_shares.script_pubkey = sbtc_signer.bitcoin_tx_inputs.script_pubkey;
+
+
+-- Fill in the started at bitcoin blockhash and block height. The timestamp
+-- of when we write the DKG shares row to the database should correspond
+-- with the tenure of the block that started the DKG round.
+WITH block_times AS (
     SELECT 
-        s.aggregate_key,
-        bb.block_hash AS verified_at_bitcoin_block_hash,
-        bb.block_height AS verified_at_bitcoin_block_height
-    FROM sbtc_signer.dkg_shares s
-    INNER JOIN sbtc_signer.rotate_keys_transactions rkt 
-        ON s.aggregate_key = rkt.aggregate_key
-    INNER JOIN sbtc_signer.stacks_transactions stx
-        ON rkt.txid = stx.txid
-    INNER JOIN sbtc_signer.stacks_blocks sb
-        ON stx.block_hash = sb.block_hash
-    INNER JOIN sbtc_signer.bitcoin_blocks bb
-        ON sb.bitcoin_anchor = bb.block_hash
-    ORDER BY bb.block_height DESC
-    LIMIT 1
+        bb1.block_hash
+      , bb1.block_height
+      , bb1.created_at
+      , bb2.created_at AS ended_at
+    FROM sbtc_signer.bitcoin_blocks AS bb2
+    JOIN sbtc_signer.bitcoin_blocks AS bb1
+      ON bb2.parent_hash = bb1.block_hash
 )
 UPDATE sbtc_signer.dkg_shares
 SET 
-    dkg_shares_status_id = 1,
-    verified_at_bitcoin_block_hash = updated_shares.verified_at_bitcoin_block_hash,
-    verified_at_bitcoin_block_height = updated_shares.verified_at_bitcoin_block_height
-FROM updated_shares
-WHERE sbtc_signer.dkg_shares.aggregate_key = updated_shares.aggregate_key;
+    started_at_bitcoin_block_hash = block_times.block_hash
+  , started_at_bitcoin_block_height = block_times.block_height
+FROM block_times
+WHERE sbtc_signer.dkg_shares.created_at >= block_times.created_at
+  AND sbtc_signer.dkg_shares.created_at < block_times.ended_at;
 
--- Make the `dkg_shares_status_id` column `NOT NULL` now that they should all
--- have a value.
+-- Make the new column `NOT NULL` now that they should all have a value.
 ALTER TABLE sbtc_signer.dkg_shares
-    ALTER COLUMN dkg_shares_status_id SET NOT NULL;
+    ALTER COLUMN dkg_shares_status SET NOT NULL,
+    ALTER COLUMN started_at_bitcoin_block_hash SET NOT NULL,
+    ALTER COLUMN started_at_bitcoin_block_height SET NOT NULL;

--- a/signer/migrations/0012__dkg_verification_extensions.sql
+++ b/signer/migrations/0012__dkg_verification_extensions.sql
@@ -15,7 +15,7 @@ ALTER TABLE sbtc_signer.dkg_shares
 
 
 UPDATE sbtc_signer.dkg_shares
-SET dkg_shares_status_id = 'unverified';
+SET dkg_shares_status = 'unverified';
 
 -- These are all DKG shares associated scriptPubKeys that have been successfully spent
 UPDATE sbtc_signer.dkg_shares

--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -997,7 +997,7 @@ mod tests {
             public_shares: Vec::new(),
             signer_set_public_keys: vec![aggregate_key],
             signature_share_threshold: 1,
-            status: DkgSharesStatus::Unverified,
+            dkg_shares_status: DkgSharesStatus::Unverified,
             started_at_bitcoin_block_hash: block_hash.into(),
             started_at_bitcoin_block_height: 1,
         };

--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -997,7 +997,9 @@ mod tests {
             public_shares: Vec::new(),
             signer_set_public_keys: vec![aggregate_key],
             signature_share_threshold: 1,
-            status: DkgSharesStatus::Pending,
+            status: DkgSharesStatus::Unverified,
+            started_at_bitcoin_block_hash: block_hash.into(),
+            started_at_bitcoin_block_height: 1,
         };
         storage.write_encrypted_dkg_shares(&shares).await.unwrap();
 

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -22,11 +22,11 @@ pub enum Error {
 
     /// The DKG shares for the provided aggregate key have not been verified.
     #[error("the dkg shares for the provided aggregate key have not been verified: {0}")]
-    DkgSharesNotVerified(Box<PublicKeyXOnly>),
+    DkgSharesNotVerified(PublicKey),
 
     /// The DKG shares for the provided aggregate key have been revoked.
     #[error("the provided aggregate key has been revoked: {0}")]
-    DkgSharesRevoked(Box<PublicKeyXOnly>),
+    DkgSharesRevoked(PublicKey),
 
     /// An IO error was returned from the [`bitcoin`] library. This is usually an
     /// error that occurred during encoding/decoding of bitcoin types.

--- a/signer/src/stacks/contracts.rs
+++ b/signer/src/stacks/contracts.rs
@@ -1143,7 +1143,7 @@ impl AsContractCall for RotateKeysV1 {
         }
 
         // 4. That the DKG shares are in the verified state.
-        match latest_dkg.status {
+        match latest_dkg.dkg_shares_status {
             DkgSharesStatus::Unverified => {
                 return Err(Error::DkgSharesNotVerified(latest_dkg.aggregate_key));
             }

--- a/signer/src/stacks/contracts.rs
+++ b/signer/src/stacks/contracts.rs
@@ -1144,17 +1144,13 @@ impl AsContractCall for RotateKeysV1 {
 
         // 4. That the DKG shares are in the verified state.
         match latest_dkg.status {
-            DkgSharesStatus::Pending => {
-                return Err(Error::DkgSharesNotVerified(Box::new(
-                    latest_dkg.aggregate_key.into(),
-                )));
+            DkgSharesStatus::Unverified => {
+                return Err(Error::DkgSharesNotVerified(latest_dkg.aggregate_key));
             }
-            DkgSharesStatus::Revoked => {
-                return Err(Error::DkgSharesRevoked(Box::new(
-                    latest_dkg.aggregate_key.into(),
-                )));
+            DkgSharesStatus::Failed => {
+                return Err(Error::DkgSharesRevoked(latest_dkg.aggregate_key));
             }
-            DkgSharesStatus::Verified(_) => {}
+            DkgSharesStatus::Verified => {}
         }
 
         // 5. That the signature threshold matches the one that was used in the

--- a/signer/src/storage/in_memory.rs
+++ b/signer/src/storage/in_memory.rs
@@ -1278,25 +1278,29 @@ impl super::DbWrite for SharedStore {
         Ok(())
     }
 
-    async fn revoke_dkg_shares<X>(&self, aggregate_key: X) -> Result<(), Error>
+    async fn revoke_dkg_shares<X>(&self, aggregate_key: X) -> Result<bool, Error>
     where
         X: Into<PublicKeyXOnly> + Send,
     {
         let mut store = self.lock().await;
         if let Some((_, shares)) = store.encrypted_dkg_shares.get_mut(&aggregate_key.into()) {
             shares.dkg_shares_status = DkgSharesStatus::Failed;
+            Ok(true)
+        } else {
+            Ok(false)
         }
-        Ok(())
     }
 
-    async fn verify_dkg_shares<X>(&self, aggregate_key: X) -> Result<(), Error>
+    async fn verify_dkg_shares<X>(&self, aggregate_key: X) -> Result<bool, Error>
     where
         X: Into<PublicKeyXOnly> + Send,
     {
         let mut store = self.lock().await;
         if let Some((_, shares)) = store.encrypted_dkg_shares.get_mut(&aggregate_key.into()) {
             shares.dkg_shares_status = DkgSharesStatus::Verified;
+            Ok(true)
+        } else {
+            Ok(false)
         }
-        Ok(())
     }
 }

--- a/signer/src/storage/in_memory.rs
+++ b/signer/src/storage/in_memory.rs
@@ -1278,29 +1278,25 @@ impl super::DbWrite for SharedStore {
         Ok(())
     }
 
-    async fn revoke_dkg_shares<X>(&self, aggregate_key: X) -> Result<bool, Error>
+    async fn revoke_dkg_shares<X>(&self, aggregate_key: X) -> Result<(), Error>
     where
         X: Into<PublicKeyXOnly> + Send,
     {
         let mut store = self.lock().await;
         if let Some((_, shares)) = store.encrypted_dkg_shares.get_mut(&aggregate_key.into()) {
             shares.dkg_shares_status = DkgSharesStatus::Failed;
-            Ok(true)
-        } else {
-            Ok(false)
         }
+        Ok(())
     }
 
-    async fn verify_dkg_shares<X>(&self, aggregate_key: X) -> Result<bool, Error>
+    async fn verify_dkg_shares<X>(&self, aggregate_key: X) -> Result<(), Error>
     where
         X: Into<PublicKeyXOnly> + Send,
     {
         let mut store = self.lock().await;
         if let Some((_, shares)) = store.encrypted_dkg_shares.get_mut(&aggregate_key.into()) {
             shares.dkg_shares_status = DkgSharesStatus::Verified;
-            Ok(true)
-        } else {
-            Ok(false)
         }
+        Ok(())
     }
 }

--- a/signer/src/storage/in_memory.rs
+++ b/signer/src/storage/in_memory.rs
@@ -1284,7 +1284,7 @@ impl super::DbWrite for SharedStore {
     {
         let mut store = self.lock().await;
         if let Some((_, shares)) = store.encrypted_dkg_shares.get_mut(&aggregate_key.into()) {
-            shares.status = DkgSharesStatus::Revoked;
+            shares.status = DkgSharesStatus::Failed;
             Ok(true)
         } else {
             Ok(false)
@@ -1301,7 +1301,7 @@ impl super::DbWrite for SharedStore {
     {
         let mut store = self.lock().await;
         if let Some((_, shares)) = store.encrypted_dkg_shares.get_mut(&aggregate_key.into()) {
-            shares.status = DkgSharesStatus::Verified(*bitcoin_block);
+            shares.status = DkgSharesStatus::Verified;
             Ok(true)
         } else {
             Ok(false)

--- a/signer/src/storage/in_memory.rs
+++ b/signer/src/storage/in_memory.rs
@@ -1291,11 +1291,7 @@ impl super::DbWrite for SharedStore {
         }
     }
 
-    async fn verify_dkg_shares<X>(
-        &self,
-        aggregate_key: X,
-        bitcoin_block: &model::BitcoinBlockRef,
-    ) -> Result<bool, Error>
+    async fn verify_dkg_shares<X>(&self, aggregate_key: X) -> Result<bool, Error>
     where
         X: Into<PublicKeyXOnly> + Send,
     {

--- a/signer/src/storage/in_memory.rs
+++ b/signer/src/storage/in_memory.rs
@@ -1284,7 +1284,7 @@ impl super::DbWrite for SharedStore {
     {
         let mut store = self.lock().await;
         if let Some((_, shares)) = store.encrypted_dkg_shares.get_mut(&aggregate_key.into()) {
-            shares.status = DkgSharesStatus::Failed;
+            shares.dkg_shares_status = DkgSharesStatus::Failed;
             Ok(true)
         } else {
             Ok(false)
@@ -1297,7 +1297,7 @@ impl super::DbWrite for SharedStore {
     {
         let mut store = self.lock().await;
         if let Some((_, shares)) = store.encrypted_dkg_shares.get_mut(&aggregate_key.into()) {
-            shares.status = DkgSharesStatus::Verified;
+            shares.dkg_shares_status = DkgSharesStatus::Verified;
             Ok(true)
         } else {
             Ok(false)

--- a/signer/src/storage/mod.rs
+++ b/signer/src/storage/mod.rs
@@ -516,7 +516,6 @@ pub trait DbWrite {
     fn verify_dkg_shares<X>(
         &self,
         aggregate_key: X,
-        bitcoin_block: &model::BitcoinBlockRef,
     ) -> impl Future<Output = Result<bool, Error>> + Send
     where
         X: Into<PublicKeyXOnly> + Send;

--- a/signer/src/storage/mod.rs
+++ b/signer/src/storage/mod.rs
@@ -507,7 +507,7 @@ pub trait DbWrite {
     fn revoke_dkg_shares<X>(
         &self,
         aggregate_key: X,
-    ) -> impl Future<Output = Result<(), Error>> + Send
+    ) -> impl Future<Output = Result<bool, Error>> + Send
     where
         X: Into<PublicKeyXOnly> + Send;
 
@@ -516,7 +516,7 @@ pub trait DbWrite {
     fn verify_dkg_shares<X>(
         &self,
         aggregate_key: X,
-    ) -> impl Future<Output = Result<(), Error>> + Send
+    ) -> impl Future<Output = Result<bool, Error>> + Send
     where
         X: Into<PublicKeyXOnly> + Send;
 }

--- a/signer/src/storage/mod.rs
+++ b/signer/src/storage/mod.rs
@@ -507,7 +507,7 @@ pub trait DbWrite {
     fn revoke_dkg_shares<X>(
         &self,
         aggregate_key: X,
-    ) -> impl Future<Output = Result<bool, Error>> + Send
+    ) -> impl Future<Output = Result<(), Error>> + Send
     where
         X: Into<PublicKeyXOnly> + Send;
 
@@ -516,7 +516,7 @@ pub trait DbWrite {
     fn verify_dkg_shares<X>(
         &self,
         aggregate_key: X,
-    ) -> impl Future<Output = Result<bool, Error>> + Send
+    ) -> impl Future<Output = Result<(), Error>> + Send
     where
         X: Into<PublicKeyXOnly> + Send;
 }

--- a/signer/src/storage/model.rs
+++ b/signer/src/storage/model.rs
@@ -464,7 +464,7 @@ pub struct EncryptedDkgShares {
     #[sqlx(try_from = "i32")]
     pub signature_share_threshold: u16,
     /// The current status of the DKG shares.
-    pub status: DkgSharesStatus,
+    pub dkg_shares_status: DkgSharesStatus,
     /// The block hash of the chain tip of the canonical bitcoin blockchain
     /// when the DKG round associated with these shares started.
     pub started_at_bitcoin_block_hash: BitcoinBlockHash,

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -1491,8 +1491,8 @@ impl super::DbRead for PgStore {
               , signer_set_public_keys
               , signature_share_threshold
               , dkg_shares_status
-              , verified_at_bitcoin_block_hash
-              , verified_at_bitcoin_block_height
+              , started_at_bitcoin_block_hash
+              , started_at_bitcoin_block_height
             FROM sbtc_signer.dkg_shares
             WHERE substring(aggregate_key FROM 2) = $1;
             "#,
@@ -1517,8 +1517,8 @@ impl super::DbRead for PgStore {
               , signer_set_public_keys
               , signature_share_threshold
               , dkg_shares_status
-              , verified_at_bitcoin_block_hash
-              , verified_at_bitcoin_block_height
+              , started_at_bitcoin_block_hash
+              , started_at_bitcoin_block_height
             FROM sbtc_signer.dkg_shares
             ORDER BY created_at DESC
             LIMIT 1;
@@ -2450,8 +2450,8 @@ impl super::DbWrite for PgStore {
               , signer_set_public_keys
               , signature_share_threshold
               , dkg_shares_status
-              , verified_at_bitcoin_block_hash
-              , verified_at_bitcoin_block_height
+              , started_at_bitcoin_block_hash
+              , started_at_bitcoin_block_height
             )
             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
             ON CONFLICT DO NOTHING"#,

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -2463,7 +2463,7 @@ impl super::DbWrite for PgStore {
         .bind(&shares.script_pubkey)
         .bind(&shares.signer_set_public_keys)
         .bind(i32::from(shares.signature_share_threshold))
-        .bind(shares.status)
+        .bind(shares.dkg_shares_status)
         .bind(shares.started_at_bitcoin_block_hash)
         .bind(started_at_bitcoin_block_height)
         .execute(&self.0)

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -2869,11 +2869,11 @@ impl super::DbWrite for PgStore {
         Ok(())
     }
 
-    async fn revoke_dkg_shares<X>(&self, aggregate_key: X) -> Result<bool, Error>
+    async fn revoke_dkg_shares<X>(&self, aggregate_key: X) -> Result<(), Error>
     where
         X: Into<PublicKeyXOnly> + Send,
     {
-        let result = sqlx::query(
+        sqlx::query(
             r#"
             UPDATE sbtc_signer.dkg_shares
             SET dkg_shares_status = 'failed'
@@ -2884,16 +2884,15 @@ impl super::DbWrite for PgStore {
         .bind(aggregate_key.into())
         .execute(&self.0)
         .await
-        .map_err(Error::SqlxQuery)?;
-
-        Ok(result.rows_affected() > 0)
+        .map(|_| ())
+        .map_err(Error::SqlxQuery)
     }
 
-    async fn verify_dkg_shares<X>(&self, aggregate_key: X) -> Result<bool, Error>
+    async fn verify_dkg_shares<X>(&self, aggregate_key: X) -> Result<(), Error>
     where
         X: Into<PublicKeyXOnly> + Send,
     {
-        let result = sqlx::query(
+        sqlx::query(
             r#"
             UPDATE sbtc_signer.dkg_shares
             SET dkg_shares_status = 'verified'
@@ -2904,10 +2903,8 @@ impl super::DbWrite for PgStore {
         .bind(aggregate_key.into())
         .execute(&self.0)
         .await
-        .map_err(Error::SqlxQuery)?;
-
-        //
-        Ok(result.rows_affected() > 0)
+        .map(|_| ())
+        .map_err(Error::SqlxQuery)
     }
 }
 

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -2869,7 +2869,7 @@ impl super::DbWrite for PgStore {
         Ok(())
     }
 
-    async fn revoke_dkg_shares<X>(&self, aggregate_key: X) -> Result<(), Error>
+    async fn revoke_dkg_shares<X>(&self, aggregate_key: X) -> Result<bool, Error>
     where
         X: Into<PublicKeyXOnly> + Send,
     {
@@ -2884,11 +2884,11 @@ impl super::DbWrite for PgStore {
         .bind(aggregate_key.into())
         .execute(&self.0)
         .await
-        .map(|_| ())
+        .map(|res| res.rows_affected() > 0)
         .map_err(Error::SqlxQuery)
     }
 
-    async fn verify_dkg_shares<X>(&self, aggregate_key: X) -> Result<(), Error>
+    async fn verify_dkg_shares<X>(&self, aggregate_key: X) -> Result<bool, Error>
     where
         X: Into<PublicKeyXOnly> + Send,
     {
@@ -2903,7 +2903,7 @@ impl super::DbWrite for PgStore {
         .bind(aggregate_key.into())
         .execute(&self.0)
         .await
-        .map(|_| ())
+        .map(|res| res.rows_affected() > 0)
         .map_err(Error::SqlxQuery)
     }
 }

--- a/signer/src/storage/sqlx.rs
+++ b/signer/src/storage/sqlx.rs
@@ -12,9 +12,6 @@ use bitcoin::hashes::Hash as _;
 use sqlx::encode::IsNull;
 use sqlx::error::BoxDynError;
 use sqlx::postgres::PgArgumentBuffer;
-use sqlx::postgres::PgRow;
-use sqlx::FromRow;
-use sqlx::Row as _;
 
 use crate::keys::PublicKey;
 use crate::keys::PublicKeyXOnly;
@@ -26,10 +23,6 @@ use crate::storage::model::SigHash;
 use crate::storage::model::StacksBlockHash;
 use crate::storage::model::StacksPrincipal;
 use crate::storage::model::StacksTxId;
-
-use super::model::BitcoinBlockRef;
-use super::model::DkgSharesStatus;
-use super::model::EncryptedDkgShares;
 
 // For the [`ScriptPubKey`]
 
@@ -311,68 +304,5 @@ impl<'r> sqlx::Encode<'r, sqlx::Postgres> for SigHash {
 impl sqlx::postgres::PgHasArrayType for SigHash {
     fn array_type_info() -> sqlx::postgres::PgTypeInfo {
         <[u8; 32] as sqlx::postgres::PgHasArrayType>::array_type_info()
-    }
-}
-
-impl<'r> FromRow<'r, PgRow> for EncryptedDkgShares {
-    fn from_row(row: &'r PgRow) -> Result<Self, sqlx::Error> {
-        let block_hash: Option<Vec<u8>> =
-            row.try_get(EncryptedDkgShares::VERIFIED_AT_BITCOIN_BLOCK_HASH)?;
-        let block_height: Option<i64> =
-            row.try_get(EncryptedDkgShares::VERIFIED_AT_BITCOIN_BLOCK_HEIGHT)?;
-
-        let verified_at_bitcoin_block = block_hash
-            .zip(block_height)
-            .map(|(hash, height)| {
-                let hash: [u8; 32] = hash
-                    .as_slice()
-                    .try_into()
-                    .map_err(|e| sqlx::Error::Decode(Box::new(e)))?;
-                Ok::<BitcoinBlockRef, sqlx::Error>(BitcoinBlockRef {
-                    block_hash: hash.into(),
-                    block_height: height as u64,
-                })
-            })
-            .transpose()?;
-
-        let status_id: i32 = row.try_get(EncryptedDkgShares::DKG_SHARES_STATUS_ID)?;
-        let status = match status_id {
-            0 => DkgSharesStatus::Pending,
-            1 => {
-                let verified_at_bitcoin_block = verified_at_bitcoin_block.ok_or_else(|| {
-                    let message = format!(
-                        "{} is '1' but {} or {} is NULL",
-                        EncryptedDkgShares::DKG_SHARES_STATUS_ID,
-                        EncryptedDkgShares::VERIFIED_AT_BITCOIN_BLOCK_HASH,
-                        EncryptedDkgShares::VERIFIED_AT_BITCOIN_BLOCK_HEIGHT
-                    );
-                    sqlx::Error::Decode(Box::new(crate::error::Error::SqlxFromRow(message.into())))
-                })?;
-                DkgSharesStatus::Verified(verified_at_bitcoin_block)
-            }
-            2 => DkgSharesStatus::Revoked,
-            _ => {
-                let message = format!(
-                    "{} is not in [0, 1, 2]",
-                    EncryptedDkgShares::DKG_SHARES_STATUS_ID
-                );
-                return Err(sqlx::Error::Decode(Box::new(
-                    crate::error::Error::SqlxFromRow(message.into()),
-                )));
-            }
-        };
-
-        Ok(Self {
-            aggregate_key: row.try_get(EncryptedDkgShares::AGGREGATE_KEY)?,
-            tweaked_aggregate_key: row.try_get(EncryptedDkgShares::TWEAKED_AGGREGATE_KEY)?,
-            script_pubkey: row.try_get(EncryptedDkgShares::SCRIPT_PUBKEY)?,
-            encrypted_private_shares: row.try_get(EncryptedDkgShares::ENCRYPTED_PRIVATE_SHARES)?,
-            public_shares: row.try_get(EncryptedDkgShares::PUBLIC_SHARES)?,
-            signer_set_public_keys: row.try_get(EncryptedDkgShares::SIGNER_SET_PUBLIC_KEYS)?,
-            signature_share_threshold: row
-                .try_get::<i32, _>(EncryptedDkgShares::SIGNATURE_SHARE_THRESHOLD)?
-                as u16,
-            status,
-        })
     }
 }

--- a/signer/src/testing/dummy.rs
+++ b/signer/src/testing/dummy.rs
@@ -274,7 +274,7 @@ pub fn encrypted_dkg_shares<R: rand::RngCore + rand::CryptoRng>(
         script_pubkey: group_key.signers_script_pubkey().into(),
         signer_set_public_keys: vec![fake::Faker.fake_with_rng(rng)],
         signature_share_threshold: 1,
-        status,
+        dkg_shares_status: status,
         started_at_bitcoin_block_hash: Faker.fake_with_rng(rng),
         started_at_bitcoin_block_height: Faker.fake_with_rng::<u32, _>(rng) as u64,
     }
@@ -446,7 +446,7 @@ impl fake::Dummy<SignerSetConfig> for EncryptedDkgShares {
             public_shares: Vec::new(),
             signer_set_public_keys,
             signature_share_threshold: config.signatures_required,
-            status: DkgSharesStatus::Verified,
+            dkg_shares_status: DkgSharesStatus::Verified,
             started_at_bitcoin_block_hash: Faker.fake_with_rng(rng),
             started_at_bitcoin_block_height: Faker.fake_with_rng::<u32, _>(rng) as u64,
         }

--- a/signer/src/testing/dummy.rs
+++ b/signer/src/testing/dummy.rs
@@ -275,6 +275,8 @@ pub fn encrypted_dkg_shares<R: rand::RngCore + rand::CryptoRng>(
         signer_set_public_keys: vec![fake::Faker.fake_with_rng(rng)],
         signature_share_threshold: 1,
         status,
+        started_at_bitcoin_block_hash: Faker.fake_with_rng(rng),
+        started_at_bitcoin_block_height: Faker.fake_with_rng::<u32, _>(rng) as u64,
     }
 }
 
@@ -444,7 +446,9 @@ impl fake::Dummy<SignerSetConfig> for EncryptedDkgShares {
             public_shares: Vec::new(),
             signer_set_public_keys,
             signature_share_threshold: config.signatures_required,
-            status: DkgSharesStatus::Verified(Faker.fake_with_rng(rng)),
+            status: DkgSharesStatus::Verified,
+            started_at_bitcoin_block_hash: Faker.fake_with_rng(rng),
+            started_at_bitcoin_block_height: Faker.fake_with_rng::<u32, _>(rng) as u64,
         }
     }
 }

--- a/signer/src/testing/request_decider.rs
+++ b/signer/src/testing/request_decider.rs
@@ -178,7 +178,7 @@ where
             &handle.context.get_storage_mut(),
             group_key,
             signer_set.clone(),
-            DkgSharesStatus::Verified(test_data.bitcoin_blocks[0].clone().into()),
+            DkgSharesStatus::Verified,
         )
         .await;
 
@@ -344,7 +344,7 @@ where
                 &handle.context.get_storage_mut(),
                 group_key,
                 signer_set.clone(),
-                DkgSharesStatus::Verified(test_data.bitcoin_blocks[0].clone().into()),
+                DkgSharesStatus::Verified,
             )
             .await;
         }

--- a/signer/src/testing/wsts.rs
+++ b/signer/src/testing/wsts.rs
@@ -420,6 +420,11 @@ impl SignerSet {
             self.signers.push(signer)
         }
 
+        let started_at = model::BitcoinBlockRef {
+            block_hash: bitcoin_chain_tip,
+            block_height: 0,
+        };
+
         (
             aggregate_key,
             self.signers
@@ -427,7 +432,7 @@ impl SignerSet {
                 .map(|signer| {
                     signer
                         .wsts_signer
-                        .get_encrypted_dkg_shares(rng)
+                        .get_encrypted_dkg_shares(rng, &started_at)
                         .expect("failed to get encrypted shares")
                 })
                 .collect(),

--- a/signer/src/wsts_state_machine.rs
+++ b/signer/src/wsts_state_machine.rs
@@ -41,15 +41,15 @@ use wsts::v2::Aggregator;
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum StateMachineId {
     /// Identifier for a DKG state machines
-    Dkg(model::BitcoinBlockHash),
+    Dkg(model::BitcoinBlockRef),
     /// Identifier for a Bitcoin signing state machines
     BitcoinSign(SigHash),
     /// Identifier for a rotate key verification signing round
     RotateKey(PublicKeyXOnly, model::BitcoinBlockHash),
 }
 
-impl From<&model::BitcoinBlockHash> for StateMachineId {
-    fn from(value: &model::BitcoinBlockHash) -> Self {
+impl From<&model::BitcoinBlockRef> for StateMachineId {
+    fn from(value: &model::BitcoinBlockRef) -> Self {
         StateMachineId::Dkg(*value)
     }
 }
@@ -485,6 +485,7 @@ impl SignerStateMachine {
     pub fn get_encrypted_dkg_shares<Rng: rand::CryptoRng + rand::RngCore>(
         &self,
         rng: &mut Rng,
+        started_at: &model::BitcoinBlockRef,
     ) -> Result<model::EncryptedDkgShares, error::Error> {
         let saved_state = self.signer.save();
         let aggregate_key = PublicKey::try_from(&saved_state.group_key)?;
@@ -524,7 +525,9 @@ impl SignerStateMachine {
             public_shares,
             signer_set_public_keys,
             signature_share_threshold,
-            status: DkgSharesStatus::Pending,
+            status: DkgSharesStatus::Unverified,
+            started_at_bitcoin_block_hash: started_at.block_hash,
+            started_at_bitcoin_block_height: started_at.block_height,
         })
     }
 }

--- a/signer/src/wsts_state_machine.rs
+++ b/signer/src/wsts_state_machine.rs
@@ -525,7 +525,7 @@ impl SignerStateMachine {
             public_shares,
             signer_set_public_keys,
             signature_share_threshold,
-            status: DkgSharesStatus::Unverified,
+            dkg_shares_status: DkgSharesStatus::Unverified,
             started_at_bitcoin_block_hash: started_at.block_hash,
             started_at_bitcoin_block_height: started_at.block_height,
         })

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -1325,7 +1325,7 @@ async fn fetching_deposit_request_votes() {
         signatures_required: 4,
     };
     let shares = EncryptedDkgShares {
-        status: DkgSharesStatus::Unverified,
+        dkg_shares_status: DkgSharesStatus::Unverified,
         ..signer_set_config.fake_with_rng(&mut rng)
     };
 
@@ -1540,7 +1540,7 @@ async fn fetching_withdrawal_request_votes() {
         signatures_required: 4,
     };
     let shares = EncryptedDkgShares {
-        status: DkgSharesStatus::Unverified,
+        dkg_shares_status: DkgSharesStatus::Unverified,
         ..signer_set_config.fake_with_rng(&mut rng)
     };
 
@@ -1787,7 +1787,7 @@ async fn is_signer_script_pub_key_checks_dkg_shares_for_script_pubkeys() {
         aggregate_key,
         signer_set_public_keys: vec![fake::Faker.fake_with_rng(&mut rng)],
         signature_share_threshold: 1,
-        status: Faker.fake_with_rng(&mut rng),
+        dkg_shares_status: Faker.fake_with_rng(&mut rng),
         started_at_bitcoin_block_hash: fake::Faker.fake_with_rng(&mut rng),
         started_at_bitcoin_block_height: fake::Faker.fake_with_rng::<u32, _>(&mut rng) as u64,
     };
@@ -3397,7 +3397,7 @@ async fn write_and_get_dkg_shares_is_pending() {
         public_shares: vec![],
         signer_set_public_keys: vec![],
         signature_share_threshold: 1,
-        status: DkgSharesStatus::Unverified,
+        dkg_shares_status: DkgSharesStatus::Unverified,
         ..fake::Faker.fake()
     };
 
@@ -3420,7 +3420,7 @@ async fn verify_dkg_shares_succeeds() {
 
     // We start with a pending entry.
     let insert = EncryptedDkgShares {
-        status: DkgSharesStatus::Unverified,
+        dkg_shares_status: DkgSharesStatus::Unverified,
         ..Faker.fake()
     };
 
@@ -3452,7 +3452,7 @@ async fn verify_dkg_shares_succeeds() {
     // Assert that the status is now verified and that the block hash and height
     // are correct, and that the rest of the fields remain the same.
     let compare = EncryptedDkgShares {
-        status: DkgSharesStatus::Verified,
+        dkg_shares_status: DkgSharesStatus::Verified,
         ..insert.clone()
     };
     assert_eq!(select, compare);
@@ -3466,7 +3466,7 @@ async fn revoke_dkg_shares_succeeds() {
 
     // We start with a pending entry.
     let insert = EncryptedDkgShares {
-        status: DkgSharesStatus::Unverified,
+        dkg_shares_status: DkgSharesStatus::Unverified,
         ..Faker.fake()
     };
 
@@ -3499,7 +3499,7 @@ async fn revoke_dkg_shares_succeeds() {
     // Assert that the status is now revoked and that the rest of the fields
     // remain the same.
     let compare = EncryptedDkgShares {
-        status: DkgSharesStatus::Failed,
+        dkg_shares_status: DkgSharesStatus::Failed,
         ..insert.clone()
     };
     assert_eq!(select, compare);
@@ -3513,7 +3513,7 @@ async fn revoke_verified_dkg_shares_succeeds() {
 
     // We start with a pending entry.
     let insert = EncryptedDkgShares {
-        status: DkgSharesStatus::Unverified,
+        dkg_shares_status: DkgSharesStatus::Unverified,
         ..Faker.fake()
     };
 
@@ -3559,7 +3559,7 @@ async fn revoke_verified_dkg_shares_succeeds() {
     // Assert that the status is now revoked and that the rest of the fields
     // remain the same.
     let compare = EncryptedDkgShares {
-        status: DkgSharesStatus::Failed,
+        dkg_shares_status: DkgSharesStatus::Failed,
         ..insert.clone()
     };
     assert_eq!(select, compare);
@@ -3591,7 +3591,7 @@ async fn verify_revoked_dkg_shares_fails() {
 
     // We start with a pending entry.
     let insert = EncryptedDkgShares {
-        status: DkgSharesStatus::Unverified,
+        dkg_shares_status: DkgSharesStatus::Unverified,
         ..Faker.fake()
     };
 
@@ -3636,7 +3636,7 @@ async fn verify_revoked_dkg_shares_fails() {
     // Assert that the status is still revoked and that the rest of the fields
     // remain the same.
     let compare = EncryptedDkgShares {
-        status: DkgSharesStatus::Failed,
+        dkg_shares_status: DkgSharesStatus::Failed,
         ..insert.clone()
     };
     assert_eq!(select, compare);

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -3436,7 +3436,7 @@ async fn verify_dkg_shares_succeeds() {
 
     // Now try to verify.
     let result = db
-        .verify_dkg_shares(insert.aggregate_key, &block.clone().into())
+        .verify_dkg_shares(insert.aggregate_key)
         .await
         .expect("failed to mark shares as verified");
 
@@ -3529,7 +3529,7 @@ async fn revoke_verified_dkg_shares_succeeds() {
 
     // Now try to verify.
     let result = db
-        .verify_dkg_shares(insert.aggregate_key, &block.clone().into())
+        .verify_dkg_shares(insert.aggregate_key)
         .await
         .expect("failed to mark shares as verified");
 
@@ -3618,7 +3618,7 @@ async fn verify_revoked_dkg_shares_fails() {
 
     // Now try to verify. This should fail.
     let result = db
-        .verify_dkg_shares(insert.aggregate_key, &block.clone().into())
+        .verify_dkg_shares(insert.aggregate_key)
         .await
         .expect("failed to mark shares as verified");
 

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -3433,7 +3433,8 @@ async fn verify_dkg_shares_succeeds() {
     db.write_encrypted_dkg_shares(&insert).await.unwrap();
 
     // Now to verify the shares.
-    db.verify_dkg_shares(insert.aggregate_key).await.unwrap();
+    let result = db.verify_dkg_shares(insert.aggregate_key).await.unwrap();
+    assert!(result, "verify failed, when it should succeed");
 
     // Get the dkg_shares entry.
     let select = db
@@ -3467,7 +3468,8 @@ async fn revoke_dkg_shares_succeeds() {
     db.write_encrypted_dkg_shares(&insert).await.unwrap();
 
     // Now try to fail the keys.
-    db.revoke_dkg_shares(insert.aggregate_key).await.unwrap();
+    let result = db.revoke_dkg_shares(insert.aggregate_key).await.unwrap();
+    assert!(result, "revoke failed, when it should succeed");
 
     // Get the dkg_shares entry we just inserted.
     let select = db
@@ -3502,7 +3504,8 @@ async fn verification_status_one_way_street() {
     db.write_encrypted_dkg_shares(&insert).await.unwrap();
 
     // Now try to verify.
-    db.verify_dkg_shares(insert.aggregate_key).await.unwrap();
+    let result = db.verify_dkg_shares(insert.aggregate_key).await.unwrap();
+    assert!(result, "verify failed, when it should succeed");
 
     let select1 = db
         .get_encrypted_dkg_shares(insert.aggregate_key)
@@ -3514,7 +3517,8 @@ async fn verification_status_one_way_street() {
 
     // Now try to revoke. This shouldn't have any effect because we have
     // verified the shares already.
-    db.revoke_dkg_shares(insert.aggregate_key).await.unwrap();
+    let result = db.revoke_dkg_shares(insert.aggregate_key).await.unwrap();
+    assert!(!result, "revoking succeeded, when it should fail");
 
     // Get the dkg_shares entry we just inserted.
     let select2 = db
@@ -3541,7 +3545,8 @@ async fn verification_status_one_way_street() {
     db.write_encrypted_dkg_shares(&insert).await.unwrap();
 
     // Now try to revoke.
-    db.revoke_dkg_shares(insert.aggregate_key).await.unwrap();
+    let result = db.revoke_dkg_shares(insert.aggregate_key).await.unwrap();
+    assert!(result, "revoke failed, when it should succeed");
 
     let select1 = db
         .get_encrypted_dkg_shares(insert.aggregate_key)
@@ -3553,7 +3558,8 @@ async fn verification_status_one_way_street() {
 
     // Now try to verify them. This should be a no-op, since the keys have
     // already been marked as failed.
-    db.verify_dkg_shares(insert.aggregate_key).await.unwrap();
+    let result = db.verify_dkg_shares(insert.aggregate_key).await.unwrap();
+    assert!(!result, "verify succeeded, when it should fail");
 
     // Get the dkg_shares entry we just inserted.
     let select2 = db

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -3569,7 +3569,7 @@ async fn revoke_verified_dkg_shares_succeeds() {
     let aggregate_key: PublicKeyXOnly = insert.aggregate_key.into();
     let (block_hash, block_height): (Option<Vec<u8>>, Option<i64>) = sqlx::query_as(
         r#"
-            SELECT verified_at_bitcoin_block_hash, verified_at_bitcoin_block_height
+            SELECT started_at_bitcoin_block_hash, started_at_bitcoin_block_height
             FROM sbtc_signer.dkg_shares
             WHERE substring(aggregate_key FROM 2) = $1
             "#,

--- a/signer/tests/integration/rotate_keys.rs
+++ b/signer/tests/integration/rotate_keys.rs
@@ -118,7 +118,7 @@ impl TestRotateKeySetup {
             aggregate_key,
             signer_set_public_keys: self.signer_keys.clone(),
             signature_share_threshold: self.signatures_required,
-            status: DkgSharesStatus::Verified,
+            dkg_shares_status: DkgSharesStatus::Verified,
             started_at_bitcoin_block_hash: self.chain_tip.block_hash,
             started_at_bitcoin_block_height: self.chain_tip.block_height,
         };

--- a/signer/tests/integration/rotate_keys.rs
+++ b/signer/tests/integration/rotate_keys.rs
@@ -44,6 +44,7 @@ struct TestRotateKeySetup {
     /// Bitcoin chain tip used when generating current setup
     pub chain_tip: BitcoinBlock,
 }
+
 impl TestRotateKeySetup {
     pub async fn new<R>(
         db: &PgStore,
@@ -108,7 +109,6 @@ impl TestRotateKeySetup {
     /// Store mocked shares in dkg_shares table.
     pub async fn store_dkg_shares(&self, db: &PgStore) {
         let aggregate_key: PublicKey = self.aggregate_key();
-        let verified_at_block = self.chain_tip.clone().into();
 
         let shares = EncryptedDkgShares {
             script_pubkey: aggregate_key.signers_script_pubkey().into(),
@@ -118,7 +118,9 @@ impl TestRotateKeySetup {
             aggregate_key,
             signer_set_public_keys: self.signer_keys.clone(),
             signature_share_threshold: self.signatures_required,
-            status: DkgSharesStatus::Verified(verified_at_block),
+            status: DkgSharesStatus::Verified,
+            started_at_bitcoin_block_hash: self.chain_tip.block_hash,
+            started_at_bitcoin_block_height: self.chain_tip.block_height,
         };
         db.write_encrypted_dkg_shares(&shares).await.unwrap();
     }

--- a/signer/tests/integration/setup.rs
+++ b/signer/tests/integration/setup.rs
@@ -380,7 +380,7 @@ impl TestSweepSetup {
             aggregate_key,
             signer_set_public_keys: self.signer_keys.clone(),
             signature_share_threshold: self.signatures_required,
-            status: model::DkgSharesStatus::Verified,
+            dkg_shares_status: model::DkgSharesStatus::Verified,
             started_at_bitcoin_block_hash: self.deposit_block_hash.into(),
             started_at_bitcoin_block_height: 0,
         };
@@ -981,7 +981,7 @@ impl TestSweepSetup2 {
             aggregate_key,
             signer_set_public_keys: self.signers.keys.clone(),
             signature_share_threshold: self.signatures_required,
-            status: model::DkgSharesStatus::Verified,
+            dkg_shares_status: model::DkgSharesStatus::Verified,
             started_at_bitcoin_block_hash: self.deposit_block_hash.into(),
             started_at_bitcoin_block_height: 0,
         };

--- a/signer/tests/integration/setup.rs
+++ b/signer/tests/integration/setup.rs
@@ -36,7 +36,6 @@ use signer::keys::PublicKey;
 use signer::keys::SignerScriptPubKey;
 use signer::storage::model;
 use signer::storage::model::BitcoinBlockHash;
-use signer::storage::model::BitcoinBlockRef;
 use signer::storage::model::BitcoinTxRef;
 use signer::storage::model::EncryptedDkgShares;
 use signer::storage::model::QualifiedRequestId;
@@ -373,10 +372,6 @@ impl TestSweepSetup {
     /// associated with the signers aggregate key.
     pub async fn store_dkg_shares(&self, db: &PgStore) {
         let aggregate_key: PublicKey = self.aggregated_signer.keypair.public_key().into();
-        let verified_at = BitcoinBlockRef {
-            block_hash: self.deposit_block_hash.into(),
-            block_height: 0,
-        };
         let shares = EncryptedDkgShares {
             script_pubkey: aggregate_key.signers_script_pubkey().into(),
             tweaked_aggregate_key: aggregate_key.signers_tweaked_pubkey().unwrap(),
@@ -385,7 +380,9 @@ impl TestSweepSetup {
             aggregate_key,
             signer_set_public_keys: self.signer_keys.clone(),
             signature_share_threshold: self.signatures_required,
-            status: model::DkgSharesStatus::Verified(verified_at),
+            status: model::DkgSharesStatus::Verified,
+            started_at_bitcoin_block_hash: self.deposit_block_hash.into(),
+            started_at_bitcoin_block_height: 0,
         };
         db.write_encrypted_dkg_shares(&shares).await.unwrap();
     }
@@ -976,11 +973,6 @@ impl TestSweepSetup2 {
                 .expect("failed to encrypt");
         let public_shares: BTreeMap<u32, wsts::net::DkgPublicShares> = BTreeMap::new();
 
-        let verified_at = BitcoinBlockRef {
-            block_hash: self.deposit_block_hash.into(),
-            block_height: 0,
-        };
-
         let shares = EncryptedDkgShares {
             script_pubkey: aggregate_key.signers_script_pubkey().into(),
             tweaked_aggregate_key: aggregate_key.signers_tweaked_pubkey().unwrap(),
@@ -989,7 +981,9 @@ impl TestSweepSetup2 {
             aggregate_key,
             signer_set_public_keys: self.signers.keys.clone(),
             signature_share_threshold: self.signatures_required,
-            status: model::DkgSharesStatus::Verified(verified_at),
+            status: model::DkgSharesStatus::Verified,
+            started_at_bitcoin_block_hash: self.deposit_block_hash.into(),
+            started_at_bitcoin_block_height: 0,
         };
         db.write_encrypted_dkg_shares(&shares).await.unwrap();
     }

--- a/signer/tests/integration/transaction_coordinator.rs
+++ b/signer/tests/integration/transaction_coordinator.rs
@@ -1101,7 +1101,7 @@ async fn run_subsequent_dkg() {
         db.write_encrypted_dkg_shares(&EncryptedDkgShares {
             aggregate_key: aggregate_key_1,
             signer_set_public_keys: signer_set_public_keys.iter().copied().collect(),
-            status: DkgSharesStatus::Verified(data.bitcoin_blocks[0].clone().into()),
+            status: DkgSharesStatus::Verified,
             ..Faker.fake()
         })
         .await
@@ -2677,7 +2677,7 @@ async fn test_get_btc_state_with_no_available_sweep_transactions() {
     let dkg_shares = model::EncryptedDkgShares {
         aggregate_key: aggregate_key.clone(),
         script_pubkey: aggregate_key.signers_script_pubkey().into(),
-        status: DkgSharesStatus::Pending,
+        status: DkgSharesStatus::Unverified,
         ..Faker.fake_with_rng(&mut rng)
     };
     db.write_encrypted_dkg_shares(&dkg_shares).await.unwrap();
@@ -2812,7 +2812,7 @@ async fn test_get_btc_state_with_available_sweep_transactions_and_rbf() {
     let dkg_shares = model::EncryptedDkgShares {
         aggregate_key: aggregate_key.clone(),
         script_pubkey: aggregate_key.signers_script_pubkey().into(),
-        status: DkgSharesStatus::Pending,
+        status: DkgSharesStatus::Unverified,
         ..Faker.fake_with_rng(&mut rng)
     };
     db.write_encrypted_dkg_shares(&dkg_shares).await.unwrap();

--- a/signer/tests/integration/transaction_coordinator.rs
+++ b/signer/tests/integration/transaction_coordinator.rs
@@ -1101,7 +1101,7 @@ async fn run_subsequent_dkg() {
         db.write_encrypted_dkg_shares(&EncryptedDkgShares {
             aggregate_key: aggregate_key_1,
             signer_set_public_keys: signer_set_public_keys.iter().copied().collect(),
-            status: DkgSharesStatus::Verified,
+            dkg_shares_status: DkgSharesStatus::Verified,
             ..Faker.fake()
         })
         .await
@@ -2677,7 +2677,7 @@ async fn test_get_btc_state_with_no_available_sweep_transactions() {
     let dkg_shares = model::EncryptedDkgShares {
         aggregate_key: aggregate_key.clone(),
         script_pubkey: aggregate_key.signers_script_pubkey().into(),
-        status: DkgSharesStatus::Unverified,
+        dkg_shares_status: DkgSharesStatus::Unverified,
         ..Faker.fake_with_rng(&mut rng)
     };
     db.write_encrypted_dkg_shares(&dkg_shares).await.unwrap();
@@ -2812,7 +2812,7 @@ async fn test_get_btc_state_with_available_sweep_transactions_and_rbf() {
     let dkg_shares = model::EncryptedDkgShares {
         aggregate_key: aggregate_key.clone(),
         script_pubkey: aggregate_key.signers_script_pubkey().into(),
-        status: DkgSharesStatus::Unverified,
+        dkg_shares_status: DkgSharesStatus::Unverified,
         ..Faker.fake_with_rng(&mut rng)
     };
     db.write_encrypted_dkg_shares(&dkg_shares).await.unwrap();

--- a/signer/tests/integration/transaction_signer.rs
+++ b/signer/tests/integration/transaction_signer.rs
@@ -475,7 +475,7 @@ async fn max_one_state_machine_per_bitcoin_block_hash_for_dkg() {
 
     // We should have a state machine associated with the current chain tip
     // request message that we just received.
-    let id1 = StateMachineId::from(&chain_tip.block_hash);
+    let id1 = StateMachineId::from(&chain_tip);
     let state_machine = tx_signer.wsts_state_machines.get(&id1).unwrap();
     assert_eq!(state_machine.dkg_id, dkg_id);
     assert_eq!(tx_signer.wsts_state_machines.len(), 1);
@@ -507,7 +507,7 @@ async fn max_one_state_machine_per_bitcoin_block_hash_for_dkg() {
         .await
         .unwrap();
 
-    let id2 = StateMachineId::from(&report.chain_tip.block_hash);
+    let id2 = StateMachineId::from(&report.chain_tip);
     let state_machine = tx_signer.wsts_state_machines.get(&id2).unwrap();
     assert_eq!(state_machine.dkg_id, dkg_id);
     assert_eq!(tx_signer.wsts_state_machines.len(), 2);


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/1313.

This PR introduces a few changes that we had spoken about earlier. Also, it turns out that https://github.com/stacks-network/sbtc/issues/1313 was already handled the necessary logic required for https://github.com/stacks-network/sbtc/pull/1301, this just adds a test.

## Changes

* Change the `dkg_shares_status_id` column to just be an enum. Also rename it to `dkg_shares_status`.
* Rename the `verified_at_bitcoin_block_*` columns to `started_at_bitcoin_block_*`.
* Removed the foreign key constraints on the `dkg_shares` table. This was kinda accidental, if we want it I don't mind adding it back.
* Only allow going from `unverified` to `verified` or `failed`, no other status transitions are allowed. This allowed for some simplifications.
* The `SignerStateMachine::get_encrypted_dkg_shares` function now takes a bitcoin block ref for when DKG started. It probably makes more sense to put this information in the `SignerStateMachine` but the diff was growing and it looked more complex than the route took here.

## Testing Information

This PR adds a test for the new behavior of the `revoke_dkg_shares` and `verify_dkg_shares` functions. It also adds a new test for the validation condition in `RotateKeysV1` struct.

## Checklist:

- [x] I have performed a self-review of my code
