### PR TITLE
[chore] Remove no longer used code

### DIFF
--- a/signer/src/storage/in_memory.rs
+++ b/signer/src/storage/in_memory.rs
@@ -963,13 +963,6 @@ impl super::DbRead for SharedStore {
 
         Ok(result)
     }
-
-    async fn get_withdrawal_outputs(
-        &self,
-        _id: &model::QualifiedRequestId,
-    ) -> Result<Vec<model::BitcoinWithdrawalOutput>, Error> {
-        unimplemented!()
-    }
 }
 
 impl super::DbWrite for SharedStore {

--- a/signer/src/storage/mod.rs
+++ b/signer/src/storage/mod.rs
@@ -416,12 +416,6 @@ pub trait DbRead {
         &self,
         sighash: &model::SigHash,
     ) -> impl Future<Output = Result<Option<(bool, PublicKeyXOnly)>, Error>> + Send;
-
-    /// Get all the request's withdrawal outputs
-    fn get_withdrawal_outputs(
-        &self,
-        id: &model::QualifiedRequestId,
-    ) -> impl Future<Output = Result<Vec<model::BitcoinWithdrawalOutput>, Error>> + Send;
 }
 
 /// Represents the ability to write data to the signer storage.

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -2553,33 +2553,6 @@ impl super::DbRead for PgStore {
         .await
         .map_err(Error::SqlxQuery)
     }
-
-    async fn get_withdrawal_outputs(
-        &self,
-        id: &model::QualifiedRequestId,
-    ) -> Result<Vec<model::BitcoinWithdrawalOutput>, Error> {
-        sqlx::query_as::<_, model::BitcoinWithdrawalOutput>(
-            r#"
-            SELECT
-                bwo.bitcoin_txid
-              , bwo.bitcoin_chain_tip
-              , bwo.output_index
-              , bwo.request_id
-              , bwo.stacks_txid
-              , bwo.stacks_block_hash
-              , bwo.validation_result
-              , bwo.is_valid_tx
-            FROM sbtc_signer.bitcoin_withdrawals_outputs AS bwo
-            WHERE bwo.request_id = $1
-              AND bwo.stacks_block_hash = $2
-            "#,
-        )
-        .bind(i64::try_from(id.request_id).map_err(Error::ConversionDatabaseInt)?)
-        .bind(id.block_hash)
-        .fetch_all(&self.0)
-        .await
-        .map_err(Error::SqlxQuery)
-    }
 }
 
 impl super::DbWrite for PgStore {


### PR DESCRIPTION
## Description

Closes: #?

## Changes

Two nits about removing no longer used code we didn't squeeze in during the crunch:
 - Remove `get_withdrawal_outputs`: replaced by `is_withdrawal_inflight`
 - Proto convert wrappers for tests: now they derive eq (after https://github.com/stacks-network/sbtc/pull/1265)

## Testing Information

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
