### PR TITLE
feat: implement query returning `WithdrawalRequestReport`

### DIFF
--- a/signer/src/bitcoin/validation.rs
+++ b/signer/src/bitcoin/validation.rs
@@ -136,8 +136,8 @@ impl BitcoinPreSignRequest {
         let mut cache = ValidationCache::default();
 
         let bitcoin_chain_tip = &btc_ctx.chain_tip;
-        let stacks_chain_tip = db.get_stacks_chain_tip(bitcoin_chain_tip).await?;
-        let Some(stacks_chain_tip) = stacks_chain_tip.map(|b| b.block_hash) else {
+        let maybe_stacks_chain_tip = db.get_stacks_chain_tip(bitcoin_chain_tip).await?;
+        let Some(stacks_chain_tip) = maybe_stacks_chain_tip.map(|b| b.block_hash) else {
             return Err(Error::NoStacksChainTip);
         };
 

--- a/signer/src/bitcoin/validation.rs
+++ b/signer/src/bitcoin/validation.rs
@@ -19,6 +19,7 @@ use crate::keys::PublicKey;
 use crate::message::BitcoinPreSignRequest;
 use crate::storage::model::BitcoinBlockHash;
 use crate::storage::model::BitcoinTxId;
+use crate::storage::model::BitcoinTxRef;
 use crate::storage::model::BitcoinTxSigHash;
 use crate::storage::model::BitcoinWithdrawalOutput;
 use crate::storage::model::DkgSharesStatus;
@@ -833,11 +834,11 @@ pub enum WithdrawalRequestStatus {
     /// block anchoring the Stacks block that confirmed the withdrawal
     /// request, and the block hash is the associated block hash of that
     /// bitcoin block.
-    Confirmed(u64, BitcoinBlockHash),
+    Confirmed,
     /// We have a record of the withdrawal request being included as an
     /// output in another bitcoin transaction that has been confirmed on
     /// the canonical bitcoin blockchain.
-    Fulfilled(BitcoinTxId),
+    Fulfilled(BitcoinTxRef),
     /// We have a record of the withdrawal request transaction, and it has
     /// not been confirmed on the canonical Stacks blockchain.
     ///
@@ -869,6 +870,13 @@ pub struct WithdrawalRequestReport {
     pub max_fee: u64,
     /// The script_pubkey of the output.
     pub script_pubkey: ScriptBuf,
+    /// Whether this signers' blocklist client accepted the withdrawal
+    /// request or not. This should only be `None` if we do not have a
+    /// record of the withdrawal request.
+    pub is_accepted: Option<bool>,
+    /// The height of the bitcoin chain tip during the execution of the
+    /// contract call that generated the withdrawal request.
+    pub block_height: u64,
 }
 
 impl WithdrawalRequestReport {

--- a/signer/src/bitcoin/validation.rs
+++ b/signer/src/bitcoin/validation.rs
@@ -878,7 +878,7 @@ pub struct WithdrawalRequestReport {
     /// the funds.
     pub max_fee: u64,
     /// The script_pubkey of the output.
-    pub script_pubkey: ScriptBuf,
+    pub recipient: ScriptBuf,
     /// Whether this signers' blocklist client accepted the withdrawal
     /// request or not. This should only be `None` if we do not have a
     /// record of the withdrawal request.
@@ -910,7 +910,7 @@ impl WithdrawalRequestReport {
             block_hash: self.id.block_hash,
             amount: self.amount,
             max_fee: self.max_fee,
-            script_pubkey: self.script_pubkey.clone().into(),
+            script_pubkey: self.recipient.clone().into(),
             signer_bitmap: votes.into(),
         }
     }

--- a/signer/src/bitcoin/validation.rs
+++ b/signer/src/bitcoin/validation.rs
@@ -839,10 +839,7 @@ impl DepositRequestReport {
 pub enum WithdrawalRequestStatus {
     /// We have a record of the withdrawal request transaction, and it has
     /// been confirmed on the canonical Stacks blockchain. We have not
-    /// fulfilled the request. The integer is the height of the bitcoin
-    /// block anchoring the Stacks block that confirmed the withdrawal
-    /// request, and the block hash is the associated block hash of that
-    /// bitcoin block.
+    /// fulfilled the request.
     Confirmed,
     /// We have a record of the withdrawal request being included as an
     /// output in another bitcoin transaction that has been confirmed on

--- a/signer/src/storage/in_memory.rs
+++ b/signer/src/storage/in_memory.rs
@@ -555,7 +555,8 @@ impl super::DbRead for SharedStore {
 
     async fn get_withdrawal_request_report(
         &self,
-        _chain_tip: &model::BitcoinBlockHash,
+        _bitcoin_chain_tip: &model::BitcoinBlockHash,
+        _stacks_chain_tip: &model::StacksBlockHash,
         _id: &model::QualifiedRequestId,
         _signer_public_key: &PublicKey,
     ) -> Result<Option<WithdrawalRequestReport>, Error> {

--- a/signer/src/storage/mod.rs
+++ b/signer/src/storage/mod.rs
@@ -187,19 +187,19 @@ pub trait DbRead {
     /// 1. Check that the current signer accepted by the withdrawal
     ///    request.
     /// 2. Check that the transaction that created the withdrawal is in a
-    ///    stacks block anchored by a bitcoin block on the blockchain
-    ///    identified by the given chain tip.
-    /// 3. Check that the withdrawal has not been included on a sweep
+    ///    stacks block on the stacks blockchain identified by the given
+    ///    chain tip.
+    /// 3. Check that the withdrawal has not been included in a sweep
     ///    transaction that has been confirmed by block on the bitcoin
     ///    blockchain identified by the given chain tip.
     ///
-    ///  `Ok(None)` is returned if we do not have a record of the
-    /// withdrawal request.
-    ///
-    /// Note: The above list is probably not exhaustive.
+    /// `Ok(None)` is returned if we do not have a record of the withdrawal
+    /// request or if the withdrawal request is confirmed on a stacks block
+    /// that we do not know about
     fn get_withdrawal_request_report(
         &self,
-        chain_tip: &model::BitcoinBlockHash,
+        bitcoin_chain_tip: &model::BitcoinBlockHash,
+        stacks_chain_tip: &model::StacksBlockHash,
         id: &model::QualifiedRequestId,
         signer_public_key: &PublicKey,
     ) -> impl Future<Output = Result<Option<WithdrawalRequestReport>, Error>> + Send;

--- a/signer/src/storage/mod.rs
+++ b/signer/src/storage/mod.rs
@@ -485,7 +485,7 @@ pub trait DbWrite {
         prevout: &model::TxPrevout,
     ) -> impl Future<Output = Result<(), Error>> + Send;
 
-    /// Write the bitcoin transactions sighaes to the database.
+    /// Write the bitcoin transactions sighashes to the database.
     fn write_bitcoin_txs_sighashes(
         &self,
         sighashes: &[model::BitcoinTxSigHash],

--- a/signer/src/storage/model.rs
+++ b/signer/src/storage/model.rs
@@ -316,7 +316,7 @@ impl WithdrawalSigner {
 }
 
 /// A connection between a bitcoin block and a bitcoin transaction.
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, sqlx::FromRow)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, sqlx::FromRow)]
 pub struct BitcoinTxRef {
     /// Transaction ID.
     pub txid: BitcoinTxId,

--- a/signer/src/storage/model.rs
+++ b/signer/src/storage/model.rs
@@ -248,6 +248,7 @@ pub struct WithdrawalRequest {
     /// affects a transaction that calls the initiate-withdrawal-request
     /// public function.
     #[sqlx(try_from = "i64")]
+    #[cfg_attr(feature = "testing", dummy(faker = "0..u32::MAX as u64"))]
     pub request_id: u64,
     /// The stacks transaction ID that lead to the creation of the
     /// withdrawal request.

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -1617,7 +1617,7 @@ impl super::DbRead for PgStore {
             amount: summary.amount,
             max_fee: summary.max_fee,
             is_accepted: summary.is_accepted,
-            script_pubkey: summary.recipient.into(),
+            recipient: summary.recipient.into(),
             status,
             block_height: summary.bitcoin_block_height,
         }))

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -786,13 +786,13 @@ impl PgStore {
                 UNION ALL
 
                 SELECT
-                    child.block_hash
-                  , child.block_height
-                  , child.parent_hash
-                FROM sbtc_signer.stacks_blocks AS child
-                JOIN tx_block_chain AS parent
-                  ON child.block_hash = parent.parent_hash
-                WHERE parent.block_height > $2
+                    parent.block_hash
+                  , parent.block_height
+                  , parent.parent_hash
+                FROM sbtc_signer.stacks_blocks AS parent
+                JOIN tx_block_chain AS child
+                  ON parent.block_hash = child.parent_hash
+                WHERE child.block_height > $2
             )
             SELECT EXISTS (
                 SELECT TRUE

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -833,7 +833,8 @@ impl PgStore {
               , wr.block_hash   AS stacks_block_hash
               , sb.block_height AS stacks_block_height
             FROM sbtc_signer.withdrawal_requests AS wr
-            JOIN sbtc_signer.stacks_blocks AS sb USING (block_hash)
+            JOIN sbtc_signer.stacks_blocks AS sb 
+              ON sb.block_hash = wr.block_hash
             LEFT JOIN sbtc_signer.withdrawal_signers AS ws
               ON ws.request_id = wr.request_id
              AND ws.block_hash = wr.block_hash

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -132,12 +132,12 @@ struct DepositStatusSummary {
     signers_public_key: PublicKeyXOnly,
 }
 
-/// A convenience struct for retrieving a deposit request report
+/// A convenience struct for retrieving a withdrawal request report
 #[derive(sqlx::FromRow)]
 pub struct WithdrawalStatusSummary {
-    /// The current signer may not have a record of their vote for
-    /// the deposit. When that happens the `can_accept` and
-    /// `can_sign` fields will be None.
+    /// The current signer may not have a record of their vote for the
+    /// withdrawal. When that happens the `is_accepted` field will be
+    /// [`None`].
     is_accepted: Option<bool>,
     /// The height of the bitcoin chain tip during the execution of the
     /// contract call that generated the withdrawal request.
@@ -150,7 +150,7 @@ pub struct WithdrawalStatusSummary {
     /// in the funds.
     #[sqlx(try_from = "i64")]
     max_fee: u64,
-    /// The reclaim script for the deposit.
+    /// The recipient scriptPubKey of the withdrawn funds.
     recipient: model::ScriptPubKey,
     /// Stacks block ID of the block that includes the transaction
     /// associated with this withdrawal request.

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -767,7 +767,7 @@ impl PgStore {
 
     /// Check whether the given block hash is a part of the stacks
     /// blockchain identified by the given chain-tip.
-    pub async fn in_canonical_stacks_blockchain(
+    async fn in_canonical_stacks_blockchain(
         &self,
         chain_tip: &model::StacksBlockHash,
         block_hash: &model::StacksBlockHash,
@@ -817,7 +817,7 @@ impl PgStore {
     /// `None` is returned if withdrawal request is not in the database or
     /// if the withdrawal request is not associated with a stacks block in
     /// the database.
-    pub async fn get_withdrawal_request_status_summary(
+    async fn get_withdrawal_request_status_summary(
         &self,
         id: &model::QualifiedRequestId,
         signer_public_key: &PublicKey,
@@ -857,7 +857,7 @@ impl PgStore {
     /// `None` is returned if there is no transaction sweeping out the
     /// funds that has been confirmed on the blockchain identified by the
     /// given chain-tip.
-    pub async fn get_withdrawal_sweep_info(
+    async fn get_withdrawal_sweep_info(
         &self,
         chain_tip: &model::BitcoinBlockHash,
         id: &model::QualifiedRequestId,

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -134,7 +134,7 @@ struct DepositStatusSummary {
 
 /// A convenience struct for retrieving a withdrawal request report
 #[derive(sqlx::FromRow)]
-pub struct WithdrawalStatusSummary {
+struct WithdrawalStatusSummary {
     /// The current signer may not have a record of their vote for the
     /// withdrawal. When that happens the `is_accepted` field will be
     /// [`None`].

--- a/signer/tests/integration/bitcoin_validation.rs
+++ b/signer/tests/integration/bitcoin_validation.rs
@@ -110,6 +110,7 @@ async fn one_tx_per_request_set() {
     setup.deposits.sort_by_key(|(x, _, _)| x.outpoint);
     backfill_bitcoin_blocks(&db, rpc, &setup.deposit_block_hash).await;
 
+    setup.store_stacks_genesis_block(&db).await;
     setup.store_dkg_shares(&db).await;
     setup.store_donation(&db).await;
     setup.store_deposit_txs(&db).await;
@@ -212,6 +213,7 @@ async fn one_invalid_deposit_invalidates_tx() {
     setup.deposits.sort_by_key(|(x, _, _)| x.outpoint);
     backfill_bitcoin_blocks(&db, rpc, &setup.deposit_block_hash).await;
 
+    setup.store_stacks_genesis_block(&db).await;
     setup.store_dkg_shares(&db).await;
     setup.store_donation(&db).await;
     setup.store_deposit_txs(&db).await;
@@ -325,6 +327,7 @@ async fn one_withdrawal_errors_validation() {
     setup.deposits.sort_by_key(|(x, _, _)| x.outpoint);
     backfill_bitcoin_blocks(&db, rpc, &setup.deposit_block_hash).await;
 
+    setup.store_stacks_genesis_block(&db).await;
     setup.store_dkg_shares(&db).await;
     setup.store_donation(&db).await;
     setup.store_deposit_txs(&db).await;
@@ -401,6 +404,7 @@ async fn cannot_sign_deposit_is_ok() {
 
     backfill_bitcoin_blocks(&db, rpc, &setup.deposit_block_hash).await;
 
+    setup.store_stacks_genesis_block(&db).await;
     setup.store_dkg_shares(&db).await;
     setup.store_donation(&db).await;
     setup.store_deposit_txs(&db).await;
@@ -556,6 +560,7 @@ async fn sighashes_match_from_sbtc_requests_object() {
     setup.deposits.sort_by_key(|(x, _, _)| x.outpoint);
     backfill_bitcoin_blocks(&db, rpc, &setup.deposit_block_hash).await;
 
+    setup.store_stacks_genesis_block(&db).await;
     setup.store_dkg_shares(&db).await;
     setup.store_donation(&db).await;
     setup.store_deposit_txs(&db).await;
@@ -695,6 +700,7 @@ async fn outcome_is_independent_of_input_order() {
     setup.deposits.sort_by_key(|(x, _, _)| x.outpoint);
     backfill_bitcoin_blocks(&db, rpc, &setup.deposit_block_hash).await;
 
+    setup.store_stacks_genesis_block(&db).await;
     setup.store_dkg_shares(&db).await;
     setup.store_donation(&db).await;
     setup.store_deposit_txs(&db).await;

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -3319,10 +3319,11 @@ async fn withdrawal_report_with_withdrawal_request_reorged() {
     // Now let's generate a report where we know that the withdrawal
     // request is not on the blockchain identified by the given chain tip.
     let qualified_id = withdrawal_request.qualified_id();
+    let random_stacks_chain_tip = Faker.fake_with_rng(&mut rng);
     let report = db
         .get_withdrawal_request_report(
             &bitcoin_chain_tip,
-            &stacks_chain_tip_block.parent_hash,
+            &random_stacks_chain_tip,
             &qualified_id,
             signer_public_key,
         )

--- a/signer/tests/integration/transaction_signer.rs
+++ b/signer/tests/integration/transaction_signer.rs
@@ -170,6 +170,7 @@ pub async fn assert_should_be_able_to_handle_sbtc_requests() {
     fill_signers_utxo(&db, bitcoin_block.unwrap(), &public_aggregate_key, &mut rng).await;
 
     // Store the necessary data for passing validation
+    setup.store_stacks_genesis_block(&db).await;
     setup.store_deposit_tx(&db).await;
     setup.store_dkg_shares(&db).await;
     setup.store_deposit_request(&db).await;
@@ -311,6 +312,7 @@ pub async fn presign_requests_with_dkg_shares_status(status: DkgSharesStatus, is
 
     backfill_bitcoin_blocks(&db, rpc, &setup.deposit_block_hash).await;
 
+    setup.store_stacks_genesis_block(&db).await;
     setup.store_dkg_shares(&db).await;
     setup.store_donation(&db).await;
     setup.store_deposit_txs(&db).await;


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/1308.

## Changes

1. Add three new queries that together construct the withdrawal request report.
2. Made some modifications to the `WithdrawalRequestReport` that make it easier to do https://github.com/stacks-network/sbtc/issues/1323.

## Testing Information

This PR adds a bunch of integration tests, checking that the values in the report are valid. I still need to add some comments to the tests, but this is ready for review.

## Checklist:

- [x] I have performed a self-review of my code
