### PR TITLE
ci: use ubuntu 24.04 for cargo vet

### DIFF
--- a/.github/workflows/cargo-vet.yaml
+++ b/.github/workflows/cargo-vet.yaml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   cargo-vet:
     name: Run cargo vet
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 


### PR DESCRIPTION
## Description

We're getting CI issues for using ubuntu 20.04, so let's upgrade

## Changes

* Change the version of ubuntu used in CI for cargo vet.

## Testing Information

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
