### PR TITLE
fix: enable TLS in the blocklist client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4979,6 +4979,7 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.28",
+ "hyper-rustls",
  "ipnet",
  "js-sys",
  "log",
@@ -4986,17 +4987,21 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls 0.21.12",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 0.1.2",
  "system-configuration 0.5.1",
  "tokio",
+ "tokio-rustls",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots 0.25.4",
  "winreg 0.50.0",
 ]
 
@@ -5942,7 +5947,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "url",
- "webpki-roots",
+ "webpki-roots 0.26.3",
 ]
 
 [[package]]
@@ -7302,6 +7307,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ openssl = { version = "0.10.68", default-features = false, features = ["vendored
 p256k1 = { version = "7.2.2", default-features = false }
 prost = { version = "0.13.4", default-features = false, features = ["derive"] }
 rand = { version = "0.8.5", default-features = false }
-reqwest = { version = "0.11.27", default-features = false, features = ["json"] }
+reqwest = { version = "0.11.27", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1.0.217", default-features = false, features = ["derive"] }
 serde_bytes = { version = "0.11.15", default-features = false }
 serde_dynamo = { version = "4.2.14", default-features = false, features = ["aws-sdk-dynamodb+1"] }

--- a/blocklist-client/tests/tls_checking.rs
+++ b/blocklist-client/tests/tls_checking.rs
@@ -1,0 +1,15 @@
+use std::time::Duration;
+
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[tokio::test]
+async fn check_tls_support() {
+    let resp = reqwest::Client::new()
+        .get("https://google.com")
+        .timeout(REQUEST_TIMEOUT)
+        .send()
+        .await
+        .unwrap();
+
+    resp.error_for_status().unwrap();
+}

--- a/signer/tests/integration/main.rs
+++ b/signer/tests/integration/main.rs
@@ -15,6 +15,7 @@ mod request_decider;
 mod rotate_keys;
 mod setup;
 mod stacks_events_observer;
+mod tls_checking;
 mod transaction_coordinator;
 mod transaction_signer;
 mod utxo_construction;

--- a/signer/tests/integration/tls_checking.rs
+++ b/signer/tests/integration/tls_checking.rs
@@ -1,0 +1,15 @@
+use std::time::Duration;
+
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[tokio::test]
+async fn check_tls_support() {
+    let resp = reqwest::Client::new()
+        .get("https://google.com")
+        .timeout(REQUEST_TIMEOUT)
+        .send()
+        .await
+        .unwrap();
+
+    resp.error_for_status().unwrap();
+}

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -18,6 +18,11 @@ criteria = "safe-to-deploy"
 version = "7.2.2"
 notes = "This change only adds wrapping to some additional bindings so that they get mangled and avoid linking errors."
 
+[[audits.webpki-roots]]
+who = "djordon <dan.jordon@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.25.4"
+
 [[audits.wsts]]
 who = "cylewitruk <cyle.witruk@outlook.com>"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
## Description

We accidentally disabled TLS support in reqwests and none of our tests caught it. That has been fixed.

I have branched off of tag `0.0.9-rc7` here.

## Changes

* Enable TLS using `rustls` for the reqwests library
* Add some simple tests that fail if we disable it in reqwests.

## Testing Information

## Checklist:

- [x] I have performed a self-review of my code
