### PR TITLE
[feat] Change Validation Check

### DIFF
--- a/docker/mainnet/nodes/docker-compose.chains.yml
+++ b/docker/mainnet/nodes/docker-compose.chains.yml
@@ -61,9 +61,6 @@ services:
       - ./nodes/stacks/Config.toml.in:/stacks/Config.toml.in:ro
       - /mnt/stacks:/stacks
     environment:
-      BITCOIN_RPC_USERNAME: *BITCOIN_RPC_USERNAME
-      BITCOIN_RPC_PASSWORD: *BITCOIN_RPC_PASSWORD
-      BITCOIN_RPC_PORT: *BITCOIN_RPC_PORT
       STACKS_RPC_PORT: *STACKS_RPC_PORT
     entrypoint:
       - /bin/bash

--- a/docker/mainnet/nodes/stacks/Config.toml.in
+++ b/docker/mainnet/nodes/stacks/Config.toml.in
@@ -10,9 +10,6 @@ bootstrap_node = "02196f005965cebe6ddc3901b7b1cc1aa7a88f305bb8c5893456b8f9a60592
 chain = "bitcoin"
 mode = "mainnet"
 peer_host = "bitcoin"
-username = "$BITCOIN_RPC_USERNAME"
-password = "$BITCOIN_RPC_PASSWORD"
-rpc_port = $BITCOIN_RPC_PORT
 peer_port = 8333
 
 [connection_options]

