### PR TITLE
feat: check mempool for withdrawal outputs before rejection

### DIFF
--- a/signer/src/stacks/contracts.rs
+++ b/signer/src/stacks/contracts.rs
@@ -1021,24 +1021,27 @@ pub enum WithdrawalRejectErrorMsg {
     /// The smart contract deployer is fixed, so this should always match.
     #[error("the deployer in the transaction does not match the expected deployer")]
     DeployerMismatch,
+    /// The withdrawal request is likely being fulfilled right now.
+    #[error("the withdrawal request may be fulfilled by a transaction in the mempool")]
+    RequestBeingFulfilled,
     /// We have checked the smart contract for the status of the
     /// withdrawal's request ID and it has indicated that the request has
     /// been either accepted or rejected already.
     #[error("the smart contract has been updated to indicate that the request has been completed")]
     RequestCompleted,
+    /// Withdrawal request fulfilled
+    #[error("Withdrawal request fulfilled")]
+    RequestFulfilled,
     /// We do not have a record of the withdrawal request in our list of
     /// pending and accepted withdrawal requests.
     #[error("no record of withdrawal request in pending and accepted withdrawal requests")]
     RequestMissing,
-    /// Withdrawal request fulfilled
-    #[error("Withdrawal request fulfilled")]
-    RequestFulfilled,
-    /// Withdrawal request unconfirmed
-    #[error("Withdrawal request unconfirmed")]
-    RequestUnconfirmed,
     /// Withdrawal request is not final
     #[error("Withdrawal request is not final")]
     RequestNotFinal,
+    /// Withdrawal request unconfirmed
+    #[error("Withdrawal request unconfirmed")]
+    RequestUnconfirmed,
 }
 
 impl WithdrawalRejectErrorMsg {
@@ -1104,10 +1107,14 @@ impl AsContractCall for RejectWithdrawalV1 {
     /// 4. Whether the request has been fulfilled. Fail if it has.
     /// 5. Whether the signer bitmap matches the bitmap from our records.
     /// 6. Whether the withdrawal request has expired. Fail if it hasn't.
+    /// 7. Whether the withdrawal request is being serviced by a sweep
+    ///    transaction that is in the mempool.
     async fn validate<C>(&self, ctx: &C, req_ctx: &ReqContext) -> Result<(), Error>
     where
         C: Context + Send + Sync,
     {
+        let db = ctx.get_storage();
+        let bitcoin_chain_tip = &req_ctx.chain_tip.block_hash;
         // 1. Check whether the withdrawal request is already completed.
         let withdrawal_completed = ctx
             .get_stacks_client()
@@ -1127,15 +1134,13 @@ impl AsContractCall for RejectWithdrawalV1 {
         // 3. Whether the associated withdrawal request transaction is
         //    confirmed on the canonical stacks blockchain.
         // 4. Whether the request has been fulfilled.
-        let stacks_chain_tip = ctx
-            .get_storage()
-            .get_stacks_chain_tip(&req_ctx.chain_tip.block_hash)
+        let stacks_chain_tip = db
+            .get_stacks_chain_tip(bitcoin_chain_tip)
             .await?
             .ok_or(Error::NoStacksChainTip)?;
-        let maybe_report = ctx
-            .get_storage()
+        let maybe_report = db
             .get_withdrawal_request_report(
-                &req_ctx.chain_tip.block_hash,
+                bitcoin_chain_tip,
                 &stacks_chain_tip.block_hash,
                 &self.id,
                 &ctx.config().signer.public_key(),
@@ -1176,6 +1181,12 @@ impl AsContractCall for RejectWithdrawalV1 {
 
         if blocks_observed <= WITHDRAWAL_BLOCKS_EXPIRY {
             return Err(WithdrawalRejectErrorMsg::RequestNotFinal.into_error(req_ctx, self));
+        }
+
+        // 7. Check whether the withdrawal request may be serviced by a
+        //    sweep transaction that may be in the mempool.
+        if db.is_withdrawal_live(&self.id, bitcoin_chain_tip).await? {
+            return Err(WithdrawalRejectErrorMsg::RequestBeingFulfilled.into_error(req_ctx, self));
         }
 
         Ok(())

--- a/signer/src/stacks/contracts.rs
+++ b/signer/src/stacks/contracts.rs
@@ -1185,7 +1185,10 @@ impl AsContractCall for RejectWithdrawalV1 {
 
         // 7. Check whether the withdrawal request may be serviced by a
         //    sweep transaction that may be in the mempool.
-        if db.is_withdrawal_live(&self.id, bitcoin_chain_tip).await? {
+        let withdrawal_is_inflight = db
+            .is_withdrawal_inflight(&self.id, bitcoin_chain_tip)
+            .await?;
+        if withdrawal_is_inflight {
             return Err(WithdrawalRejectErrorMsg::RequestBeingFulfilled.into_error(req_ctx, self));
         }
 

--- a/signer/src/storage/in_memory.rs
+++ b/signer/src/storage/in_memory.rs
@@ -814,6 +814,14 @@ impl super::DbRead for SharedStore {
             .any(|(_, share)| &share.script_pubkey == script))
     }
 
+    async fn is_withdrawal_in_mempool(
+        &self,
+        _: &model::QualifiedRequestId,
+        _: &model::BitcoinBlockHash,
+    ) -> Result<bool, Error> {
+        unimplemented!()
+    }
+
     async fn get_bitcoin_tx(
         &self,
         txid: &model::BitcoinTxId,

--- a/signer/src/storage/in_memory.rs
+++ b/signer/src/storage/in_memory.rs
@@ -814,7 +814,7 @@ impl super::DbRead for SharedStore {
             .any(|(_, share)| &share.script_pubkey == script))
     }
 
-    async fn is_withdrawal_live(
+    async fn is_withdrawal_inflight(
         &self,
         _: &model::QualifiedRequestId,
         _: &model::BitcoinBlockHash,

--- a/signer/src/storage/in_memory.rs
+++ b/signer/src/storage/in_memory.rs
@@ -814,7 +814,7 @@ impl super::DbRead for SharedStore {
             .any(|(_, share)| &share.script_pubkey == script))
     }
 
-    async fn is_withdrawal_in_mempool(
+    async fn is_withdrawal_live(
         &self,
         _: &model::QualifiedRequestId,
         _: &model::BitcoinBlockHash,

--- a/signer/src/storage/mod.rs
+++ b/signer/src/storage/mod.rs
@@ -324,9 +324,12 @@ pub trait DbRead {
     ///
     /// # Notes
     ///
-    /// The tables that would be able to answer whether a withdrawal is
-    /// "live" in the mempool are populated during validation of pre-sign
-    /// requests.
+    /// At this time, we cannot use the bitcoin mempool for this
+    /// information since we cannot match withdrawals with transaction
+    /// outputs unless a lot of computational effort. Instead we use our
+    /// database, where the query is straightforward. The tables that are
+    /// be able to answer whether a withdrawal is potentially in the
+    /// mempool are populated during validation of pre-sign requests.
     fn is_withdrawal_inflight(
         &self,
         id: &model::QualifiedRequestId,

--- a/signer/src/storage/mod.rs
+++ b/signer/src/storage/mod.rs
@@ -320,10 +320,10 @@ pub trait DbRead {
     ) -> impl Future<Output = Result<bool, Error>> + Send;
 
     /// Check whether it is possible that the withdrawal identified by the
-    /// given request identifier is currently in the mempool, assuming that
-    /// we have processed all recent pre-sign requests and stored the
+    /// given request identifier live in the bitcoin mempool. This assumes
+    /// that we have processed all recent pre-sign requests and stored the
     /// results into our database.
-    fn is_withdrawal_in_mempool(
+    fn is_withdrawal_live(
         &self,
         id: &model::QualifiedRequestId,
         bitcoin_chain_tip: &model::BitcoinBlockHash,

--- a/signer/src/storage/mod.rs
+++ b/signer/src/storage/mod.rs
@@ -319,11 +319,15 @@ pub trait DbRead {
         script: &model::ScriptPubKey,
     ) -> impl Future<Output = Result<bool, Error>> + Send;
 
-    /// Check whether it is possible that the withdrawal identified by the
-    /// given request identifier live in the bitcoin mempool. This assumes
-    /// that we have processed all recent pre-sign requests and stored the
-    /// results into our database.
-    fn is_withdrawal_live(
+    /// Returns whether the identified withdrawal may be included in a
+    /// sweep transaction that is in the bitcoin mempool.
+    ///
+    /// # Notes
+    ///
+    /// The tables that would be able to answer whether a withdrawal is
+    /// "live" in the mempool are populated during validation of pre-sign
+    /// requests.
+    fn is_withdrawal_inflight(
         &self,
         id: &model::QualifiedRequestId,
         bitcoin_chain_tip: &model::BitcoinBlockHash,

--- a/signer/src/storage/mod.rs
+++ b/signer/src/storage/mod.rs
@@ -319,6 +319,16 @@ pub trait DbRead {
         script: &model::ScriptPubKey,
     ) -> impl Future<Output = Result<bool, Error>> + Send;
 
+    /// Check whether it is possible that the withdrawal identified by the
+    /// given request identifier is currently in the mempool, assuming that
+    /// we have processed all recent pre-sign requests and stored the
+    /// results into our database.
+    fn is_withdrawal_in_mempool(
+        &self,
+        id: &model::QualifiedRequestId,
+        bitcoin_chain_tip: &model::BitcoinBlockHash,
+    ) -> impl Future<Output = Result<bool, Error>> + Send;
+
     /// Fetch the bitcoin transaction that is included in the block
     /// identified by the block hash.
     fn get_bitcoin_tx(

--- a/signer/src/storage/mod.rs
+++ b/signer/src/storage/mod.rs
@@ -326,7 +326,7 @@ pub trait DbRead {
     ///
     /// At this time, we cannot use the bitcoin mempool for this
     /// information since we cannot match withdrawals with transaction
-    /// outputs unless a lot of computational effort. Instead we use our
+    /// outputs unless a lot of computational effort. Instead, we use our
     /// database, where the query is straightforward. The tables that are
     /// be able to answer whether a withdrawal is potentially in the
     /// mempool are populated during validation of pre-sign requests.

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -2070,7 +2070,7 @@ impl super::DbRead for PgStore {
         .map_err(Error::SqlxQuery)
     }
 
-    async fn is_withdrawal_in_mempool(
+    async fn is_withdrawal_live(
         &self,
         id: &model::QualifiedRequestId,
         bitcoin_chain_tip: &model::BitcoinBlockHash,

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -2081,9 +2081,10 @@ impl super::DbRead for PgStore {
         let txid: model::BitcoinTxId = signer_utxo.outpoint.txid.into();
 
         // This should execute quite quickly, since the recursive part of
-        // this query should be is limited to 25 transactions for the
-        // actual bitcoin chain tip without any forks. In the case of
-        // forks, it is bounded by the fork length multiplied by 25.
+        // this query should be limited to 25 transactions when the most
+        // recent signer UTXO hasn't been reorged. When a reorg affects
+        // sweep transactions, this recursive part of the query is bounded
+        // by the reorg depth length multiplied by 25.
         sqlx::query_scalar::<_, bool>(
             r#"
             WITH RECURSIVE proposed_transactions AS (

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -2082,7 +2082,8 @@ impl super::DbRead for PgStore {
 
         // This should execute quite quickly, since the recursive part of
         // this query should be is limited to 25 transactions for the
-        // actual bitcoin chain tip.
+        // actual bitcoin chain tip without any forks. In the case of
+        // forks, it is bounded by the fork length multiplied by 25.
         sqlx::query_scalar::<_, bool>(
             r#"
             WITH RECURSIVE proposed_transactions AS (

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -2070,7 +2070,7 @@ impl super::DbRead for PgStore {
         .map_err(Error::SqlxQuery)
     }
 
-    async fn is_withdrawal_live(
+    async fn is_withdrawal_inflight(
         &self,
         id: &model::QualifiedRequestId,
         bitcoin_chain_tip: &model::BitcoinBlockHash,

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -5482,7 +5482,7 @@ async fn is_withdrawal_live_catches_withdrawals_in_package() {
     let mut rng = rand::rngs::StdRng::seed_from_u64(2);
     let (rpc, faucet) = sbtc::testing::regtest::initialize_blockchain();
 
-    // We use TestSweepSetup2 to help setup the signers' UTXO, which needs
+    // We use TestSweepSetup2 to help set up the signers' UTXO, which needs
     // to be available for this test.
     let signers = TestSignerSet::new(&mut rng);
     let setup = TestSweepSetup2::new_setup(signers, faucet, &[]);

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -19,6 +19,7 @@ use more_asserts::assert_le;
 use rand::seq::IteratorRandom as _;
 use rand::seq::SliceRandom as _;
 use signer::bitcoin::validation::WithdrawalRequestStatus;
+use signer::bitcoin::validation::WithdrawalValidationResult;
 use signer::storage::model::DkgSharesStatus;
 use signer::storage::model::SweptWithdrawalRequest;
 use signer::storage::model::WithdrawalRequest;
@@ -76,6 +77,7 @@ use test_case::test_case;
 use test_log::test;
 
 use crate::setup::backfill_bitcoin_blocks;
+use crate::setup::fetch_canonical_bitcoin_blockchain;
 use crate::setup::SweepAmounts;
 use crate::setup::TestSignerSet;
 use crate::setup::TestSweepSetup;
@@ -5398,4 +5400,183 @@ async fn pending_rejected_withdrawal_already_accepted() {
     assert!(pending_rejected.is_empty());
 
     signer::testing::storage::drop_db(db).await;
+}
+
+/// Check that is_withdrawal_inflight correctly picks up withdrawal
+/// requests that have rows associated with sweep transactions that have
+/// been proposed by the coordinator.
+#[tokio::test]
+async fn is_withdrawal_live_catches_withdrawals_with_rows_in_table() {
+    let db = testing::storage::new_test_database().await;
+    let mut rng = rand::rngs::StdRng::seed_from_u64(2);
+
+    let (rpc, faucet) = sbtc::testing::regtest::initialize_blockchain();
+
+    let signers = TestSignerSet::new(&mut rng);
+    let setup = TestSweepSetup2::new_setup(signers, faucet, &[]);
+
+    // Normal: the signer follows the bitcoin blockchain and event observer
+    // should be getting new block events from bitcoin-core. We haven't
+    // hooked up our block observer, so we need to manually update the
+    // database with new bitcoin block headers.
+    fetch_canonical_bitcoin_blockchain(&db, rpc).await;
+
+    let chain_tip = db.get_bitcoin_canonical_chain_tip().await.unwrap().unwrap();
+
+    // This is needed for the part of the query that fetches the signers'
+    // UTXO.
+    setup.store_dkg_shares(&db).await;
+
+    // This donation is currently the signers' UTXO, which is needed in the
+    // `is_withdrawal_live` implementation.
+    setup.store_donation(&db).await;
+
+    let id = QualifiedRequestId {
+        request_id: 234,
+        block_hash: Faker.fake_with_rng(&mut rng),
+        txid: Faker.fake_with_rng(&mut rng),
+    };
+
+    assert!(!db.is_withdrawal_inflight(&id, &chain_tip).await.unwrap());
+
+    let bitcoin_txid: model::BitcoinTxId = Faker.fake_with_rng(&mut rng);
+    let output = BitcoinWithdrawalOutput {
+        request_id: id.request_id,
+        stacks_txid: id.txid,
+        stacks_block_hash: id.block_hash,
+        bitcoin_chain_tip: chain_tip,
+        bitcoin_txid,
+        is_valid_tx: true,
+        validation_result: WithdrawalValidationResult::Ok,
+        output_index: 2,
+    };
+    db.write_bitcoin_withdrawals_outputs(&[output])
+        .await
+        .unwrap();
+
+    assert!(!db.is_withdrawal_inflight(&id, &chain_tip).await.unwrap());
+
+    let sighash = BitcoinTxSigHash {
+        txid: bitcoin_txid,
+        prevout_type: model::TxPrevoutType::SignersInput,
+        prevout_txid: setup.donation.txid.into(),
+        prevout_output_index: setup.donation.vout,
+        validation_result: signer::bitcoin::validation::InputValidationResult::Ok,
+        aggregate_key: setup.signers.aggregate_key().into(),
+        is_valid_tx: false,
+        will_sign: false,
+        chain_tip,
+        sighash: bitcoin::TapSighash::from_byte_array([88; 32]).into(),
+    };
+    db.write_bitcoin_txs_sighashes(&[sighash]).await.unwrap();
+
+    assert!(db.is_withdrawal_inflight(&id, &chain_tip).await.unwrap());
+}
+
+/// Check that is_withdrawal_inflight correctly picks up withdrawal
+/// requests that are fulfilled further down the chain of sweep
+/// transactions that have been proposed by a coordinator.
+#[tokio::test]
+async fn is_withdrawal_live_catches_withdrawals_in_package() {
+    let db = testing::storage::new_test_database().await;
+    let mut rng = rand::rngs::StdRng::seed_from_u64(2);
+    let (rpc, faucet) = sbtc::testing::regtest::initialize_blockchain();
+
+    // We use TestSweepSetup2 to help setup the signers' UTXO, which needs
+    // to be available for this test.
+    let signers = TestSignerSet::new(&mut rng);
+    let setup = TestSweepSetup2::new_setup(signers, faucet, &[]);
+
+    // Normal: the signer follows the bitcoin blockchain and event observer
+    // should be getting new block events from bitcoin-core. We haven't
+    // hooked up our block observer, so we need to manually update the
+    // database with new bitcoin block headers.
+    fetch_canonical_bitcoin_blockchain(&db, rpc).await;
+    let chain_tip = db.get_bitcoin_canonical_chain_tip().await.unwrap().unwrap();
+
+    // This is needed for the part of the query that fetches the signers'
+    // UTXO.
+    setup.store_dkg_shares(&db).await;
+    // This donation is currently the signers' UTXO, which is needed in the
+    // `is_withdrawal_live` implementation.
+    setup.store_donation(&db).await;
+
+    let id = QualifiedRequestId {
+        request_id: 234,
+        block_hash: Faker.fake_with_rng(&mut rng),
+        txid: Faker.fake_with_rng(&mut rng),
+    };
+
+    assert!(!db.is_withdrawal_inflight(&id, &chain_tip).await.unwrap());
+
+    let bitcoin_txid1: model::BitcoinTxId = Faker.fake_with_rng(&mut rng);
+    let bitcoin_txid2: model::BitcoinTxId = Faker.fake_with_rng(&mut rng);
+    let bitcoin_txid3: model::BitcoinTxId = Faker.fake_with_rng(&mut rng);
+
+    let output = BitcoinWithdrawalOutput {
+        request_id: id.request_id,
+        stacks_txid: id.txid,
+        stacks_block_hash: id.block_hash,
+        bitcoin_chain_tip: chain_tip,
+        bitcoin_txid: bitcoin_txid3,
+        is_valid_tx: true,
+        validation_result: WithdrawalValidationResult::Ok,
+        output_index: 2,
+    };
+    db.write_bitcoin_withdrawals_outputs(&[output])
+        .await
+        .unwrap();
+
+    // This is the first input of the third transaction in the chain. We
+    // write it first to show that the transactions need to be chained in
+    // order for the query to pick up the above output.
+    let sighash3 = BitcoinTxSigHash {
+        txid: bitcoin_txid3,
+        prevout_type: model::TxPrevoutType::SignersInput,
+        prevout_txid: bitcoin_txid2,
+        prevout_output_index: 0,
+        validation_result: signer::bitcoin::validation::InputValidationResult::Ok,
+        aggregate_key: setup.signers.aggregate_key().into(),
+        is_valid_tx: false,
+        will_sign: false,
+        chain_tip,
+        sighash: bitcoin::TapSighash::from_byte_array([66; 32]).into(),
+    };
+    db.write_bitcoin_txs_sighashes(&[sighash3]).await.unwrap();
+
+    assert!(!db.is_withdrawal_inflight(&id, &chain_tip).await.unwrap());
+
+    let sighash2 = BitcoinTxSigHash {
+        txid: bitcoin_txid2,
+        prevout_type: model::TxPrevoutType::SignersInput,
+        prevout_txid: bitcoin_txid1,
+        prevout_output_index: 0,
+        validation_result: signer::bitcoin::validation::InputValidationResult::Ok,
+        aggregate_key: setup.signers.aggregate_key().into(),
+        is_valid_tx: false,
+        will_sign: false,
+        chain_tip,
+        sighash: bitcoin::TapSighash::from_byte_array([77; 32]).into(),
+    };
+    db.write_bitcoin_txs_sighashes(&[sighash2]).await.unwrap();
+
+    assert!(!db.is_withdrawal_inflight(&id, &chain_tip).await.unwrap());
+
+    // Okay now we add in the first input of the first transaction in the
+    // chain. The query should be able to find our output now.
+    let sighash1 = BitcoinTxSigHash {
+        txid: bitcoin_txid1,
+        prevout_type: model::TxPrevoutType::SignersInput,
+        prevout_txid: setup.donation.txid.into(),
+        prevout_output_index: setup.donation.vout,
+        validation_result: signer::bitcoin::validation::InputValidationResult::Ok,
+        aggregate_key: setup.signers.aggregate_key().into(),
+        is_valid_tx: false,
+        will_sign: false,
+        chain_tip,
+        sighash: bitcoin::TapSighash::from_byte_array([88; 32]).into(),
+    };
+    db.write_bitcoin_txs_sighashes(&[sighash1]).await.unwrap();
+
+    assert!(db.is_withdrawal_inflight(&id, &chain_tip).await.unwrap());
 }

--- a/signer/tests/integration/setup.rs
+++ b/signer/tests/integration/setup.rs
@@ -418,7 +418,9 @@ pub async fn backfill_bitcoin_blocks(db: &PgStore, rpc: &Client, chain_tip: &bit
 /// Fetch all block headers from bitcoin-core and store it in the database.
 pub async fn backfill_bitcoin_blockchain(db: &PgStore, rpc: &Client) {
     let chain_tip_info = rpc.get_blockchain_info().unwrap();
-    let mut block_header = rpc.get_block_header_info(&chain_tip_info.best_block_hash).unwrap();
+    let mut block_header = rpc
+        .get_block_header_info(&chain_tip_info.best_block_hash)
+        .unwrap();
 
     // There are no non-coinbase transactions below this height.
     while block_header.height as u64 >= regtest::MIN_BLOCKCHAIN_HEIGHT {

--- a/signer/tests/integration/setup.rs
+++ b/signer/tests/integration/setup.rs
@@ -416,7 +416,7 @@ pub async fn backfill_bitcoin_blocks(db: &PgStore, rpc: &Client, chain_tip: &bit
 }
 
 /// Fetch all block headers from bitcoin-core and store it in the database.
-pub async fn backfill_bitcoin_blockchain(db: &PgStore, rpc: &Client) {
+pub async fn fetch_canonical_bitcoin_blockchain(db: &PgStore, rpc: &Client) {
     let chain_tip_info = rpc.get_blockchain_info().unwrap();
     let mut block_header = rpc
         .get_block_header_info(&chain_tip_info.best_block_hash)

--- a/signer/tests/integration/withdrawal_reject.rs
+++ b/signer/tests/integration/withdrawal_reject.rs
@@ -113,8 +113,10 @@ async fn reject_withdrawal_validation_happy_path() {
     set_withdrawal_incomplete(&mut ctx).await;
 
     // Normal: we need to store a row in the dkg_shares table so that we
-    // have a record of the scriptPubKey that the signers control.
+    // have a record of the scriptPubKey that the signers control. The
+    // signers normally have a UTXO, so we add one here too.
     setup.store_dkg_shares(&db).await;
+    setup.store_donation(&db).await;
 
     // Normal: the request and how the signers voted needs to be added to
     // the database. Here the bitmap in the withdrawal request object
@@ -167,8 +169,10 @@ async fn reject_withdrawal_validation_not_final() {
     set_withdrawal_incomplete(&mut ctx).await;
 
     // Normal: we need to store a row in the dkg_shares table so that we
-    // have a record of the scriptPubKey that the signers control.
+    // have a record of the scriptPubKey that the signers control. The
+    // signers normally have a UTXO, so we add one here too.
     setup.store_dkg_shares(&db).await;
+    setup.store_donation(&db).await;
 
     // Normal: the request and how the signers voted needs to be added to
     // the database. Here the bitmap in the withdrawal request object
@@ -237,8 +241,10 @@ async fn reject_withdrawal_validation_deployer_mismatch() {
     set_withdrawal_incomplete(&mut ctx).await;
 
     // Normal: we need to store a row in the dkg_shares table so that we
-    // have a record of the scriptPubKey that the signers control.
+    // have a record of the scriptPubKey that the signers control. The
+    // signers normally have a UTXO, so we add one here too.
     setup.store_dkg_shares(&db).await;
+    setup.store_donation(&db).await;
 
     // Normal: the request and how the signers voted needs to be added to
     // the database. Here the bitmap in the withdrawal request object
@@ -301,8 +307,10 @@ async fn reject_withdrawal_validation_missing_withdrawal_request() {
     set_withdrawal_incomplete(&mut ctx).await;
 
     // Normal: we need to store a row in the dkg_shares table so that we
-    // have a record of the scriptPubKey that the signers control.
+    // have a record of the scriptPubKey that the signers control. The
+    // signers normally have a UTXO, so we add one here too.
     setup.store_dkg_shares(&db).await;
+    setup.store_donation(&db).await;
 
     // Normal: the request and how the signers voted needs to be added to
     // the database. Here the bitmap in the withdrawal request object
@@ -366,8 +374,10 @@ async fn reject_withdrawal_validation_bitmap_mismatch() {
     set_withdrawal_incomplete(&mut ctx).await;
 
     // Normal: we need to store a row in the dkg_shares table so that we
-    // have a record of the scriptPubKey that the signers control.
+    // have a record of the scriptPubKey that the signers control. The
+    // signers normally have a UTXO, so we add one here too.
     setup.store_dkg_shares(&db).await;
+    setup.store_donation(&db).await;
 
     // Normal: the request and how the signers voted needs to be added to
     // the database. Here the bitmap in the withdrawal request object
@@ -433,8 +443,10 @@ async fn reject_withdrawal_validation_request_completed() {
     set_withdrawal_completed(&mut ctx).await;
 
     // Normal: we need to store a row in the dkg_shares table so that we
-    // have a record of the scriptPubKey that the signers control.
+    // have a record of the scriptPubKey that the signers control. The
+    // signers normally have a UTXO, so we add one here too.
     setup.store_dkg_shares(&db).await;
+    setup.store_donation(&db).await;
 
     // Normal: the request and how the signers voted needs to be added to
     // the database. Here the bitmap in the withdrawal request object
@@ -515,10 +527,12 @@ async fn reject_withdrawal_validation_request_being_fulfilled() {
 
     let sweep = setup.sweep_tx_info.as_ref().unwrap();
 
-    // Different: The donation is necessary in order to have a signer UTXO,
-    // which is necessary for the query to correctly return whether the
-    // withdrawal is inflight.
-    setup.store_donation(&db).await;
+    // Different: We're adding a row that let the signer know that someone
+    // may have tried to fulfill the withdrawal request. If that
+    // transaction is spending the current signer UTXO, then it could
+    // possibly be in the mempool. Since the signers' UTXO is a donation,
+    // we're saying that the coordinator may have tried to fulfill the
+    // withdrawal.
     setup.store_bitcoin_withdrawals_outputs(&db).await;
 
     let signer_tx_sighash = BitcoinTxSigHash {

--- a/signer/tests/integration/withdrawal_reject.rs
+++ b/signer/tests/integration/withdrawal_reject.rs
@@ -25,7 +25,7 @@ use signer::context::Context;
 use signer::testing::context::*;
 use signer::WITHDRAWAL_BLOCKS_EXPIRY;
 
-use crate::setup::backfill_bitcoin_blockchain;
+use crate::setup::fetch_canonical_bitcoin_blockchain;
 use crate::setup::set_withdrawal_completed;
 use crate::setup::set_withdrawal_incomplete;
 use crate::setup::SweepAmounts;
@@ -136,7 +136,7 @@ async fn reject_withdrawal_validation_happy_path() {
     // should be getting new block events from bitcoin-core. We haven't
     // hooked up our block observer, so we need to manually update the
     // database with new bitcoin block headers.
-    backfill_bitcoin_blockchain(&db, rpc).await;
+    fetch_canonical_bitcoin_blockchain(&db, rpc).await;
 
     // Normal: we need to store a row in the dkg_shares table so that we
     // have a record of the scriptPubKey that the signers control.
@@ -152,7 +152,7 @@ async fn reject_withdrawal_validation_happy_path() {
     // WITHDRAWAL_BLOCKS_EXPIRY blocks have been observered since the smart
     // contract that created the withdrawal request has bene observed.
     faucet.generate_blocks(WITHDRAWAL_BLOCKS_EXPIRY + 1);
-    backfill_bitcoin_blockchain(&db, rpc).await;
+    fetch_canonical_bitcoin_blockchain(&db, rpc).await;
 
     // Generate the transaction and corresponding request context.
     let (reject_withdrawal_tx, req_ctx) = make_withdrawal_reject(&setup, &db).await;
@@ -198,7 +198,7 @@ async fn reject_withdrawal_validation_not_final() {
     // should be getting new block events from bitcoin-core. We haven't
     // hooked up our block observer, so we need to manually update the
     // database with new bitcoin block headers.
-    backfill_bitcoin_blockchain(&db, rpc).await;
+    fetch_canonical_bitcoin_blockchain(&db, rpc).await;
 
     // Normal: we need to store a row in the dkg_shares table so that we
     // have a record of the scriptPubKey that the signers control.
@@ -215,7 +215,7 @@ async fn reject_withdrawal_validation_not_final() {
     // contract that created the withdrawal request has bene observed. We
     // are generating one too few blocks.
     faucet.generate_blocks(WITHDRAWAL_BLOCKS_EXPIRY);
-    backfill_bitcoin_blockchain(&db, rpc).await;
+    fetch_canonical_bitcoin_blockchain(&db, rpc).await;
 
     // Generate the transaction and corresponding request context.
     let (reject_withdrawal_tx, req_ctx) = make_withdrawal_reject(&setup, &db).await;
@@ -230,7 +230,7 @@ async fn reject_withdrawal_validation_not_final() {
 
     // Generate more block then backfill the DB
     faucet.generate_blocks(1);
-    backfill_bitcoin_blockchain(&db, rpc).await;
+    fetch_canonical_bitcoin_blockchain(&db, rpc).await;
 
     // Generate the transaction and corresponding request context.
     let (reject_withdrawal_tx, req_ctx) = make_withdrawal_reject(&setup, &db).await;
@@ -258,7 +258,7 @@ async fn reject_withdrawal_validation_deployer_mismatch() {
     // should be getting new block events from bitcoin-core. We haven't
     // hooked up our block observer, so we need to manually update the
     // database with new bitcoin block headers.
-    backfill_bitcoin_blockchain(&db, rpc).await;
+    fetch_canonical_bitcoin_blockchain(&db, rpc).await;
 
     // Normal: we need to store a row in the dkg_shares table so that we
     // have a record of the scriptPubKey that the signers control.
@@ -316,7 +316,7 @@ async fn reject_withdrawal_validation_missing_withdrawal_request() {
     // should be getting new block events from bitcoin-core. We haven't
     // hooked up our block observer, so we need to manually update the
     // database with new bitcoin block headers.
-    backfill_bitcoin_blockchain(&db, rpc).await;
+    fetch_canonical_bitcoin_blockchain(&db, rpc).await;
 
     // Normal: we need to store a row in the dkg_shares table so that we
     // have a record of the scriptPubKey that the signers control.
@@ -332,7 +332,7 @@ async fn reject_withdrawal_validation_missing_withdrawal_request() {
     // WITHDRAWAL_BLOCKS_EXPIRY blocks have been observered since the smart
     // contract that created the withdrawal request has bene observed.
     faucet.generate_blocks(WITHDRAWAL_BLOCKS_EXPIRY + 1);
-    backfill_bitcoin_blockchain(&db, rpc).await;
+    fetch_canonical_bitcoin_blockchain(&db, rpc).await;
 
     // Generate the transaction and corresponding request context.
     let (mut reject_withdrawal_tx, req_ctx) = make_withdrawal_reject(&setup, &db).await;
@@ -400,7 +400,7 @@ async fn reject_withdrawal_validation_bitmap_mismatch() {
     // should be getting new block events from bitcoin-core. We haven't
     // hooked up our block observer, so we need to manually update the
     // database with new bitcoin block headers.
-    backfill_bitcoin_blockchain(&db, rpc).await;
+    fetch_canonical_bitcoin_blockchain(&db, rpc).await;
 
     // Normal: we need to store a row in the dkg_shares table so that we
     // have a record of the scriptPubKey that the signers control.
@@ -416,7 +416,7 @@ async fn reject_withdrawal_validation_bitmap_mismatch() {
     // WITHDRAWAL_BLOCKS_EXPIRY blocks have been observered since the smart
     // contract that created the withdrawal request has bene observed.
     faucet.generate_blocks(WITHDRAWAL_BLOCKS_EXPIRY + 1);
-    backfill_bitcoin_blockchain(&db, rpc).await;
+    fetch_canonical_bitcoin_blockchain(&db, rpc).await;
 
     // Generate the transaction and corresponding request context.
     let (mut reject_withdrawal_tx, req_ctx) = make_withdrawal_reject(&setup, &db).await;
@@ -475,7 +475,7 @@ async fn reject_withdrawal_validation_request_completed() {
     // should be getting new block events from bitcoin-core. We haven't
     // hooked up our block observer, so we need to manually update the
     // database with new bitcoin block headers.
-    backfill_bitcoin_blockchain(&db, rpc).await;
+    fetch_canonical_bitcoin_blockchain(&db, rpc).await;
 
     // Normal: we need to store a row in the dkg_shares table so that we
     // have a record of the scriptPubKey that the signers control.
@@ -491,7 +491,7 @@ async fn reject_withdrawal_validation_request_completed() {
     // WITHDRAWAL_BLOCKS_EXPIRY blocks have been observered since the smart
     // contract that created the withdrawal request has bene observed.
     faucet.generate_blocks(WITHDRAWAL_BLOCKS_EXPIRY + 1);
-    backfill_bitcoin_blockchain(&db, rpc).await;
+    fetch_canonical_bitcoin_blockchain(&db, rpc).await;
 
     // Generate the transaction and corresponding request context.
     let (reject_withdrawal_tx, req_ctx) = make_withdrawal_reject(&setup, &db).await;
@@ -545,7 +545,7 @@ async fn reject_withdrawal_validation_request_being_fulfilled() {
     // should be getting new block events from bitcoin-core. We haven't
     // hooked up our block observer, so we need to manually update the
     // database with new bitcoin block headers.
-    backfill_bitcoin_blockchain(&db, rpc).await;
+    fetch_canonical_bitcoin_blockchain(&db, rpc).await;
 
     // Normal: we need to store a row in the dkg_shares table so that we
     // have a record of the scriptPubKey that the signers control. We need
@@ -588,7 +588,7 @@ async fn reject_withdrawal_validation_request_being_fulfilled() {
     // WITHDRAWAL_BLOCKS_EXPIRY blocks have been observered since the smart
     // contract that created the withdrawal request has bene observed.
     faucet.generate_blocks(WITHDRAWAL_BLOCKS_EXPIRY + 1);
-    backfill_bitcoin_blockchain(&db, rpc).await;
+    fetch_canonical_bitcoin_blockchain(&db, rpc).await;
 
     // Generate the transaction and corresponding request context.
     let (reject_withdrawal_tx, req_ctx) = make_withdrawal_reject(&setup, &db).await;

--- a/signer/tests/integration/withdrawal_reject.rs
+++ b/signer/tests/integration/withdrawal_reject.rs
@@ -310,7 +310,6 @@ async fn reject_withdrawal_validation_missing_withdrawal_request() {
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
     let (rpc, faucet) = regtest::initialize_blockchain();
 
-    
     let test_signer_set = TestSignerSet::new(&mut rng);
     let setup = new_sweep_setup(&test_signer_set, &faucet);
     // Normal: the signer follows the bitcoin blockchain and event observer
@@ -508,10 +507,69 @@ async fn reject_withdrawal_validation_request_completed() {
     testing::storage::drop_db(db).await;
 }
 
+/// For this test we check that the `RejectWithdrawalV1::validate` function
+/// returns a withdrawal validation error with a RequestBeingFulfilled
+/// message when the stacks node returns that the withdrawal request has
+/// been completed.
+#[tokio::test]
+async fn reject_withdrawal_validation_request_being_fulfilled() {
+    // Normal: this generates the blockchain as well as a transaction
+    // sweeping out the funds for a withdrawal request. This is just setup
+    // and should be essentially the same between tests.
+    let db = testing::storage::new_test_database().await;
+    let mut rng = rand::rngs::StdRng::seed_from_u64(51);
+    let (rpc, faucet) = regtest::initialize_blockchain();
 
-    // Normal: we take the sweep transaction as is from the test setup and
-    // store it in the database.
-    setup.store_sweep_tx(&db).await;
+    let test_signer_set = TestSignerSet::new(&mut rng);
+    let mut setup = new_sweep_setup(&test_signer_set, &faucet);
+
+    let mut ctx = TestContext::builder()
+        .with_storage(db.clone())
+        .with_first_bitcoin_core_client()
+        .with_mocked_stacks_client()
+        .with_mocked_emily_client()
+        .build();
+
+    // Normal: the request has not been marked as completed in the smart
+    // contract.
+    set_withdrawal_incomplete(&mut ctx).await;
+
+    let public_keys = test_signer_set
+        .keys
+        .iter()
+        .cloned()
+        .collect::<BTreeSet<PublicKey>>();
+    ctx.state().update_current_signer_set(public_keys);
+
+    // Normal: the signer follows the bitcoin blockchain and event observer
+    // should be getting new block events from bitcoin-core. We haven't
+    // hooked up our block observer, so we need to manually update the
+    // database with new bitcoin block headers.
+    backfill_bitcoin_blockchain(&db, rpc).await;
+
+    //Different
+    setup.submit_sweep_tx(rpc, faucet);
+
+    let sweep = setup.sweep_tx_info.as_ref().unwrap();
+
+    setup.store_donation(&db).await;
+    setup.store_bitcoin_withdrawals_outputs(&db).await;
+
+    let signer_tx_sighash = BitcoinTxSigHash {
+        txid: sweep.tx_info.txid.into(),
+        prevout_type: model::TxPrevoutType::SignersInput,
+        prevout_txid: setup.donation.txid.into(),
+        prevout_output_index: setup.donation.vout,
+        validation_result: signer::bitcoin::validation::InputValidationResult::Ok,
+        aggregate_key: setup.signers.aggregate_key().into(),
+        is_valid_tx: true,
+        will_sign: true,
+        chain_tip: rpc.get_blockchain_info().unwrap().best_block_hash.into(),
+        sighash: bitcoin::TapSighash::from_byte_array([23; 32]).into(),
+    };
+    db.write_bitcoin_txs_sighashes(&[signer_tx_sighash])
+        .await
+        .unwrap();
 
     // Normal: we need to store a row in the dkg_shares table so that we
     // have a record of the scriptPubKey that the signers control.
@@ -523,18 +581,19 @@ async fn reject_withdrawal_validation_request_completed() {
     setup.store_withdrawal_requests(&db).await;
     setup.store_withdrawal_decisions(&db).await;
 
-    // Generate more blocks then backfill the DB
-    let mut hashes = faucet.generate_blocks(WITHDRAWAL_BLOCKS_EXPIRY);
-    let last = hashes.pop().unwrap();
-    backfill_bitcoin_blocks(&db, rpc, &last).await;
+    // Normal: We do not reject a withdrawal requests until more than
+    // WITHDRAWAL_BLOCKS_EXPIRY blocks have been observered since the smart
+    // contract that created the withdrawal request has bene observed.
+    faucet.generate_blocks(WITHDRAWAL_BLOCKS_EXPIRY + 1);
+    backfill_bitcoin_blockchain(&db, rpc).await;
 
     // Generate the transaction and corresponding request context.
-    let (reject_withdrawal_tx, req_ctx) = make_withdrawal_reject2(&setup, &db).await;
+    let (reject_withdrawal_tx, req_ctx) = make_withdrawal_reject(&setup, &db).await;
 
     let validation_result = reject_withdrawal_tx.validate(&ctx, &req_ctx).await;
     match validation_result.unwrap_err() {
         Error::WithdrawalRejectValidation(ref err) => {
-            assert_eq!(err.error, WithdrawalRejectErrorMsg::RequestCompleted)
+            assert_eq!(err.error, WithdrawalRejectErrorMsg::RequestBeingFulfilled)
         }
         err => panic!("unexpected error during validation {err}"),
     }

--- a/signer/tests/integration/withdrawal_reject.rs
+++ b/signer/tests/integration/withdrawal_reject.rs
@@ -1,5 +1,7 @@
 use std::collections::BTreeSet;
 
+use bitcoin::hashes::Hash;
+use bitcoincore_rpc::RpcApi;
 use blockstack_lib::types::chainstate::StacksAddress;
 use rand::rngs::OsRng;
 use sbtc::testing::regtest;
@@ -10,9 +12,11 @@ use signer::stacks::contracts::AsContractCall as _;
 use signer::stacks::contracts::RejectWithdrawalV1;
 use signer::stacks::contracts::ReqContext;
 use signer::stacks::contracts::WithdrawalRejectErrorMsg;
-use signer::storage::model::BitcoinBlockRef;
+use signer::storage::model;
+use signer::storage::model::BitcoinTxSigHash;
 use signer::storage::postgres::PgStore;
 use signer::storage::DbRead;
+use signer::storage::DbWrite;
 use signer::testing;
 
 use fake::Fake;
@@ -21,61 +25,18 @@ use signer::context::Context;
 use signer::testing::context::*;
 use signer::WITHDRAWAL_BLOCKS_EXPIRY;
 
-use crate::setup::backfill_bitcoin_blocks;
+use crate::setup::backfill_bitcoin_blockchain;
 use crate::setup::set_withdrawal_completed;
 use crate::setup::set_withdrawal_incomplete;
 use crate::setup::SweepAmounts;
 use crate::setup::TestSignerSet;
-use crate::setup::TestSweepSetup;
 use crate::setup::TestSweepSetup2;
 
 /// Create a "proper" [`RejectWithdrawalV1`] object and context with the
 /// given information. If the information here is correct then the returned
 /// [`RejectWithdrawalV1`] object will pass validation with the given
 /// context.
-fn make_withdrawal_reject(data: &TestSweepSetup) -> (RejectWithdrawalV1, ReqContext) {
-    // Okay now we get ready to create the transaction using the
-    // `RejectWithdrawalV1` type.
-    let complete_withdrawal_tx = RejectWithdrawalV1 {
-        // This points to the withdrawal request transaction.
-        id: data.withdrawal_request.qualified_id(),
-        signer_bitmap: data.withdrawal_request.signer_bitmap,
-        // The deployer must match what is in the signers' context.
-        deployer: StacksAddress::burn_address(false),
-    };
-
-    // This is what the current signer thinks is the state of things.
-    let req_ctx = ReqContext {
-        chain_tip: BitcoinBlockRef {
-            block_hash: data.sweep_block_hash.into(),
-            block_height: data.sweep_block_height,
-        },
-        // This value means that the signer will go back 20 blocks when
-        // looking for pending and rejected withdrawal requests.
-        context_window: 20,
-        // The value here doesn't matter.
-        origin: fake::Faker.fake_with_rng(&mut OsRng),
-        // When checking whether the transaction is from the signer, we
-        // check that the first "prevout" has a `scriptPubKey` that the
-        // signers control.
-        aggregate_key: data.aggregated_signer.keypair.public_key().into(),
-        // This value affects whether a withdrawal request is considered
-        // "rejected". During validation, a signer won't sign a transaction
-        // if it is not considered rejected but the collection of signers.
-        signatures_required: 2,
-        // This is who the current signer thinks deployed the sBTC
-        // contracts.
-        deployer: StacksAddress::burn_address(false),
-    };
-
-    (complete_withdrawal_tx, req_ctx)
-}
-
-/// Create a "proper" [`RejectWithdrawalV1`] object and context with the
-/// given information. If the information here is correct then the returned
-/// [`RejectWithdrawalV1`] object will pass validation with the given
-/// context.
-async fn make_withdrawal_reject2(
+async fn make_withdrawal_reject(
     data: &TestSweepSetup2,
     db: &PgStore,
 ) -> (RejectWithdrawalV1, ReqContext) {
@@ -151,9 +112,7 @@ async fn reject_withdrawal_validation_happy_path() {
     let (rpc, faucet) = regtest::initialize_blockchain();
 
     let test_signer_set = TestSignerSet::new(&mut rng);
-    let mut setup = new_sweep_setup(&test_signer_set, &faucet);
-
-    setup.submit_sweep_tx(rpc, faucet);
+    let setup = new_sweep_setup(&test_signer_set, &faucet);
 
     let mut ctx = TestContext::builder()
         .with_storage(db.clone())
@@ -162,6 +121,8 @@ async fn reject_withdrawal_validation_happy_path() {
         .with_mocked_emily_client()
         .build();
 
+    // Normal: the request has not been marked as completed in the smart
+    // contract.
     set_withdrawal_incomplete(&mut ctx).await;
 
     let public_keys = test_signer_set
@@ -175,11 +136,7 @@ async fn reject_withdrawal_validation_happy_path() {
     // should be getting new block events from bitcoin-core. We haven't
     // hooked up our block observer, so we need to manually update the
     // database with new bitcoin block headers.
-    backfill_bitcoin_blocks(&db, rpc, &setup.sweep_block_hash().unwrap()).await;
-
-    // Normal: we take the sweep transaction as is from the test setup and
-    // store it in the database.
-    setup.store_sweep_tx(&db).await;
+    backfill_bitcoin_blockchain(&db, rpc).await;
 
     // Normal: we need to store a row in the dkg_shares table so that we
     // have a record of the scriptPubKey that the signers control.
@@ -191,13 +148,14 @@ async fn reject_withdrawal_validation_happy_path() {
     setup.store_withdrawal_requests(&db).await;
     setup.store_withdrawal_decisions(&db).await;
 
-    // Generate more blocks then backfill the DB
-    let mut hashes = faucet.generate_blocks(WITHDRAWAL_BLOCKS_EXPIRY);
-    let last = hashes.pop().unwrap();
-    backfill_bitcoin_blocks(&db, rpc, &last).await;
+    // Normal: We do not reject a withdrawal requests until more than
+    // WITHDRAWAL_BLOCKS_EXPIRY blocks have been observered since the smart
+    // contract that created the withdrawal request has bene observed.
+    faucet.generate_blocks(WITHDRAWAL_BLOCKS_EXPIRY + 1);
+    backfill_bitcoin_blockchain(&db, rpc).await;
 
     // Generate the transaction and corresponding request context.
-    let (reject_withdrawal_tx, req_ctx) = make_withdrawal_reject2(&setup, &db).await;
+    let (reject_withdrawal_tx, req_ctx) = make_withdrawal_reject(&setup, &db).await;
 
     reject_withdrawal_tx.validate(&ctx, &req_ctx).await.unwrap();
 
@@ -216,9 +174,7 @@ async fn reject_withdrawal_validation_not_final() {
     let (rpc, faucet) = regtest::initialize_blockchain();
 
     let test_signer_set = TestSignerSet::new(&mut rng);
-    let mut setup = new_sweep_setup(&test_signer_set, &faucet);
-
-    setup.submit_sweep_tx(rpc, faucet);
+    let setup = new_sweep_setup(&test_signer_set, &faucet);
 
     let mut ctx = TestContext::builder()
         .with_storage(db.clone())
@@ -227,6 +183,8 @@ async fn reject_withdrawal_validation_not_final() {
         .with_mocked_emily_client()
         .build();
 
+    // Normal: the request has not been marked as completed in the smart
+    // contract.
     set_withdrawal_incomplete(&mut ctx).await;
 
     let public_keys = test_signer_set
@@ -240,11 +198,7 @@ async fn reject_withdrawal_validation_not_final() {
     // should be getting new block events from bitcoin-core. We haven't
     // hooked up our block observer, so we need to manually update the
     // database with new bitcoin block headers.
-    backfill_bitcoin_blocks(&db, rpc, &setup.sweep_block_hash().unwrap()).await;
-
-    // Normal: we take the sweep transaction as is from the test setup and
-    // store it in the database.
-    setup.store_sweep_tx(&db).await;
+    backfill_bitcoin_blockchain(&db, rpc).await;
 
     // Normal: we need to store a row in the dkg_shares table so that we
     // have a record of the scriptPubKey that the signers control.
@@ -256,13 +210,15 @@ async fn reject_withdrawal_validation_not_final() {
     setup.store_withdrawal_requests(&db).await;
     setup.store_withdrawal_decisions(&db).await;
 
-    // Generate more blocks then backfill the DB
-    let mut hashes = faucet.generate_blocks(WITHDRAWAL_BLOCKS_EXPIRY - 2);
-    let last = hashes.pop().unwrap();
-    backfill_bitcoin_blocks(&db, rpc, &last).await;
+    // Different: We do not reject a withdrawal requests until more than
+    // WITHDRAWAL_BLOCKS_EXPIRY blocks have been observered since the smart
+    // contract that created the withdrawal request has bene observed. We
+    // are generating one too few blocks.
+    faucet.generate_blocks(WITHDRAWAL_BLOCKS_EXPIRY);
+    backfill_bitcoin_blockchain(&db, rpc).await;
 
     // Generate the transaction and corresponding request context.
-    let (reject_withdrawal_tx, req_ctx) = make_withdrawal_reject2(&setup, &db).await;
+    let (reject_withdrawal_tx, req_ctx) = make_withdrawal_reject(&setup, &db).await;
 
     let validate_future = reject_withdrawal_tx.validate(&ctx, &req_ctx);
     match validate_future.await.unwrap_err() {
@@ -272,13 +228,12 @@ async fn reject_withdrawal_validation_not_final() {
         err => panic!("unexpected error during validation {err}"),
     }
 
-    // Generate more blocks then backfill the DB
-    let mut hashes = faucet.generate_blocks(2);
-    let last = hashes.pop().unwrap();
-    backfill_bitcoin_blocks(&db, rpc, &last).await;
+    // Generate more block then backfill the DB
+    faucet.generate_blocks(1);
+    backfill_bitcoin_blockchain(&db, rpc).await;
 
     // Generate the transaction and corresponding request context.
-    let (reject_withdrawal_tx, req_ctx) = make_withdrawal_reject2(&setup, &db).await;
+    let (reject_withdrawal_tx, req_ctx) = make_withdrawal_reject(&setup, &db).await;
 
     reject_withdrawal_tx.validate(&ctx, &req_ctx).await.unwrap();
 
@@ -295,17 +250,15 @@ async fn reject_withdrawal_validation_deployer_mismatch() {
     let db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
     let (rpc, faucet) = regtest::initialize_blockchain();
-    let setup = TestSweepSetup::new_setup(&rpc, &faucet, 1_000_000, &mut rng);
+
+    let test_signer_set = TestSignerSet::new(&mut rng);
+    let setup = new_sweep_setup(&test_signer_set, &faucet);
 
     // Normal: the signer follows the bitcoin blockchain and event observer
     // should be getting new block events from bitcoin-core. We haven't
     // hooked up our block observer, so we need to manually update the
     // database with new bitcoin block headers.
-    backfill_bitcoin_blocks(&db, rpc, &setup.sweep_block_hash).await;
-
-    // Normal: we take the sweep transaction as is from the test setup and
-    // store it in the database.
-    setup.store_sweep_tx(&db).await;
+    backfill_bitcoin_blockchain(&db, rpc).await;
 
     // Normal: we need to store a row in the dkg_shares table so that we
     // have a record of the scriptPubKey that the signers control.
@@ -314,14 +267,14 @@ async fn reject_withdrawal_validation_deployer_mismatch() {
     // Normal: the request and how the signers voted needs to be added to
     // the database. Here the bitmap in the withdrawal request object
     // corresponds to how the signers voted.
-    setup.store_withdrawal_request(&db).await;
+    setup.store_withdrawal_requests(&db).await;
     setup.store_withdrawal_decisions(&db).await;
 
     // Generate the transaction and corresponding request context.
-    let (mut reject_withdrawal_tx, mut req_ctx) = make_withdrawal_reject(&setup);
+    let (mut reject_withdrawal_tx, mut req_ctx) = make_withdrawal_reject(&setup, &db).await;
     // Different: Okay, let's make sure the deployers do not match.
-    reject_withdrawal_tx.deployer = StacksAddress::p2pkh(false, &setup.signer_keys[0].into());
-    req_ctx.deployer = StacksAddress::p2pkh(false, &setup.signer_keys[1].into());
+    reject_withdrawal_tx.deployer = StacksAddress::p2pkh(false, &setup.signers.keys[0].into());
+    req_ctx.deployer = StacksAddress::p2pkh(false, &setup.signers.keys[1].into());
 
     let mut ctx = TestContext::builder()
         .with_storage(db.clone())
@@ -330,12 +283,9 @@ async fn reject_withdrawal_validation_deployer_mismatch() {
         .with_mocked_emily_client()
         .build();
 
+    // Normal: the request has not been marked as completed in the smart
+    // contract.
     set_withdrawal_incomplete(&mut ctx).await;
-
-    // Generate more blocks then backfill the DB
-    let mut hashes = faucet.generate_blocks(6);
-    let last = hashes.pop().unwrap();
-    backfill_bitcoin_blocks(&db, rpc, &last).await;
 
     let validate_future = reject_withdrawal_tx.validate(&ctx, &req_ctx);
     match validate_future.await.unwrap_err() {
@@ -359,17 +309,15 @@ async fn reject_withdrawal_validation_missing_withdrawal_request() {
     let db = testing::storage::new_test_database().await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(51);
     let (rpc, faucet) = regtest::initialize_blockchain();
-    let setup = TestSweepSetup::new_setup(&rpc, &faucet, 1_000_000, &mut rng);
 
+    
+    let test_signer_set = TestSignerSet::new(&mut rng);
+    let setup = new_sweep_setup(&test_signer_set, &faucet);
     // Normal: the signer follows the bitcoin blockchain and event observer
     // should be getting new block events from bitcoin-core. We haven't
     // hooked up our block observer, so we need to manually update the
     // database with new bitcoin block headers.
-    backfill_bitcoin_blocks(&db, rpc, &setup.sweep_block_hash).await;
-
-    // Normal: we take the sweep transaction as is from the test setup and
-    // store it in the database.
-    setup.store_sweep_tx(&db).await;
+    backfill_bitcoin_blockchain(&db, rpc).await;
 
     // Normal: we need to store a row in the dkg_shares table so that we
     // have a record of the scriptPubKey that the signers control.
@@ -378,11 +326,17 @@ async fn reject_withdrawal_validation_missing_withdrawal_request() {
     // Normal: the request and how the signers voted needs to be added to
     // the database. Here the bitmap in the withdrawal request object
     // corresponds to how the signers voted.
-    setup.store_withdrawal_request(&db).await;
+    setup.store_withdrawal_requests(&db).await;
     setup.store_withdrawal_decisions(&db).await;
 
+    // Normal: We do not reject a withdrawal requests until more than
+    // WITHDRAWAL_BLOCKS_EXPIRY blocks have been observered since the smart
+    // contract that created the withdrawal request has bene observed.
+    faucet.generate_blocks(WITHDRAWAL_BLOCKS_EXPIRY + 1);
+    backfill_bitcoin_blockchain(&db, rpc).await;
+
     // Generate the transaction and corresponding request context.
-    let (mut reject_withdrawal_tx, req_ctx) = make_withdrawal_reject(&setup);
+    let (mut reject_withdrawal_tx, req_ctx) = make_withdrawal_reject(&setup, &db).await;
     // Different: Let's use a request_id that does not exist in our
     // database. In these tests, the withdrawal id starts at 0 and
     // increments by 1 for each withdrawal request generated.
@@ -395,12 +349,9 @@ async fn reject_withdrawal_validation_missing_withdrawal_request() {
         .with_mocked_emily_client()
         .build();
 
+    // Normal: the request has not been marked as completed in the smart
+    // contract.
     set_withdrawal_incomplete(&mut ctx).await;
-
-    // Generate more blocks then backfill the DB
-    let mut hashes = faucet.generate_blocks(6);
-    let last = hashes.pop().unwrap();
-    backfill_bitcoin_blocks(&db, rpc, &last).await;
 
     let validation_result = reject_withdrawal_tx.validate(&ctx, &req_ctx).await;
     match validation_result.unwrap_err() {
@@ -426,28 +377,7 @@ async fn reject_withdrawal_validation_bitmap_mismatch() {
     let (rpc, faucet) = regtest::initialize_blockchain();
 
     let test_signer_set = TestSignerSet::new(&mut rng);
-    let mut setup = new_sweep_setup(&test_signer_set, &faucet);
-
-    setup.submit_sweep_tx(rpc, faucet);
-    let amount = 1_000_000;
-    let test_signer_set = TestSignerSet::new(&mut rng);
-    let deposit_amounts = SweepAmounts {
-        amount,
-        max_fee: amount / 2,
-        is_deposit: true,
-    };
-    let withdraw_amounts = SweepAmounts {
-        amount,
-        max_fee: amount / 2,
-        is_deposit: false,
-    };
-    let mut setup = TestSweepSetup2::new_setup(
-        test_signer_set.clone(),
-        &faucet,
-        &[deposit_amounts, withdraw_amounts],
-    );
-
-    setup.submit_sweep_tx(rpc, faucet);
+    let setup = new_sweep_setup(&test_signer_set, &faucet);
 
     let mut ctx = TestContext::builder()
         .with_storage(db.clone())
@@ -456,6 +386,8 @@ async fn reject_withdrawal_validation_bitmap_mismatch() {
         .with_mocked_emily_client()
         .build();
 
+    // Normal: the request has not been marked as completed in the smart
+    // contract.
     set_withdrawal_incomplete(&mut ctx).await;
 
     let public_keys = test_signer_set
@@ -469,11 +401,7 @@ async fn reject_withdrawal_validation_bitmap_mismatch() {
     // should be getting new block events from bitcoin-core. We haven't
     // hooked up our block observer, so we need to manually update the
     // database with new bitcoin block headers.
-    backfill_bitcoin_blocks(&db, rpc, &setup.sweep_block_hash().unwrap()).await;
-
-    // Normal: we take the sweep transaction as is from the test setup and
-    // store it in the database.
-    setup.store_sweep_tx(&db).await;
+    backfill_bitcoin_blockchain(&db, rpc).await;
 
     // Normal: we need to store a row in the dkg_shares table so that we
     // have a record of the scriptPubKey that the signers control.
@@ -485,13 +413,14 @@ async fn reject_withdrawal_validation_bitmap_mismatch() {
     setup.store_withdrawal_requests(&db).await;
     setup.store_withdrawal_decisions(&db).await;
 
-    // Generate more blocks then backfill the DB
-    let mut hashes = faucet.generate_blocks(6);
-    let last = hashes.pop().unwrap();
-    backfill_bitcoin_blocks(&db, rpc, &last).await;
+    // Normal: We do not reject a withdrawal requests until more than
+    // WITHDRAWAL_BLOCKS_EXPIRY blocks have been observered since the smart
+    // contract that created the withdrawal request has bene observed.
+    faucet.generate_blocks(WITHDRAWAL_BLOCKS_EXPIRY + 1);
+    backfill_bitcoin_blockchain(&db, rpc).await;
 
     // Generate the transaction and corresponding request context.
-    let (mut reject_withdrawal_tx, req_ctx) = make_withdrawal_reject2(&setup, &db).await;
+    let (mut reject_withdrawal_tx, req_ctx) = make_withdrawal_reject(&setup, &db).await;
 
     // Different: We're going to get the bitmap that is a little different
     // from what is expected.
@@ -523,9 +452,7 @@ async fn reject_withdrawal_validation_request_completed() {
     let (rpc, faucet) = regtest::initialize_blockchain();
 
     let test_signer_set = TestSignerSet::new(&mut rng);
-    let mut setup = new_sweep_setup(&test_signer_set, &faucet);
-
-    setup.submit_sweep_tx(rpc, faucet);
+    let setup = new_sweep_setup(&test_signer_set, &faucet);
 
     let mut ctx = TestContext::builder()
         .with_storage(db.clone())
@@ -549,7 +476,38 @@ async fn reject_withdrawal_validation_request_completed() {
     // should be getting new block events from bitcoin-core. We haven't
     // hooked up our block observer, so we need to manually update the
     // database with new bitcoin block headers.
-    backfill_bitcoin_blocks(&db, rpc, &setup.sweep_block_hash().unwrap()).await;
+    backfill_bitcoin_blockchain(&db, rpc).await;
+
+    // Normal: we need to store a row in the dkg_shares table so that we
+    // have a record of the scriptPubKey that the signers control.
+    setup.store_dkg_shares(&db).await;
+
+    // Normal: the request and how the signers voted needs to be added to
+    // the database. Here the bitmap in the withdrawal request object
+    // corresponds to how the signers voted.
+    setup.store_withdrawal_requests(&db).await;
+    setup.store_withdrawal_decisions(&db).await;
+
+    // Normal: We do not reject a withdrawal requests until more than
+    // WITHDRAWAL_BLOCKS_EXPIRY blocks have been observered since the smart
+    // contract that created the withdrawal request has bene observed.
+    faucet.generate_blocks(WITHDRAWAL_BLOCKS_EXPIRY + 1);
+    backfill_bitcoin_blockchain(&db, rpc).await;
+
+    // Generate the transaction and corresponding request context.
+    let (reject_withdrawal_tx, req_ctx) = make_withdrawal_reject(&setup, &db).await;
+
+    let validation_result = reject_withdrawal_tx.validate(&ctx, &req_ctx).await;
+    match validation_result.unwrap_err() {
+        Error::WithdrawalRejectValidation(ref err) => {
+            assert_eq!(err.error, WithdrawalRejectErrorMsg::RequestCompleted)
+        }
+        err => panic!("unexpected error during validation {err}"),
+    }
+
+    testing::storage::drop_db(db).await;
+}
+
 
     // Normal: we take the sweep transaction as is from the test setup and
     // store it in the database.


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/1374

## Changes

* Add a query that checks whether the signer thinks it's possible for an output in the mempool to fulfill a withdrawal request.
* Fail `withdrawal-reject` validation if the signer suspects that there is a sweep transaction in the mempool that is fulfilling a withdrawal request.
* Change the `withdrawal-reject` tests to remove unnecessary actions so that it's easier to see that they fail only for the difference condition that they are testing.

## Testing Information

This PR adds one new integration test for the new condition in the `RejectWithdrawalV1::validation` function, and two new integration tests for the new query.

## Checklist:

- [x] I have performed a self-review of my code

