### PR TITLE
chore: fix bitcoin-miner image in devenv

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -268,7 +268,7 @@ services:
       - bitcoin-mempool
 
   bitcoin-miner:
-    build: bitcoin
+    image: bitcoin/bitcoin:25.2
     depends_on:
       bitcoin:
         condition: service_healthy
@@ -286,6 +286,7 @@ services:
       - /bin/bash
       - -c
       - |
+        apt-get update && apt-get install -y jq
         set -e
         trap "exit" INT TERM
         trap "kill 0" EXIT


### PR DESCRIPTION
## Description

Address https://github.com/stacks-network/sbtc/issues/1384
Follow up for https://github.com/stacks-network/sbtc/pull/1307

We removed the `bitcoin` Dockerfile, but the miner was still referencing it. We didn't catch this because we didn't try to rebuild the whole stack and devenv doesn't run in CI.

A possible downside of the current approach is that we require a network connection for the container to start up (this applies to `stacks-node`, `stacks-signer-*` and `bitcoin-miner`), so it's not possible to run devenv offline.

## Testing Information

Tested with `docker compose -f docker/docker-compose.yml --profile default --profile bitcoin-mempool --profile sbtc-signer build --no-cache --pull` (+ usual demo run).

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
