### PR TITLE
[feature] `get_deposits` returns accepted and pending

### DIFF
--- a/signer/src/emily_client.rs
+++ b/signer/src/emily_client.rs
@@ -89,9 +89,15 @@ pub trait EmilyInteract: Sync + Send {
         output_index: u32,
     ) -> impl std::future::Future<Output = Result<Option<CreateDepositRequest>, Error>> + Send;
 
-    /// Get pending deposits from Emily.
+    /// Get pending and accepted deposits to process from Emily.
     fn get_deposits(
         &self,
+    ) -> impl std::future::Future<Output = Result<Vec<CreateDepositRequest>, Error>> + Send;
+
+    /// Get pending deposits from Emily.
+    fn get_deposits_with_status(
+        &self,
+        status: Status,
     ) -> impl std::future::Future<Output = Result<Vec<CreateDepositRequest>, Error>> + Send;
 
     /// Update accepted deposits after their sweep bitcoin transaction has been
@@ -243,13 +249,43 @@ impl EmilyInteract for EmilyClient {
     }
 
     async fn get_deposits(&self) -> Result<Vec<CreateDepositRequest>, Error> {
+        let pending_deposits = self.get_deposits_with_status(Status::Pending).await;
+        let accepted_deposits = self.get_deposits_with_status(Status::Accepted).await;
+
+        match (pending_deposits, accepted_deposits) {
+            (Err(pending_err), Err(_accepted_err)) => {
+                // If both calls fail, return the error from the first call
+                Err(pending_err)
+            }
+            (Ok(pending), Err(accepted_err)) => {
+                // If the pending call succeeds, return the pending deposits
+                tracing::warn!("failed to fetch accepted deposits: {:?}", accepted_err);
+                Ok(pending)
+            }
+            (Err(pending_err), Ok(accepted)) => {
+                // If the pending call fails, return the accepted deposits
+                tracing::warn!("failed to fetch pending deposits: {:?}", pending_err);
+                Ok(accepted)
+            }
+            (Ok(mut pending), Ok(mut accepted)) => {
+                // Combine the results
+                pending.append(&mut accepted);
+                Ok(pending)
+            }
+        }
+    }
+
+    async fn get_deposits_with_status(
+        &self,
+        status: Status,
+    ) -> Result<Vec<CreateDepositRequest>, Error> {
         let mut all_deposits = Vec::new();
         let mut next_token: Option<String> = None;
         let start_time = Instant::now();
         loop {
             let resp = match deposit_api::get_deposits(
                 &self.config,
-                Status::Pending,
+                status,
                 next_token.as_deref(),
                 self.page_size,
             )
@@ -423,6 +459,14 @@ impl EmilyInteract for ApiFallbackClient<EmilyClient> {
 
     async fn get_deposits(&self) -> Result<Vec<CreateDepositRequest>, Error> {
         self.exec(|client, _| client.get_deposits()).await
+    }
+
+    async fn get_deposits_with_status(
+        &self,
+        status: Status,
+    ) -> Result<Vec<CreateDepositRequest>, Error> {
+        self.exec(|client, _| client.get_deposits_with_status(status))
+            .await
     }
 
     async fn update_deposits(

--- a/signer/src/testing/block_observer.rs
+++ b/signer/src/testing/block_observer.rs
@@ -25,6 +25,7 @@ use clarity::types::chainstate::SortitionId;
 use clarity::vm::costs::ExecutionCost;
 use emily_client::models::Chainstate;
 use emily_client::models::CreateWithdrawalRequestBody;
+use emily_client::models::Status;
 use emily_client::models::Withdrawal;
 use rand::seq::IteratorRandom;
 use sbtc::deposits::CreateDepositRequest;
@@ -498,6 +499,16 @@ impl EmilyInteract for TestHarness {
     }
     async fn get_deposits(&self) -> Result<Vec<CreateDepositRequest>, Error> {
         Ok(self.pending_deposits.clone())
+    }
+
+    async fn get_deposits_with_status(
+        &self,
+        status: Status,
+    ) -> Result<Vec<CreateDepositRequest>, Error> {
+        match status {
+            Status::Pending => Ok(self.pending_deposits.clone()),
+            _ => Ok(Vec::new()),
+        }
     }
 
     async fn update_deposits(

--- a/signer/src/testing/context.rs
+++ b/signer/src/testing/context.rs
@@ -14,6 +14,7 @@ use blockstack_lib::{
     },
 };
 use clarity::types::chainstate::{StacksAddress, StacksBlockId};
+use emily_client::models::Status;
 use tokio::sync::{broadcast, Mutex};
 use tokio::time::error::Elapsed;
 
@@ -510,8 +511,20 @@ impl EmilyInteract for WrappedMock<MockEmilyInteract> {
             .get_deposit(txid, output_index)
             .await
     }
+
     async fn get_deposits(&self) -> Result<Vec<sbtc::deposits::CreateDepositRequest>, Error> {
         self.inner.lock().await.get_deposits().await
+    }
+
+    async fn get_deposits_with_status(
+        &self,
+        status: Status,
+    ) -> Result<Vec<sbtc::deposits::CreateDepositRequest>, Error> {
+        self.inner
+            .lock()
+            .await
+            .get_deposits_with_status(status)
+            .await
     }
 
     async fn update_deposits(

--- a/signer/tests/integration/emily.rs
+++ b/signer/tests/integration/emily.rs
@@ -25,6 +25,9 @@ use blockstack_lib::net::api::getsortition::SortitionInfo;
 use clarity::types::chainstate::BurnchainHeaderHash;
 use emily_client::apis::deposit_api;
 use emily_client::models::CreateDepositRequestBody;
+use emily_client::models::DepositUpdate;
+use emily_client::models::Status;
+use emily_client::models::UpdateDepositsRequestBody;
 use sbtc::testing::regtest::Recipient;
 use signer::bitcoin::rpc::BitcoinTxInfo;
 use signer::bitcoin::rpc::GetTxResponse;
@@ -622,7 +625,7 @@ async fn get_deposit_request_works() {
 #[test_case(3, 10, Some(2), 3; "handles paging")]
 #[test_case(3, 0, Some(2), 2; "handles timeout")]
 #[tokio::test]
-async fn test_get_deposits_request_paging(
+async fn test_get_deposits_with_status_request_paging(
     num_deposits: usize,
     timeout_secs: u64,
     page_size: Option<u16>,
@@ -670,6 +673,84 @@ async fn test_get_deposits_request_paging(
         result.expect("cannot create emily deposit");
     }
 
-    let deposits = emily_client.get_deposits().await.unwrap();
+    let deposits = emily_client
+        .get_deposits_with_status(Status::Pending)
+        .await
+        .unwrap();
     assert_eq!(deposits.len(), expected_result);
+}
+
+#[tokio::test]
+async fn test_get_deposits_returns_pending_and_accepted() {
+    let max_fee: u64 = 15000;
+    let amount_sats = 49_900_000;
+    let lock_time = 150;
+    let num_deposits = 5;
+    let num_accepted = 2;
+
+    let emily_client = EmilyClient::try_new(
+        &Url::parse("http://testApiKey@localhost:3031").unwrap(),
+        Duration::from_secs(10),
+        None,
+    )
+    .unwrap();
+
+    wipe_databases(&emily_client.config().as_testing())
+        .await
+        .expect("Wiping Emily database in test setup failed.");
+
+    // Create deposits
+    let tx_setups: Vec<sbtc::testing::deposits::TxSetup> = (0..num_deposits)
+        .map(|_| sbtc::testing::deposits::tx_setup(lock_time, max_fee, &[amount_sats]))
+        .collect();
+    let futures = tx_setups.iter().map(|setup| {
+        let create_deposit_request_body = CreateDepositRequestBody {
+            bitcoin_tx_output_index: 0,
+            bitcoin_txid: setup.tx.compute_txid().to_string(),
+            deposit_script: setup
+                .deposits
+                .first()
+                .unwrap()
+                .deposit_script()
+                .to_hex_string(),
+            reclaim_script: setup
+                .reclaims
+                .first()
+                .unwrap()
+                .reclaim_script()
+                .to_hex_string(),
+            transaction_hex: serialize_hex(&setup.tx),
+        };
+        deposit_api::create_deposit(emily_client.config(), create_deposit_request_body)
+    });
+
+    let results = join_all(futures).await;
+    for result in results {
+        result.expect("cannot create emily deposit");
+    }
+
+    // Update some deposits to accepted
+    let deposits = tx_setups[0..num_accepted]
+        .iter()
+        .map(|setup| DepositUpdate {
+            bitcoin_tx_output_index: 0,
+            bitcoin_txid: setup.tx.compute_txid().to_string(),
+            fulfillment: None,
+            last_update_block_hash: "block-hash".to_string(),
+            last_update_height: 42,
+            status: Status::Accepted,
+            status_message: "accepted".to_string(),
+        })
+        .collect();
+
+    deposit_api::update_deposits(
+        emily_client.config(),
+        UpdateDepositsRequestBody { deposits: deposits },
+    )
+    .await
+    .expect("cannot update deposits");
+
+    // Check that we get all deposits
+    let deposits = emily_client.get_deposits().await.unwrap();
+    assert_eq!(deposits.len(), num_deposits);
 }


### PR DESCRIPTION
## Description

Closes: #1463

## Changes
- renamed the previous `get_deposits` -> `get_deposits_with_status`. 
- add a new `get_deposits` implementation that returns both `Pending` and `Accepted` deposits. If only one of the two calls fails, we log an error but still return the deposits fetched by the other call.

## Testing Information
- added an integration test

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
