### PR TITLE
feat: query for pending rejected withdrawals

### DIFF
--- a/signer/src/storage/in_memory.rs
+++ b/signer/src/storage/in_memory.rs
@@ -535,7 +535,6 @@ impl super::DbRead for SharedStore {
         &self,
         _chain_tip: &model::BitcoinBlockRef,
         _context_window: u16,
-        _max_rejections: u16,
     ) -> Result<Vec<model::WithdrawalRequest>, Error> {
         unimplemented!()
     }

--- a/signer/src/storage/in_memory.rs
+++ b/signer/src/storage/in_memory.rs
@@ -531,6 +531,15 @@ impl super::DbRead for SharedStore {
             .collect())
     }
 
+    async fn get_pending_rejected_withdrawal_requests(
+        &self,
+        _chain_tip: &model::BitcoinBlockRef,
+        _context_window: u16,
+        _max_rejections: u16,
+    ) -> Result<Vec<model::WithdrawalRequest>, Error> {
+        unimplemented!()
+    }
+
     async fn get_withdrawal_request_report(
         &self,
         _bitcoin_chain_tip: &model::BitcoinBlockHash,

--- a/signer/src/storage/mod.rs
+++ b/signer/src/storage/mod.rs
@@ -175,6 +175,15 @@ pub trait DbRead {
         threshold: u16,
     ) -> impl Future<Output = Result<Vec<model::WithdrawalRequest>, Error>> + Send;
 
+    /// Get pending rejected withdrawal requests that have failed but are not
+    /// rejected yet
+    fn get_pending_rejected_withdrawal_requests(
+        &self,
+        chain_tip: &model::BitcoinBlockRef,
+        context_window: u16,
+        max_rejections: u16,
+    ) -> impl Future<Output = Result<Vec<model::WithdrawalRequest>, Error>> + Send;
+
     /// This function returns a withdrawal request report that does the
     /// following:
     ///

--- a/signer/src/storage/mod.rs
+++ b/signer/src/storage/mod.rs
@@ -181,7 +181,6 @@ pub trait DbRead {
         &self,
         chain_tip: &model::BitcoinBlockRef,
         context_window: u16,
-        max_rejections: u16,
     ) -> impl Future<Output = Result<Vec<model::WithdrawalRequest>, Error>> + Send;
 
     /// This function returns a withdrawal request report that does the

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -1626,7 +1626,6 @@ impl super::DbRead for PgStore {
                 ON wre.request_id = wr.request_id
             LEFT JOIN stacks_context_window sc2
                 ON wre.block_hash = sc2.block_hash
-            -- TODO: check also for accept-withdrawal events?
             -- Request is expired
             WHERE wr.bitcoin_block_height < $4
 

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -32,6 +32,8 @@ use crate::storage::model::WithdrawalRejectEvent;
 use crate::DEPOSIT_LOCKTIME_BLOCK_BUFFER;
 use crate::MAX_MEMPOOL_PACKAGE_TX_COUNT;
 use crate::MAX_REORG_BLOCK_COUNT;
+use crate::WITHDRAWAL_BLOCKS_EXPIRY;
+use crate::WITHDRAWAL_MIN_CONFIRMATIONS;
 
 /// All migration scripts from the `signer/migrations` directory.
 static PGSQL_MIGRATIONS: include_dir::Dir =
@@ -767,7 +769,7 @@ impl PgStore {
 
     /// Check whether the given block hash is a part of the stacks
     /// blockchain identified by the given chain-tip.
-    async fn in_canonical_stacks_blockchain(
+    pub async fn in_canonical_stacks_blockchain(
         &self,
         chain_tip: &model::StacksBlockHash,
         block_hash: &model::StacksBlockHash,
@@ -1548,6 +1550,152 @@ impl super::DbRead for PgStore {
         .bind(stacks_chain_tip.block_hash)
         .bind(i32::from(context_window))
         .bind(i64::from(threshold))
+        .fetch_all(&self.0)
+        .await
+        .map_err(Error::SqlxQuery)
+    }
+
+    async fn get_pending_rejected_withdrawal_requests(
+        &self,
+        chain_tip: &model::BitcoinBlockRef,
+        context_window: u16,
+        max_rejections: u16,
+    ) -> Result<Vec<model::WithdrawalRequest>, Error> {
+        let Some(stacks_chain_tip) = self.get_stacks_chain_tip(&chain_tip.block_hash).await? else {
+            return Ok(Vec::new());
+        };
+
+        let confirmation_height = chain_tip
+            .block_height
+            .saturating_sub(WITHDRAWAL_MIN_CONFIRMATIONS);
+        let expiration_height = chain_tip
+            .block_height
+            .saturating_sub(WITHDRAWAL_BLOCKS_EXPIRY);
+
+        sqlx::query_as::<_, model::WithdrawalRequest>(
+            r#"
+            WITH RECURSIVE bitcoin_blockchain AS (
+                SELECT
+                    block_hash
+                  , block_height
+                FROM bitcoin_blockchain_of($1, $2)
+            ),
+            stacks_context_window AS (
+                SELECT
+                    stacks_blocks.block_hash
+                  , stacks_blocks.block_height
+                  , stacks_blocks.parent_hash
+                FROM sbtc_signer.stacks_blocks stacks_blocks
+                WHERE stacks_blocks.block_hash = $3
+
+                UNION ALL
+
+                SELECT
+                    parent.block_hash
+                  , parent.block_height
+                  , parent.parent_hash
+                FROM sbtc_signer.stacks_blocks parent
+                JOIN stacks_context_window last
+                  ON parent.block_hash = last.parent_hash
+                JOIN bitcoin_blockchain block
+                  ON block.block_hash = parent.bitcoin_anchor
+            ),
+            -- First compute the pending requests, i.e. requestes that are final
+            -- but have no confirmed withdrawals outputs tx nor rejected events 
+            pending_withdrawals AS (
+                SELECT
+                    wr.request_id
+                  , wr.txid
+                  , wr.block_hash
+                  , wr.recipient
+                  , wr.amount
+                  , wr.max_fee
+                  , wr.sender_address
+                  , wr.bitcoin_block_height
+                FROM sbtc_signer.withdrawal_requests wr
+                -- Request confirmed on stacks chain
+                JOIN stacks_context_window sc ON wr.block_hash = sc.block_hash
+                -- Request not accepted
+                LEFT JOIN sbtc_signer.bitcoin_withdrawals_outputs AS bwo
+                  ON bwo.request_id = wr.request_id
+                 AND bwo.stacks_block_hash = wr.block_hash
+                LEFT JOIN bitcoin_transactions AS bc_trx
+                  ON bc_trx.txid = bwo.bitcoin_txid
+                LEFT JOIN bitcoin_blockchain
+                  ON bc_trx.block_hash = bitcoin_blockchain.block_hash
+                -- Request not rejected
+                LEFT JOIN withdrawal_reject_events AS wre
+                  ON wre.request_id = wr.request_id
+                LEFT JOIN stacks_context_window sc2
+                  ON wre.block_hash = sc2.block_hash
+                WHERE
+                    -- Request is final
+                    wr.bitcoin_block_height <= $4
+
+                -- we need to group since we could have multiple withdrawals 
+                -- outputs for a single request, and some of them may not be in
+                -- the canonical chain, resulting in a NULL bc_trx.block_hash;
+                -- so we group and check that all the rows have NULL
+                GROUP BY
+                    wr.request_id
+                  , wr.txid
+                  , wr.block_hash
+                  , wr.recipient
+                  , wr.amount
+                  , wr.max_fee
+                  , wr.sender_address
+                  , wr.bitcoin_block_height
+                HAVING
+                    -- Request not accepted (cont'd)
+                    COUNT(bc_trx.block_hash) = 0
+                    -- Request not rejected (cont'd)
+                AND COUNT(sc2.block_hash) = 0
+            )
+            -- Now from the above pick the ones having either enough votes
+            -- against, or have expired
+            SELECT
+                wr.request_id
+              , wr.txid
+              , wr.block_hash
+              , wr.recipient
+              , wr.amount
+              , wr.max_fee
+              , wr.sender_address
+              , wr.bitcoin_block_height
+            FROM pending_withdrawals wr
+            JOIN sbtc_signer.withdrawal_signers signers USING(request_id, block_hash)
+            WHERE NOT signers.is_accepted
+            GROUP BY wr.request_id
+                   , wr.txid
+                   , wr.block_hash
+                   , wr.recipient
+                   , wr.amount
+                   , wr.max_fee
+                   , wr.sender_address
+                   , wr.bitcoin_block_height
+            HAVING COUNT(wr.request_id) > $5
+            
+            UNION
+            
+            SELECT
+                wr.request_id
+              , wr.txid
+              , wr.block_hash
+              , wr.recipient
+              , wr.amount
+              , wr.max_fee
+              , wr.sender_address
+              , wr.bitcoin_block_height
+            FROM pending_withdrawals wr
+            WHERE wr.bitcoin_block_height < $6
+            "#,
+        )
+        .bind(chain_tip.block_hash)
+        .bind(i32::from(context_window))
+        .bind(stacks_chain_tip.block_hash)
+        .bind(i64::try_from(confirmation_height).map_err(Error::ConversionDatabaseInt)?)
+        .bind(i32::from(max_rejections))
+        .bind(i64::try_from(expiration_height).map_err(Error::ConversionDatabaseInt)?)
         .fetch_all(&self.0)
         .await
         .map_err(Error::SqlxQuery)

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -14,7 +14,6 @@ use blockstack_lib::types::chainstate::StacksAddress;
 use fake::Faker;
 use futures::future::join_all;
 use futures::StreamExt as _;
-use more_asserts::assert_ge;
 use more_asserts::assert_gt;
 use more_asserts::assert_le;
 use rand::seq::IteratorRandom as _;
@@ -24,7 +23,6 @@ use signer::storage::model::DkgSharesStatus;
 use signer::storage::model::WithdrawalRequest;
 use signer::testing::IterTestExt as _;
 use signer::WITHDRAWAL_BLOCKS_EXPIRY;
-use signer::WITHDRAWAL_MIN_CONFIRMATIONS;
 use time::OffsetDateTime;
 
 use signer::bitcoin::validation::DepositConfirmationStatus;
@@ -4499,8 +4497,7 @@ async fn pending_rejected_withdrawal_no_events() {
     let mut rng = rand::rngs::StdRng::seed_from_u64(42);
 
     let num_signers = 10;
-    let threshold = 6;
-    let context_window = 10;
+    let context_window = 1000;
     let test_model_params = testing::storage::model::Params {
         num_bitcoin_blocks: 50,
         num_stacks_blocks_per_bitcoin_block: 3,
@@ -4509,34 +4506,35 @@ async fn pending_rejected_withdrawal_no_events() {
         num_signers_per_request: num_signers,
         consecutive_blocks: false,
     };
-    let max_rejections = (num_signers - threshold) as u16;
 
     let signer_set = testing::wsts::generate_signer_set_public_keys(&mut rng, num_signers);
 
     let test_data = TestData::generate(&mut rng, &signer_set, &test_model_params);
 
     test_data.write_to(&mut db).await;
-    // Also write DKG shares to later fetch the votes
-    let shares = EncryptedDkgShares {
-        signer_set_public_keys: signer_set,
-        signature_share_threshold: threshold as u16,
-        dkg_shares_status: model::DkgSharesStatus::Verified,
-        ..fake::Faker.fake_with_rng(&mut rng)
-    };
-    db.write_encrypted_dkg_shares(&shares).await.unwrap();
 
-    let bitcoin_chain_tip = db
+    let mut bitcoin_chain_tip = db
         .get_bitcoin_canonical_chain_tip_ref()
         .await
         .expect("failed to get canonical chain tip")
         .expect("no chain tip");
 
+    let chain_depth = bitcoin_chain_tip.block_height - test_data.bitcoin_blocks[0].block_height;
+
+    // Append some blocks to ensure we have expired requests
+    for _ in chain_depth..WITHDRAWAL_BLOCKS_EXPIRY + 5 {
+        let new_block = BitcoinBlock {
+            block_hash: fake::Faker.fake_with_rng(&mut rng),
+            block_height: bitcoin_chain_tip.block_height + 1,
+            parent_hash: bitcoin_chain_tip.block_hash,
+        };
+        db.write_bitcoin_block(&new_block).await.unwrap();
+
+        bitcoin_chain_tip = new_block.into();
+    }
+
     let pending_rejected = db
-        .get_pending_rejected_withdrawal_requests(
-            &bitcoin_chain_tip,
-            context_window,
-            max_rejections,
-        )
+        .get_pending_rejected_withdrawal_requests(&bitcoin_chain_tip, context_window)
         .await
         .expect("failed to get pending rejected withdrawals");
     assert!(!pending_rejected.is_empty());
@@ -4568,30 +4566,11 @@ async fn pending_rejected_withdrawal_no_events() {
             continue;
         }
 
-        let id = withdrawal.qualified_id();
         let confirmations = bitcoin_chain_tip.block_height - withdrawal.bitcoin_block_height;
-
-        if confirmations < WITHDRAWAL_MIN_CONFIRMATIONS {
-            assert!(!pending_rejected.contains(&withdrawal));
-            continue;
-        }
-
-        let is_expired = confirmations > WITHDRAWAL_BLOCKS_EXPIRY;
-
-        let vote_against = db
-            .get_withdrawal_request_signer_votes(&id, &shares.aggregate_key)
-            .await
-            .unwrap()
-            .iter()
-            .filter(|vote| !vote.is_accepted.unwrap_or(true))
-            .count();
-        let is_rejected = vote_against as u16 > max_rejections;
-
-        if pending_rejected.contains(&withdrawal) {
-            assert!(is_expired || is_rejected);
-        } else {
-            assert!(!is_expired && !is_rejected);
-        }
+        assert_eq!(
+            pending_rejected.contains(&withdrawal),
+            confirmations > WITHDRAWAL_BLOCKS_EXPIRY
+        )
     }
 
     signer::testing::storage::drop_db(db).await;
@@ -4605,8 +4584,6 @@ async fn pending_rejected_withdrawal_expiration() {
     let mut rng = rand::rngs::StdRng::seed_from_u64(42);
 
     let num_signers = 10;
-    let threshold = 6;
-    let max_rejections = (num_signers - threshold) as u16;
 
     // Let's start with a fork-less chain
     let test_model_params = testing::storage::model::Params {
@@ -4621,7 +4598,7 @@ async fn pending_rejected_withdrawal_expiration() {
     let test_data = TestData::generate(&mut rng, &signer_set, &test_model_params);
     test_data.write_to(&mut db).await;
 
-    // Add a withdrawal request not yet confirmed
+    // Add a withdrawal request not yet confirmed nor expired
     let request_confirmations = 1;
     let request_bitcoin_block = test_data
         .bitcoin_blocks
@@ -4663,7 +4640,7 @@ async fn pending_rejected_withdrawal_expiration() {
 
         // Check that now we do get it as rejected
         let pending_rejected = db
-            .get_pending_rejected_withdrawal_requests(&new_block.into(), 1000, max_rejections)
+            .get_pending_rejected_withdrawal_requests(&new_block.into(), 1000)
             .await
             .expect("failed to get pending rejected withdrawals");
 
@@ -4691,121 +4668,11 @@ async fn pending_rejected_withdrawal_expiration() {
 
     // Check that now we do get it as rejected
     let pending_rejected = db
-        .get_pending_rejected_withdrawal_requests(&new_block.into(), 1000, max_rejections)
+        .get_pending_rejected_withdrawal_requests(&new_block.into(), 1000)
         .await
         .expect("failed to get pending rejected withdrawals");
 
     assert_eq!(&pending_rejected.single(), &request);
-
-    signer::testing::storage::drop_db(db).await;
-}
-
-/// Test that a withdrawal with enough votes against is considered rejected
-/// after being confirmed on bitcoin.
-#[test_log::test(tokio::test)]
-async fn pending_rejected_withdrawal_rejected() {
-    let mut db = testing::storage::new_test_database().await;
-    let mut rng = rand::rngs::StdRng::seed_from_u64(42);
-
-    let num_signers = 10;
-    let threshold = 6;
-    let max_rejections = (num_signers - threshold) as u16;
-
-    // Let's start with a fork-less chain
-    let test_model_params = testing::storage::model::Params {
-        num_bitcoin_blocks: 10,
-        num_stacks_blocks_per_bitcoin_block: 3,
-        num_deposit_requests_per_block: 0,
-        num_withdraw_requests_per_block: 0,
-        num_signers_per_request: 0,
-        consecutive_blocks: true,
-    };
-    let signer_set = testing::wsts::generate_signer_set_public_keys(&mut rng, num_signers);
-    let test_data = TestData::generate(&mut rng, &signer_set, &test_model_params);
-    test_data.write_to(&mut db).await;
-
-    // Add a withdrawal request not yet confirmed
-    let request_confirmations = WITHDRAWAL_MIN_CONFIRMATIONS as usize - 1;
-    let request_bitcoin_block = test_data
-        .bitcoin_blocks
-        .get(test_data.bitcoin_blocks.len() - request_confirmations - 1)
-        .unwrap();
-    let request_stacks_block = test_data
-        .stacks_blocks
-        .iter()
-        .find(|block| block.bitcoin_anchor == request_bitcoin_block.block_hash)
-        .unwrap();
-
-    let request = WithdrawalRequest {
-        block_hash: request_stacks_block.block_hash,
-        bitcoin_block_height: request_bitcoin_block.block_height,
-        ..fake::Faker.fake_with_rng(&mut rng)
-    };
-    db.write_withdrawal_request(&request).await.unwrap();
-
-    // Add enough votes against
-    for signer in signer_set.iter().take(max_rejections as usize + 1) {
-        let decision = WithdrawalSigner {
-            request_id: request.request_id,
-            txid: request.txid,
-            block_hash: request.block_hash,
-            signer_pub_key: signer.clone(),
-            is_accepted: false,
-        };
-        db.write_withdrawal_signer_decision(&decision)
-            .await
-            .unwrap();
-    }
-
-    let bitcoin_chain_tip = db
-        .get_bitcoin_canonical_chain_tip_ref()
-        .await
-        .expect("failed to get canonical chain tip")
-        .expect("no chain tip");
-
-    assert_eq!(
-        bitcoin_chain_tip.block_height - request.bitcoin_block_height,
-        WITHDRAWAL_MIN_CONFIRMATIONS - 1
-    );
-
-    // Check we don't get it as rejected yet
-    let pending_rejected = db
-        .get_pending_rejected_withdrawal_requests(&bitcoin_chain_tip, 1000, max_rejections)
-        .await
-        .expect("failed to get pending rejected withdrawals");
-
-    assert!(pending_rejected.is_empty());
-
-    // Append a new block, reaching WITHDRAWAL_MIN_CONFIRMATIONS, and then
-    // continue exceeding WITHDRAWAL_BLOCKS_EXPIRY, checking that the request
-    // stays rejected
-    for _ in 0..WITHDRAWAL_BLOCKS_EXPIRY {
-        let bitcoin_chain_tip = db
-            .get_bitcoin_canonical_chain_tip_ref()
-            .await
-            .expect("failed to get canonical chain tip")
-            .expect("no chain tip");
-
-        let new_block = BitcoinBlock {
-            block_hash: fake::Faker.fake_with_rng(&mut rng),
-            block_height: bitcoin_chain_tip.block_height + 1,
-            parent_hash: bitcoin_chain_tip.block_hash,
-        };
-        db.write_bitcoin_block(&new_block).await.unwrap();
-
-        assert_ge!(
-            new_block.block_height - request.bitcoin_block_height,
-            WITHDRAWAL_MIN_CONFIRMATIONS
-        );
-
-        // Check that now we do get it as rejected
-        let pending_rejected = db
-            .get_pending_rejected_withdrawal_requests(&new_block.into(), 1000, max_rejections)
-            .await
-            .expect("failed to get pending rejected withdrawals");
-
-        assert_eq!(&pending_rejected.single(), &request);
-    }
 
     signer::testing::storage::drop_db(db).await;
 }
@@ -4818,12 +4685,10 @@ async fn pending_rejected_withdrawal_rejected_already_rejected() {
     let mut rng = rand::rngs::StdRng::seed_from_u64(42);
 
     let num_signers = 10;
-    let threshold = 6;
-    let max_rejections = (num_signers - threshold) as u16;
 
     // Let's start with a fork-less chain
     let test_model_params = testing::storage::model::Params {
-        num_bitcoin_blocks: 10,
+        num_bitcoin_blocks: 30,
         num_stacks_blocks_per_bitcoin_block: 3,
         num_deposit_requests_per_block: 0,
         num_withdraw_requests_per_block: 0,
@@ -4834,8 +4699,8 @@ async fn pending_rejected_withdrawal_rejected_already_rejected() {
     let test_data = TestData::generate(&mut rng, &signer_set, &test_model_params);
     test_data.write_to(&mut db).await;
 
-    // Add a withdrawal request not yet confirmed
-    let request_confirmations = WITHDRAWAL_MIN_CONFIRMATIONS as usize;
+    // Add a withdrawal request already expired
+    let request_confirmations = WITHDRAWAL_BLOCKS_EXPIRY as usize + 1;
     let request_bitcoin_block = test_data
         .bitcoin_blocks
         .get(test_data.bitcoin_blocks.len() - request_confirmations - 1)
@@ -4853,20 +4718,6 @@ async fn pending_rejected_withdrawal_rejected_already_rejected() {
     };
     db.write_withdrawal_request(&request).await.unwrap();
 
-    // Add enough votes against
-    for signer in signer_set.iter().take(max_rejections as usize + 1) {
-        let decision = WithdrawalSigner {
-            request_id: request.request_id,
-            txid: request.txid,
-            block_hash: request.block_hash,
-            signer_pub_key: signer.clone(),
-            is_accepted: false,
-        };
-        db.write_withdrawal_signer_decision(&decision)
-            .await
-            .unwrap();
-    }
-
     // First, check that the request is pending rejected
     let bitcoin_chain_tip = db
         .get_bitcoin_canonical_chain_tip_ref()
@@ -4875,7 +4726,7 @@ async fn pending_rejected_withdrawal_rejected_already_rejected() {
         .expect("no chain tip");
 
     let pending_rejected = db
-        .get_pending_rejected_withdrawal_requests(&bitcoin_chain_tip, 1000, max_rejections)
+        .get_pending_rejected_withdrawal_requests(&bitcoin_chain_tip, 1000)
         .await
         .expect("failed to get pending rejected withdrawals");
 
@@ -4895,6 +4746,7 @@ async fn pending_rejected_withdrawal_rejected_already_rejected() {
             .unwrap()
             .unwrap();
     }
+
     // Create the forked block that will contain the reject event
     let forked_stacks_block = StacksBlock {
         parent_hash: fork_base.block_hash,
@@ -4909,6 +4761,14 @@ async fn pending_rejected_withdrawal_rejected_already_rejected() {
         .await
         .unwrap()
         .unwrap();
+    assert!(db
+        .in_canonical_stacks_blockchain(
+            &stacks_chain_tip.block_hash,
+            &fork_base.block_hash,
+            fork_base.block_height
+        )
+        .await
+        .unwrap());
     assert!(!db
         .in_canonical_stacks_blockchain(
             &stacks_chain_tip.block_hash,
@@ -4927,13 +4787,13 @@ async fn pending_rejected_withdrawal_rejected_already_rejected() {
 
     // With a forked rejection event, the request is still pending rejected
     let pending_rejected = db
-        .get_pending_rejected_withdrawal_requests(&bitcoin_chain_tip, 1000, max_rejections)
+        .get_pending_rejected_withdrawal_requests(&bitcoin_chain_tip, 1000)
         .await
         .expect("failed to get pending rejected withdrawals");
 
     assert_eq!(&pending_rejected.single(), &request);
 
-    // Now let's add a confirmed rejection event (to fork base, so it's in the
+    // Now let's add a confirmed rejection event to fork base, so it's in the
     // canonical chain.
     let event = WithdrawalRejectEvent {
         request_id: request.request_id,
@@ -4944,10 +4804,174 @@ async fn pending_rejected_withdrawal_rejected_already_rejected() {
 
     // With a confirmed rejection event, we should no longer get the request
     let pending_rejected = db
-        .get_pending_rejected_withdrawal_requests(&bitcoin_chain_tip, 1000, max_rejections)
+        .get_pending_rejected_withdrawal_requests(&bitcoin_chain_tip, 1000)
         .await
         .expect("failed to get pending rejected withdrawals");
 
+    assert!(pending_rejected.is_empty());
+
+    signer::testing::storage::drop_db(db).await;
+}
+
+/// Check that pending_rejected_withdrawal correctly skips expired requests
+/// that have a confirmed withdrawal output.
+#[test_log::test(tokio::test)]
+async fn pending_rejected_withdrawal_already_accepted() {
+    let mut db = testing::storage::new_test_database().await;
+    let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+
+    let num_signers = 10;
+
+    // Let's start with a fork-less chain
+    let test_model_params = testing::storage::model::Params {
+        num_bitcoin_blocks: 30,
+        num_stacks_blocks_per_bitcoin_block: 3,
+        num_deposit_requests_per_block: 0,
+        num_withdraw_requests_per_block: 0,
+        num_signers_per_request: 0,
+        consecutive_blocks: true,
+    };
+    let signer_set = testing::wsts::generate_signer_set_public_keys(&mut rng, num_signers);
+    let test_data = TestData::generate(&mut rng, &signer_set, &test_model_params);
+    test_data.write_to(&mut db).await;
+
+    // Add a withdrawal request already expired
+    let request_confirmations = WITHDRAWAL_BLOCKS_EXPIRY as usize + 1;
+    let request_bitcoin_block = test_data
+        .bitcoin_blocks
+        .get(test_data.bitcoin_blocks.len() - request_confirmations - 1)
+        .unwrap();
+    let request_stacks_block = test_data
+        .stacks_blocks
+        .iter()
+        .find(|block| block.bitcoin_anchor == request_bitcoin_block.block_hash)
+        .unwrap();
+
+    let request = WithdrawalRequest {
+        block_hash: request_stacks_block.block_hash,
+        bitcoin_block_height: request_bitcoin_block.block_height,
+        ..fake::Faker.fake_with_rng(&mut rng)
+    };
+    db.write_withdrawal_request(&request).await.unwrap();
+
+    // First, check that the request is pending rejected
+    let bitcoin_chain_tip = db
+        .get_bitcoin_canonical_chain_tip_ref()
+        .await
+        .expect("failed to get canonical chain tip")
+        .expect("no chain tip");
+
+    let pending_rejected = db
+        .get_pending_rejected_withdrawal_requests(&bitcoin_chain_tip, 1000)
+        .await
+        .expect("failed to get pending rejected withdrawals");
+
+    assert_eq!(&pending_rejected.single(), &request);
+
+    // Now, let's add a withdrawal output in a fork (tip - 2)
+    let mut fork_base = db
+        .get_bitcoin_block(&bitcoin_chain_tip.block_hash)
+        .await
+        .unwrap()
+        .unwrap();
+    for _ in 0..2 {
+        fork_base = db
+            .get_bitcoin_block(&fork_base.parent_hash)
+            .await
+            .unwrap()
+            .unwrap();
+    }
+
+    // Create the forked block that will contain the withdrawal output
+    let forked_block = BitcoinBlock {
+        parent_hash: fork_base.block_hash,
+        block_height: fork_base.block_height + 1,
+        ..fake::Faker.fake_with_rng(&mut rng)
+    };
+    db.write_bitcoin_block(&forked_block).await.unwrap();
+
+    let forked_withdrawal_output = BitcoinWithdrawalOutput {
+        request_id: request.request_id,
+        stacks_block_hash: request.block_hash,
+        ..fake::Faker.fake_with_rng(&mut rng)
+    };
+    db.write_bitcoin_withdrawals_outputs(&[forked_withdrawal_output.clone()])
+        .await
+        .unwrap();
+    db.write_transaction(&model::Transaction {
+        txid: forked_withdrawal_output.bitcoin_txid.into_bytes(),
+        tx: vec![],
+        tx_type: model::TransactionType::SbtcTransaction,
+        block_hash: forked_block.block_hash.into_bytes(),
+    })
+    .await
+    .unwrap();
+    db.write_bitcoin_transaction(&model::BitcoinTxRef {
+        txid: forked_withdrawal_output.bitcoin_txid,
+        block_hash: forked_block.block_hash,
+    })
+    .await
+    .unwrap();
+
+    let bitcoin_chain_tip = db
+        .get_bitcoin_canonical_chain_tip_ref()
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(db
+        .in_canonical_bitcoin_blockchain(&bitcoin_chain_tip, &fork_base.clone().into(),)
+        .await
+        .unwrap());
+    assert!(!db
+        .in_canonical_bitcoin_blockchain(&bitcoin_chain_tip, &forked_block.into(),)
+        .await
+        .unwrap());
+
+    // With a forked withdrawal output, the request is still pending rejected
+    let pending_rejected = db
+        .get_pending_rejected_withdrawal_requests(&bitcoin_chain_tip, 1000)
+        .await
+        .expect("failed to get pending rejected withdrawals");
+    assert_eq!(&pending_rejected.single(), &request);
+
+    // Now let's add a withdrawal output in the canonical chain
+    let canonical_withdrawal_output = BitcoinWithdrawalOutput {
+        request_id: request.request_id,
+        stacks_block_hash: request.block_hash,
+        ..fake::Faker.fake_with_rng(&mut rng)
+    };
+    db.write_bitcoin_withdrawals_outputs(&[canonical_withdrawal_output.clone()])
+        .await
+        .unwrap();
+
+    // The output is not confirmed yet, so it shouldn't affect the request
+    let pending_rejected = db
+        .get_pending_rejected_withdrawal_requests(&bitcoin_chain_tip, 1000)
+        .await
+        .expect("failed to get pending rejected withdrawals");
+    assert_eq!(&pending_rejected.single(), &request);
+
+    // Confirming it (putting the output txid in a confirmed block)
+    db.write_transaction(&model::Transaction {
+        txid: canonical_withdrawal_output.bitcoin_txid.into_bytes(),
+        tx: vec![],
+        tx_type: model::TransactionType::SbtcTransaction,
+        block_hash: fork_base.block_hash.into_bytes(),
+    })
+    .await
+    .unwrap();
+    db.write_bitcoin_transaction(&model::BitcoinTxRef {
+        txid: canonical_withdrawal_output.bitcoin_txid,
+        block_hash: fork_base.block_hash,
+    })
+    .await
+    .unwrap();
+
+    // With a confirmed withdrawal output, we should no longer get the request
+    let pending_rejected = db
+        .get_pending_rejected_withdrawal_requests(&bitcoin_chain_tip, 1000)
+        .await
+        .expect("failed to get pending rejected withdrawals");
     assert!(pending_rejected.is_empty());
 
     signer::testing::storage::drop_db(db).await;

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -4546,6 +4546,13 @@ async fn pending_rejected_withdrawal_no_events() {
         .expect("no chain tip");
 
     for withdrawal in test_data.withdraw_requests {
+        if withdrawal.bitcoin_block_height == test_data.bitcoin_blocks[0].block_height {
+            // The stacks blocks in the first bitcoin block have an hallucinated
+            // anchor, so they are in the canonical chain but have no link to
+            // bitcoin chain, making things weird.
+            continue;
+        }
+
         let stacks_block = db
             .get_stacks_block(&withdrawal.block_hash)
             .await


### PR DESCRIPTION
## Description

Closes: https://github.com/stacks-network/sbtc/issues/1354

## Changes

Implement `get_pending_rejected_withdrawal_requests` to get requests that must be rejected via a contract call.

## Testing Information

Add tests covering different scenarios.

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
