### PR TITLE
fix: Remove Bitcoin RPC

### DIFF
--- a/docker/mainnet/nodes/docker-compose.chains.yml
+++ b/docker/mainnet/nodes/docker-compose.chains.yml
@@ -61,9 +61,6 @@ services:
       - ./nodes/stacks/Config.toml.in:/stacks/Config.toml.in:ro
       - /mnt/stacks:/stacks
     environment:
-      BITCOIN_RPC_USERNAME: *BITCOIN_RPC_USERNAME
-      BITCOIN_RPC_PASSWORD: *BITCOIN_RPC_PASSWORD
-      BITCOIN_RPC_PORT: *BITCOIN_RPC_PORT
       STACKS_RPC_PORT: *STACKS_RPC_PORT
     entrypoint:
       - /bin/bash

--- a/docker/mainnet/nodes/stacks/Config.toml.in
+++ b/docker/mainnet/nodes/stacks/Config.toml.in
@@ -10,9 +10,6 @@ bootstrap_node = "02196f005965cebe6ddc3901b7b1cc1aa7a88f305bb8c5893456b8f9a60592
 chain = "bitcoin"
 mode = "mainnet"
 peer_host = "bitcoin"
-username = "$BITCOIN_RPC_USERNAME"
-password = "$BITCOIN_RPC_PASSWORD"
-rpc_port = $BITCOIN_RPC_PORT
 peer_port = 8333
 
 [connection_options]


### PR DESCRIPTION
## Description

Remove the RPC Bitcoin connection

Following a PR for the documentation.

Closes: https://github.com/stacks-network/sbtc/issues/1309

## Changes

- Remove RPC Bitcoin connection from the docker-compose examples

## Testing Information

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
