### PR TITLE
fix: random update_withdrawals_is_forbidden fails

### DIFF
--- a/emily/handler/tests/integration/deposit.rs
+++ b/emily/handler/tests/integration/deposit.rs
@@ -994,7 +994,6 @@ async fn create_deposit_handles_duplicates(status: Status) {
     assert_eq!(response.status, status);
 }
 
-#[tokio::test]
 #[test_case(Status::Pending, Status::Pending, "untrusted_api_key", true; "untrusted_key_pending_to_pending")]
 #[test_case(Status::Pending, Status::Accepted, "untrusted_api_key", false; "untrusted_key_pending_to_accepted")]
 #[test_case(Status::Pending, Status::Reprocessing, "untrusted_api_key", true; "untrusted_key_pending_to_reprocessing")]
@@ -1014,6 +1013,7 @@ async fn create_deposit_handles_duplicates(status: Status) {
 #[test_case(Status::Pending, Status::Confirmed, "testApiKey", false; "trusted_key_pending_to_confirmed")]
 #[test_case(Status::Pending, Status::Failed, "testApiKey", false; "trusted_key_pending_to_failed")]
 #[test_case(Status::Confirmed, Status::Pending, "testApiKey", false; "trusted_key_confirmed_to_pending")]
+#[tokio::test]
 async fn update_deposits_is_forbidden(
     previous_status: Status,
     new_status: Status,

--- a/emily/handler/tests/integration/deposit.rs
+++ b/emily/handler/tests/integration/deposit.rs
@@ -891,12 +891,12 @@ async fn update_deposits_updates_chainstate() {
     }
 }
 
-#[tokio::test]
 #[test_case(Status::Pending; "pending")]
 #[test_case(Status::Reprocessing; "reprocessing")]
 #[test_case(Status::Confirmed; "confirmed")]
 #[test_case(Status::Failed; "failed")]
 #[test_case(Status::Accepted; "accepted")]
+#[tokio::test]
 async fn create_deposit_handles_duplicates(status: Status) {
     let configuration = clean_setup().await;
     // Arrange.

--- a/emily/handler/tests/integration/withdrawal.rs
+++ b/emily/handler/tests/integration/withdrawal.rs
@@ -574,7 +574,6 @@ async fn update_withdrawals_updates_chainstate() {
     }
 }
 
-#[tokio::test]
 #[test_case(Status::Pending, Status::Pending, "untrusted_api_key", true; "untrusted_key_pending_to_pending")]
 #[test_case(Status::Pending, Status::Accepted, "untrusted_api_key", false; "untrusted_key_pending_to_accepted")]
 #[test_case(Status::Pending, Status::Reprocessing, "untrusted_api_key", true; "untrusted_key_pending_to_reprocessing")]
@@ -594,6 +593,7 @@ async fn update_withdrawals_updates_chainstate() {
 #[test_case(Status::Pending, Status::Confirmed, "testApiKey", false; "trusted_key_pending_to_confirmed")]
 #[test_case(Status::Pending, Status::Failed, "testApiKey", false; "trusted_key_pending_to_failed")]
 #[test_case(Status::Confirmed, Status::Pending, "testApiKey", false; "trusted_key_confirmed_to_pending")]
+#[tokio::test]
 async fn update_withdrawals_is_forbidden(
     previous_status: Status,
     new_status: Status,


### PR DESCRIPTION
## Description

Fixes the test that were occasionally failing in CI. As described in [here ](https://github.com/frondeus/test-case/pull/48), that's a known problem in the test_case library. It requires the tokio::test to be defined after the test cases

Note that I wasn't able to reproduce the error locally.

## Changes
- move tokio::test definition after the test cases

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
