### PR TITLE
[feat] Sidecar update Emily for withdrawal and deposits

### DIFF
--- a/emily_sidecar/clarity.py
+++ b/emily_sidecar/clarity.py
@@ -1,0 +1,88 @@
+from bitcoinlib.keys import Address
+from settings import LOGGER, NETWORK
+
+
+# Types
+# {"Tuple": {"key1": {}, key2: {}, ..}}
+# {"Sequence": {"Buffer": {"data": []}}}
+# {"Sequence": {"String": {"ASCII": {"data": []}}}}
+# {"UInt": 0}
+# {"Int": 0}
+# {"Principal": {"Standard": [0, [0x0, 0x0, ..., 0x0]]}} TODO: Implement this
+def parse_clarity_value(v: dict) -> dict:
+    """
+    Parses a Clarity value and transforms it into a Python dictionary with appropriate value types.
+
+    This function handles a subset of Clarity types: Tuples, Sequences (Buffers and Strings), UInts and Ints.
+    Only the subset used by the sBTC print events is supported. The other types are not handled.
+
+    Note: The function expects the input to be properly formatted Clarity values. If the input is not properly
+    formatted, the function will raise an exception.
+
+    Args:
+        v (dict[str, Any]): Clarity value to be parsed.
+
+    Returns:
+        dict[str, Any] corresponding Python type.
+
+    """
+    if "Tuple" in v:
+        return {
+            k: parse_clarity_value(val) for k, val in v["Tuple"]["data_map"].items()
+        }
+    if "Sequence" in v:
+        sequence = v["Sequence"]
+        if "Buffer" in sequence:
+            return sequence["Buffer"]["data"]
+        if "String" in sequence:
+            return "".join(map(chr, sequence["String"]["ASCII"]["data"]))
+    elif "UInt" in v:
+        return v["UInt"]
+    elif "Int" in v:
+        return v["Int"]
+    return v
+
+
+def parse_clarity_value_safe(value: dict) -> dict | None:
+    try:
+        return parse_clarity_value(value)
+    except Exception as e:
+        # We are only interested in events that we can parse
+        LOGGER.debug("Failed to parse Clarity value: %s", e)
+        return None
+
+
+def try_into_address(version: bytes, hash_bytes: bytes) -> str:
+    """
+    Tries to convert the version and hash_bytes into a Script object.
+
+    Args:
+        version (bytes): the version of the recipient
+        hash_bytes (bytes): the hash of the recipient
+
+    Raises:
+        Exception: If the version is not handled
+
+    Returns:
+        str: The address
+    """
+    script_map = {
+        b"\x00": ("p2pkh", 20),
+        b"\x01": ("p2sh", 20),
+        b"\x02": ("p2sh", 20),
+        b"\x03": ("p2sh", 20),
+        b"\x04": ("p2wpkh", 20),
+        b"\x05": ("p2wsh", 32),
+        b"\x06": ("p2tr", 32),
+    }
+
+    script_type, expected_length = script_map.get(version, (None, None))
+    if script_type and len(hash_bytes) == expected_length:
+        return Address(
+            hash_bytes,
+            encoding="base58" if expected_length == 20 else "bech32",
+            script_type=script_type,
+            network=NETWORK,
+        ).address
+
+    raise Exception(f"Unhandled recipient version: {version}, hash_bytes: {hash_bytes}")

