### PR TITLE
[fix] add missing sender field after merge

### DIFF
--- a/emily/handler/tests/integration/withdrawal.rs
+++ b/emily/handler/tests/integration/withdrawal.rs
@@ -618,6 +618,7 @@ async fn update_withdrawals_is_forbidden(
         amount: 10000,
         parameters: Box::new(WithdrawalParameters { max_fee: 100 }),
         recipient: RECIPIENT.into(),
+        sender: SENDER.into(),
         request_id,
         stacks_block_hash: BLOCK_HASH.into(),
         stacks_block_height: BLOCK_HEIGHT,


### PR DESCRIPTION
## Description

#1383 merge added a new field `recipient` to the withdrawal requests, that #1472 didn't pull in before the merge. 

## Changes
- add the sender field to the test 


## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
