### PR TITLE
chore: add comments for `get_swept_*` queries near context boundary

### DIFF
--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -2305,6 +2305,10 @@ impl super::DbRead for PgStore {
         // - [X] get_swept_deposit_requests_does_not_return_unswept_deposit_requests
         // - [X] get_swept_deposit_requests_does_not_return_deposit_requests_with_responses
         // - [X] get_swept_deposit_requests_response_tx_reorged
+        //
+        // Note that this query may return completed requests if the stacks
+        // event is anchored to a bitcoin block that is outside the context
+        // window, while the sweep is still inside it.
 
         let Some(stacks_chain_tip) = self.get_stacks_chain_tip(chain_tip).await? else {
             return Ok(Vec::new());
@@ -2390,6 +2394,10 @@ impl super::DbRead for PgStore {
         // - [X] get_swept_withdrawal_requests_does_not_return_unswept_withdrawal_requests
         // - [X] get_swept_withdrawal_requests_does_not_return_withdrawal_requests_with_responses
         // - [X] get_swept_withdrawal_requests_response_tx_reorged
+        //
+        // Note that this query may return completed requests if the stacks
+        // event is anchored to a bitcoin block that is outside the context
+        // window, while the sweep is still inside it.
 
         let Some(stacks_chain_tip) = self.get_stacks_chain_tip(chain_tip).await? else {
             return Ok(Vec::new());


### PR DESCRIPTION
## Description

Closes: #?

## Changes

The `get_swept_deposit_requests` and `get_swept_withdrawal_requests` queries may return completed requests as swept and pending if the relative completed events are anchored to a bitcoin block that precede the sweep bitcoin block.
This is fine as we have other layers taking care of this:
 - The signers validating the contract call will ask the stacks node it the request is still pending
 - The contracts rejecting replay

This PR add comments about it.

## Testing Information

Add a test to show this situation.

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
