### PR TITLE
feat: #1321 break-out: get_stacks_anchor_block_ref (maybe?)

### DIFF
--- a/signer/src/storage/in_memory.rs
+++ b/signer/src/storage/in_memory.rs
@@ -318,6 +318,18 @@ impl super::DbRead for SharedStore {
         Ok(self.lock().await.get_stacks_chain_tip(bitcoin_chain_tip))
     }
 
+    async fn get_stacks_anchor_block_ref(
+        &self,
+        stacks_block_hash: &model::StacksBlockHash,
+    ) -> Result<Option<model::BitcoinBlockRef>, Error> {
+        let store = self.lock().await;
+        let anchor_block = store
+            .stacks_blocks
+            .get(stacks_block_hash)
+            .and_then(|block| store.bitcoin_blocks.get(&block.bitcoin_anchor));
+        Ok(anchor_block.map(model::BitcoinBlockRef::from))
+    }
+
     async fn get_pending_deposit_requests(
         &self,
         chain_tip: &model::BitcoinBlockHash,

--- a/signer/src/storage/mod.rs
+++ b/signer/src/storage/mod.rs
@@ -58,6 +58,14 @@ pub trait DbRead {
         bitcoin_chain_tip: &model::BitcoinBlockHash,
     ) -> impl Future<Output = Result<Option<model::StacksBlock>, Error>> + Send;
 
+    /// Gets the Bitcoin anchor block height and hash for the given Stacks block
+    /// hash. Returns [`None`] if either the Stacks or Bitcoin block are not
+    /// found.
+    fn get_stacks_anchor_block_ref(
+        &self,
+        stacks_block_hash: &model::StacksBlockHash,
+    ) -> impl Future<Output = Result<Option<model::BitcoinBlockRef>, Error>> + Send;
+
     /// Get pending deposit requests
     ///
     /// These are deposit requests that have been added to our database but


### PR DESCRIPTION
## Description

I had written this for something, but then ended up not using it.

Before I delete it all, does anyone feel like they'd have a use for it?

## Changes

Adds a `DbRead` method `get_stacks_anchor_block_ref` which retrieves a `BitcoinBlockRef` for the anchor block of the provided `StacksBlockHash`.

## Testing Information

Nothing special to note.

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
