### PR TITLE
chore: update devenv for the bridge

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -242,9 +242,21 @@ services:
       - emily-server
       - bitcoin
     ports:
-      - "3010:3000"
+      - "3000:3000"
     profiles:
       - default
+    environment:
+      BITCOIND_URL: http://bitcoin:18443
+      EMILY_URL: http://emily-server:3031
+      MEMPOOL_API_URL: http://mempool-web:8083/api
+      PUBLIC_MEMPOOL_URL: http://localhost:8083
+      BITCOIN_RPC_USER_NAME: devnet
+      BITCOIN_RPC_PASSWORD: devnet
+      WALLET_NETWORK: sbtcDevenv
+      RECLAIM_LOCK_TIME: 18
+      SBTC_CONTRACT_DEPLOYER: SN3R84XZYA63QS28932XQF3G1J8R9PC3W76P9CSQS
+      BANNER_CONTENT: devenv!
+      STACKS_API_URL: http://stacks-api:3999
 
   # Bitcoin / Burnchain.
   # --------------------


### PR DESCRIPTION
## Description

Follow up for https://github.com/stacks-network/sbtc/issues/1441

## Changes

 - Add the missing envs to the compose
 - Expose the bridge on 3000 to make leather `sBTC Devenv` working as expected
 - Add `fund-btc` (and `fund-stx`) to demo cli to fund accounts

## Testing Information

Did a bridge deposit, it worked (almost completely): because of https://github.com/stacks-network/sbtc/pull/1421, deposits are no longer marked confirmed by the signers, so the deposit will be fulfilled but not marked as such on the bridge. Once the sidecar is updated (https://github.com/stacks-network/sbtc/pull/1409 & co) it should work as expected.

Note that to rebuild the bridge you need `--no-cache`:
```
docker compose -f docker/docker-compose.yml --profile default build --no-cache sbtc-bridge-website
```

To fund your BTC account you can:
```
cargo run -p signer --bin demo-cli fund-btc --recipient bcrt1qezfmjvnaeu66wm52h7885mccjfh9lmh2v4kf8n
```

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
