### PR TITLE
fix: swept withdrawal in case of forked accepts

### DIFF
--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -2242,7 +2242,6 @@ impl super::DbRead for PgStore {
                     ON wae.request_id = wr.request_id
                 LEFT JOIN stacks_blockchain AS sb
                     ON sb.block_hash = wae.block_hash
-                WHERE sb.block_hash IS NULL
 
                 GROUP BY
                     bwo.bitcoin_txid


### PR DESCRIPTION
## Description

Closes: #?

## Changes

Fix the swept withdrawal query to cover for the case of forked events: if we have a canonical accept event and a forked one, we should still consider the request as accepted (and not return it).

## Testing Information

Add a check in an existing test.

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
