### PR TITLE
feat: sidecar long pending deposits management

### DIFF
--- a/emily_cron/app/services/deposit_processor.py
+++ b/emily_cron/app/services/deposit_processor.py
@@ -87,16 +87,13 @@ class DepositProcessor:
             list[DepositUpdate]: List of deposit updates
         """
         updates = []
-
         # Find transactions with expired locktime
         locktime_expired_txs = [
             tx
             for tx in enriched_deposits
             if tx.confirmed_height > 0  # Only process confirmed transactions
-            and bitcoin_chaintip.height
-            >= tx.confirmed_height
-            + tx.lock_time
-            + settings.MIN_BLOCK_CONFIRMATIONS  # Check if locktime has expired
+            # Check if locktime has expired
+            and bitcoin_chaintip.height >= tx.confirmed_height + tx.lock_time + settings.MIN_BLOCK_CONFIRMATIONS
         ]
 
         if not locktime_expired_txs:
@@ -121,6 +118,50 @@ class DepositProcessor:
 
         return updates
 
+    def process_long_pending(
+        self,
+        enriched_deposits: list[EnrichedDepositInfo],
+        stacks_chaintip: BlockInfo,
+    ) -> list[DepositUpdate]:
+        """Process long-pending transactions.
+        Args:
+            enriched_deposits: List of enriched deposit information
+            stacks_chaintip: Current Stacks block info
+        Returns:
+            list[DepositUpdate]: List of deposit updates
+        """
+        updates = []
+
+        # Get the current time
+        current_time = int(datetime.now().timestamp())
+
+        long_pending_txs = [
+            tx
+            for tx in enriched_deposits
+            if tx.status == RequestStatus.PENDING.value  # Only check pending transactions
+            and not tx.in_mempool  # that we can't find via the mempool API (it might have been dropped)
+            and current_time - tx.deposit_time >= settings.MAX_UNCONFIRMED_TIME  # and has been pending for too long
+        ]
+
+        if not long_pending_txs:
+            return updates
+
+        logger.info(f"Found {len(long_pending_txs)} long-pending transactions to mark as FAILED")
+
+        for tx in long_pending_txs:
+            logger.info(f"Marking long-pending transaction {tx.bitcoin_txid} as FAILED")
+            updates.append(
+                DepositUpdate(
+                    bitcoin_txid=tx.bitcoin_txid,
+                    bitcoin_tx_output_index=tx.bitcoin_tx_output_index,
+                    last_update_height=stacks_chaintip.height,
+                    last_update_block_hash=stacks_chaintip.hash,
+                    status=RequestStatus.FAILED.value,
+                    status_message=f"Pending for too long ({settings.MAX_UNCONFIRMED_TIME} seconds)",
+                )
+            )
+
+        return updates
 
     def update_deposits(self) -> None:
         """Update deposit statuses.
@@ -161,6 +202,13 @@ class DepositProcessor:
             stacks_chaintip,
         )
         updates.extend(rbf_updates)
+
+        # Process long-pending transactions
+        pending_updates = self.process_long_pending(
+            enriched_deposits,
+            stacks_chaintip,
+        )
+        updates.extend(pending_updates)
 
         # Apply updates
         if updates:

--- a/emily_cron/app/settings.py
+++ b/emily_cron/app/settings.py
@@ -11,3 +11,6 @@ HIRO_API_URL = os.getenv("HIRO_API_URL", "https://api.hiro.so/extended").removes
 
 # The number of confirmations required for a deposit update to be considered final
 MIN_BLOCK_CONFIRMATIONS = int(os.getenv("MIN_BLOCK_CONFIRMATIONS", 6))
+
+# Maximum time (in seconds) a transaction can remain unconfirmed before being marked as FAILED
+MAX_UNCONFIRMED_TIME = int(os.getenv("MAX_UNCONFIRMED_TIME", 60 * 60 * 24))  # 24 hours in seconds


### PR DESCRIPTION
## Description

This PR adds support for handling long-pending transactions. It addresses the issue of transactions that remain in a pending state for extended periods without being confirmed in the mempool, which can lead to system bloat.

## Changes

- Added long-pending transaction detection and processing to the DepositProcessor service:
- Implemented process_long_pending method to identify transactions that have been pending for too long
- Added logic to mark transactions as FAILED if they:
       - Are in PENDING status
       - Cannot be found in the mempool (likely dropped)
       - Have been pending for longer than the configured maximum time (default: 24 hours)
       - Integrated long-pending transaction processing into the main deposit update workflow
- Added MAX_UNCONFIRMED_TIME configuration setting (default: 86400 seconds / 24 hours) to control how long a transaction can remain unconfirmed before being marked as failed

## Testing Information
- WIP

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
