### PR TITLE
feat: feature wait before rejecting a withdrawal request

### DIFF
--- a/signer/src/stacks/contracts.rs
+++ b/signer/src/stacks/contracts.rs
@@ -1115,8 +1115,8 @@ impl AsContractCall for RejectWithdrawalV1 {
     /// 7. Whether the withdrawal request is being serviced by a sweep
     ///    transaction that is in the mempool.
     /// 8. Whether we need to worry about forks causing the withdrawal to
-    ///    be confirmed by a sweep that was broadcst changing the status of
-    ///    the request from rejected to accepted.
+    ///    be confirmed by a sweep that was broadcast changing the status
+    ///    of the request from rejected to accepted.
     async fn validate<C>(&self, ctx: &C, req_ctx: &ReqContext) -> Result<(), Error>
     where
         C: Context + Send + Sync,

--- a/signer/src/stacks/contracts.rs
+++ b/signer/src/stacks/contracts.rs
@@ -59,6 +59,7 @@ use crate::storage::model::ToLittleEndianOrder as _;
 use crate::storage::DbRead;
 use crate::DEPOSIT_DUST_LIMIT;
 use crate::WITHDRAWAL_BLOCKS_EXPIRY;
+use crate::WITHDRAWAL_MIN_CONFIRMATIONS;
 
 use super::api::StacksInteract;
 
@@ -1029,6 +1030,10 @@ pub enum WithdrawalRejectErrorMsg {
     /// been either accepted or rejected already.
     #[error("the smart contract has been updated to indicate that the request has been completed")]
     RequestCompleted,
+    /// A withdrawal request is still active if it's reasonably possible
+    /// for the request to be fulfilled by a sweep transaction on bitcoin.
+    #[error("the withdrawal request is still active, we cannot reject it yet")]
+    RequestStillActive,
     /// Withdrawal request fulfilled
     #[error("Withdrawal request fulfilled")]
     RequestFulfilled,
@@ -1109,6 +1114,9 @@ impl AsContractCall for RejectWithdrawalV1 {
     /// 6. Whether the withdrawal request has expired. Fail if it hasn't.
     /// 7. Whether the withdrawal request is being serviced by a sweep
     ///    transaction that is in the mempool.
+    /// 8. Whether we need to worry about forks causing the withdrawal to
+    ///    be confirmed by a sweep that was broadcst changing the status of
+    ///    the request from rejected to accepted.
     async fn validate<C>(&self, ctx: &C, req_ctx: &ReqContext) -> Result<(), Error>
     where
         C: Context + Send + Sync,
@@ -1189,6 +1197,16 @@ impl AsContractCall for RejectWithdrawalV1 {
             .await?;
         if withdrawal_is_inflight {
             return Err(WithdrawalRejectErrorMsg::RequestBeingFulfilled.into_error(req_ctx, self));
+        }
+
+        // 8. Check whether the withdrawal request is still active, as in
+        //    it could still be fulfilled.
+        let withdrawal_is_active = db
+            .is_withdrawal_active(&self.id, &req_ctx.chain_tip, WITHDRAWAL_MIN_CONFIRMATIONS)
+            .await?;
+
+        if withdrawal_is_active {
+            return Err(WithdrawalRejectErrorMsg::RequestStillActive.into_error(req_ctx, self));
         }
 
         Ok(())

--- a/signer/src/storage/in_memory.rs
+++ b/signer/src/storage/in_memory.rs
@@ -822,6 +822,15 @@ impl super::DbRead for SharedStore {
         unimplemented!()
     }
 
+    async fn is_withdrawal_inactive(
+        &self,
+        _: &model::BitcoinBlockRef,
+        _: &model::QualifiedRequestId,
+        _: u64,
+    ) -> Result<bool, Error> {
+        unimplemented!()
+    }
+
     async fn get_bitcoin_tx(
         &self,
         txid: &model::BitcoinTxId,

--- a/signer/src/storage/in_memory.rs
+++ b/signer/src/storage/in_memory.rs
@@ -822,10 +822,10 @@ impl super::DbRead for SharedStore {
         unimplemented!()
     }
 
-    async fn is_withdrawal_inactive(
+    async fn is_withdrawal_active(
         &self,
-        _: &model::BitcoinBlockRef,
         _: &model::QualifiedRequestId,
+        _: &model::BitcoinBlockRef,
         _: u64,
     ) -> Result<bool, Error> {
         unimplemented!()

--- a/signer/src/storage/mod.rs
+++ b/signer/src/storage/mod.rs
@@ -336,6 +336,16 @@ pub trait DbRead {
         bitcoin_chain_tip: &model::BitcoinBlockHash,
     ) -> impl Future<Output = Result<bool, Error>> + Send;
 
+    /// Returns whether we can consider the withdrawal inactive. This means
+    /// that there is no risk of the withdrawal being confirmed from a fork
+    /// of blocks less than `min_wait_blocks`.
+    fn is_withdrawal_inactive(
+        &self,
+        chain_tip: &model::BitcoinBlockRef,
+        id: &model::QualifiedRequestId,
+        min_wait_blocks: u64,
+    ) -> impl Future<Output = Result<bool, Error>> + Send;
+
     /// Fetch the bitcoin transaction that is included in the block
     /// identified by the block hash.
     fn get_bitcoin_tx(

--- a/signer/src/storage/mod.rs
+++ b/signer/src/storage/mod.rs
@@ -336,14 +336,15 @@ pub trait DbRead {
         bitcoin_chain_tip: &model::BitcoinBlockHash,
     ) -> impl Future<Output = Result<bool, Error>> + Send;
 
-    /// Returns whether we can consider the withdrawal inactive. This means
-    /// that there is no risk of the withdrawal being confirmed from a fork
-    /// of blocks less than `min_wait_blocks`.
-    fn is_withdrawal_inactive(
+    /// Returns whether we should consider the withdrawal active. A
+    /// withdrawal request is considered active if there is a reasonable
+    /// risk of the withdrawal being confirmed from a fork of blocks less
+    /// than `min_confirmations`.
+    fn is_withdrawal_active(
         &self,
-        chain_tip: &model::BitcoinBlockRef,
         id: &model::QualifiedRequestId,
-        min_wait_blocks: u64,
+        bitcoin_chain_tip: &model::BitcoinBlockRef,
+        min_confirmations: u64,
     ) -> impl Future<Output = Result<bool, Error>> + Send;
 
     /// Fetch the bitcoin transaction that is included in the block

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -448,7 +448,7 @@ impl PgStore {
     /// This function returns the bitcoin block height of the first
     /// confirmed sweep that happened on or after the given minimum block
     /// height.
-    pub async fn get_least_txo_height(
+    async fn get_least_txo_height(
         &self,
         chain_tip: &model::BitcoinBlockHash,
         min_block_height: i64,

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -2150,8 +2150,10 @@ impl super::DbRead for PgStore {
         let output_type = model::TxOutputType::SignersOutput;
         let chain_tip_hash = &bitcoin_chain_tip.block_hash;
         let signer_utxo_fut = self.get_utxo(chain_tip_hash, output_type, min_block_height);
+        // If this returns None, then the sweep itself could be in the
+        // mempool. If that's the case then this is definitely active.
         let Some(signer_utxo) = signer_utxo_fut.await? else {
-            return Ok(false);
+            return Ok(true);
         };
 
         Ok(signer_utxo.block_height + min_confirmations >= bitcoin_chain_tip.block_height)

--- a/signer/src/testing/dummy.rs
+++ b/signer/src/testing/dummy.rs
@@ -754,7 +754,7 @@ impl fake::Dummy<fake::Faker> for RotateKeysV1 {
 impl fake::Dummy<fake::Faker> for QualifiedRequestId {
     fn dummy_with_rng<R: rand::RngCore + ?Sized>(config: &fake::Faker, rng: &mut R) -> Self {
         QualifiedRequestId {
-            request_id: config.fake_with_rng(rng),
+            request_id: config.fake_with_rng::<u32, _>(rng) as u64,
             txid: config.fake_with_rng(rng),
             block_hash: config.fake_with_rng(rng),
         }

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -5584,3 +5584,21 @@ async fn is_withdrawal_inflight_catches_withdrawals_in_package() {
 
     signer::testing::storage::drop_db(db).await;
 }
+
+/// Check that is_withdrawal_active correctly returns false for unknown
+/// withdrawal requests.
+#[tokio::test]
+async fn is_withdrawal_active_unknown_withdrawal() {
+    let db = testing::storage::new_test_database().await;
+    let mut rng = rand::rngs::StdRng::seed_from_u64(2);
+
+    let chain_tip = Faker.fake_with_rng(&mut rng);
+    let qualified_id: QualifiedRequestId = Faker.fake_with_rng(&mut rng);
+    let active = db
+        .is_withdrawal_active(&qualified_id, &chain_tip, 1)
+        .await
+        .unwrap();
+    assert!(!active);
+
+    signer::testing::storage::drop_db(db).await;
+}

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -5471,6 +5471,8 @@ async fn is_withdrawal_inflight_catches_withdrawals_with_rows_in_table() {
     db.write_bitcoin_txs_sighashes(&[sighash]).await.unwrap();
 
     assert!(db.is_withdrawal_inflight(&id, &chain_tip).await.unwrap());
+
+    signer::testing::storage::drop_db(db).await;
 }
 
 /// Check that is_withdrawal_inflight correctly picks up withdrawal
@@ -5579,4 +5581,6 @@ async fn is_withdrawal_inflight_catches_withdrawals_in_package() {
     db.write_bitcoin_txs_sighashes(&[sighash1]).await.unwrap();
 
     assert!(db.is_withdrawal_inflight(&id, &chain_tip).await.unwrap());
+
+    signer::testing::storage::drop_db(db).await;
 }

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -5602,3 +5602,40 @@ async fn is_withdrawal_active_unknown_withdrawal() {
 
     signer::testing::storage::drop_db(db).await;
 }
+
+/// Check that is_withdrawal_active correctly returns true when there is a
+/// sweep fulfilling a withdrawal request that might be in the mempool.
+#[tokio::test]
+async fn is_withdrawal_active_for_considered_withdrawal() {
+    let db = testing::storage::new_test_database().await;
+    let mut rng = rand::rngs::StdRng::seed_from_u64(4);
+
+    let chain_tip: model::BitcoinBlock = Faker.fake_with_rng(&mut rng);
+    let qualified_id: QualifiedRequestId = Faker.fake_with_rng(&mut rng);
+
+    let output = BitcoinWithdrawalOutput {
+        request_id: qualified_id.request_id,
+        stacks_txid: qualified_id.txid,
+        stacks_block_hash: qualified_id.block_hash,
+        bitcoin_chain_tip: chain_tip.block_hash,
+        is_valid_tx: true,
+        validation_result: WithdrawalValidationResult::Ok,
+        output_index: 2,
+        bitcoin_txid: Faker.fake_with_rng(&mut rng),
+    };
+    db.write_bitcoin_withdrawals_outputs(&[output])
+        .await
+        .unwrap();
+
+    db.write_bitcoin_block(&chain_tip).await.unwrap();
+
+    let chain_tip_ref = chain_tip.into();
+        
+    let active = db
+        .is_withdrawal_active(&qualified_id, &chain_tip_ref, 1)
+        .await
+        .unwrap();
+    assert!(active);
+
+    signer::testing::storage::drop_db(db).await;
+}

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -5630,7 +5630,7 @@ async fn is_withdrawal_active_for_considered_withdrawal() {
     db.write_bitcoin_block(&chain_tip).await.unwrap();
 
     let chain_tip_ref = chain_tip.into();
-        
+
     let active = db
         .is_withdrawal_active(&qualified_id, &chain_tip_ref, 1)
         .await

--- a/signer/tests/integration/setup.rs
+++ b/signer/tests/integration/setup.rs
@@ -941,7 +941,9 @@ impl TestSweepSetup2 {
     /// deposited funds and sweeps out the withdrawal funds in a proper
     /// sweep transaction, that is also confirmed on bitcoin.
     pub fn submit_sweep_tx(&mut self, rpc: &Client, faucet: &Faucet) {
-        self.broadcast_sweep_tx(rpc);
+        if self.broadcast_info.is_none() {
+            self.broadcast_sweep_tx(rpc);
+        }
         let txid = self.broadcast_info.as_ref().unwrap().txid;
 
         // Let's confirm the sweep transaction

--- a/signer/tests/integration/setup.rs
+++ b/signer/tests/integration/setup.rs
@@ -869,7 +869,7 @@ impl TestSweepSetup2 {
         let signer_utxo = aggregated_signer.get_utxos(rpc, None).pop().unwrap();
 
         // Well we want a BitcoinCoreClient, so we create one using the
-        // context. Not, the best thing to do, sorry. TODO: pass in a
+        // settings. Not, the best thing to do, sorry. TODO: pass in a
         // bitcoin core client object.
         let settings = Settings::new_from_default_config().unwrap();
         let btc = BitcoinCoreClient::try_from(&settings.bitcoin.rpc_endpoints[0]).unwrap();
@@ -883,7 +883,7 @@ impl TestSweepSetup2 {
                 total: entry.fees.base.to_sat(),
                 rate: entry.fees.base.to_sat() as f64 / entry.vsize as f64,
             })
-            .max_by(|fee1, fee2| fee1.rate.total_cmp(&fee2.rate));
+            .max_by_key(|fees| fees.total);
 
         let withdrawals = self
             .withdrawals

--- a/signer/tests/integration/transaction_coordinator.rs
+++ b/signer/tests/integration/transaction_coordinator.rs
@@ -3056,6 +3056,7 @@ fn create_test_setup(
         deposit_block_hash,
         deposits: vec![(deposit_info, deposit_request, tx_info)],
         sweep_tx_info: None,
+        broadcast_info: None,
         donation,
         stacks_blocks: vec![stacks_block],
         signers: test_signers,


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/1407

## Changes

* Add in a validation check that looks for "active" withdrawals. These are withdrawals where it's possible that a fork could make the transaction valid in the eyes of the bitcoin network.
* Made sure that the coordinator did the same "is active" check when selecting requests to reject.

## Testing Information

So far this PR has added one test. The comments in it are likely wrong and stuff, and it needs a little polish. I will fix that all up and add more tests.

## Checklist:

- [ ] I have performed a self-review of my code
