### PR TITLE
chore: small `signers.sh` fixes

### DIFF
--- a/signers.sh
+++ b/signers.sh
@@ -35,7 +35,6 @@ exec_run() {
   printf "${GRAY}Running ${NC}${BOLD}$*${NC} signers\n"
 
   # Turn all the relevant postgres instances off and on.
-  docker compose -f "$DOCKER_COMPOSE_PATH" --profile sbtc-postgres down
   docker compose -f "$DOCKER_COMPOSE_PATH" --profile sbtc-postgres up --detach
 
   # Wait for the postgres instances to start (can get ssl handshake errors etc. otherwise)

--- a/signers.sh
+++ b/signers.sh
@@ -58,6 +58,7 @@ exec_run() {
   printf "${BOLD}Using bootstrap signer set:${NC} $BOOTSTRAP_SIGNER_SET\n"
 
   # Spin up the specified number of signers.
+  cargo build --bin  signer
   i=1
   while [ $i -le "$1" ]
   do


### PR DESCRIPTION
## Description

These are just a couple of small `signers.sh` shell improvements

## Changes

* Only build the binary once for all signers.
* Don't bring down the database when stopping the signers.

## Testing Information

## Checklist:

- [x] I have performed a self-review of my code

Hat tip to @tonyjzhou for pointing me to these fixes.