### PR TITLE
feat: add withdrawal rejection to the coordinator loop

### DIFF
--- a/signer/src/storage/in_memory.rs
+++ b/signer/src/storage/in_memory.rs
@@ -946,7 +946,7 @@ impl super::DbRead for SharedStore {
         Ok(result)
     }
 
-    async fn get_valid_withdrawal_outputs(
+    async fn get_withdrawal_outputs(
         &self,
         _id: &model::QualifiedRequestId,
     ) -> Result<Vec<model::BitcoinWithdrawalOutput>, Error> {

--- a/signer/src/storage/in_memory.rs
+++ b/signer/src/storage/in_memory.rs
@@ -945,6 +945,13 @@ impl super::DbRead for SharedStore {
 
         Ok(result)
     }
+
+    async fn get_valid_withdrawal_outputs(
+        &self,
+        _id: &model::QualifiedRequestId,
+    ) -> Result<Vec<model::BitcoinWithdrawalOutput>, Error> {
+        unimplemented!()
+    }
 }
 
 impl super::DbWrite for SharedStore {

--- a/signer/src/storage/mod.rs
+++ b/signer/src/storage/mod.rs
@@ -364,8 +364,8 @@ pub trait DbRead {
         sighash: &model::SigHash,
     ) -> impl Future<Output = Result<Option<(bool, PublicKeyXOnly)>, Error>> + Send;
 
-    /// Get all the valid request's withdrawal outputs
-    fn get_valid_withdrawal_outputs(
+    /// Get all the request's withdrawal outputs
+    fn get_withdrawal_outputs(
         &self,
         id: &model::QualifiedRequestId,
     ) -> impl Future<Output = Result<Vec<model::BitcoinWithdrawalOutput>, Error>> + Send;

--- a/signer/src/storage/mod.rs
+++ b/signer/src/storage/mod.rs
@@ -363,6 +363,12 @@ pub trait DbRead {
         &self,
         sighash: &model::SigHash,
     ) -> impl Future<Output = Result<Option<(bool, PublicKeyXOnly)>, Error>> + Send;
+
+    /// Get all the valid request's withdrawal outputs
+    fn get_valid_withdrawal_outputs(
+        &self,
+        id: &model::QualifiedRequestId,
+    ) -> impl Future<Output = Result<Vec<model::BitcoinWithdrawalOutput>, Error>> + Send;
 }
 
 /// Represents the ability to write data to the signer storage.

--- a/signer/src/storage/model.rs
+++ b/signer/src/storage/model.rs
@@ -1126,7 +1126,7 @@ pub struct BitcoinTxSigHash {
 }
 
 /// An output that was created due to a withdrawal request.
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, sqlx::FromRow)]
 #[cfg_attr(feature = "testing", derive(fake::Dummy))]
 pub struct BitcoinWithdrawalOutput {
     /// The ID of the transaction that includes this withdrawal output.
@@ -1136,12 +1136,14 @@ pub struct BitcoinWithdrawalOutput {
     /// containing inputs
     pub bitcoin_chain_tip: BitcoinBlockHash,
     /// The index of the referenced output in the transaction's outputs.
+    #[sqlx(try_from = "i32")]
     #[cfg_attr(feature = "testing", dummy(faker = "0..i32::MAX as u32"))]
     pub output_index: u32,
     /// The request ID of the withdrawal request. These increment for each
     /// withdrawal, but there can be duplicates if there is a reorg that
     /// affects a transaction that calls the `initiate-withdrawal-request`
     /// public function.
+    #[sqlx(try_from = "i64")]
     #[cfg_attr(feature = "testing", dummy(faker = "0..i64::MAX as u64"))]
     pub request_id: u64,
     /// The stacks transaction ID that lead to the creation of the

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -2268,6 +2268,35 @@ impl super::DbRead for PgStore {
         .await
         .map_err(Error::SqlxQuery)
     }
+
+    async fn get_valid_withdrawal_outputs(
+        &self,
+        id: &model::QualifiedRequestId,
+    ) -> Result<Vec<model::BitcoinWithdrawalOutput>, Error> {
+        sqlx::query_as::<_, model::BitcoinWithdrawalOutput>(
+            r#"
+            SELECT
+                bwo.bitcoin_txid
+              , bwo.bitcoin_chain_tip
+              , bwo.output_index
+              , bwo.request_id
+              , bwo.stacks_txid
+              , bwo.stacks_block_hash
+              , bwo.validation_result
+              , bwo.is_valid_tx
+            FROM sbtc_signer.bitcoin_withdrawals_outputs AS bwo
+            WHERE bwo.request_id = $1
+              AND bwo.stacks_block_hash = $2
+              AND bwo.validation_result = 'ok'
+              AND bwo.is_valid_tx = true
+            "#,
+        )
+        .bind(i64::try_from(id.request_id).map_err(Error::ConversionDatabaseInt)?)
+        .bind(id.block_hash)
+        .fetch_all(&self.0)
+        .await
+        .map_err(Error::SqlxQuery)
+    }
 }
 
 impl super::DbWrite for PgStore {

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -2269,7 +2269,7 @@ impl super::DbRead for PgStore {
         .map_err(Error::SqlxQuery)
     }
 
-    async fn get_valid_withdrawal_outputs(
+    async fn get_withdrawal_outputs(
         &self,
         id: &model::QualifiedRequestId,
     ) -> Result<Vec<model::BitcoinWithdrawalOutput>, Error> {
@@ -2287,8 +2287,6 @@ impl super::DbRead for PgStore {
             FROM sbtc_signer.bitcoin_withdrawals_outputs AS bwo
             WHERE bwo.request_id = $1
               AND bwo.stacks_block_hash = $2
-              AND bwo.validation_result = 'ok'
-              AND bwo.is_valid_tx = true
             "#,
         )
         .bind(i64::try_from(id.request_id).map_err(Error::ConversionDatabaseInt)?)

--- a/signer/src/testing/transaction_coordinator.rs
+++ b/signer/src/testing/transaction_coordinator.rs
@@ -804,7 +804,7 @@ where
 
         let (sign_request, multi_tx) = coordinator
             .construct_withdrawal_reject_stacks_sign_request(
-                withdrawal_req.clone(),
+                &withdrawal_req,
                 &bitcoin_aggregate_key,
                 &WALLET.0,
             )

--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -778,16 +778,14 @@ where
             return Ok(());
         }
 
-        let valid_outputs = db
-            .get_valid_withdrawal_outputs(&request.qualified_id())
-            .await?;
+        let valid_outputs = db.get_withdrawal_outputs(&request.qualified_id()).await?;
 
         for output in valid_outputs {
-            let mempool_entry = bitcoin
-                .get_mempool_entry(&output.bitcoin_txid.into())
-                .await?;
-            if mempool_entry.is_some() {
-                // There's an output for this request in the mempool, let's wait
+            // We get a tx if it's either confirmed or in the mempool
+            let maybe_tx = bitcoin.get_tx(&output.bitcoin_txid.into()).await?;
+            if maybe_tx.is_some() {
+                // There's an output for this request that may still be valid,
+                // so we skip the rejection for now.
                 return Ok(());
             }
         }

--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -342,7 +342,7 @@ where
         }
 
         self.construct_and_sign_stacks_sbtc_response_transactions(
-            bitcoin_chain_tip.as_ref(),
+            &bitcoin_chain_tip,
             &aggregate_key,
         )
         .await?;
@@ -646,10 +646,11 @@ where
     #[tracing::instrument(skip_all)]
     async fn construct_and_sign_stacks_sbtc_response_transactions(
         &mut self,
-        chain_tip: &model::BitcoinBlockHash,
+        chain_tip: &model::BitcoinBlockRef,
         bitcoin_aggregate_key: &PublicKey,
     ) -> Result<(), Error> {
-        let wallet = SignerWallet::load(&self.context, chain_tip).await?;
+        let db = self.context.get_storage();
+        let wallet = SignerWallet::load(&self.context, chain_tip.as_ref()).await?;
         let stacks = self.context.get_stacks_client();
 
         // Fetch deposit and withdrawal requests from the database where
@@ -663,21 +664,25 @@ where
         // For withdrawals, we need to have a record of the `request_id`
         // associated with the bitcoin transaction's outputs.
 
-        let deposit_requests = self
-            .context
-            .get_storage()
-            .get_swept_deposit_requests(chain_tip, self.context_window)
+        let swept_deposits = db
+            .get_swept_deposit_requests(chain_tip.as_ref(), self.context_window)
             .await?;
 
-        if deposit_requests.is_empty() {
+        let rejected_withdrawals = db
+            .get_pending_rejected_withdrawal_requests(chain_tip, self.context_window)
+            .await?;
+
+        if swept_deposits.is_empty() && rejected_withdrawals.is_empty() {
             tracing::debug!("no stacks transactions to create, exiting");
             return Ok(());
         }
 
         tracing::debug!(
-            num_deposits = %deposit_requests.len(),
-            "we have deposit requests that have been swept that may need minting"
+            swept_deposits = %swept_deposits.len(),
+            rejected_withdrawals = %rejected_withdrawals.len(),
+            "we have requests that may need a response on stacks"
         );
+
         // We need to know the nonce to use, so we reach out to our stacks
         // node for the account information for our multi-sig address.
         //
@@ -686,7 +691,7 @@ where
         let account = stacks.get_account(wallet.address()).await?;
         wallet.set_nonce(account.nonce);
 
-        for req in deposit_requests {
+        for req in swept_deposits {
             let outpoint = req.deposit_outpoint();
             let sign_request_fut =
                 self.construct_deposit_stacks_sign_request(req, bitcoin_aggregate_key, &wallet);
@@ -705,7 +710,7 @@ where
             // transaction because someone else is now the coordinator, and
             // all the signers are now ignoring us.
             let process_request_fut =
-                self.process_sign_request(sign_request, chain_tip, multi_tx, &wallet);
+                self.process_sign_request(sign_request, chain_tip.as_ref(), multi_tx, &wallet);
 
             let status = match process_request_fut.await {
                 Ok(txid) => {
@@ -732,9 +737,102 @@ where
             .increment(1);
         }
 
+        for withdrawal in rejected_withdrawals {
+            let withdrawal_id = withdrawal.qualified_id();
+            let fut = self.construct_and_sign_withdrawal_reject(
+                chain_tip,
+                &wallet,
+                bitcoin_aggregate_key,
+                withdrawal,
+            );
+            if let Err(error) = fut.await {
+                tracing::warn!(
+                    %error,
+                    ?withdrawal_id,
+                    "could not construct and sign withdrawal reject"
+                );
+            }
+        }
+
         Ok(())
     }
 
+    async fn construct_and_sign_withdrawal_reject(
+        &mut self,
+        chain_tip: &model::BitcoinBlockRef,
+        wallet: &SignerWallet,
+        bitcoin_aggregate_key: &PublicKey,
+        request: model::WithdrawalRequest,
+    ) -> Result<(), Error> {
+        let db = self.context.get_storage();
+        let stacks = self.context.get_stacks_client();
+        let bitcoin = self.context.get_bitcoin_client();
+        let deployer = self.context.config().signer.deployer;
+
+        let is_completed = stacks
+            .is_withdrawal_completed(&deployer, request.request_id)
+            .await?;
+
+        if is_completed {
+            // The request is already completed according to the contract
+            return Ok(());
+        }
+
+        let valid_outputs = db
+            .get_valid_withdrawal_outputs(&request.qualified_id())
+            .await?;
+
+        for output in valid_outputs {
+            let mempool_entry = bitcoin
+                .get_mempool_entry(&output.bitcoin_txid.into())
+                .await?;
+            if mempool_entry.is_some() {
+                // There's an output for this request in the mempool, let's wait
+                return Ok(());
+            }
+        }
+
+        let sign_request_fut = self.construct_withdrawal_reject_stacks_sign_request(
+            &request,
+            bitcoin_aggregate_key,
+            wallet,
+        );
+
+        let (sign_request, multi_tx) = sign_request_fut.await?;
+
+        // If we fail to sign the transaction for some reason, we
+        // decrement the nonce by one, and try the next transaction.
+        // This is not a fatal error, since we could fail to sign the
+        // transaction because someone else is now the coordinator, and
+        // all the signers are now ignoring us.
+        let process_request_fut =
+            self.process_sign_request(sign_request, chain_tip.as_ref(), multi_tx, wallet);
+
+        let status = match process_request_fut.await {
+            Ok(txid) => {
+                tracing::info!(%txid, "successfully submitted withdrawal reject transaction");
+                "success"
+            }
+            Err(error) => {
+                tracing::warn!(
+                    %error,
+                    qualified_id = ?request.qualified_id(),
+                    "could not process the stacks sign request for a withdrawal reject"
+                );
+                wallet.set_nonce(wallet.get_nonce().saturating_sub(1));
+                "failure"
+            }
+        };
+
+        metrics::counter!(
+            Metrics::TransactionsSubmittedTotal,
+            "blockchain" => STACKS_BLOCKCHAIN,
+            "status" => status,
+        )
+        .increment(1);
+
+        Ok(())
+    }
     /// Performs verification of the DKG process by running a FROST signing
     /// round using the new key. This is done to assert that all signers have
     /// successfully signed with the new aggregate key before proceeding with
@@ -1038,7 +1136,7 @@ where
     #[tracing::instrument(skip_all)]
     pub async fn construct_withdrawal_reject_stacks_sign_request(
         &self,
-        req: model::WithdrawalRequest,
+        req: &model::WithdrawalRequest,
         bitcoin_aggregate_key: &PublicKey,
         wallet: &SignerWallet,
     ) -> Result<(StacksTransactionSignRequest, MultisigTx), Error> {

--- a/signer/tests/integration/transaction_coordinator.rs
+++ b/signer/tests/integration/transaction_coordinator.rs
@@ -46,6 +46,7 @@ use secp256k1::Keypair;
 use signer::bitcoin::rpc::BitcoinCoreClient;
 use signer::bitcoin::utxo::BitcoinInputsOutputs;
 use signer::bitcoin::utxo::Fees;
+use signer::bitcoin::validation::WithdrawalValidationResult;
 use signer::bitcoin::BitcoinInteract as _;
 use signer::context::RequestDeciderEvent;
 
@@ -57,17 +58,23 @@ use signer::network::in_memory2::WanNetwork;
 use signer::request_decider::RequestDeciderEventLoop;
 use signer::stacks::api::TenureBlocks;
 use signer::stacks::contracts::AsContractCall;
+use signer::stacks::contracts::RejectWithdrawalV1;
 use signer::stacks::contracts::RotateKeysV1;
 use signer::stacks::contracts::SmartContract;
 use signer::storage::model::BitcoinBlockHash;
 use signer::storage::model::BitcoinTx;
 use signer::storage::model::DkgSharesStatus;
+use signer::storage::model::WithdrawalRequest;
 use signer::storage::postgres::PgStore;
 use signer::testing::stacks::DUMMY_SORTITION_INFO;
 use signer::testing::stacks::DUMMY_TENURE_INFO;
+use signer::testing::storage::DbReadTestExt;
+use signer::testing::storage::DbWriteTestExt as _;
 use signer::testing::transaction_coordinator::select_coordinator;
 use signer::testing::wsts::SignerInfo;
+use signer::testing::IterTestExt;
 use signer::transaction_coordinator::given_key_is_coordinator;
+use signer::WITHDRAWAL_BLOCKS_EXPIRY;
 use stacks_common::types::chainstate::BurnchainHeaderHash;
 use stacks_common::types::chainstate::ConsensusHash;
 use stacks_common::types::chainstate::SortitionId;
@@ -3412,4 +3419,269 @@ async fn test_conservative_initial_sbtc_limits() {
     for (_, db, _, _) in signers {
         testing::storage::drop_db(db).await;
     }
+}
+
+#[test_case(false, false; "rejectable")]
+#[test_case(true, false; "completed")]
+#[test_case(false, true; "in mempool")]
+#[tokio::test]
+async fn process_rejected_withdrawal(is_completed: bool, is_in_mempool: bool) {
+    let db = testing::storage::new_test_database().await;
+    let mut rng = rand::rngs::StdRng::seed_from_u64(51);
+    let (rpc, faucet) = regtest::initialize_blockchain();
+
+    let mut context = TestContext::builder()
+        .with_storage(db.clone())
+        .with_first_bitcoin_core_client()
+        .with_mocked_stacks_client()
+        .with_mocked_emily_client()
+        .build();
+
+    let expect_tx = !is_completed && !is_in_mempool;
+
+    let nonce = 12;
+    // Mock required stacks client functions
+    context
+        .with_stacks_client(|client| {
+            client.expect_get_account().once().returning(move |_| {
+                Box::pin(async move {
+                    Ok(AccountInfo {
+                        balance: 0,
+                        locked: 0,
+                        unlock_height: 0,
+                        // The nonce is used to create the stacks tx
+                        nonce,
+                    })
+                })
+            });
+
+            // Dummy value
+            client
+                .expect_estimate_fees()
+                .returning(move |_, _, _| Box::pin(async move { Ok(25505) }));
+
+            client
+                .expect_is_withdrawal_completed()
+                .returning(move |_, _| Box::pin(async move { Ok(is_completed) }));
+        })
+        .await;
+
+    let num_signers = 7;
+    let signing_threshold = 5;
+    let context_window = 100;
+
+    let network = network::in_memory::InMemoryNetwork::new();
+    let signer_info = testing::wsts::generate_signer_info(&mut rng, num_signers);
+
+    let mut testing_signer_set =
+        testing::wsts::SignerSet::new(&signer_info, signing_threshold, || network.connect());
+
+    let bitcoin_chain_tip = rpc.get_blockchain_info().unwrap().best_block_hash;
+    backfill_bitcoin_blocks(&db, rpc, &bitcoin_chain_tip).await;
+
+    // Ensure we have a stacks chain tip
+    let genesis_block = model::StacksBlock {
+        block_hash: Faker.fake_with_rng(&mut OsRng),
+        block_height: 0,
+        parent_hash: StacksBlockId::first_mined().into(),
+        bitcoin_anchor: bitcoin_chain_tip.into(),
+    };
+    db.write_stacks_blocks([&genesis_block]).await;
+
+    let (aggregate_key, _) = run_dkg(&context, &mut rng, &mut testing_signer_set).await;
+
+    // When the signer binary starts up in main(), it sets the current
+    // signer set public keys in the context state using the values in the
+    // bootstrap_signing_set configuration parameter. Later, the aggregate
+    // key gets set in the block observer. We're not running a block
+    // observer in this test, nor are we going through main, so we manually
+    // update the state here.
+    let signer_set_public_keys = testing_signer_set.signer_keys().into_iter().collect();
+    let state = context.state();
+    state.update_current_signer_set(signer_set_public_keys);
+    state.set_current_aggregate_key(aggregate_key);
+
+    let (bitcoin_chain_tip, stacks_chain_tip) = db.get_chain_tips().await;
+    assert_eq!(stacks_chain_tip, genesis_block.block_hash);
+
+    // Now we create a withdrawal request (without voting for it)
+    let request = WithdrawalRequest {
+        block_hash: genesis_block.block_hash,
+        bitcoin_block_height: bitcoin_chain_tip.block_height,
+        ..fake::Faker.fake_with_rng(&mut rng)
+    };
+    db.write_withdrawal_request(&request).await.unwrap();
+
+    // The request should not be pending yet (missing enough confirmation)
+    assert!(context
+        .get_storage()
+        .get_pending_rejected_withdrawal_requests(&bitcoin_chain_tip, context_window)
+        .await
+        .unwrap()
+        .is_empty());
+
+    let new_tip = faucet
+        .generate_blocks(WITHDRAWAL_BLOCKS_EXPIRY + 1)
+        .pop()
+        .unwrap();
+    backfill_bitcoin_blocks(&db, rpc, &new_tip).await;
+    let (bitcoin_chain_tip, _) = db.get_chain_tips().await;
+
+    // Now it should be pending rejected
+    assert_eq!(
+        context
+            .get_storage()
+            .get_pending_rejected_withdrawal_requests(&bitcoin_chain_tip, context_window)
+            .await
+            .unwrap()
+            .single(),
+        request
+    );
+
+    // If we are testing the mempool scenario, we need to fake it: we add an
+    // output for both cases, chaning the validation result
+    let output_validation_result = if is_in_mempool {
+        WithdrawalValidationResult::Ok
+    } else {
+        WithdrawalValidationResult::NoVote // random one
+    };
+    let outpoint = faucet.send_to(1000, &faucet.address);
+    let withdrawal_output = model::BitcoinWithdrawalOutput {
+        bitcoin_txid: outpoint.txid.into(),
+        bitcoin_chain_tip: bitcoin_chain_tip.block_hash,
+        output_index: outpoint.vout,
+        request_id: request.request_id,
+        stacks_txid: request.txid,
+        stacks_block_hash: request.block_hash,
+        validation_result: output_validation_result,
+        is_valid_tx: true,
+    };
+    db.write_bitcoin_withdrawals_outputs(&[withdrawal_output])
+        .await
+        .unwrap();
+
+    let (broadcasted_transaction_tx, _broadcasted_transaction_rxeiver) =
+        tokio::sync::broadcast::channel(1);
+
+    // This task gets all transactions broadcasted by the coordinator.
+    let mut wait_for_transaction_rx = broadcasted_transaction_tx.subscribe();
+    let wait_for_transaction_task =
+        tokio::spawn(async move { wait_for_transaction_rx.recv().await });
+
+    // Setup the stacks client mock to broadcast the transaction to our channel.
+    context
+        .with_stacks_client(|client| {
+            client
+                .expect_submit_tx()
+                .times(if expect_tx { 1 } else { 0 })
+                .returning(move |tx| {
+                    let tx = tx.clone();
+                    let txid = tx.txid();
+                    let broadcasted_transaction_tx = broadcasted_transaction_tx.clone();
+                    Box::pin(async move {
+                        broadcasted_transaction_tx
+                            .send(tx)
+                            .expect("Failed to send result");
+                        Ok(SubmitTxResponse::Acceptance(txid))
+                    })
+                });
+
+            client
+                .expect_get_current_signers_aggregate_key()
+                .returning(move |_| Box::pin(std::future::ready(Ok(Some(aggregate_key)))));
+        })
+        .await;
+
+    // Get the private key of the coordinator of the signer set.
+    let private_key = select_coordinator(&bitcoin_chain_tip.block_hash, &signer_info);
+
+    // Bootstrap the tx coordinator event loop
+    context.state().set_sbtc_contracts_deployed();
+    let tx_coordinator = transaction_coordinator::TxCoordinatorEventLoop {
+        context: context.clone(),
+        network: network.connect(),
+        private_key,
+        context_window,
+        threshold: signing_threshold as u16,
+        signing_round_max_duration: Duration::from_secs(5),
+        bitcoin_presign_request_max_duration: Duration::from_secs(5),
+        dkg_max_duration: Duration::from_secs(5),
+        is_epoch3: true,
+    };
+    let tx_coordinator_handle = tokio::spawn(async move { tx_coordinator.run().await });
+
+    // Here signers use all the same storage, but we don't care in this test
+    let _event_loop_handles: Vec<_> = signer_info
+        .clone()
+        .into_iter()
+        .map(|signer_info| {
+            let event_loop_harness = TxSignerEventLoopHarness::create(
+                context.clone(),
+                network.connect(),
+                context_window,
+                signer_info.signer_private_key,
+                signing_threshold,
+                rng.clone(),
+            );
+
+            event_loop_harness.start()
+        })
+        .collect();
+
+    // Yield to get signers ready
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Wake coordinator up
+    context
+        .signal(RequestDeciderEvent::NewRequestsHandled.into())
+        .expect("failed to signal");
+
+    // Await for tenure completion
+    let tenure_completed_signal = TxCoordinatorEvent::TenureCompleted.into();
+    context
+        .wait_for_signal(Duration::from_secs(5), |signal| {
+            signal == &tenure_completed_signal
+        })
+        .await
+        .unwrap();
+
+    // Await the `wait_for_tx_task` to receive the first transaction broadcasted.
+    let broadcasted_tx =
+        tokio::time::timeout(Duration::from_secs(1), wait_for_transaction_task).await;
+
+    // Stop event loops
+    tx_coordinator_handle.abort();
+
+    if !expect_tx {
+        assert!(broadcasted_tx.is_err());
+        testing::storage::drop_db(db).await;
+        return;
+    }
+
+    let broadcasted_tx = broadcasted_tx
+        .unwrap()
+        .expect("failed to receive message")
+        .expect("no message received");
+
+    broadcasted_tx.verify().unwrap();
+
+    assert_eq!(broadcasted_tx.get_origin_nonce(), nonce);
+
+    let TransactionPayload::ContractCall(contract_call) = broadcasted_tx.payload else {
+        panic!("unexpected tx payload")
+    };
+    assert_eq!(
+        contract_call.contract_name.to_string(),
+        RejectWithdrawalV1::CONTRACT_NAME
+    );
+    assert_eq!(
+        contract_call.function_name.to_string(),
+        RejectWithdrawalV1::FUNCTION_NAME
+    );
+    assert_eq!(
+        contract_call.function_args[0],
+        ClarityValue::UInt(request.request_id as u128)
+    );
+
+    testing::storage::drop_db(db).await;
 }


### PR DESCRIPTION
## Description

Closes: https://github.com/stacks-network/sbtc/issues/568

## Changes

Add the withdrawal rejection to the coordinator event loop. Also add a query to fetch all the valid withdrawal outputs, required to check if any is in mempool and we want to skip rejection.

## Testing Information

Add a test checking the _off-query_ conditions for skipping a rejection (already accepted in the contract or output tx in mempool).

## Checklist:

- [X] I have performed a self-review of my code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
