### PR TITLE
chore: don't `continue` on rejected peer connection

### DIFF
--- a/signer/src/network/libp2p/event_loop.rs
+++ b/signer/src/network/libp2p/event_loop.rs
@@ -100,9 +100,9 @@ pub async fn run(ctx: &impl Context, swarm: Arc<Mutex<Swarm<SignerBehavior>>>) {
                         if !ctx.state().current_signer_set().is_allowed_peer(&peer_id) {
                             tracing::warn!(%peer_id, ?endpoint, "connected to peer, however it is not a known signer; disconnecting");
                             let _ = swarm.disconnect_peer_id(peer_id);
-                            continue;
+                        } else {
+                            tracing::debug!(%peer_id, ?endpoint, "connected to peer");
                         }
-                        tracing::debug!(%peer_id, ?endpoint, "connected to peer");
                     }
                     SwarmEvent::ConnectionClosed { peer_id, cause, endpoint, .. } => {
                         tracing::trace!(%peer_id, ?cause, ?endpoint, "connection closed");


### PR DESCRIPTION
## Description

Closes: #1419

## Changes

Removes the `continue` statement upon p2p peer connection rejection which otherwise prevents the event loop from continuing to outbound message processing.

## Testing Information

All existing tests pass.

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
