### PR TITLE
feat: expire signature hashes with bitcoin blocks

### DIFF
--- a/signer/migrations/0014__add_bitcoin_chain_tip_sighashes_table.sql
+++ b/signer/migrations/0014__add_bitcoin_chain_tip_sighashes_table.sql
@@ -1,0 +1,12 @@
+BEGIN;
+
+-- 1. Drop the old primary key constraint on 'sighash'.
+ALTER TABLE sbtc_signer.bitcoin_tx_sighashes
+    DROP CONSTRAINT bitcoin_tx_sighashes_pkey;
+
+-- 2. Create a new primary key that includes 'chain_tip' as well.
+ALTER TABLE sbtc_signer.bitcoin_tx_sighashes
+    ADD CONSTRAINT bitcoin_tx_sighashes_pkey
+    PRIMARY KEY (sighash, chain_tip);
+
+COMMIT;

--- a/signer/src/storage/mod.rs
+++ b/signer/src/storage/mod.rs
@@ -350,7 +350,14 @@ pub trait DbRead {
         output_index: u32,
     ) -> impl Future<Output = Result<Option<model::DepositRequest>, Error>> + Send;
 
-    /// Get the bitcoin sighash output.
+    /// Return whether this signer will sign for the given sighash given
+    /// the current bitcoin chain tip. Also return the associated x-only
+    /// public key associated with the sighash.
+    ///
+    /// A signer should only use the current bitcoin chain tip here. Each
+    /// sighash is created with an associated bitcoin chain tip. When that
+    /// chain tip changes, a signer should no longer sign for any
+    /// associated sighashes.
     fn will_sign_bitcoin_tx_sighash(
         &self,
         sighash: &model::SigHash,

--- a/signer/src/storage/mod.rs
+++ b/signer/src/storage/mod.rs
@@ -354,6 +354,7 @@ pub trait DbRead {
     fn will_sign_bitcoin_tx_sighash(
         &self,
         sighash: &model::SigHash,
+        chain_tip: &model::BitcoinBlockHash,
     ) -> impl Future<Output = Result<Option<(bool, PublicKeyXOnly)>, Error>> + Send;
 }
 

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -2114,6 +2114,7 @@ impl super::DbRead for PgStore {
     async fn will_sign_bitcoin_tx_sighash(
         &self,
         sighash: &model::SigHash,
+        chain_tip: &model::BitcoinBlockHash,
     ) -> Result<Option<(bool, PublicKeyXOnly)>, Error> {
         sqlx::query_as::<_, (bool, PublicKeyXOnly)>(
             r#"
@@ -2122,9 +2123,11 @@ impl super::DbRead for PgStore {
               , x_only_public_key
             FROM sbtc_signer.bitcoin_tx_sighashes
             WHERE sighash = $1
+              AND chain_tip = $2
             "#,
         )
         .bind(sighash)
+        .bind(chain_tip)
         .fetch_optional(&self.0)
         .await
         .map_err(Error::SqlxQuery)

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -747,7 +747,7 @@ where
                         span.record("txid", txid.to_string());
 
                         let accepted_sighash =
-                            Self::validate_bitcoin_sign_request(&db, &request.message, &chain_tip)
+                            Self::validate_bitcoin_sign_request(&db, &request.message, chain_tip)
                                 .await;
 
                         let validation_status = match &accepted_sighash {
@@ -855,7 +855,7 @@ where
 
                         // Validate the sighash and upon success, convert it to
                         // a state machine ID.
-                        Self::validate_bitcoin_sign_request(&db, &request.message, &chain_tip)
+                        Self::validate_bitcoin_sign_request(&db, &request.message, chain_tip)
                             .await?
                             .sighash
                             .into()

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -3886,7 +3886,7 @@ async fn can_write_and_get_multiple_bitcoin_txs_sighashes() {
 
     let withdrawal_outputs_futures = sighashes
         .iter()
-        .map(|sighash| db.will_sign_bitcoin_tx_sighash(&sighash.sighash));
+        .map(|sighash| db.will_sign_bitcoin_tx_sighash(&sighash.sighash, &sighash.chain_tip));
 
     let results = join_all(withdrawal_outputs_futures).await;
 

--- a/signer/tests/integration/transaction_signer.rs
+++ b/signer/tests/integration/transaction_signer.rs
@@ -288,6 +288,17 @@ pub async fn assert_should_be_able_to_handle_sbtc_requests() {
 
     assert!(will_sign);
 
+    // Check that an incorrect block hash leads to None being returned by
+    // the `will_sign_bitcoin_tx_sighash` query
+    let some_block_hash = setup.deposit_block_hash.into();
+    assert_ne!(some_block_hash, chain_tip.block_hash);
+    let response = db
+        .will_sign_bitcoin_tx_sighash(&deposit_digest.sighash.into(), &some_block_hash)
+        .await
+        .expect("query to check if deposit sighash is stored failed");
+
+    assert!(response.is_none());
+
     testing::storage::drop_db(db).await;
 }
 

--- a/signer/tests/integration/transaction_signer.rs
+++ b/signer/tests/integration/transaction_signer.rs
@@ -274,14 +274,14 @@ pub async fn assert_should_be_able_to_handle_sbtc_requests() {
     // Check that the intentions to sign the requests sighashes
     // are stored in the database
     let (will_sign, _) = db
-        .will_sign_bitcoin_tx_sighash(&signer_digest.sighash.into())
+        .will_sign_bitcoin_tx_sighash(&signer_digest.sighash.into(), &chain_tip.block_hash)
         .await
         .expect("query to check if signer sighash is stored failed")
         .expect("signer sighash not stored");
 
     assert!(will_sign);
     let (will_sign, _) = db
-        .will_sign_bitcoin_tx_sighash(&deposit_digest.sighash.into())
+        .will_sign_bitcoin_tx_sighash(&deposit_digest.sighash.into(), &chain_tip.block_hash)
         .await
         .expect("query to check if deposit sighash is stored failed")
         .expect("deposit sighash not stored");


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/1365.

## Changes

* Change the primary key on the `bitcoin_tx_sighashes` table to be a compound primary key with the bitcoin chain tip block hash.
* Require the chain tip when querying whether a signer will sign for a given sighash.

## Testing Information

This PR adds a small check that a given sighash does not return the same result with a different sighash.

## Checklist:

- [x] I have performed a self-review of my code
