### PR TITLE
[feat] Update Withdrawal Request Validation

### DIFF
--- a/signer/src/bitcoin/validation.rs
+++ b/signer/src/bitcoin/validation.rs
@@ -94,11 +94,14 @@ impl From<&Requests<'_>> for TxRequestIds {
 pub fn is_unique(package: &[TxRequestIds]) -> bool {
     let mut deposits_set = HashSet::new();
     let mut withdrawal_request_id_set = HashSet::new();
-    
+
     package.iter().all(|reqs| {
         let deposits = reqs.deposits.iter().all(|out| deposits_set.insert(out));
-        let withdrawal_requests = reqs.withdrawals.iter().all(|id| withdrawal_request_id_set.insert(id.request_id));
-            
+        let withdrawal_requests = reqs
+            .withdrawals
+            .iter()
+            .all(|id| withdrawal_request_id_set.insert(id.request_id));
+
         deposits && withdrawal_requests
     })
 }
@@ -1717,7 +1720,7 @@ mod tests {
                         block_hash: StacksBlockHash::from([1; 32]),
                     },
                     QualifiedRequestId {
-                        request_id: 0,
+                        request_id: 1,
                         txid: StacksTxId::from([1; 32]),
                         block_hash: StacksBlockHash::from([2; 32]),
                     },
@@ -1746,7 +1749,7 @@ mod tests {
                         block_hash: StacksBlockHash::from([1; 32]),
                     },
                     QualifiedRequestId {
-                        request_id: 0,
+                        request_id: 1,
                         txid: StacksTxId::from([1; 32]),
                         block_hash: StacksBlockHash::from([2; 32]),
                     },
@@ -1775,7 +1778,7 @@ mod tests {
                         block_hash: StacksBlockHash::from([1; 32]),
                     },
                     QualifiedRequestId {
-                        request_id: 0,
+                        request_id: 1,
                         txid: StacksTxId::from([1; 32]),
                         block_hash: StacksBlockHash::from([2; 32]),
                     },
@@ -1843,7 +1846,7 @@ mod tests {
                 TxRequestIds {
                     deposits: vec![OutPoint {
                         txid: Txid::from_byte_array([1; 32]),
-                        vout: 1,
+                        vout: 0,
                     }],
                     withdrawals: vec![],
                 },
@@ -1874,36 +1877,7 @@ mod tests {
         }, false; "basically-empty-package_requests")]
     #[test_case(
         BitcoinPreSignRequest {
-            request_package: vec![
-                TxRequestIds {
-                    deposits: vec![
-                        OutPoint {
-                            txid: Txid::from_byte_array([1; 32]),
-                            vout: 0,
-                        },
-                        OutPoint {
-                            txid: Txid::from_byte_array([1; 32]),
-                            vout: 1,
-                        },
-                    ],
-                    withdrawals: vec![
-                        QualifiedRequestId {
-                            request_id: 0,
-                            txid: StacksTxId::from([1; 32]),
-                            block_hash: StacksBlockHash::from([1; 32]),
-                        },
-                        QualifiedRequestId {
-                            request_id: 0,
-                            txid: StacksTxId::from([1; 32]),
-                            block_hash: StacksBlockHash::from([2; 32]),
-                        },
-                    ],
-                },
-                TxRequestIds {
-                    deposits: Vec::new(),
-                    withdrawals: Vec::new(),
-                },
-            ],
+            request_package: vec![],
             fee_rate: 1.0,
             last_fees: None,
         }, false; "contains-empty-tx-requests")]

