### PR TITLE
feat: some dkg verification integration tests

### DIFF
--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -55,8 +55,13 @@ pub enum Error {
     DkgVerificationWindowElapsed(PublicKey),
 
     /// Expected two aggregate keys to match, but they did not.
-    #[error("two aggregate keys were expected to match but did not: {0:?}, {1:?}")]
-    AggregateKeyMismatch(Box<PublicKeyXOnly>, Box<PublicKeyXOnly>),
+    #[error("two aggregate keys were expected to match but did not: actual={actual}, expected={expected}")]
+    AggregateKeyMismatch {
+        /// The aggregate key being compared to the `expected` aggregate key.
+        actual: Box<PublicKeyXOnly>,
+        /// The expected aggregate key.
+        expected: Box<PublicKeyXOnly>,
+    },
 
     /// The aggregate key for the given block hash could not be determined.
     #[error("the signer set aggregate key could not be determined for bitcoin block {0}")]
@@ -149,7 +154,7 @@ pub enum Error {
     BitcoinTxMissing(bitcoin::Txid, Option<bitcoin::BlockHash>),
 
     /// This is the error that is returned when validating a bitcoin
-    /// trasnaction.
+    /// transaction.
     #[error("bitcoin validation error: {0}")]
     BitcoinValidation(#[from] Box<crate::bitcoin::validation::BitcoinValidationError>),
 
@@ -320,12 +325,12 @@ pub enum Error {
     InvalidEcdsaSignatureBytes(#[source] secp256k1::Error),
 
     /// This happens when we attempt to convert a `[u8; 65]` into a
-    /// recoverable EDCSA signature.
+    /// recoverable ECDSA signature.
     #[error("could not recover the public key from the signature: {0}")]
     InvalidRecoverableSignatureBytes(#[source] secp256k1::Error),
 
     /// This happens when we attempt to recover a public key from a
-    /// recoverable EDCSA signature.
+    /// recoverable ECDSA signature.
     #[error("could not recover the public key from the signature: {0}, digest: {1}")]
     InvalidRecoverableSignature(#[source] secp256k1::Error, secp256k1::Message),
 

--- a/signer/src/keys.rs
+++ b/signer/src/keys.rs
@@ -284,6 +284,12 @@ impl From<PublicKey> for PublicKeyXOnly {
     }
 }
 
+impl From<(secp256k1::XOnlyPublicKey, secp256k1::Parity)> for PublicKeyXOnly {
+    fn from(value: (bitcoin::XOnlyPublicKey, secp256k1::Parity)) -> Self {
+        Self(value.0)
+    }
+}
+
 impl From<&PublicKey> for PublicKeyXOnly {
     fn from(value: &PublicKey) -> Self {
         Self(secp256k1::XOnlyPublicKey::from(value))

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -702,7 +702,7 @@ async fn should_return_the_same_pending_accepted_withdraw_requests_as_in_memory_
     signer::testing::storage::drop_db(pg_store).await;
 }
 
-/// This tests that when fetching pending accepted deposits we ingore swept ones.
+/// This tests that when fetching pending accepted deposits we ignore swept ones.
 #[tokio::test]
 async fn should_not_return_swept_deposits_as_pending_accepted() {
     let db = testing::storage::new_test_database().await;
@@ -870,7 +870,7 @@ async fn should_return_only_accepted_pending_deposits_that_are_within_reclaim_bo
         * percent_of_original_requests_expected_to_be_in_bounds)
         .floor() as usize;
 
-    // Prepare some datastructures to filter the deposit requests that we're going to put out of bounds
+    // Prepare some data structures to filter the deposit requests that we're going to put out of bounds
     // and to check against later.
     pending_accepted_deposit_requests.shuffle(&mut rng);
     let mut unique_deposit_ids = pending_accepted_deposit_requests
@@ -1916,7 +1916,7 @@ async fn get_last_encrypted_dkg_shares_gets_most_recent_shares() {
 /// fetch the last encrypted DKG shares with status 'verified' from in the
 /// database.
 #[tokio::test]
-async fn get_last_verfied_dkg_shares_does_whats_advertised() {
+async fn get_last_verified_dkg_shares_does_whats_advertised() {
     let db = testing::storage::new_test_database().await;
 
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
@@ -2775,7 +2775,7 @@ async fn deposit_report_with_deposit_request_spent() {
     let test_data = TestData::generate(&mut rng, &signer_set, &test_params);
     test_data.write_to(&db).await;
 
-    // Let's write the deposit request and associated trasnaction to the
+    // Let's write the deposit request and associated transaction to the
     // database. Here the deposit transaction will be confirmed on the
     // canonical bitcoin blockchain.
     let deposit_request: model::DepositRequest = fake::Faker.fake_with_rng(&mut rng);
@@ -2873,7 +2873,7 @@ async fn deposit_report_with_deposit_request_swept_but_swept_reorged() {
     let test_data = TestData::generate(&mut rng, &signer_set, &test_params);
     test_data.write_to(&db).await;
 
-    // Let's write the deposit request and associated trasnaction to the
+    // Let's write the deposit request and associated transaction to the
     // database. Here the deposit transaction will be confirmed on the
     // canonical bitcoin blockchain.
     let deposit_request: model::DepositRequest = fake::Faker.fake_with_rng(&mut rng);

--- a/signer/tests/integration/transaction_signer.rs
+++ b/signer/tests/integration/transaction_signer.rs
@@ -680,7 +680,6 @@ mod validate_dkg_verification_message {
     #[tokio::test]
     async fn no_dkg_shares() {
         let db = testing::storage::new_test_database().await;
-        //let aggregate_key = Keypair::new_global(&mut OsRng).x_only_public_key().into();
 
         // Just use default since we don't even have stored shares.
         let params = TestParams::default();

--- a/signer/tests/integration/transaction_signer.rs
+++ b/signer/tests/integration/transaction_signer.rs
@@ -6,7 +6,15 @@ use bitcoincore_rpc::RpcApi;
 use fake::Fake as _;
 use fake::Faker;
 use lru::LruCache;
+use rand::rngs::OsRng;
 use rand::SeedableRng as _;
+use signer::bitcoin::MockBitcoinInteract;
+use signer::emily_client::MockEmilyInteract;
+use signer::network::in_memory2::SignerNetworkInstance;
+use signer::stacks::api::MockStacksInteract;
+use signer::storage::postgres::PgStore;
+use signer::storage::DbRead;
+use signer::storage::DbWrite;
 use test_case::test_case;
 
 use signer::bitcoin::utxo::RequestRef;
@@ -35,8 +43,6 @@ use signer::storage::model::BitcoinTxSigHash;
 use signer::storage::model::DkgSharesStatus;
 use signer::storage::model::SigHash;
 use signer::storage::model::StacksTxId;
-use signer::storage::DbRead as _;
-use signer::storage::DbWrite as _;
 use signer::testing;
 use signer::testing::context::*;
 use signer::transaction_signer::ChainTipStatus;
@@ -53,6 +59,17 @@ use crate::setup::DepositAmounts;
 use crate::setup::TestSignerSet;
 use crate::setup::TestSweepSetup;
 use crate::setup::TestSweepSetup2;
+
+type MockedTxSigner = TxSignerEventLoop<
+    TestContext<
+        PgStore,
+        WrappedMock<MockBitcoinInteract>,
+        WrappedMock<MockStacksInteract>,
+        WrappedMock<MockEmilyInteract>,
+    >,
+    SignerNetworkInstance,
+    OsRng,
+>;
 
 /// Test that [`TxSignerEventLoop::assert_valid_stacks_tx_sign_request`]
 /// errors when the signer is not in the signer set.
@@ -246,7 +263,7 @@ pub async fn assert_should_be_able_to_handle_sbtc_requests() {
         .await
         .unwrap();
 
-    // check if we are receving an Ack from the signer
+    // Check if we are receiving an Ack from the signer
     tokio::time::timeout(Duration::from_secs(2), async move {
         handle.receive().await.unwrap();
     })
@@ -598,4 +615,269 @@ async fn max_one_state_machine_per_bitcoin_block_hash_for_dkg() {
     assert_eq!(tx_signer.wsts_state_machines.len(), 2);
 
     testing::storage::drop_db(db).await;
+}
+
+/// Module containing tests for the
+/// [`MockedTxSigner::validate_dkg_verification_message`] function. See
+/// [`MockedTxSigner`] for information on the validations that these tests
+/// are asserting.
+mod validate_dkg_verification_message {
+    use rand::rngs::StdRng;
+    use secp256k1::Keypair;
+
+    use signer::{
+        bitcoin::utxo::UnsignedMockTransaction, keys::PublicKeyXOnly,
+        storage::model::EncryptedDkgShares,
+    };
+
+    use super::*;
+
+    /// Helper struct for testing
+    /// [`MockedTxSigner::validate_dkg_verification_message`].
+    struct TestParams {
+        pub new_aggregate_key: PublicKeyXOnly,
+        pub dkg_verification_window: u16,
+        pub bitcoin_chain_tip: BitcoinBlockRef,
+        pub message: Option<Vec<u8>>,
+    }
+
+    impl Default for TestParams {
+        fn default() -> Self {
+            let new_aggregate_key = Keypair::new_global(&mut OsRng).x_only_public_key().into();
+            Self {
+                new_aggregate_key,
+                dkg_verification_window: 0,
+                bitcoin_chain_tip: BitcoinBlockRef {
+                    block_hash: BitcoinBlockHash::from([0; 32]),
+                    block_height: 0,
+                },
+                message: None,
+            }
+        }
+    }
+
+    impl TestParams {
+        fn new(new_aggregate_key: PublicKeyXOnly) -> Self {
+            Self {
+                new_aggregate_key,
+                ..Self::default()
+            }
+        }
+        /// Executes [`MockedTxSigner::validate_dkg_verification_message`] with
+        /// the values in this [`TestParams`] instance.
+        async fn execute(&self, db: &PgStore) -> Result<(), Error> {
+            MockedTxSigner::validate_dkg_verification_message::<PgStore>(
+                &db,
+                &self.new_aggregate_key,
+                self.message.as_deref(),
+                self.dkg_verification_window,
+                &self.bitcoin_chain_tip,
+            )
+            .await
+        }
+    }
+
+    #[tokio::test]
+    async fn no_dkg_shares() {
+        let db = testing::storage::new_test_database().await;
+        //let aggregate_key = Keypair::new_global(&mut OsRng).x_only_public_key().into();
+
+        // Just use default since we don't even have stored shares.
+        let params = TestParams::default();
+
+        let result = params.execute(&db).await.unwrap_err();
+        assert!(matches!(result, Error::NoDkgShares));
+    }
+
+    #[tokio::test]
+    async fn latest_key_mismatch() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let db = testing::storage::new_test_database().await;
+        let latest_aggregate_key = Keypair::new_global(&mut rng).public_key().into();
+        let new_aggregate_key = Keypair::new_global(&mut rng).x_only_public_key().into();
+
+        // Create new DKG shares and store them in the database. We expect the
+        // aggregate keys to not match, so we set them to values we explicitly
+        // know won't match.
+        let shares = EncryptedDkgShares {
+            aggregate_key: latest_aggregate_key,
+            ..Faker.fake()
+        };
+        db.write_encrypted_dkg_shares(&shares).await.unwrap();
+
+        // Just to show that these two aren't equal.
+        assert_ne!(new_aggregate_key, shares.aggregate_key.into());
+
+        // New params with the new aggregate key which won't match.
+        let params = TestParams::new(new_aggregate_key);
+
+        let result = params.execute(&db).await.unwrap_err();
+
+        if let Error::AggregateKeyMismatch { actual, expected } = result {
+            let actual = *actual;
+            let expected = *expected;
+
+            assert_eq!(actual, latest_aggregate_key.into());
+            assert_eq!(expected, new_aggregate_key);
+            assert_ne!(actual, expected);
+        } else {
+            panic!("Expected an AggregateKeyMismatch error, got: {:?}", result);
+        }
+    }
+
+    #[tokio::test]
+    async fn latest_key_in_failed_state() {
+        let db = testing::storage::new_test_database().await;
+        let aggregate_key: PublicKey = Keypair::new_global(&mut OsRng).public_key().into();
+        let aggregate_key_x_only = aggregate_key.into();
+
+        // Create new DKG shares and store them in the database. We expect the
+        // aggregate keys to match but validation to fail due to the latest shares
+        // being marked as `Failed`.
+        let shares = EncryptedDkgShares {
+            aggregate_key,
+            dkg_shares_status: DkgSharesStatus::Failed,
+            ..Faker.fake()
+        };
+        db.write_encrypted_dkg_shares(&shares).await.unwrap();
+
+        // Setup the test parameters.
+        let params = TestParams::new(aggregate_key_x_only);
+
+        let result = params.execute(&db).await.unwrap_err();
+
+        assert!(matches!(
+            result,
+            Error::DkgVerificationFailed(key) if aggregate_key_x_only == key
+        ))
+    }
+
+    #[tokio::test]
+    async fn verification_window_elapsed() {
+        let db = testing::storage::new_test_database().await;
+        let aggregate_key: PublicKey = Keypair::new_global(&mut OsRng).public_key().into();
+
+        // Create new DKG shares and store them in the database. We expect the
+        // aggregate keys to match and the status to be allowed. We use 0 as the
+        // starting block.
+        let shares = EncryptedDkgShares {
+            aggregate_key,
+            dkg_shares_status: DkgSharesStatus::Unverified,
+            started_at_bitcoin_block_height: 0,
+            ..Faker.fake()
+        };
+        db.write_encrypted_dkg_shares(&shares).await.unwrap();
+
+        // Setup the test parameters with a verification window of 10 blocks and
+        // the actual time elapsed being 11 blocks.
+        let params = TestParams {
+            new_aggregate_key: aggregate_key.into(),
+            dkg_verification_window: 10,
+            bitcoin_chain_tip: BitcoinBlockRef {
+                block_hash: BitcoinBlockHash::from([0; 32]),
+                block_height: 11,
+            },
+            ..Default::default()
+        };
+
+        let result = params.execute(&db).await.unwrap_err();
+
+        assert!(matches!(
+            result,
+            Error::DkgVerificationWindowElapsed(key) if aggregate_key == key
+        ))
+    }
+
+    #[tokio::test]
+    async fn verification_window_is_inclusive() {
+        let db = testing::storage::new_test_database().await;
+        let aggregate_key: PublicKey = Keypair::new_global(&mut OsRng).public_key().into();
+
+        // Create new DKG shares and store them in the database. We expect the
+        // aggregate keys to match and the status to be allowed. We use 0 as the
+        // starting block.
+        let shares = EncryptedDkgShares {
+            aggregate_key,
+            dkg_shares_status: DkgSharesStatus::Unverified,
+            started_at_bitcoin_block_height: 0,
+            ..Faker.fake()
+        };
+        db.write_encrypted_dkg_shares(&shares).await.unwrap();
+
+        // Setup the test parameters with a verification window of 10 blocks and
+        // the actual time elapsed being 10 blocks. Tests that the verification
+        // window is inclusive.
+        let params = TestParams {
+            new_aggregate_key: aggregate_key.into(),
+            dkg_verification_window: 10,
+            bitcoin_chain_tip: BitcoinBlockRef {
+                block_hash: BitcoinBlockHash::from([0; 32]),
+                block_height: 10,
+            },
+            ..Default::default()
+        };
+
+        params.execute(&db).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn expected_sighash_succeeds() {
+        let db = testing::storage::new_test_database().await;
+        let aggregate_key: PublicKey = Keypair::new_global(&mut OsRng).public_key().into();
+
+        // Create new DKG shares and store them in the database. We expect
+        // all other verifications to succeed.
+        let shares = EncryptedDkgShares {
+            aggregate_key,
+            dkg_shares_status: DkgSharesStatus::Unverified,
+            started_at_bitcoin_block_height: 0,
+            ..Faker.fake()
+        };
+        db.write_encrypted_dkg_shares(&shares).await.unwrap();
+
+        let sighash = UnsignedMockTransaction::new(aggregate_key.into())
+            .compute_sighash()
+            .unwrap();
+
+        // Setup the test parameters using the expected sighash.
+        let params = TestParams {
+            new_aggregate_key: aggregate_key.into(),
+            message: Some(sighash.as_byte_array().to_vec()),
+            ..Default::default()
+        };
+
+        params.execute(&db).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn unexpected_sighash_fails() {
+        let db = testing::storage::new_test_database().await;
+        let aggregate_key: PublicKey = Keypair::new_global(&mut OsRng).public_key().into();
+
+        // Create new DKG shares and store them in the database. We expect
+        // all other verifications to succeed.
+        let shares = EncryptedDkgShares {
+            aggregate_key,
+            dkg_shares_status: DkgSharesStatus::Unverified,
+            started_at_bitcoin_block_height: 0,
+            ..Faker.fake()
+        };
+        db.write_encrypted_dkg_shares(&shares).await.unwrap();
+
+        // Setup the test parameters using a random sighash, which we expect
+        // to fail validation.
+        let params = TestParams {
+            new_aggregate_key: aggregate_key.into(),
+            dkg_verification_window: 10,
+            bitcoin_chain_tip: BitcoinBlockRef {
+                block_hash: BitcoinBlockHash::from([0; 32]),
+                block_height: 10,
+            },
+            message: Some(Faker.fake()),
+        };
+
+        let result = params.execute(&db).await.unwrap_err();
+
+        assert!(matches!(result, Error::InvalidSigHash(_)));
+    }
 }


### PR DESCRIPTION
## Description

Had forgotten that I had these stashed -- might as well have them, so I did a quick cleaning and here they are.

## Changes

- Adds a few integration tests for dkg verification. Not a complete suite, just a few that I had stashed the other day.
- Changes `Error::AggregateKeyMismatch` to struct syntax and makes a little logging tweak.
- Fixes a few random spelling mistakes.

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