--- a/emily_sidecar/event_handlers.py
+++ b/emily_sidecar/event_handlers.py
@@ -1,0 +1,100 @@
+import logging
+
+import emily_client
+
+from clarity import try_into_address
+
+
+def le_bytes_to_hex(le_bytes: list[str]) -> str:
+    return bytes(reversed(le_bytes)).hex()
+
+
+def handle_completed_deposit(
+    event: dict, stacks_txid: str, stacks_block_hash: str, stacks_block_height: int
+) -> emily_client.DepositUpdate:
+    # amount = event.pop("amount")
+    fulfillment = emily_client.Fulfillment(
+        bitcoin_block_hash=le_bytes_to_hex(event["burn-hash"]),
+        bitcoin_block_height=event["burn-height"],
+        bitcoin_tx_index=0,  # in the signer, we are using output-index
+        bitcoin_txid=le_bytes_to_hex(
+            event["sweep-txid"]
+        ),  # in the signer, we are using bitcoin-txid
+        btc_fee=0,  # in the signer, we can compute the fee from the amount and the tx amount in the DB
+        stacks_txid=stacks_txid,
+    )
+    return emily_client.DepositUpdate(
+        bitcoin_tx_output_index=event["output-index"],
+        bitcoin_txid=le_bytes_to_hex(event["bitcoin-txid"]),
+        status="confirmed",
+        fulfillment=fulfillment,
+        status_message=f"Included in block {fulfillment.bitcoin_block_hash}",
+        last_update_block_hash=stacks_block_hash,
+        last_update_height=stacks_block_height,
+    )
+
+
+def handle_withdrawal_create(
+    event: dict, _stacks_txid: str, stacks_block_hash: str, stacks_block_height: int
+) -> emily_client.CreateWithdrawalRequestBody:
+    # block_height: int = event["block-height"],  # Not used
+    # sender: str = event["sender"]  # Not used
+    recipient = try_into_address(
+        bytes(event["recipient"]["version"]), bytes(event["recipient"]["hashbytes"])
+    )
+    return emily_client.CreateWithdrawalRequestBody(
+        amount=event["amount"],
+        parameters=emily_client.WithdrawalParameters(max_fee=event["max-fee"]),
+        recipient=recipient,
+        request_id=event["request-id"],
+        stacks_block_hash=stacks_block_hash,
+        stacks_block_height=stacks_block_height,
+    )
+
+
+def handle_withdrawal_accept(
+    event: dict, stacks_txid: str, stacks_block_hash: str, stacks_block_height: int
+) -> emily_client.WithdrawalUpdate:
+    # bitmap: int = event["signer-bitmap"]  # Not used
+    # bitcoin_txid = event["bitcoin-txid"]  # Not used
+    bitcoin_tx_index = event["output-index"]
+    fulfillment = emily_client.Fulfillment(
+        bitcoin_block_hash=le_bytes_to_hex(event["burn-hash"]),
+        bitcoin_block_height=event["burn-height"],
+        bitcoin_tx_index=bitcoin_tx_index,
+        bitcoin_txid=le_bytes_to_hex(
+            event["sweep-txid"]
+        ),  # in the signer, we are using bitcoin-txid
+        btc_fee=event["fee"],
+        stacks_txid=stacks_txid,
+    )
+    return emily_client.WithdrawalUpdate(
+        request_id=event["request-id"],
+        status="confirmed",
+        fulfillment=fulfillment,
+        status_message=f"Included in block {fulfillment.bitcoin_block_hash}",
+        last_update_block_hash=stacks_block_hash,
+        last_update_height=stacks_block_height,
+    )
+
+
+def handle_withdrawal_reject(
+    event: dict, _stacks_txid: str, stacks_block_hash: str, stacks_block_height: int
+) -> emily_client.WithdrawalUpdate:
+    # bitmap: int = event["signer-bitmap"]  # Not used
+    return emily_client.WithdrawalUpdate(
+        fulfillment=None,
+        request_id=event["request-id"],
+        status="failed",
+        status_message="Rejected",
+        last_update_block_hash=stacks_block_hash,
+        last_update_height=stacks_block_height,
+    )
+
+
+EVENT_HANDLERS = {
+    "completed-deposit": handle_completed_deposit,
+    "withdrawal-accept": handle_withdrawal_accept,
+    "withdrawal-reject": handle_withdrawal_reject,
+    "withdrawal-create": handle_withdrawal_create,
+}

--- a/emily_sidecar/main.py
+++ b/emily_sidecar/main.py
@@ -1,44 +1,22 @@
-import os
-import logging
+from typing import Any
 
-from fastapi import FastAPI, Request, HTTPException
-from pydantic import BaseModel, ValidationError, Field
-
+from fastapi import FastAPI, HTTPException
 import emily_client
 
+import settings
+from settings import LOGGER
+from event_handlers import EVENT_HANDLERS
+from clarity import parse_clarity_value_safe
+from models import NewBlockEventModel, TransactionEventModel
 
 # Initialize the FastAPI app
 app = FastAPI()
 