--- a/signer/src/bitcoin/validation.rs
+++ b/signer/src/bitcoin/validation.rs
@@ -1837,6 +1837,37 @@ mod tests {
                             block_hash: StacksBlockHash::from([1; 32]),
                         },
                         QualifiedRequestId {
+                            request_id: 0,
+                            txid: StacksTxId::from([1; 32]),
+                            block_hash: StacksBlockHash::from([2; 32]),
+                        },
+                    ],
+                },
+            ],
+            fee_rate: 1.0,
+            last_fees: None,
+        }, false; "duplicate-withdrawal-request-ids-in-same-tx")]
+    #[test_case(
+        BitcoinPreSignRequest {
+            request_package: vec![
+                TxRequestIds {
+                    deposits: vec![
+                        OutPoint {
+                            txid: Txid::from_byte_array([1; 32]),
+                            vout: 0,
+                        },
+                        OutPoint {
+                            txid: Txid::from_byte_array([1; 32]),
+                            vout: 1,
+                        },
+                    ],
+                    withdrawals: vec![
+                        QualifiedRequestId {
+                            request_id: 0,
+                            txid: StacksTxId::from([1; 32]),
+                            block_hash: StacksBlockHash::from([1; 32]),
+                        },
+                        QualifiedRequestId {
                             request_id: 1,
                             txid: StacksTxId::from([1; 32]),
                             block_hash: StacksBlockHash::from([2; 32]),
@@ -1877,7 +1908,36 @@ mod tests {
         }, false; "basically-empty-package_requests")]
     #[test_case(
         BitcoinPreSignRequest {
-            request_package: vec![],
+            request_package: vec![
+                TxRequestIds {
+                    deposits: vec![
+                        OutPoint {
+                            txid: Txid::from_byte_array([1; 32]),
+                            vout: 0,
+                        },
+                        OutPoint {
+                            txid: Txid::from_byte_array([1; 32]),
+                            vout: 1,
+                        },
+                    ],
+                    withdrawals: vec![
+                        QualifiedRequestId {
+                            request_id: 0,
+                            txid: StacksTxId::from([1; 32]),
+                            block_hash: StacksBlockHash::from([1; 32]),
+                        },
+                        QualifiedRequestId {
+                            request_id: 0,
+                            txid: StacksTxId::from([1; 32]),
+                            block_hash: StacksBlockHash::from([2; 32]),
+                        },
+                    ],
+                },
+                TxRequestIds {
+                    deposits: Vec::new(),
+                    withdrawals: Vec::new(),
+                },
+            ],
             fee_rate: 1.0,
             last_fees: None,
         }, false; "contains-empty-tx-requests")]

--- a/signer/src/bitcoin/validation.rs
+++ b/signer/src/bitcoin/validation.rs
@@ -1688,7 +1688,7 @@ mod tests {
                         block_hash: StacksBlockHash::from([1; 32]),
                     },
                     QualifiedRequestId {
-                        request_id: 0,
+                        request_id: 1,
                         txid: StacksTxId::from([1; 32]),
                         block_hash: StacksBlockHash::from([2; 32]),
                     },

--- a/signer/src/bitcoin/validation.rs
+++ b/signer/src/bitcoin/validation.rs
@@ -93,11 +93,13 @@ impl From<&Requests<'_>> for TxRequestIds {
 /// Check that this does not contain duplicate deposits or withdrawals.
 pub fn is_unique(package: &[TxRequestIds]) -> bool {
     let mut deposits_set = HashSet::new();
-    let mut withdrawals_set = HashSet::new();
+    let mut withdrawal_request_id_set = HashSet::new();
+    
     package.iter().all(|reqs| {
         let deposits = reqs.deposits.iter().all(|out| deposits_set.insert(out));
-        let withdrawals = reqs.withdrawals.iter().all(|id| withdrawals_set.insert(id));
-        deposits && withdrawals
+        let withdrawal_requests = reqs.withdrawals.iter().all(|id| withdrawal_request_id_set.insert(id.request_id));
+            
+        deposits && withdrawal_requests
     })
 }
 


### PR DESCRIPTION
## Description
This PR updates the 'is_unique' validation inside the 'pre_validation' checker. Specifically, this update swaps out the logic of checking the uniqueness of a withdrawal 'QualifiedRequestID' with checking the uniqueness of a withdrawal on-chain 'RequestID' (a property found in the withdrawal QualifiedRequestID).

Closes: #1375 

## Changes
Changes were made to the 'is_unique' helper found inside the 'pre_validation' function found inside the 'validation.rs' file within 'signer'.

## Testing Information
A test was updated to match the fail-case scenario here (the same request_id within the same tx). Additionally, a handful of other tests were updated to fail correctly (aka adhere to the name given).

## Checklist:
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
