### PR TITLE
feat: Disable nightly Docker builds on CI

### DIFF
--- a/.github/workflows/image-build.yaml
+++ b/.github/workflows/image-build.yaml
@@ -4,8 +4,8 @@ name: Docker Image (Binary)
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '0 2 * * *'
+  # schedule:
+  #   - cron: '0 2 * * *'
   push:
     tags:
       - '*'


### PR DESCRIPTION
Fixes a small annoyance as long as we don't get automated builds to ECR (https://github.com/stacks-network/sbtc/issues/1305).