--- a/emily/cdk/lib/constants.ts
+++ b/emily/cdk/lib/constants.ts
@@ -26,6 +26,11 @@ export class Constants {
     static TEMP_STAGE_NAME: string = "temp";
 
     /**
+     * Stage name used for temporary stacks.
+     */
+    static PRIVATE_MAINNET_STAGE_NAME: string = "private-mainnet";
+
+    /**
      * Default stage name used when no stage name is provided.
      */
     static DEFAULT_STAGE_NAME: string = "dev";

--- a/emily/cdk/lib/emily-stack-utils.ts
+++ b/emily/cdk/lib/emily-stack-utils.ts
@@ -148,7 +148,8 @@ export class EmilyStackUtils {
         return this.getStageName() === Constants.DEV_STAGE_NAME
             || this.getStageName() === Constants.LOCAL_STAGE_NAME
             || this.getStageName() === Constants.UNIT_TEST_STAGE_NAME
-            || this.getStageName() === Constants.TEMP_STAGE_NAME;
+            || this.getStageName() === Constants.TEMP_STAGE_NAME
+            || this.getStageName() === Constants.PRIVATE_MAINNET_STAGE_NAME;
     }
 
     /*

--- a/emily/cdk/lib/emily-stack.ts
+++ b/emily/cdk/lib/emily-stack.ts
@@ -343,7 +343,7 @@ export class EmilyStack extends cdk.Stack {
                 // already expected to be present in the lambda.
                 IS_LOCAL: "false",
                 TRUSTED_REORG_API_KEY: props.trustedReorgApiKey,
-                IS_MAINNET: props.stageName == Constants.PROD_STAGE_NAME ? "true" : "false",
+                IS_MAINNET: props.stageName == Constants.PROD_STAGE_NAME || props.stageName == Constants.PRIVATE_MAINNET_STAGE_NAME ? "true" : "false",
             },
             description: `Emily Api Handler. ${EmilyStackUtils.getLambdaGitIdentifier()}`,
             currentVersionOptions: {

--- a/scripts/deploy-emily.sh
+++ b/scripts/deploy-emily.sh
@@ -36,6 +36,6 @@ fi
         --profile "${AWS_DEPLOYMENT_PROFILE}"
     echo "Done bootstrapping CDK."
     npx aws-cdk deploy \
-        --profile "${AWS_DEPLOYMENT_PROFILE}"
+        --profile "${AWS_DEPLOYMENT_PROFILE}" \
         --require-approval any-change
 }

--- a/signer/src/testing/block_observer.rs
+++ b/signer/src/testing/block_observer.rs
@@ -330,6 +330,9 @@ impl StacksInteract for TestHarness {
     ) -> Result<bool, Error> {
         unimplemented!()
     }
+    async fn is_withdrawal_completed(&self, _: &StacksAddress, _: u64) -> Result<bool, Error> {
+        unimplemented!()
+    }
     async fn get_account(&self, _address: &StacksAddress) -> Result<AccountInfo, Error> {
         // issue #118
         todo!()

--- a/signer/src/testing/context.rs
+++ b/signer/src/testing/context.rs
@@ -414,6 +414,18 @@ impl StacksInteract for WrappedMock<MockStacksInteract> {
             .await
     }
 
+    async fn is_withdrawal_completed(
+        &self,
+        contract_principal: &StacksAddress,
+        request_id: u64,
+    ) -> Result<bool, Error> {
+        self.inner
+            .lock()
+            .await
+            .is_withdrawal_completed(contract_principal, request_id)
+            .await
+    }
+
     async fn get_account(&self, address: &StacksAddress) -> Result<AccountInfo, Error> {
         self.inner.lock().await.get_account(address).await
     }

--- a/signer/tests/integration/contracts.rs
+++ b/signer/tests/integration/contracts.rs
@@ -17,6 +17,7 @@ use signer::config::Settings;
 use signer::stacks::api::StacksInteract;
 use signer::stacks::contracts::AcceptWithdrawalV1;
 use signer::stacks::contracts::AsContractCall;
+use signer::stacks::contracts::AsTxPayload;
 use signer::stacks::contracts::RejectWithdrawalV1;
 use signer::stacks::contracts::RotateKeysV1;
 use signer::stacks::contracts::SmartContract;
@@ -24,6 +25,7 @@ use signer::stacks::contracts::SMART_CONTRACTS;
 use signer::stacks::wallet::SignerWallet;
 use signer::storage::model::BitcoinBlockHash;
 use signer::storage::model::BitcoinTxId;
+use signer::storage::model::StacksTxId;
 use signer::testing::wallet::ContractCallWrapper;
 use signer::util::ApiFallbackClient;
 use tokio::sync::OnceCell;
@@ -37,7 +39,6 @@ use signer::stacks::wallet::MultisigTx;
 use signer::storage::in_memory::Store;
 use signer::storage::model::QualifiedRequestId;
 use signer::storage::model::StacksBlockHash;
-use signer::storage::model::StacksTxId;
 use signer::storage::postgres;
 use signer::testing;
 use signer::testing::wallet::InitiateWithdrawalRequest;
@@ -80,6 +81,22 @@ impl SignerStxState {
 
         match self.stacks_client.submit_tx(&tx).await.unwrap() {
             SubmitTxResponse::Acceptance(_) => (),
+            SubmitTxResponse::Rejection(err) => panic!("{}", serde_json::to_string(&err).unwrap()),
+        }
+    }
+
+    /// Sign and submit an object that can be turned into the payload of a
+    /// Stacks transaction.
+    async fn sign_and_submit<P: AsTxPayload>(&self, payload: &P) -> StacksTxId {
+        let mut unsigned = MultisigTx::new_tx(payload, &self.wallet, TX_FEE);
+        for signature in make_signatures(unsigned.tx(), &self.keys) {
+            unsigned.add_signature(signature).unwrap();
+        }
+
+        let tx = unsigned.finalize_transaction();
+
+        match self.stacks_client.submit_tx(&tx).await.unwrap() {
+            SubmitTxResponse::Acceptance(txid) => txid.into(),
             SubmitTxResponse::Rejection(err) => panic!("{}", serde_json::to_string(&err).unwrap()),
         }
     }
@@ -164,9 +181,9 @@ pub async fn deploy_smart_contracts() -> &'static SignerStxState {
 }); "create-withdrawal")]
 #[test_case(ContractCallWrapper(RejectWithdrawalV1 {
     id: QualifiedRequestId {
-	request_id: 2,
-	txid: StacksTxId::from([0; 32]),
-	block_hash: StacksBlockHash::from([0; 32]),
+	    request_id: 2,
+	    txid: StacksTxId::from([0; 32]),
+	    block_hash: StacksBlockHash::from([0; 32]),
     },
     signer_bitmap: BitArray::ZERO,
     deployer: *testing::wallet::WALLET.0.address(),
@@ -179,27 +196,18 @@ pub async fn deploy_smart_contracts() -> &'static SignerStxState {
 #[tokio::test]
 async fn complete_deposit_wrapper_tx_accepted<T: AsContractCall>(contract: ContractCallWrapper<T>) {
     let signer = deploy_smart_contracts().await;
-    let mut unsigned = MultisigTx::new_tx(&contract, &signer.wallet, TX_FEE);
-
-    for signature in make_signatures(unsigned.tx(), &signer.keys) {
-        unsigned.add_signature(signature).unwrap();
-    }
-    let tx = unsigned.finalize_transaction();
 
     // We need to wait for the deployed contracts to be mined before we can
     // use them. Five seconds seems to be enough time for that to happen.
     tokio::time::sleep(std::time::Duration::from_secs(5)).await;
 
-    match signer.stacks_client.submit_tx(&tx).await.unwrap() {
-        SubmitTxResponse::Acceptance(_) => (),
-        SubmitTxResponse::Rejection(err) => panic!("{}", serde_json::to_string(&err).unwrap()),
-    }
+    let txid = signer.sign_and_submit(&contract).await;
 
     // The submitted transaction tends to linger in the mempool for quite
     // some time before being confirmed in a Nakamoto block (best guess is
     // 5-10 minutes). It's not clear why this is the case.
     if true {
-        println!("{}", tx.txid());
+        println!("{}", txid);
         return;
     }
 
@@ -227,7 +235,7 @@ async fn complete_deposit_wrapper_tx_accepted<T: AsContractCall>(contract: Contr
         .collect::<Option<HashSet<_>>>()
         .unwrap();
 
-    assert!(txids.contains(&tx.txid()));
+    assert!(txids.contains(&txid));
 }
 
 #[ignore = "This is an integration test that requires a stacks-node to work"]
@@ -284,44 +292,105 @@ async fn is_deposit_completed_works() {
     };
 
     // Make the request to the mock server
-    let response = stacks_client
+    let is_completed = stacks_client
         .is_deposit_completed(signers.wallet.address(), &outpoint)
         .await
         .unwrap();
 
-    assert_eq!(response, false);
+    assert!(!is_completed);
 
-    let chain_tip_block_hash = rpc.get_best_block_hash().unwrap();
-    let header = rpc.get_block_header_info(&chain_tip_block_hash).unwrap();
+    let chain_tip_info = rpc.get_blockchain_info().unwrap();
 
-    let contract = CompleteDepositV1 {
+    let complete_deposit = CompleteDepositV1 {
         outpoint,
         amount: 123654789,
         recipient: PrincipalData::parse("SN2V7WTJ7BHR03MPHZ1C9A9ZR6NZGR4WM8HT4V67Y").unwrap(),
         deployer: *testing::wallet::WALLET.0.address(),
         sweep_txid: BitcoinTxId::from([0; 32]),
-        sweep_block_hash: BitcoinBlockHash::from(chain_tip_block_hash),
-        sweep_block_height: header.height as u64,
+        sweep_block_hash: BitcoinBlockHash::from(chain_tip_info.best_block_hash),
+        sweep_block_height: chain_tip_info.blocks as u64,
     };
-    let mut unsigned = MultisigTx::new_tx(&contract, &signers.wallet, TX_FEE);
 
-    for signature in make_signatures(unsigned.tx(), &signers.keys) {
-        unsigned.add_signature(signature).unwrap();
-    }
-    let tx = unsigned.finalize_transaction();
-
-    match stacks_client.submit_tx(&tx).await.unwrap() {
-        SubmitTxResponse::Acceptance(_) => (),
-        SubmitTxResponse::Rejection(err) => panic!("{}", serde_json::to_string(&err).unwrap()),
-    }
+    signers.sign_and_submit(&complete_deposit).await;
 
     // We sleep so that the block gets confirmed.
     tokio::time::sleep(Duration::from_secs(5)).await;
 
-    let response = stacks_client
+    let is_completed = stacks_client
         .is_deposit_completed(signers.wallet.address(), &outpoint)
         .await
         .unwrap();
 
-    assert_eq!(response, true);
+    assert!(is_completed);
+}
+
+/// This tests whether the `is_withdrawal_completed` function works when
+/// the smart contract has been completed with a rejection.
+#[ignore = "This is an integration test that requires a stacks-node to work"]
+#[tokio::test]
+async fn is_withdrawal_completed_rejection_works() {
+    let stacks_client = stacks_client();
+    let stacks_client = stacks_client.get_client();
+    let rpc = {
+        let username = regtest::BITCOIN_CORE_RPC_USERNAME.to_string();
+        let password = regtest::BITCOIN_CORE_RPC_PASSWORD.to_string();
+        let auth = bitcoincore_rpc::Auth::UserPass(username, password);
+        bitcoincore_rpc::Client::new("http://localhost:18443", auth).unwrap()
+    };
+
+    let signers = deploy_smart_contracts().await;
+    let chain_tip_info = rpc.get_blockchain_info().unwrap();
+
+    let txid: BitcoinTxId = Faker.fake_with_rng(&mut rand::rngs::OsRng);
+
+    let mint_sbtc = ContractCallWrapper(CompleteDepositV1 {
+        outpoint: bitcoin::OutPoint::new(txid.into(), 0),
+        amount: 123654789,
+        recipient: PrincipalData::from(*testing::wallet::WALLET.0.address()),
+        deployer: *testing::wallet::WALLET.0.address(),
+        sweep_txid: BitcoinTxId::from([0; 32]),
+        sweep_block_hash: chain_tip_info.best_block_hash.into(),
+        sweep_block_height: chain_tip_info.blocks,
+    });
+
+    signers.sign_and_submit(&mint_sbtc).await;
+
+    let start_withdrawal = ContractCallWrapper(InitiateWithdrawalRequest {
+        amount: 22500,
+        recipient: (0x00, vec![0; 20]),
+        max_fee: 3000,
+        deployer: *testing::wallet::WALLET.0.address(),
+    });
+
+    signers.sign_and_submit(&start_withdrawal).await;
+
+    let is_completed = stacks_client
+        .is_withdrawal_completed(signers.wallet.address(), 1)
+        .await
+        .unwrap();
+
+    assert!(!is_completed);
+
+    let reject_withdrawal = ContractCallWrapper(RejectWithdrawalV1 {
+        id: QualifiedRequestId {
+            request_id: 1,
+            block_hash: StacksBlockHash::from([0; 32]),
+            txid: StacksTxId::from([0; 32]),
+        },
+        signer_bitmap: BitArray::ZERO,
+        deployer: *testing::wallet::WALLET.0.address(),
+    });
+
+    signers.sign_and_submit(&reject_withdrawal).await;
+
+    // Wait for confirmation. The stacks node takes it's sweet time
+    // confirming transactions.
+    tokio::time::sleep(Duration::from_secs(5)).await;
+
+    let is_completed = stacks_client
+        .is_withdrawal_completed(signers.wallet.address(), 1)
+        .await
+        .unwrap();
+
+    assert!(is_completed);
 }


### PR DESCRIPTION
## Description
This PR updates the 'is_unique' validation inside the 'pre_validation' checker. Specifically, this update swaps out the logic of checking the uniqueness of a withdrawal 'QualifiedRequestID' with checking the uniqueness of a withdrawal on-chain 'RequestID' (a property found in the withdrawal QualifiedRequestID).

Closes: #1375 

## Changes
Changes were made to the 'is_unique' helper found inside the 'pre_validation' function found inside the 'validation.rs' file within 'signer'.

## Testing Information
A test was updated to match the fail-case scenario here (the same request_id within the same tx). Additionally, a handful of other tests were updated to fail correctly (aka adhere to the name given).

## Checklist:
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
