### PR TITLE
chore: remove signer's emily-client implementations to call private endpoints

### DIFF
--- a/signer/src/testing/block_observer.rs
+++ b/signer/src/testing/block_observer.rs
@@ -23,9 +23,6 @@ use blockstack_lib::types::chainstate::StacksBlockId;
 use clarity::types::chainstate::BurnchainHeaderHash;
 use clarity::types::chainstate::SortitionId;
 use clarity::vm::costs::ExecutionCost;
-use emily_client::models::Chainstate;
-use emily_client::models::CreateWithdrawalRequestBody;
-use emily_client::models::Withdrawal;
 use rand::seq::IteratorRandom;
 use sbtc::deposits::CreateDepositRequest;
 
@@ -515,22 +512,11 @@ impl EmilyInteract for TestHarness {
         unimplemented!()
     }
 
-    async fn create_withdrawals(
-        &self,
-        _create_withdrawals: Vec<CreateWithdrawalRequestBody>,
-    ) -> Vec<Result<Withdrawal, Error>> {
-        unimplemented!()
-    }
-
     async fn update_withdrawals(
         &self,
         _update_withdrawals: Vec<emily_client::models::WithdrawalUpdate>,
     ) -> Result<emily_client::models::UpdateWithdrawalsResponse, Error> {
         unimplemented!()
-    }
-
-    async fn set_chainstate(&self, chainstate: Chainstate) -> Result<Chainstate, Error> {
-        Ok(chainstate)
     }
 
     async fn get_limits(&self) -> Result<SbtcLimits, Error> {

--- a/signer/src/testing/context.rs
+++ b/signer/src/testing/context.rs
@@ -537,17 +537,6 @@ impl EmilyInteract for WrappedMock<MockEmilyInteract> {
             .await
     }
 
-    async fn create_withdrawals(
-        &self,
-        create_withdrawals: Vec<emily_client::models::CreateWithdrawalRequestBody>,
-    ) -> Vec<Result<emily_client::models::Withdrawal, Error>> {
-        self.inner
-            .lock()
-            .await
-            .create_withdrawals(create_withdrawals)
-            .await
-    }
-
     async fn update_withdrawals(
         &self,
         update_withdrawals: Vec<emily_client::models::WithdrawalUpdate>,
@@ -557,13 +546,6 @@ impl EmilyInteract for WrappedMock<MockEmilyInteract> {
             .await
             .update_withdrawals(update_withdrawals)
             .await
-    }
-
-    async fn set_chainstate(
-        &self,
-        chainstate: emily_client::models::Chainstate,
-    ) -> Result<emily_client::models::Chainstate, Error> {
-        self.inner.lock().await.set_chainstate(chainstate).await
     }
 
     async fn get_limits(&self) -> Result<SbtcLimits, Error> {


### PR DESCRIPTION
## Description

Remove the implementation of two private endpoints from the signer's emily-client. Those endpoints will be remove from the Public API and the signers will not have access to the autogenerated client code that are currently importing.


## Changes
- remove `create_withdrawals` - The withdrawals will be created from the `new-block`  calls from the private API.
- remove `set_chainstate` - Only the sidecar can set a chainstate from the private API.

## Testing Information
- remove mocking of the endpoints above in a few tests.

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
