### PR TITLE
[fix] remove api key requirement from health endpoint

### DIFF
--- a/.generated-sources/emily/client/rust/private/docs/HealthApi.md
+++ b/.generated-sources/emily/client/rust/private/docs/HealthApi.md
@@ -23,7 +23,7 @@ This endpoint does not need any parameter.
 
 ### Authorization
 
-[ApiGatewayKey](../README.md#ApiGatewayKey)
+No authorization required
 
 ### HTTP request headers
 

--- a/.generated-sources/emily/client/rust/private/src/apis/health_api.rs
+++ b/.generated-sources/emily/client/rust/private/src/apis/health_api.rs
@@ -18,7 +18,6 @@ use serde::{Deserialize, Serialize};
 #[serde(untagged)]
 pub enum CheckHealthError {
     Status400(models::ErrorResponse),
-    Status404(models::ErrorResponse),
     Status405(models::ErrorResponse),
     Status500(models::ErrorResponse),
     UnknownValue(serde_json::Value),
@@ -39,14 +38,6 @@ pub async fn check_health(
         local_var_req_builder =
             local_var_req_builder.header(reqwest::header::USER_AGENT, local_var_user_agent.clone());
     }
-    if let Some(ref local_var_apikey) = local_var_configuration.api_key {
-        let local_var_key = local_var_apikey.key.clone();
-        let local_var_value = match local_var_apikey.prefix {
-            Some(ref local_var_prefix) => format!("{} {}", local_var_prefix, local_var_key),
-            None => local_var_key,
-        };
-        local_var_req_builder = local_var_req_builder.header("x-api-key", local_var_value);
-    };
 
     let local_var_req = local_var_req_builder.build()?;
     let local_var_resp = local_var_client.execute(local_var_req).await?;

--- a/.generated-sources/emily/client/rust/private/src/apis/health_api.rs
+++ b/.generated-sources/emily/client/rust/private/src/apis/health_api.rs
@@ -18,6 +18,7 @@ use serde::{Deserialize, Serialize};
 #[serde(untagged)]
 pub enum CheckHealthError {
     Status400(models::ErrorResponse),
+    Status404(models::ErrorResponse),
     Status405(models::ErrorResponse),
     Status500(models::ErrorResponse),
     UnknownValue(serde_json::Value),

--- a/.generated-sources/emily/client/rust/public/docs/HealthApi.md
+++ b/.generated-sources/emily/client/rust/public/docs/HealthApi.md
@@ -23,7 +23,7 @@ This endpoint does not need any parameter.
 
 ### Authorization
 
-[ApiGatewayKey](../README.md#ApiGatewayKey)
+No authorization required
 
 ### HTTP request headers
 

--- a/.generated-sources/emily/client/rust/public/src/apis/health_api.rs
+++ b/.generated-sources/emily/client/rust/public/src/apis/health_api.rs
@@ -18,7 +18,6 @@ use serde::{Deserialize, Serialize};
 #[serde(untagged)]
 pub enum CheckHealthError {
     Status400(models::ErrorResponse),
-    Status404(models::ErrorResponse),
     Status405(models::ErrorResponse),
     Status500(models::ErrorResponse),
     UnknownValue(serde_json::Value),
@@ -39,14 +38,6 @@ pub async fn check_health(
         local_var_req_builder =
             local_var_req_builder.header(reqwest::header::USER_AGENT, local_var_user_agent.clone());
     }
-    if let Some(ref local_var_apikey) = local_var_configuration.api_key {
-        let local_var_key = local_var_apikey.key.clone();
-        let local_var_value = match local_var_apikey.prefix {
-            Some(ref local_var_prefix) => format!("{} {}", local_var_prefix, local_var_key),
-            None => local_var_key,
-        };
-        local_var_req_builder = local_var_req_builder.header("x-api-key", local_var_value);
-    };
 
     let local_var_req = local_var_req_builder.build()?;
     let local_var_resp = local_var_client.execute(local_var_req).await?;

--- a/.generated-sources/emily/client/rust/public/src/apis/health_api.rs
+++ b/.generated-sources/emily/client/rust/public/src/apis/health_api.rs
@@ -18,6 +18,7 @@ use serde::{Deserialize, Serialize};
 #[serde(untagged)]
 pub enum CheckHealthError {
     Status400(models::ErrorResponse),
+    Status404(models::ErrorResponse),
     Status405(models::ErrorResponse),
     Status500(models::ErrorResponse),
     UnknownValue(serde_json::Value),

--- a/.generated-sources/emily/client/rust/testing/docs/HealthApi.md
+++ b/.generated-sources/emily/client/rust/testing/docs/HealthApi.md
@@ -23,7 +23,7 @@ This endpoint does not need any parameter.
 
 ### Authorization
 
-[ApiGatewayKey](../README.md#ApiGatewayKey)
+No authorization required
 
 ### HTTP request headers
 

--- a/.generated-sources/emily/client/rust/testing/src/apis/health_api.rs
+++ b/.generated-sources/emily/client/rust/testing/src/apis/health_api.rs
@@ -18,7 +18,6 @@ use serde::{Deserialize, Serialize};
 #[serde(untagged)]
 pub enum CheckHealthError {
     Status400(models::ErrorResponse),
-    Status404(models::ErrorResponse),
     Status405(models::ErrorResponse),
     Status500(models::ErrorResponse),
     UnknownValue(serde_json::Value),
@@ -39,14 +38,6 @@ pub async fn check_health(
         local_var_req_builder =
             local_var_req_builder.header(reqwest::header::USER_AGENT, local_var_user_agent.clone());
     }
-    if let Some(ref local_var_apikey) = local_var_configuration.api_key {
-        let local_var_key = local_var_apikey.key.clone();
-        let local_var_value = match local_var_apikey.prefix {
-            Some(ref local_var_prefix) => format!("{} {}", local_var_prefix, local_var_key),
-            None => local_var_key,
-        };
-        local_var_req_builder = local_var_req_builder.header("x-api-key", local_var_value);
-    };
 
     let local_var_req = local_var_req_builder.build()?;
     let local_var_resp = local_var_client.execute(local_var_req).await?;

--- a/.generated-sources/emily/client/rust/testing/src/apis/health_api.rs
+++ b/.generated-sources/emily/client/rust/testing/src/apis/health_api.rs
@@ -18,6 +18,7 @@ use serde::{Deserialize, Serialize};
 #[serde(untagged)]
 pub enum CheckHealthError {
     Status400(models::ErrorResponse),
+    Status404(models::ErrorResponse),
     Status405(models::ErrorResponse),
     Status500(models::ErrorResponse),
     UnknownValue(serde_json::Value),

--- a/emily/handler/src/api/handlers/health.rs
+++ b/emily/handler/src/api/handlers/health.rs
@@ -17,7 +17,6 @@ use crate::{api::models::health::responses::HealthData, context::EmilyContext};
         (status = 405, description = "Method not allowed", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse)
     ),
-    security(("ApiGatewayKey" = []))
 )]
 pub async fn get_health(context: EmilyContext) -> impl warp::reply::Reply {
     // Handle and respond.

--- a/emily/handler/src/api/routes/mod.rs
+++ b/emily/handler/src/api/routes/mod.rs
@@ -57,10 +57,10 @@ pub fn routes(
 pub fn routes(
     context: EmilyContext,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
-    health::routes()
+    health::routes(context.clone())
         .or(chainstate::routes(context.clone()))
         .or(deposit::routes(context.clone()))
-        .or(withdrawal::routes(context))
+        .or(withdrawal::routes(context.clone()))
         .or(limits::routes(context.clone()))
         // Convert reply to tuple to that more routes can be added to the returned filter.
         .map(|reply| (reply,))

--- a/emily/openapi-gen/generated-specs/private-emily-openapi-spec.json
+++ b/emily/openapi-gen/generated-specs/private-emily-openapi-spec.json
@@ -1201,11 +1201,6 @@
             }
           }
         },
-        "security": [
-          {
-            "ApiGatewayKey": []
-          }
-        ],
         "x-amazon-apigateway-integration": {
           "httpMethod": "POST",
           "type": "aws_proxy",

--- a/emily/openapi-gen/generated-specs/public-emily-openapi-spec.json
+++ b/emily/openapi-gen/generated-specs/public-emily-openapi-spec.json
@@ -1120,11 +1120,6 @@
             }
           }
         },
-        "security": [
-          {
-            "ApiGatewayKey": []
-          }
-        ],
         "x-amazon-apigateway-integration": {
           "httpMethod": "POST",
           "type": "aws_proxy",

--- a/emily/openapi-gen/generated-specs/testing-emily-openapi-spec.json
+++ b/emily/openapi-gen/generated-specs/testing-emily-openapi-spec.json
@@ -1201,11 +1201,6 @@
             }
           }
         },
-        "security": [
-          {
-            "ApiGatewayKey": []
-          }
-        ],
         "x-amazon-apigateway-integration": {
           "httpMethod": "POST",
           "type": "aws_proxy",


### PR DESCRIPTION
## Description

The health endpoint was locked behind an API key. We don't need that. 

## Changes
- remove the ApiGatewayKey requirement from the health endpoint
- fix routes 

## Testing Information

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
