### PR TITLE
1444 chorebug restrict wipe databases to testing api

### DIFF
--- a/.generated-sources/emily/client/rust/public/.openapi-generator/FILES
+++ b/.generated-sources/emily/client/rust/public/.openapi-generator/FILES
@@ -23,7 +23,6 @@ docs/HealthData.md
 docs/Limits.md
 docs/LimitsApi.md
 docs/Status.md
-docs/TestingApi.md
 docs/UpdateDepositsRequestBody.md
 docs/UpdateDepositsResponse.md
 docs/UpdateWithdrawalsRequestBody.md
@@ -41,7 +40,6 @@ src/apis/deposit_api.rs
 src/apis/health_api.rs
 src/apis/limits_api.rs
 src/apis/mod.rs
-src/apis/testing_api.rs
 src/apis/withdrawal_api.rs
 src/lib.rs
 src/models/account_limits.rs

--- a/.generated-sources/emily/client/rust/public/README.md
+++ b/.generated-sources/emily/client/rust/public/README.md
@@ -36,7 +36,6 @@ Class | Method | HTTP request | Description
 *CorsApi* | [**health_options**](docs/CorsApi.md#health_options) | **OPTIONS** /health | CORS support
 *CorsApi* | [**limits_account_options**](docs/CorsApi.md#limits_account_options) | **OPTIONS** /limits/{account} | CORS support
 *CorsApi* | [**limits_options**](docs/CorsApi.md#limits_options) | **OPTIONS** /limits | CORS support
-*CorsApi* | [**testing_wipe_options**](docs/CorsApi.md#testing_wipe_options) | **OPTIONS** /testing/wipe | CORS support
 *CorsApi* | [**withdrawal_id_options**](docs/CorsApi.md#withdrawal_id_options) | **OPTIONS** /withdrawal/{id} | CORS support
 *CorsApi* | [**withdrawal_options**](docs/CorsApi.md#withdrawal_options) | **OPTIONS** /withdrawal | CORS support
 *CorsApi* | [**withdrawal_recipient_recipient_options**](docs/CorsApi.md#withdrawal_recipient_recipient_options) | **OPTIONS** /withdrawal/recipient/{recipient} | CORS support
@@ -53,7 +52,6 @@ Class | Method | HTTP request | Description
 *HealthApi* | [**check_health**](docs/HealthApi.md#check_health) | **GET** /health | Get health handler.
 *LimitsApi* | [**get_limits**](docs/LimitsApi.md#get_limits) | **GET** /limits | Get the global limits.
 *LimitsApi* | [**get_limits_for_account**](docs/LimitsApi.md#get_limits_for_account) | **GET** /limits/{account} | Get limits for account handler.
-*TestingApi* | [**wipe_databases**](docs/TestingApi.md#wipe_databases) | **POST** /testing/wipe | Wipe databases handler.
 *WithdrawalApi* | [**create_withdrawal**](docs/WithdrawalApi.md#create_withdrawal) | **POST** /withdrawal | Create withdrawal handler.
 *WithdrawalApi* | [**get_withdrawal**](docs/WithdrawalApi.md#get_withdrawal) | **GET** /withdrawal/{id} | Get withdrawal handler.
 *WithdrawalApi* | [**get_withdrawals**](docs/WithdrawalApi.md#get_withdrawals) | **GET** /withdrawal | Get withdrawals handler.

--- a/.generated-sources/emily/client/rust/public/docs/CorsApi.md
+++ b/.generated-sources/emily/client/rust/public/docs/CorsApi.md
@@ -14,7 +14,6 @@ Method | HTTP request | Description
 [**health_options**](CorsApi.md#health_options) | **OPTIONS** /health | CORS support
 [**limits_account_options**](CorsApi.md#limits_account_options) | **OPTIONS** /limits/{account} | CORS support
 [**limits_options**](CorsApi.md#limits_options) | **OPTIONS** /limits | CORS support
-[**testing_wipe_options**](CorsApi.md#testing_wipe_options) | **OPTIONS** /testing/wipe | CORS support
 [**withdrawal_id_options**](CorsApi.md#withdrawal_id_options) | **OPTIONS** /withdrawal/{id} | CORS support
 [**withdrawal_options**](CorsApi.md#withdrawal_options) | **OPTIONS** /withdrawal | CORS support
 [**withdrawal_recipient_recipient_options**](CorsApi.md#withdrawal_recipient_recipient_options) | **OPTIONS** /withdrawal/recipient/{recipient} | CORS support
@@ -286,33 +285,6 @@ No authorization required
 ## limits_options
 
 > limits_options()
-CORS support
-
-Handles CORS preflight requests
-
-### Parameters
-
-This endpoint does not need any parameter.
-
-### Return type
-
- (empty response body)
-
-### Authorization
-
-No authorization required
-
-### HTTP request headers
-
-- **Content-Type**: Not defined
-- **Accept**: Not defined
-
-[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
-
-
-## testing_wipe_options
-
-> testing_wipe_options()
 CORS support
 
 Handles CORS preflight requests

--- a/.generated-sources/emily/client/rust/public/src/apis/cors_api.rs
+++ b/.generated-sources/emily/client/rust/public/src/apis/cors_api.rs
@@ -83,13 +83,6 @@ pub enum LimitsOptionsError {
     UnknownValue(serde_json::Value),
 }
 
-/// struct for typed errors of method [`testing_wipe_options`]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum TestingWipeOptionsError {
-    UnknownValue(serde_json::Value),
-}
-
 /// struct for typed errors of method [`withdrawal_id_options`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -503,43 +496,6 @@ pub async fn limits_options(
         Ok(())
     } else {
         let local_var_entity: Option<LimitsOptionsError> =
-            serde_json::from_str(&local_var_content).ok();
-        let local_var_error = ResponseContent {
-            status: local_var_status,
-            content: local_var_content,
-            entity: local_var_entity,
-        };
-        Err(Error::ResponseError(local_var_error))
-    }
-}
-
-/// Handles CORS preflight requests
-pub async fn testing_wipe_options(
-    configuration: &configuration::Configuration,
-) -> Result<(), Error<TestingWipeOptionsError>> {
-    let local_var_configuration = configuration;
-
-    let local_var_client = &local_var_configuration.client;
-
-    let local_var_uri_str = format!("{}/testing/wipe", local_var_configuration.base_path);
-    let mut local_var_req_builder =
-        local_var_client.request(reqwest::Method::OPTIONS, local_var_uri_str.as_str());
-
-    if let Some(ref local_var_user_agent) = local_var_configuration.user_agent {
-        local_var_req_builder =
-            local_var_req_builder.header(reqwest::header::USER_AGENT, local_var_user_agent.clone());
-    }
-
-    let local_var_req = local_var_req_builder.build()?;
-    let local_var_resp = local_var_client.execute(local_var_req).await?;
-
-    let local_var_status = local_var_resp.status();
-    let local_var_content = local_var_resp.text().await?;
-
-    if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
-        Ok(())
-    } else {
-        let local_var_entity: Option<TestingWipeOptionsError> =
             serde_json::from_str(&local_var_content).ok();
         let local_var_error = ResponseContent {
             status: local_var_status,

--- a/.generated-sources/emily/client/rust/public/src/apis/mod.rs
+++ b/.generated-sources/emily/client/rust/public/src/apis/mod.rs
@@ -97,7 +97,6 @@ pub mod cors_api;
 pub mod deposit_api;
 pub mod health_api;
 pub mod limits_api;
-pub mod testing_api;
 pub mod withdrawal_api;
 
 pub mod configuration;

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5785,6 +5785,7 @@ dependencies = [
  "tempfile",
  "test-case",
  "test-log",
+ "testing-emily-client",
  "thiserror 2.0.11",
  "time 0.3.37",
  "tokio",

--- a/emily/openapi-gen/generated-specs/public-emily-openapi-spec.json
+++ b/emily/openapi-gen/generated-specs/public-emily-openapi-spec.json
@@ -1314,60 +1314,6 @@
         }
       }
     },
-    "/testing/wipe": {
-      "post": {
-        "tags": [
-          "testing"
-        ],
-        "summary": "Wipe databases handler.",
-        "operationId": "wipeDatabases",
-        "responses": {
-          "204": {
-            "description": "Successfully wiped databases."
-          },
-          "400": {
-            "description": "Invalid request body"
-          },
-          "404": {
-            "description": "Address not found"
-          },
-          "405": {
-            "description": "Method not allowed"
-          },
-          "500": {
-            "description": "Internal server error"
-          }
-        },
-        "security": [
-          {
-            "ApiGatewayKey": []
-          }
-        ],
-        "x-amazon-apigateway-integration": {
-          "httpMethod": "POST",
-          "type": "aws_proxy",
-          "uri": {
-            "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${OperationLambda}/invocations"
-          }
-        }
-      },
-      "options": {
-        "tags": [
-          "CORS"
-        ],
-        "summary": "CORS support",
-        "description": "Handles CORS preflight requests",
-        "parameters": [],
-        "responses": {},
-        "x-amazon-apigateway-integration": {
-          "httpMethod": "POST",
-          "type": "aws_proxy",
-          "uri": {
-            "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${OperationLambda}/invocations"
-          }
-        }
-      }
-    },
     "/withdrawal": {
       "get": {
         "tags": [

--- a/emily/openapi-gen/generators/public.rs
+++ b/emily/openapi-gen/generators/public.rs
@@ -33,7 +33,7 @@ use super::CorsSupport;
         api::handlers::chainstate::set_chainstate,
         // api::handlers::chainstate::update_chainstate, // signers may not set the chainstate to cause a reorg.
         // Testing endpoints.
-        api::handlers::testing::wipe_databases,
+        // api::handlers::testing::wipe_databases, // The public api cannot perform testing operations.
         // Limits endpoints.
         api::handlers::limits::get_limits,
         // api::handlers::limits::set_limits, // signers / users may not set limits.

--- a/signer/Cargo.toml
+++ b/signer/Cargo.toml
@@ -75,6 +75,7 @@ sbtc = { workspace = true, features = ["testing"] }
 tempfile.workspace = true
 test-case.workspace = true
 test-log.workspace = true
+testing-emily-client.workspace = true
 toml_edit.workspace = true
 tower.workspace = true
 

--- a/signer/tests/integration/block_observer.rs
+++ b/signer/tests/integration/block_observer.rs
@@ -16,7 +16,6 @@ use blockstack_lib::chainstate::nakamoto::NakamotoBlock;
 use blockstack_lib::chainstate::nakamoto::NakamotoBlockHeader;
 use blockstack_lib::net::api::getpoxinfo::RPCPoxInfoData;
 use emily_client::apis::deposit_api;
-use emily_client::apis::testing_api;
 use emily_client::models::CreateDepositRequestBody;
 use fake::Fake as _;
 use fake::Faker;
@@ -46,6 +45,7 @@ use signer::storage::postgres::PgStore;
 use signer::storage::DbWrite;
 use signer::testing::stacks::DUMMY_SORTITION_INFO;
 use signer::testing::stacks::DUMMY_TENURE_INFO;
+use testing_emily_client::apis::testing_api;
 
 use signer::block_observer::BlockObserver;
 use signer::context::Context as _;
@@ -61,6 +61,7 @@ use signer::transaction_coordinator::should_coordinate_dkg;
 use signer::transaction_signer::assert_allow_dkg_begin;
 use url::Url;
 
+use crate::setup::IntoEmilyTestingConfig as _;
 use crate::setup::TestSweepSetup;
 use crate::transaction_coordinator::mock_reqwests_status_code_error;
 use crate::utxo_construction::make_deposit_request;
@@ -363,7 +364,7 @@ async fn block_observer_stores_donation_and_sbtc_utxos() {
     )
     .unwrap();
 
-    testing_api::wipe_databases(emily_client.config())
+    testing_api::wipe_databases(&emily_client.config().as_testing())
         .await
         .unwrap();
 

--- a/signer/tests/integration/emily.rs
+++ b/signer/tests/integration/emily.rs
@@ -24,7 +24,6 @@ use blockstack_lib::net::api::getpoxinfo::RPCPoxInfoData;
 use blockstack_lib::net::api::getsortition::SortitionInfo;
 use clarity::types::chainstate::BurnchainHeaderHash;
 use emily_client::apis::deposit_api;
-use emily_client::apis::testing_api::wipe_databases;
 use emily_client::models::CreateDepositRequestBody;
 use sbtc::testing::regtest::Recipient;
 use signer::bitcoin::rpc::BitcoinTxInfo;
@@ -61,7 +60,9 @@ use signer::testing::storage::model::TestData;
 use signer::testing::transaction_coordinator::select_coordinator;
 use signer::testing::wsts::SignerSet;
 use signer::transaction_coordinator;
+use testing_emily_client::apis::testing_api::wipe_databases;
 
+use crate::setup::IntoEmilyTestingConfig as _;
 use crate::utxo_construction::make_deposit_request;
 
 async fn run_dkg<Rng, C>(
@@ -165,7 +166,7 @@ async fn deposit_flow() {
     let stacks_client = WrappedMock::default();
 
     // Wipe the Emily database to start fresh
-    wipe_databases(&emily_client.config())
+    wipe_databases(&emily_client.config().as_testing())
         .await
         .expect("Wiping Emily database in test setup failed.");
 
@@ -585,7 +586,7 @@ async fn get_deposit_request_works() {
     )
     .unwrap();
 
-    wipe_databases(&emily_client.config())
+    wipe_databases(&emily_client.config().as_testing())
         .await
         .expect("Wiping Emily database in test setup failed.");
 
@@ -638,7 +639,7 @@ async fn test_get_deposits_request_paging(
     )
     .unwrap();
 
-    wipe_databases(&emily_client.config())
+    wipe_databases(&emily_client.config().as_testing())
         .await
         .expect("Wiping Emily database in test setup failed.");
 

--- a/signer/tests/integration/request_decider.rs
+++ b/signer/tests/integration/request_decider.rs
@@ -12,7 +12,6 @@ use serde_json::json;
 use url::Url;
 
 use emily_client::apis::deposit_api;
-use emily_client::apis::testing_api;
 use emily_client::models::CreateDepositRequestBody;
 use signer::bitcoin::MockBitcoinInteract;
 use signer::blocklist_client::BlocklistClient;
@@ -32,8 +31,10 @@ use signer::storage::DbRead as _;
 use signer::testing;
 use signer::testing::context::*;
 use signer::testing::request_decider::TestEnvironment;
+use testing_emily_client::apis::testing_api;
 
 use crate::setup::backfill_bitcoin_blocks;
+use crate::setup::IntoEmilyTestingConfig as _;
 use crate::setup::TestSweepSetup;
 
 fn test_environment(
@@ -314,7 +315,7 @@ async fn persist_received_deposit_decision_fetches_missing_deposit_requests() {
     )
     .unwrap();
 
-    testing_api::wipe_databases(emily_client.config())
+    testing_api::wipe_databases(&emily_client.config().as_testing())
         .await
         .unwrap();
 

--- a/signer/tests/integration/setup.rs
+++ b/signer/tests/integration/setup.rs
@@ -13,6 +13,7 @@ use blockstack_lib::types::chainstate::StacksAddress;
 use clarity::types::chainstate::StacksBlockId;
 use clarity::vm::types::PrincipalData;
 
+use emily_client::apis::configuration::Configuration as EmilyApiConfiguration;
 use fake::Fake;
 use fake::Faker;
 use rand::rngs::OsRng;
@@ -57,6 +58,8 @@ use signer::testing::context::TestContext;
 use signer::testing::context::*;
 use signer::testing::dummy::Unit;
 use signer::DEFAULT_MAX_DEPOSITS_PER_BITCOIN_TX;
+use testing_emily_client::apis::configuration::ApiKey as TestingEmilyApiKey;
+use testing_emily_client::apis::configuration::Configuration as TestingEmilyApiConfiguration;
 
 use crate::utxo_construction::generate_withdrawal;
 use crate::utxo_construction::make_deposit_request;
@@ -71,6 +74,27 @@ impl AsBlockRef for bitcoincore_rpc_json::GetBlockHeaderResult {
         BitcoinBlockRef {
             block_hash: self.hash.into(),
             block_height: self.height as u64,
+        }
+    }
+}
+
+pub trait IntoEmilyTestingConfig {
+    fn as_testing(&self) -> TestingEmilyApiConfiguration;
+}
+
+impl IntoEmilyTestingConfig for EmilyApiConfiguration {
+    fn as_testing(&self) -> TestingEmilyApiConfiguration {
+        TestingEmilyApiConfiguration {
+            base_path: self.base_path.clone(),
+            user_agent: self.user_agent.clone(),
+            client: self.client.clone(),
+            basic_auth: self.basic_auth.clone(),
+            oauth_access_token: self.oauth_access_token.clone(),
+            bearer_access_token: self.bearer_access_token.clone(),
+            api_key: self.api_key.clone().map(|key| TestingEmilyApiKey {
+                prefix: key.prefix.clone(),
+                key: key.key.clone(),
+            }),
         }
     }
 }

--- a/signer/tests/integration/transaction_coordinator.rs
+++ b/signer/tests/integration/transaction_coordinator.rs
@@ -30,7 +30,6 @@ use clarity::vm::types::SequenceData;
 use clarity::vm::types::StandardPrincipalData;
 use clarity::vm::Value as ClarityValue;
 use emily_client::apis::deposit_api;
-use emily_client::apis::testing_api;
 use fake::Fake as _;
 use fake::Faker;
 use futures::StreamExt as _;
@@ -50,6 +49,7 @@ use signer::bitcoin::utxo::Fees;
 use signer::bitcoin::validation::WithdrawalValidationResult;
 use signer::bitcoin::BitcoinInteract as _;
 use signer::context::RequestDeciderEvent;
+use testing_emily_client::apis::testing_api;
 
 use signer::context::SbtcLimits;
 use signer::context::TxCoordinatorEvent;
@@ -121,6 +121,7 @@ use tokio::sync::broadcast::Sender;
 use crate::complete_deposit::make_complete_deposit;
 use crate::setup::backfill_bitcoin_blocks;
 use crate::setup::AsBlockRef as _;
+use crate::setup::IntoEmilyTestingConfig as _;
 use crate::setup::TestSignerSet;
 use crate::setup::TestSweepSetup;
 use crate::setup::TestSweepSetup2;
@@ -1340,7 +1341,7 @@ async fn sign_bitcoin_transaction() {
     )
     .unwrap();
 
-    testing_api::wipe_databases(emily_client.config())
+    testing_api::wipe_databases(&emily_client.config().as_testing())
         .await
         .unwrap();
 
@@ -1762,7 +1763,7 @@ async fn sign_bitcoin_transaction_multiple_locking_keys() {
     )
     .unwrap();
 
-    testing_api::wipe_databases(emily_client.config())
+    testing_api::wipe_databases(&emily_client.config().as_testing())
         .await
         .unwrap();
 
@@ -2371,7 +2372,7 @@ async fn skip_smart_contract_deployment_and_key_rotation_if_up_to_date() {
     )
     .unwrap();
 
-    testing_api::wipe_databases(emily_client.config())
+    testing_api::wipe_databases(&emily_client.config().as_testing())
         .await
         .unwrap();
 
@@ -3466,7 +3467,7 @@ async fn sign_bitcoin_transaction_withdrawals() {
     )
     .unwrap();
 
-    testing_api::wipe_databases(emily_client.config())
+    testing_api::wipe_databases(&emily_client.config().as_testing())
         .await
         .unwrap();
 


### PR DESCRIPTION
## Description

Closes #1444 

The endpoint was already disabled in the private API (used by the sidecar) and will now only be accessible through the testing API and client.

I'm not very happy with the `as_testing()` method and am open to suggestions. Ideally, all test calls to Emily should go through the test-emily-client, but this would require a larger refactor since the structs used in the two crates are different.

## Changes
- disable the wipe_databases endoint.
- add the test-emily-client crate to the dev configuration of the signer.
- use the test-emily-client crate to call the wipe-databases.  


- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