-# Configure logging
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
+LOGGER.info("Using Emily endpoint: %s", settings.EMILY_ENDPOINT)
+LOGGER.info("Using deployer address: %s", settings.DEPLOYER_ADDRESS)
 
-
-# Define the models
-class NewBlockEventModel(BaseModel, extra="allow"):
-    block_height: int
-    index_block_hash: str
-
-
-# Environment variables and configuration
-api_key = os.getenv("EMILY_API_KEY", "testApiKey")
-# The client fails if the endpoint has a trailing slash
-emily_endpoint = os.getenv(
-    "EMILY_ENDPOINT", "http://@host.docker.internal:3031"
-).removesuffix("/")
-
-deployer_address = os.getenv(
-    "DEPLOYER_ADDRESS", "SN3R84XZYA63QS28932XQF3G1J8R9PC3W76P9CSQS"
-)
-
-logger.info("Using Emily endpoint: %s", emily_endpoint)
-logger.info("Using deployer address: %s", deployer_address)
-
-conf = emily_client.Configuration(
-    host=emily_endpoint,
-)
-conf.api_key["ApiGatewayKey"] = api_key
+conf = emily_client.Configuration(host=settings.EMILY_ENDPOINT)
+conf.api_key["ApiGatewayKey"] = settings.API_KEY
 
 api_client = emily_client.ApiClient(configuration=conf)
 
@@ -53,24 +31,92 @@ def read_root() -> dict:
 
 
 @app.post("/new_block")
-async def handle_new_block(event: NewBlockEventModel) -> dict:
-    logger.info("Received new block event: %s, %s", event, dir(event))
+async def handle_new_block(new_block_event: NewBlockEventModel) -> dict:
     chainstate = emily_client.Chainstate(
-        stacksBlockHeight=event.block_height,
-        stacksBlockHash=event.index_block_hash.removeprefix("0x"),
+        stacksBlockHeight=new_block_event.block_height,
+        stacksBlockHash=new_block_event.index_block_hash,
     )
 
     try:
         CHAINSTATE_API.set_chainstate(chainstate)
     except Exception as e:
-        logger.error(
-            "Failed to send chainstate %s to %s: %s", chainstate, emily_endpoint, e
+        LOGGER.error(
+            "Failed to send chainstate %s to %s: %s",
+            chainstate,
+            settings.EMILY_ENDPOINT,
+            e,
         )
         raise HTTPException(status_code=500, detail="Failed to send chainstate")
-    logger.info("Successfully processed new block for chainstate: %s", chainstate)
+
+    LOGGER.info("Successfully processed new block for chainstate: %s", chainstate)
+
+    contract_events = extract_sbtc_contract_events(new_block_event.events)
+
+    completed_deposits, updated_withdrawals, created_withdrawals = [], [], []
+
+    for txid, event_data in contract_events:
+        result = EVENT_HANDLERS[event_data["topic"]](
+            event_data,
+            txid,
+            new_block_event.index_block_hash,
+            new_block_event.block_height,
+        )
+        match event_data["topic"]:
+            case "completed-deposit":
+                completed_deposits.append(result)
+            case "withdrawal-create":
+                created_withdrawals.append(result)
+            case _:  # withdrawal-accept, withdrawal-reject
+                updated_withdrawals.append(result)
+
+    if completed_deposits:
+        DEPOSIT_API.update_deposits(
+            emily_client.UpdateDepositsRequestBody(deposits=completed_deposits)
+        )
+
+    for withdrawal in created_withdrawals:
+        WITHDRAWAL_API.create_withdrawal(create_withdrawal_request_body=withdrawal)
+
+    if updated_withdrawals:
+        WITHDRAWAL_API.update_withdrawals(
+            emily_client.UpdateWithdrawalsRequestBody(withdrawals=updated_withdrawals)
+        )
     return {}
 
 
 @app.post("/attachments/new")
 async def handle_attachments() -> dict:
     return {}
+
+
+def extract_sbtc_contract_events(
+    events: list[TransactionEventModel],
+) -> list[tuple[str, dict[str, Any]]]:
+    """
+    Extracts and transforms the events to only include the sBTC print events that we are interested in.
+
+    Args:
+        events (list[TransactionEventModel]): The list of transaction events to be processed.
+
+    Returns:
+        list[dict[str, Any]]: A list of tuples containing the transaction ID and the transformed contract value.
+    """
+
+    # Get the committed print events
+    events = [
+        e
+        for e in events
+        if e.committed
+        and e.contract_event
+        and e.contract_event.contract_identifier == settings.REGISTRY_ADDRESS
+        and e.contract_event.topic == "print"
+        and e.contract_event.value.get("Tuple") is not None
+    ]
+
+    # Get the contract events that we are interested in
+    return [
+        (event.txid, contract_value)
+        for event in events
+        if (contract_value := parse_clarity_value_safe(event.contract_event.value))
+        and contract_value.get("topic") in EVENT_HANDLERS
+    ]

--- a/emily_sidecar/models.py
+++ b/emily_sidecar/models.py
@@ -1,0 +1,73 @@
+from pydantic import BaseModel, field_validator
+from enum import Enum
+
+
+# The type of event that occurred within the transaction.
+class TransactionEventType(Enum):
+    # A smart contract event
+    ContractEvent = "contract_event"
+    # A STX transfer event
+    StxTransferEvent = "stx_transfer_event"
+    # An STX mint event
+    StxMintEvent = "stx_mint_event"
+    # An STX burn event
+    StxBurnEvent = "stx_burn_event"
+    # An STX lock event
+    StxLockEvent = "stx_lock_event"
+    # A transfer event for a NFT
+    NftTransferEvent = "nft_transfer_event"
+    # A non-fungible-token mint event
+    NftMintEvent = "nft_mint_event"
+    # A non-fungible-token burn event
+    NftBurnEvent = "nft_burn_event"
+    # A fungible-token transfer event
+    FtTransferEvent = "ft_transfer_event"
+    # A fungible-token mint event
+    FtMintEvent = "ft_mint_event"
+    # A fungible-token burn event
+    FtBurnEvent = "ft_burn_event"
+
+
+# Smart contracts emit events when they are executed. This represents
+# such an event. The expected type is taken from stacks-core[^1].
+#
+# [^1]: <https://github.com/stacks-network/stacks-core/blob/09c4b066e25104be8b066e8f7530ff0c6df4ccd5/clarity/src/vm/events.rs#L358-L363>
+class SmartContractEventModel(BaseModel, extra="allow"):
+    contract_identifier: str
+    raw_value: str
+    topic: str
+    value: dict
+
+
+# An event that was emitted during the execution of the transaction. It
+# is defined in [^1].
+#
+# [^1]: <https://github.com/stacks-network/stacks-core/blob/09c4b066e25104be8b066e8f7530ff0c6df4ccd5/clarity/src/vm/events.rs#L45-L51>
+class TransactionEventModel(BaseModel, extra="allow"):
+    txid: str
+    event_index: int
+    committed: bool
+    type: TransactionEventType
+    contract_event: SmartContractEventModel | None
+
+    @field_validator("txid", mode="after")
+    def remove_prefix(cls, value: str) -> str:
+        return value.removeprefix("0x")
+
+
+# This class represents the minimal body of POST /new_block events from a stacks
+# node that the Sidecar needs to handle.
+#
+## Note
+#
+# This class leaves out some of the fields that are included. For the
+# full payload, see the source here:
+# <https://github.com/stacks-network/stacks-core/blob/09c4b066e25104be8b066e8f7530ff0c6df4ccd5/testnet/stacks-node/src/event_dispatcher.rs#L644-L687>
+class NewBlockEventModel(BaseModel, extra="allow"):
+    block_height: int
+    index_block_hash: str
+    events: list[TransactionEventModel]
+
+    @field_validator("index_block_hash", mode="after")
+    def remove_prefix(cls, value: str) -> str:
+        return value.removeprefix("0x")

--- a/emily_sidecar/requirements.txt
+++ b/emily_sidecar/requirements.txt
@@ -1,3 +1,4 @@
 fastapi==0.115.8
 uvicorn==0.34.0
 setuptools==75.8.0
+bitcoinlib==0.7.2

--- a/emily_sidecar/settings.py
+++ b/emily_sidecar/settings.py
@@ -1,0 +1,25 @@
+import logging
+import os
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+LOGGER = logging.getLogger(__name__)
+
+# Environment variables and configuration
+API_KEY = os.getenv("EMILY_API_KEY", "testApiKey")
+# The client fails if the endpoint has a trailing slash
+EMILY_ENDPOINT = os.getenv(
+    "EMILY_ENDPOINT", "http://@host.docker.internal:3031"
+).removesuffix("/")
+
+DEPLOYER_ADDRESS = os.getenv(
+    "DEPLOYER_ADDRESS", "SN3R84XZYA63QS28932XQF3G1J8R9PC3W76P9CSQS"
+)
+
+SBTC_REGISTRY_CONTRACT_NAME = "sbtc-registry"
+
+REGISTRY_ADDRESS = f"{DEPLOYER_ADDRESS}.{SBTC_REGISTRY_CONTRACT_NAME}"
+
+IS_MAINNET = os.getenv("IS_MAINNET", "false").lower() == "true"
+
+NETWORK = "bitcoin" if IS_MAINNET else "regtest"

--- a/emily_sidecar/test.py
+++ b/emily_sidecar/test.py
@@ -7,12 +7,14 @@ from fastapi.testclient import TestClient
 import emily_client
 
 from main import app
+from clarity import parse_clarity_value, parse_clarity_value_safe
+
 
 client = TestClient(app)
 
 
 def read_fixture(filename):
-    with open(filename, 'r') as file:
+    with open(filename, "r") as file:
         return json.load(file)
 
 
@@ -24,10 +26,20 @@ FIXTURE_FILES = {
     "withdrawal_accept": "withdrawal-accept-event.json",
     "withdrawal_create": "withdrawal-create-event.json",
     "withdrawal_reject": "withdrawal-reject-event.json",
-    "rotate_keys": "rotate-keys-event.json"
+    "rotate_keys": "rotate-keys-event.json",
 }
 
-FIXTURES = {name: read_fixture(os.path.join(FIXTURES_PATH, file)) for name, file in FIXTURE_FILES.items()}
+FIXTURES = {
+    name: read_fixture(os.path.join(FIXTURES_PATH, file))
+    for name, file in FIXTURE_FILES.items()
+}
+
+
+def mock_success():
+    mock = MagicMock()
+    mock.status_code = 200
+    mock.json.return_value = {"message": "Success"}
+    return mock
 
 
 class NewBlockTestCase(unittest.TestCase):
@@ -35,61 +47,204 @@ class NewBlockTestCase(unittest.TestCase):
         self.app = client
         self.app.testing = True
 
-    @patch('emily_client.ChainstateApi.set_chainstate')
-    def test_new_block_valid_json(self, mock_post: MagicMock):
+    @patch("emily_client.ChainstateApi.set_chainstate")
+    def test_new_block_valid_json(self, mock_chainstate: MagicMock):
         # Mock the response from emily_client.ChainstateApi.set_chainstate
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {"message": "Success"}
-        mock_post.return_value = mock_response
+        mock_chainstate.return_value = mock_success()
 
-        for fixture in FIXTURES.values():
-            response = self.app.post('/new_block', json=fixture)
-            self.assertEqual(response.status_code, 200)
-            self.assertEqual({}, response.json())
+        response = self.app.post(
+            "/new_block",
+            json={"block_height": 1, "index_block_hash": "0x" + "1" * 64, "events": []},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual({}, response.json())
+
+        self.assertEqual(mock_chainstate.call_count, 1)
+        mock_chainstate.assert_called_with(
+            emily_client.Chainstate(stacksBlockHeight=1, stacksBlockHash="1" * 64)
+        )
 
     def test_new_block_invalid_json(self):
-        response = self.app.post('/new_block', data="Not a JSON")
-        self.assertEqual(response.status_code, 400)
-        self.assertIn("Invalid JSON", response.json()["detail"])
+        response = self.app.post("/new_block", data="Not a JSON")
+        self.assertEqual(response.status_code, 422)
+        self.assertIn("json_invalid", response.json()["detail"][0]["type"])
 
     def test_new_block_validation_error(self):
-        invalid_data = {
-            "invalid_field": "invalid_value"
-        }
-        response = self.app.post('/new_block', json=invalid_data)
-        self.assertEqual(response.status_code, 400)
+        invalid_data = {"invalid_field": "invalid_value"}
+        response = self.app.post("/new_block", json=invalid_data)
+        self.assertEqual(response.status_code, 422)
 
-    @patch('emily_client.ChainstateApi.set_chainstate')
+    @patch("emily_client.ChainstateApi.set_chainstate")
     def test_new_block_post_request_failure(self, mock_post: MagicMock):
         # Mock the response from set_chainstate to raise an exception
         mock_post.side_effect = emily_client.exceptions.ServiceException()
-        response = self.app.post('/new_block', json=FIXTURES["complete_deposit"])
+        response = self.app.post("/new_block", json=FIXTURES["complete_deposit"])
         self.assertEqual(response.status_code, 500)
         self.assertIn("Failed to send chainstate", response.json()["detail"])
 
-    @patch('emily_client.ChainstateApi.set_chainstate')
-    def test_new_block_post_request_strips_0x_prefix(self, mock_post: MagicMock):
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {"message": "Success"}
-        mock_post.return_value = mock_response
+    @patch("emily_client.ChainstateApi.set_chainstate")
+    @patch("emily_client.DepositApi.update_deposits")
+    def test_new_block_post_request_strips_0x_prefix(
+        self, mock_deposit: MagicMock, mock_chainstate: MagicMock
+    ):
+        mock_chainstate.return_value = mock_success()
+        mock_deposit.return_value = mock_success()
 
         fixture = FIXTURES["complete_deposit"].copy()
         index_block_hash = "0" * 64
         fixture["index_block_hash"] = f"0x{index_block_hash}"
 
-        response = self.app.post('/new_block', json=fixture)
+        response = self.app.post("/new_block", json=fixture)
         self.assertEqual(response.status_code, 200)
         self.assertEqual({}, response.json())
 
         chainstate = emily_client.Chainstate(
-            stacksBlockHeight=fixture["block_height"],
-            stacksBlockHash=index_block_hash
+            stacksBlockHeight=fixture["block_height"], stacksBlockHash=index_block_hash
         )
 
-        self.assertEqual(mock_post.call_count, 1)
-        mock_post.assert_called_with(chainstate)
+        self.assertEqual(mock_chainstate.call_count, 1)
+        mock_chainstate.assert_called_with(chainstate)
+
+    @patch("emily_client.ChainstateApi.set_chainstate")
+    @patch("emily_client.DepositApi.update_deposits")
+    def test_new_block_complete_deposit(
+        self, mock_withdrawals: MagicMock, mock_chainstate: MagicMock
+    ):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_withdrawals.return_value = mock_response
+        mock_chainstate.return_value = mock_success()
+
+        response = self.app.post("/new_block", json=FIXTURES["complete_deposit"])
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual({}, response.json())
+
+        self.assertEqual(mock_withdrawals.call_count, 1)
+        mock_withdrawals.assert_called_with(
+            emily_client.UpdateDepositsRequestBody(
+                deposits=[
+                    emily_client.DepositUpdate(
+                        bitcoin_tx_output_index=4294967295,
+                        bitcoin_txid="0000000000000000000000000000000000000000000000000000000000000000",
+                        fulfillment=emily_client.Fulfillment(
+                            bitcoin_block_hash="0101010101010101010101010101010101010101010101010101010101010101",
+                            bitcoin_block_height=42,
+                            bitcoin_tx_index=0,
+                            bitcoin_txid="0202020202020202020202020202020202020202020202020202020202020202",
+                            btc_fee=0,
+                            stacks_txid="58a9074c3299c2f627829b7e5ecf8b7136e380cbce3900461c679939925f77bc",
+                        ),
+                        last_update_block_hash="acf821a2df6700046a2e2cd8042b394bcae4d62aadd3e940597658ece9852c30",
+                        last_update_height=227,
+                        status="confirmed",
+                        status_message="Included in block 0101010101010101010101010101010101010101010101010101010101010101",
+                    )
+                ]
+            )
+        )
+
+    @patch("emily_client.ChainstateApi.set_chainstate")
+    @patch("emily_client.WithdrawalApi.update_withdrawals")
+    def test_new_block_withdrawal_accept(
+        self, mock_withdrawals: MagicMock, mock_chainstate: MagicMock
+    ):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_withdrawals.return_value = mock_response
+        mock_chainstate.return_value = mock_success()
+
+        response = self.app.post("/new_block", json=FIXTURES["withdrawal_accept"])
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual({}, response.json())
+
+        self.assertEqual(mock_withdrawals.call_count, 1)
+        mock_withdrawals.assert_called_with(
+            emily_client.UpdateWithdrawalsRequestBody(
+                withdrawals=[
+                    emily_client.WithdrawalUpdate(
+                        fulfillment=emily_client.Fulfillment(
+                            bitcoin_block_hash="0101010101010101010101010101010101010101010101010101010101010101",
+                            bitcoin_block_height=42,
+                            bitcoin_tx_index=4294967295,
+                            bitcoin_txid="0202020202020202020202020202020202020202020202020202020202020202",
+                            btc_fee=2500,
+                            stacks_txid="95a8cf1ed4aa559a0cd8b380174272c3629942a57eb1a2b9aa8281020c36359f",
+                        ),
+                        last_update_block_hash="0ce5807894c9da8cddcd7b00d15b916f067b1d53487ecc4cae98bc4b7e8fc253",
+                        last_update_height=301,
+                        request_id=1,
+                        status="confirmed",
+                        status_message="Included in block 0101010101010101010101010101010101010101010101010101010101010101",
+                    )
+                ]
+            )
+        )
+
+    @patch("emily_client.ChainstateApi.set_chainstate")
+    @patch("emily_client.WithdrawalApi.update_withdrawals")
+    def test_new_block_withdrawal_reject(
+        self, mock_withdrawals: MagicMock, mock_chainstate: MagicMock
+    ):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_withdrawals.return_value = mock_response
+        mock_chainstate.return_value = mock_success()
+
+        response = self.app.post("/new_block", json=FIXTURES["withdrawal_reject"])
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual({}, response.json())
+
+        self.assertEqual(mock_withdrawals.call_count, 1)
+        mock_withdrawals.assert_called_with(
+            emily_client.UpdateWithdrawalsRequestBody(
+                withdrawals=[
+                    emily_client.WithdrawalUpdate(
+                        fulfillment=None,
+                        last_update_block_hash="fc1b44b2db9997d9f37ea1c8704318ed8c1bce2f077b6e73fb583deac167ce98",
+                        last_update_height=350,
+                        request_id=2,
+                        status="failed",
+                        status_message="Rejected",
+                    )
+                ]
+            )
+        )
+
+    @patch("emily_client.ChainstateApi.set_chainstate")
+    @patch("emily_client.WithdrawalApi.create_withdrawal")
+    def test_new_block_withdrawal_create(
+        self, mock_withdrawals: MagicMock, mock_chainstate: MagicMock
+    ):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_withdrawals.return_value = mock_response
+        mock_chainstate.return_value = mock_success()
+
+        response = self.app.post("/new_block", json=FIXTURES["withdrawal_create"])
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual({}, response.json())
+
+        self.assertEqual(mock_withdrawals.call_count, 1)
+        mock_withdrawals.assert_called_with(
+            create_withdrawal_request_body=emily_client.CreateWithdrawalRequestBody(
+                amount=22500,
+                parameters=emily_client.WithdrawalParameters(max_fee=3000),
+                recipient="1EXCN4m6mNL88QzPwksBnpVqr5F1dC4SGa",
+                request_id=1,
+                stacks_block_hash="75b02b9884ec41c05f2cfa6e20823328321518dd0b027e7b609b63d4d1ea7c78",
+                stacks_block_height=253,
+            )
+        )
+
+    @patch("emily_client.ChainstateApi.set_chainstate")
+    def test_new_block_unsupported_events(self, mock_chainstate: MagicMock):
+        mock_chainstate.return_value = mock_success()
+
+        response = self.app.post("/new_block", json=FIXTURES["rotate_keys"])
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual({}, response.json())
+
+        self.assertEqual(mock_chainstate.call_count, 1)
 
 
 class AttachmentsTestCase(unittest.TestCase):
@@ -99,20 +254,91 @@ class AttachmentsTestCase(unittest.TestCase):
 
     def test_handle_attachments_with_any_json(self):
         test_json = {"key": "value"}
-        response = self.app.post('/attachments/new', json=test_json)
+        response = self.app.post("/attachments/new", json=test_json)
         self.assertEqual(response.status_code, 200)
         self.assertEqual({}, response.json())
 
     def test_handle_attachments_with_empty_json(self):
-        response = self.app.post('/attachments/new', json={})
+        response = self.app.post("/attachments/new", json={})
         self.assertEqual(response.status_code, 200)
         self.assertEqual({}, response.json())
 
     def test_handle_attachments_with_no_json(self):
-        response = self.app.post('/attachments/new')
+        response = self.app.post("/attachments/new")
         self.assertEqual(response.status_code, 200)
         self.assertEqual({}, response.json())
 
 
-if __name__ == '__main__':
+class TestParseClarityValue(unittest.TestCase):
+
+    def test_parse_tuple(self):
+        clarity_value = {
+            "Tuple": {
+                "data_map": {
+                    "key1": {"UInt": 42},
+                    "key2": {
+                        "Sequence": {
+                            "String": {"ASCII": {"data": [104, 101, 108, 108, 111]}}
+                        }
+                    },
+                }
+            }
+        }
+        expected_result = {"key1": 42, "key2": "hello"}
+        result = parse_clarity_value(clarity_value)
+        self.assertEqual(result, expected_result)
+
+    def test_parse_sequence_buffer(self):
+        clarity_value = {"Sequence": {"Buffer": {"data": [1, 2, 3, 4]}}}
+        expected_result = "04030201"
+        result = parse_clarity_value(clarity_value)
+        self.assertEqual(bytes(reversed(result)).hex(), expected_result)
+
+    def test_parse_sequence_string(self):
+        clarity_value = {
+            "Sequence": {"String": {"ASCII": {"data": [104, 101, 108, 108, 111]}}}
+        }
+        expected_result = "hello"
+        result = parse_clarity_value(clarity_value)
+        self.assertEqual(result, expected_result)
+
+    def test_parse_uint(self):
+        clarity_value = {"UInt": 42}
+        expected_result = 42
+        result = parse_clarity_value(clarity_value)
+        self.assertEqual(result, expected_result)
+
+    def test_parse_int(self):
+        clarity_value = {"Int": -42}
+        expected_result = -42
+        result = parse_clarity_value(clarity_value)
+        self.assertEqual(result, expected_result)
+
+    def test_unhandled_type(self):
+        clarity_value = {"Unhandled": "value"}
+        result = parse_clarity_value(clarity_value)
+        self.assertEqual(result, clarity_value)
+
+
+class TestParseClarityValueSafe(unittest.TestCase):
+
+    def test_parse_clarity_value_safe_success(self):
+        clarity_value = {"UInt": 42}
+        expected_result = 42
+        result = parse_clarity_value_safe(clarity_value)
+        self.assertEqual(result, expected_result)
+
+    def test_parse_clarity_value_safe_failure(self):
+        clarity_value = {"Invalid": "value"}
+        result = parse_clarity_value_safe(clarity_value)
+        self.assertEqual(result, clarity_value)
+
+    def test_parse_clarity_value_invalid_format(self):
+        # Missing ASCII between String and data
+        clarity_value = {"Sequence": {"String": {"data": [104, 101, 108, 108, 111]}}}
+        result = parse_clarity_value_safe(clarity_value)
+        self.assertEqual(result, None)
+
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Description

Part of https://github.com/stacks-network/sbtc/issues/1067 - Add parsing of sBTC events and sends the withdrawal-create, withdrawal-accept, withdrawal-reject and deposit-complete updates to Emily. 
The filtering logic and creation of the updates is very similar to the implementation in new_block.rs

## Changes
- add parsing of Clarity values (from the smart contracts events)
    - the parser was created to be simple by design, and only cover the 4 sbtc contract events we care about. Errors in parsing unsupported types will cause the event to be skipped. 
- add handling of sbtc contracts - transforming them into requests expected by Emily 
- sends updates to Emily
     
## Testing Information
- tests are not currently integrated in the `make test` suite, but can be launched with (after installing the dependencies from requirements.txt):
    - `cd emily_sidecar`
    - `python -m test`

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
