### PR TITLE
ci: add integration tests to validation on the Withdrawalequestreport tests

### DIFF
--- a/signer/src/bitcoin/validation.rs
+++ b/signer/src/bitcoin/validation.rs
@@ -345,6 +345,7 @@ impl BitcoinPreSignRequest {
 /// An intermediate struct to aid in computing validation of deposits and
 /// withdrawals and transforming the computed sighash into a
 /// [`BitcoinTxSigHash`].
+#[derive(Debug)]
 pub struct BitcoinTxValidationData {
     /// The sighash of the signers' prevout
     pub signer_sighash: SignatureHash,

--- a/signer/tests/integration/bitcoin_validation.rs
+++ b/signer/tests/integration/bitcoin_validation.rs
@@ -23,7 +23,7 @@ use signer::testing::context::TestContext;
 use signer::testing::context::*;
 
 use crate::setup::{backfill_bitcoin_blocks, TestSignerSet};
-use crate::setup::{DepositAmounts, TestSweepSetup2};
+use crate::setup::{SweepAmounts, TestSweepSetup2};
 
 const TEST_FEE_RATE: f64 = 10.0;
 
@@ -101,9 +101,10 @@ async fn one_tx_per_request_set() {
     ctx.state().update_current_limits(SbtcLimits::unlimited());
 
     let signers = TestSignerSet::new(&mut rng);
-    let amounts = [DepositAmounts {
+    let amounts = [SweepAmounts {
         amount: 1_000_000,
         max_fee: 500_000,
+        is_deposit: true,
     }];
 
     let mut setup = TestSweepSetup2::new_setup(signers, &faucet, &amounts);
@@ -197,13 +198,15 @@ async fn one_invalid_deposit_invalidates_tx() {
 
     let signers = TestSignerSet::new(&mut rng);
     let amounts = [
-        DepositAmounts {
+        SweepAmounts {
             amount: 1_000_000,
             max_fee: low_fee,
+            is_deposit: true,
         },
-        DepositAmounts {
+        SweepAmounts {
             amount: 1_000_000,
             max_fee: 500_000,
+            is_deposit: true,
         },
     ];
 
@@ -313,13 +316,15 @@ async fn one_withdrawal_passes_validation() {
 
     let signers = TestSignerSet::new(&mut rng);
     let amounts = [
-        DepositAmounts {
+        SweepAmounts {
             amount: 700_000,
             max_fee: 500_000,
+            is_deposit: true,
         },
-        DepositAmounts {
+        SweepAmounts {
             amount: 1_000_000,
             max_fee: 500_000,
+            is_deposit: true,
         },
     ];
 
@@ -360,7 +365,10 @@ async fn one_withdrawal_passes_validation() {
         aggregate_key,
     };
 
-    let validation_data = request.construct_package_sighashes(&ctx, &btc_ctx).await.unwrap();
+    let validation_data = request
+        .construct_package_sighashes(&ctx, &btc_ctx)
+        .await
+        .unwrap();
 
     // There are a few invariants that we uphold for our validation data.
     // These are things like "the transaction ID per package must be the
@@ -390,13 +398,15 @@ async fn cannot_sign_deposit_is_ok() {
     ctx.state().update_current_limits(SbtcLimits::unlimited());
 
     let amounts = [
-        DepositAmounts {
+        SweepAmounts {
             amount: 700_000,
             max_fee: 500_000,
+            is_deposit: true,
         },
-        DepositAmounts {
+        SweepAmounts {
             amount: 1_000_000,
             max_fee: 500_000,
+            is_deposit: true,
         },
     ];
 
@@ -554,13 +564,15 @@ async fn sighashes_match_from_sbtc_requests_object() {
 
     let signers = TestSignerSet::new(&mut rng);
     let amounts = [
-        DepositAmounts {
+        SweepAmounts {
             amount: 700_000,
             max_fee: 500_000,
+            is_deposit: true,
         },
-        DepositAmounts {
+        SweepAmounts {
             amount: 1_000_000,
             max_fee: 500_000,
+            is_deposit: true,
         },
     ];
 
@@ -686,21 +698,25 @@ async fn outcome_is_independent_of_input_order() {
 
     let signers = TestSignerSet::new(&mut rng);
     let amounts = [
-        DepositAmounts {
+        SweepAmounts {
             amount: 1_500_000,
             max_fee: 500_000,
+            is_deposit: true,
         },
-        DepositAmounts {
+        SweepAmounts {
             amount: 700_000,
             max_fee: 500_000,
+            is_deposit: true,
         },
-        DepositAmounts {
+        SweepAmounts {
             amount: 1_000_000,
             max_fee: 500_000,
+            is_deposit: true,
         },
-        DepositAmounts {
+        SweepAmounts {
             amount: 2_000_000,
             max_fee: 500_000,
+            is_deposit: true,
         },
     ];
 

--- a/signer/tests/integration/bitcoin_validation.rs
+++ b/signer/tests/integration/bitcoin_validation.rs
@@ -485,6 +485,10 @@ async fn swept_withdrawals_fail_validation() {
     setup.submit_sweep_tx(rpc, faucet);
     setup.store_sweep_tx(&db).await;
 
+    // The sweep happened right away, even before the withdrawal request
+    // was final, so when we go to do validation without generated enough
+    // votes, it's possible that validation will fail for a reason that's
+    // different from what we're expecting.
     let chain_tip = faucet
         .generate_blocks(WITHDRAWAL_MIN_CONFIRMATIONS)
         .pop()

--- a/signer/tests/integration/complete_deposit.rs
+++ b/signer/tests/integration/complete_deposit.rs
@@ -450,7 +450,7 @@ async fn complete_deposit_validation_fee_too_low() {
 
     // Normal: we submit the transaction sweeping the funds. It gets
     // confirmed; this generates a new bitcoin block behind the scene.
-    setup.submit_sweep_tx(rpc, faucet, false);
+    setup.submit_sweep_tx(rpc, faucet);
 
     // Normal: When a new bitcoin block is generated, we need to update the
     // signer's database with blockchain data.

--- a/signer/tests/integration/complete_deposit.rs
+++ b/signer/tests/integration/complete_deposit.rs
@@ -17,7 +17,7 @@ use signer::testing::context::*;
 use fake::Fake;
 
 use crate::setup::backfill_bitcoin_blocks;
-use crate::setup::DepositAmounts;
+use crate::setup::SweepAmounts;
 use crate::setup::TestSignerSet;
 use crate::setup::TestSweepSetup;
 use crate::setup::TestSweepSetup2;
@@ -427,7 +427,11 @@ async fn complete_deposit_validation_fee_too_low() {
     // bitcoin core for some things and rely on the database for others.
     // Hopefully this test does not become an issue down the line due to a
     // refactor.
-    let amounts = DepositAmounts { amount: 50000, max_fee: 80_000 };
+    let amounts = SweepAmounts {
+        amount: 50000,
+        max_fee: 80_000,
+        is_deposit: true,
+    };
     let mut setup = TestSweepSetup2::new_setup(signers, faucet, &[amounts]);
 
     // Normal: the signers' block observer should be getting new block

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -447,7 +447,7 @@ async fn get_pending_withdrawal_requests_only_pending() {
     let amounts = SweepAmounts {
         amount: 123456,
         max_fee: 12345,
-        is_deposit: true,
+        is_deposit: false,
     };
     let signers = TestSignerSet::new(&mut rng);
     let setup = TestSweepSetup2::new_setup(signers, faucet, &[amounts]);

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -71,7 +71,7 @@ use test_case::test_case;
 use test_log::test;
 
 use crate::setup::backfill_bitcoin_blocks;
-use crate::setup::DepositAmounts;
+use crate::setup::SweepAmounts;
 use crate::setup::TestSignerSet;
 use crate::setup::TestSweepSetup;
 use crate::setup::TestSweepSetup2;
@@ -388,7 +388,11 @@ async fn get_pending_deposit_requests_only_pending() {
 
     let mut rng = rand::rngs::StdRng::seed_from_u64(43);
 
-    let amounts = DepositAmounts { amount: 123456, max_fee: 12345 };
+    let amounts = SweepAmounts {
+        amount: 123456,
+        max_fee: 12345,
+        is_deposit: true,
+    };
     let signers = TestSignerSet::new(&mut rng);
     let setup = TestSweepSetup2::new_setup(signers, faucet, &[amounts]);
 
@@ -440,7 +444,11 @@ async fn get_pending_withdrawal_requests_only_pending() {
 
     let mut rng = rand::rngs::StdRng::seed_from_u64(43);
 
-    let amounts = DepositAmounts { amount: 123456, max_fee: 12345 };
+    let amounts = SweepAmounts {
+        amount: 123456,
+        max_fee: 12345,
+        is_deposit: true,
+    };
     let signers = TestSignerSet::new(&mut rng);
     let setup = TestSweepSetup2::new_setup(signers, faucet, &[amounts]);
 

--- a/signer/tests/integration/setup.rs
+++ b/signer/tests/integration/setup.rs
@@ -720,18 +720,23 @@ impl TestSweepSetup2 {
             bitcoin_anchor: deposit_block_hash.into(),
         };
 
-        let stacks_blocks: Vec<model::StacksBlock> = withdrawals
-            .iter()
-            .scan(genesis_block, |parent_block, (request, _, block_ref)| {
-                let child_block = model::StacksBlock {
-                    block_hash: request.block_hash,
-                    block_height: parent_block.block_height + 1,
-                    parent_hash: parent_block.block_hash,
-                    bitcoin_anchor: block_ref.block_hash,
-                };
-                *parent_block = child_block.clone();
-                Some(child_block)
-            })
+        let initial_state = genesis_block.clone();
+        let stacks_blocks =
+            withdrawals
+                .iter()
+                .scan(initial_state, |parent_block, (request, _, block_ref)| {
+                    let child_block = model::StacksBlock {
+                        block_hash: request.block_hash,
+                        block_height: parent_block.block_height + 1,
+                        parent_hash: parent_block.block_hash,
+                        bitcoin_anchor: block_ref.block_hash,
+                    };
+                    *parent_block = child_block.clone();
+                    Some(child_block)
+                });
+
+        let stacks_blocks: Vec<model::StacksBlock> = std::iter::once(genesis_block)
+            .chain(stacks_blocks)
             .collect();
 
         let settings = Settings::new_from_default_config().unwrap();

--- a/signer/tests/integration/setup.rs
+++ b/signer/tests/integration/setup.rs
@@ -1008,12 +1008,12 @@ impl TestSweepSetup2 {
     }
 
     pub async fn store_withdrawal_request(&self, db: &PgStore) {
-        for (withdrawal_request, _, block) in self.withdrawals.iter() {
+        for (withdrawal_request, _, bitcoin_block_ref) in self.withdrawals.iter() {
             let stacks_block = model::StacksBlock {
                 block_hash: withdrawal_request.block_hash,
                 block_height: Faker.fake_with_rng::<u32, _>(&mut OsRng) as u64,
                 parent_hash: Faker.fake_with_rng(&mut OsRng),
-                bitcoin_anchor: block.block_hash,
+                bitcoin_anchor: bitcoin_block_ref.block_hash,
             };
             db.write_stacks_block(&stacks_block).await.unwrap();
 
@@ -1025,7 +1025,7 @@ impl TestSweepSetup2 {
                 amount: withdrawal_request.amount,
                 max_fee: withdrawal_request.max_fee,
                 sender_address: self.withdrawal_sender.clone().into(),
-                bitcoin_block_height: block.block_height, // This should be set to the bitcoin block height.
+                bitcoin_block_height: bitcoin_block_ref.block_height,
             };
             db.write_withdrawal_request(&withdrawal_request)
                 .await

--- a/signer/tests/integration/transaction_coordinator.rs
+++ b/signer/tests/integration/transaction_coordinator.rs
@@ -24,6 +24,7 @@ use blockstack_lib::net::api::getcontractsrc::ContractSrcResponse;
 use blockstack_lib::net::api::getpoxinfo::RPCPoxInfoData;
 use blockstack_lib::net::api::getsortition::SortitionInfo;
 use clarity::types::chainstate::StacksAddress;
+use clarity::types::chainstate::StacksBlockId;
 use clarity::vm::types::PrincipalData;
 use clarity::vm::types::SequenceData;
 use clarity::vm::Value as ClarityValue;
@@ -3036,12 +3037,18 @@ fn create_test_setup(
         signer: Recipient::new(AddressType::P2tr),
     };
     let (request, recipient) = generate_withdrawal();
-
+    let stacks_block = model::StacksBlock {
+        block_hash: Faker.fake_with_rng(&mut OsRng),
+        block_height: 0,
+        parent_hash: StacksBlockId::first_mined().into(),
+        bitcoin_anchor: deposit_block_hash.into(),
+    };
     TestSweepSetup2 {
         deposit_block_hash,
         deposits: vec![(deposit_info, deposit_request, tx_info)],
         sweep_tx_info: None,
         donation,
+        stacks_blocks: vec![stacks_block],
         signers: test_signers,
         withdrawals: vec![(request, recipient, block_header.as_block_ref())],
         withdrawal_sender: PrincipalData::from(StacksAddress::burn_address(false)),

--- a/signer/tests/integration/transaction_coordinator.rs
+++ b/signer/tests/integration/transaction_coordinator.rs
@@ -3039,7 +3039,7 @@ fn create_test_setup(
         sweep_tx_info: None,
         donation,
         signers: test_signers,
-        withdrawal_request: generate_withdrawal().0,
+        withdrawals: vec![generate_withdrawal()],
         withdrawal_sender: PrincipalData::from(StacksAddress::burn_address(false)),
         signatures_required,
     }

--- a/signer/tests/integration/transaction_signer.rs
+++ b/signer/tests/integration/transaction_signer.rs
@@ -55,7 +55,7 @@ use wsts::net::NonceRequest;
 use crate::setup::backfill_bitcoin_blocks;
 use crate::setup::fill_signers_utxo;
 use crate::setup::set_verification_status;
-use crate::setup::DepositAmounts;
+use crate::setup::SweepAmounts;
 use crate::setup::TestSignerSet;
 use crate::setup::TestSweepSetup;
 use crate::setup::TestSweepSetup2;
@@ -313,7 +313,11 @@ pub async fn presign_requests_with_dkg_shares_status(status: DkgSharesStatus, is
     // Create a test setup object so that we can simply create proper DKG
     // shares in the database. Note that calling TestSweepSetup2::new_setup
     // creates two bitcoin block.
-    let amounts = DepositAmounts { amount: 100000, max_fee: 10000 };
+    let amounts = SweepAmounts {
+        amount: 100000,
+        max_fee: 10000,
+        is_deposit: true,
+    };
     let setup = TestSweepSetup2::new_setup(signers, faucet, &[amounts]);
 
     let block_header = rpc

--- a/signer/tests/integration/utxo_construction.rs
+++ b/signer/tests/integration/utxo_construction.rs
@@ -40,12 +40,16 @@ use sbtc::testing::regtest::AsUtxo;
 pub static REQUEST_IDS: AtomicU64 = AtomicU64::new(0);
 
 pub fn generate_withdrawal() -> (WithdrawalRequest, Recipient) {
-    let recipient = Recipient::new(AddressType::P2tr);
     let amount = OsRng.sample(Uniform::new(200_000, 250_000));
+    make_withdrawal(amount, amount / 2)
+}
+
+pub fn make_withdrawal(amount: u64, max_fee: u64) -> (WithdrawalRequest, Recipient) {
+    let recipient = Recipient::new(AddressType::P2tr);
 
     let req = WithdrawalRequest {
         amount,
-        max_fee: amount / 2,
+        max_fee,
         script_pubkey: recipient.script_pubkey.clone().into(),
         signer_bitmap: BitArray::ZERO,
         request_id: REQUEST_IDS.fetch_add(1, Ordering::Relaxed),


### PR DESCRIPTION
## Description

Closes: #?

## Changes

## Testing Information

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
