### PR TITLE
Revert "[feature] Ignore withdrawals in transaction coordinator (#1011)"

### DIFF
--- a/signer/src/testing/transaction_coordinator.rs
+++ b/signer/src/testing/transaction_coordinator.rs
@@ -160,7 +160,7 @@ where
     Storage: DbRead + DbWrite + Clone + Sync + Send + 'static,
 {
     /// Asserts that TxCoordinatorEventLoop::get_pending_requests ignores withdrawals
-    pub async fn assert_ignore_withdrawals(mut self) {
+    pub async fn assert_processes_withdrawals(mut self) {
         // Setup network and signer info
         let mut rng = rand::rngs::StdRng::seed_from_u64(46);
         let network = network::InMemoryNetwork::new();
@@ -240,7 +240,7 @@ where
             .expect("Error extracting withdrawals from db");
 
         // Assert that there are some withdrawals in storage while get_pending_requests return 0 withdrawals
-        assert!(withdrawals.is_empty());
+        assert!(!withdrawals.is_empty());
         assert!(!withdrawals_in_storage.is_empty());
     }
 

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -2503,14 +2503,14 @@ async fn transaction_coordinator_test_environment(
     }
 }
 
-#[test(tokio::test)]
-/// Tests that TxCoordinatorEventLoop::get_pending_requests ignores withdrawals
-async fn should_ignore_withdrawals() {
+/// Tests that TxCoordinatorEventLoop::get_pending_requests processes withdrawals
+#[tokio::test]
+async fn should_process_withdrawals() {
     let store = testing::storage::new_test_database().await;
 
     transaction_coordinator_test_environment(store.clone())
         .await
-        .assert_ignore_withdrawals()
+        .assert_processes_withdrawals()
         .await;
 
     testing::storage::drop_db(store).await;


### PR DESCRIPTION
This reverts commit 0ff9070ffdfde4a8c0fec025de5a182e2aedca2d.

## Description

Closes: #1328

## Changes
- revert the commit that removed withdrawal processing from the coordinator

## Testing Information
- adapted unit test to assert that the withdrawal requests are added to the SbtcRequests

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
