### PR TITLE
feat: remove signer vote bitmaps from transactions

### DIFF
--- a/signer/src/proto/convert.rs
+++ b/signer/src/proto/convert.rs
@@ -9,7 +9,6 @@ use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 
 use bitcoin::OutPoint;
-use bitvec::array::BitArray;
 use clarity::codec::StacksMessageCodec as _;
 use clarity::vm::types::PrincipalData;
 use p256k1::point::Point;
@@ -415,7 +414,7 @@ impl From<AcceptWithdrawalV1> for proto::AcceptWithdrawal {
             id: Some(value.id.into()),
             outpoint: Some(value.outpoint.into()),
             tx_fee: value.tx_fee,
-            signer_bitmap: value.signer_bitmap.iter().map(|e| *e).collect(),
+            signer_bitmap: Vec::new(),
             deployer: Some(value.deployer.into()),
             sweep_block_hash: Some(value.sweep_block_hash.into()),
             sweep_block_height: value.sweep_block_height,
@@ -426,24 +425,11 @@ impl From<AcceptWithdrawalV1> for proto::AcceptWithdrawal {
 impl TryFrom<proto::AcceptWithdrawal> for AcceptWithdrawalV1 {
     type Error = Error;
     fn try_from(value: proto::AcceptWithdrawal) -> Result<Self, Self::Error> {
-        let mut signer_bitmap = BitArray::ZERO;
-        value
-            .signer_bitmap
-            .iter()
-            .enumerate()
-            .take(signer_bitmap.len().min(crate::MAX_KEYS as usize))
-            .for_each(|(index, vote)| {
-                // The BitArray::<[u8; 16]>::set function panics if the
-                // index is out of bounds but that cannot be the case here
-                // because we only take 128 values.
-                signer_bitmap.set(index, *vote);
-            });
-
         Ok(AcceptWithdrawalV1 {
             id: value.id.required()?.try_into()?,
             outpoint: value.outpoint.required()?.try_into()?,
             tx_fee: value.tx_fee,
-            signer_bitmap,
+            signer_bitmap: 0,
             deployer: value.deployer.required()?.try_into()?,
             sweep_block_hash: value.sweep_block_hash.required()?.try_into()?,
             sweep_block_height: value.sweep_block_height,
@@ -455,7 +441,7 @@ impl From<RejectWithdrawalV1> for proto::RejectWithdrawal {
     fn from(value: RejectWithdrawalV1) -> Self {
         proto::RejectWithdrawal {
             id: Some(value.id.into()),
-            signer_bitmap: value.signer_bitmap.iter().map(|e| *e).collect(),
+            signer_bitmap: Vec::new(),
             deployer: Some(value.deployer.into()),
         }
     }
@@ -464,22 +450,9 @@ impl From<RejectWithdrawalV1> for proto::RejectWithdrawal {
 impl TryFrom<proto::RejectWithdrawal> for RejectWithdrawalV1 {
     type Error = Error;
     fn try_from(value: proto::RejectWithdrawal) -> Result<Self, Self::Error> {
-        let mut signer_bitmap = BitArray::ZERO;
-        value
-            .signer_bitmap
-            .iter()
-            .enumerate()
-            .take(signer_bitmap.len().min(crate::MAX_KEYS as usize))
-            .for_each(|(index, vote)| {
-                // The BitArray::<[u8; 16]>::set function panics if the
-                // index is out of bounds but that cannot be the case here
-                // because we only take 128 values.
-                signer_bitmap.set(index, *vote);
-            });
-
         Ok(RejectWithdrawalV1 {
             id: value.id.required()?.try_into()?,
-            signer_bitmap,
+            signer_bitmap: 0,
             deployer: value.deployer.required()?.try_into()?,
         })
     }

--- a/signer/src/stacks/contracts.rs
+++ b/signer/src/stacks/contracts.rs
@@ -24,8 +24,6 @@ use std::sync::OnceLock;
 use bitcoin::Amount;
 use bitcoin::OutPoint;
 use bitcoin::TxOut;
-use bitvec::array::BitArray;
-use bitvec::field::BitField as _;
 use blockstack_lib::chainstate::stacks::TransactionContractCall;
 use blockstack_lib::chainstate::stacks::TransactionPayload;
 use blockstack_lib::chainstate::stacks::TransactionPostCondition;
@@ -640,7 +638,10 @@ pub struct AcceptWithdrawalV1 {
     /// A bitmap of how the signers voted. This structure supports up to
     /// 128 distinct signers. Here, we assume that a 1 (or true) implies
     /// that the signer voted *against* the transaction.
-    pub signer_bitmap: BitArray<[u8; 16]>,
+    ///
+    /// This field is currently unused, and is assumed to be zero. See
+    /// https://github.com/stacks-network/sbtc/issues/1505.
+    pub signer_bitmap: u128,
     /// The address that deployed the contract.
     pub deployer: StacksAddress,
     /// The block hash of the bitcoin block that contains a sweep
@@ -679,7 +680,10 @@ impl AsContractCall for AcceptWithdrawalV1 {
         vec![
             ClarityValue::UInt(self.id.request_id as u128),
             ClarityValue::Sequence(SequenceData::Buffer(txid.clone())),
-            ClarityValue::UInt(self.signer_bitmap.load_le()),
+            // This is the signer bitmap field. See the following for more
+            // on why this is fixed at zero.
+            // https://github.com/stacks-network/sbtc/issues/1505
+            ClarityValue::UInt(0),
             ClarityValue::UInt(self.outpoint.vout as u128),
             ClarityValue::UInt(self.tx_fee as u128),
             ClarityValue::Sequence(SequenceData::Buffer(burn_hash_buff)),
@@ -706,8 +710,7 @@ impl AsContractCall for AcceptWithdrawalV1 {
     ///  8. That the fee matches the expected assessed fee for the output.
     ///  9. That the first input into the sweep transaction is the signers'
     ///     UTXO.
-    /// 10. That the signer bitmap matches the bitmap from our records.
-    /// 11. That the withdrawal request is not already completed.
+    /// 10. That the withdrawal request is not already completed.
     async fn validate<C>(&self, ctx: &C, req_ctx: &ReqContext) -> Result<(), Error>
     where
         C: Context + Send + Sync,
@@ -745,7 +748,6 @@ impl AcceptWithdrawalV1 {
     ///  6. The `amount` of the UTXO matches the one in the withdrawal
     ///     request.
     ///  7. That the fee is less than the desired max-fee.
-    /// 10. That the signer bitmap matches the bitmap from our records.
     async fn validate_utxo<C>(
         &self,
         ctx: &C,
@@ -806,14 +808,6 @@ impl AcceptWithdrawalV1 {
         // do a check ourselves.
         if self.tx_fee > report.max_fee {
             return Err(WithdrawalErrorMsg::FeeTooHigh.into_error(req_ctx, self));
-        }
-        // 10. That the signer bitmap matches the bitmap formed from our
-        //     records.
-        let votes = db
-            .get_withdrawal_request_signer_votes(&self.id, &req_ctx.aggregate_key)
-            .await?;
-        if self.signer_bitmap != BitArray::from(votes) {
-            return Err(WithdrawalErrorMsg::BitmapMismatch.into_error(req_ctx, self));
         }
 
         Ok(())
@@ -960,10 +954,6 @@ impl std::error::Error for WithdrawalRejectValidationError {
 /// contract call transaction.
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum WithdrawalErrorMsg {
-    /// The bitmap set in the transaction object should match the one in
-    /// our database.
-    #[error("bitmap does not match expected bitmap from")]
-    BitmapMismatch,
     /// The smart contract deployer is fixed, so this should always match.
     #[error("the deployer in the transaction does not match the expected deployer")]
     DeployerMismatch,
@@ -1026,10 +1016,6 @@ impl WithdrawalErrorMsg {
 /// contract call transaction.
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum WithdrawalRejectErrorMsg {
-    /// The bitmap set in the transaction object should match the one in
-    /// our database.
-    #[error("bitmap does not match expected bitmap from")]
-    BitmapMismatch,
     /// The smart contract deployer is fixed, so this should always match.
     #[error("the deployer in the transaction does not match the expected deployer")]
     DeployerMismatch,
@@ -1084,7 +1070,10 @@ pub struct RejectWithdrawalV1 {
     /// A bitmap of how the signers voted. This structure supports up to
     /// 128 distinct signers. Here, we assume that a 1 (or true) implies
     /// that the signer voted *against* the transaction.
-    pub signer_bitmap: BitArray<[u8; 16]>,
+    ///
+    /// This field is currently unused, and is assumed to be zero. See
+    /// https://github.com/stacks-network/sbtc/issues/1505.
+    pub signer_bitmap: u128,
     /// The address that deployed the contract.
     pub deployer: StacksAddress,
 }
@@ -1108,7 +1097,10 @@ impl AsContractCall for RejectWithdrawalV1 {
     fn as_contract_args(&self) -> Vec<ClarityValue> {
         vec![
             ClarityValue::UInt(self.id.request_id as u128),
-            ClarityValue::UInt(self.signer_bitmap.load_le()),
+            // This is the signer bitmap field. See the following for more
+            // on why this is fixed at zero.
+            // https://github.com/stacks-network/sbtc/issues/1505
+            ClarityValue::UInt(0),
         ]
     }
     /// Validates that the reject-withdrawal-request satisfies the
@@ -1121,11 +1113,10 @@ impl AsContractCall for RejectWithdrawalV1 {
     ///    confirmed on the canonical stacks blockchain. Fail if it is not
     ///    on the canonical stacks blockchain.
     /// 4. Whether the request has been fulfilled. Fail if it has.
-    /// 5. Whether the signer bitmap matches the bitmap from our records.
-    /// 6. Whether the withdrawal request has expired. Fail if it hasn't.
-    /// 7. Whether the withdrawal request is being serviced by a sweep
+    /// 5. Whether the withdrawal request has expired. Fail if it hasn't.
+    /// 6. Whether the withdrawal request is being serviced by a sweep
     ///    transaction that is in the mempool.
-    /// 8. Whether we need to worry about forks causing the withdrawal to
+    /// 7. Whether we need to worry about forks causing the withdrawal to
     ///    be confirmed by a sweep that was broadcast changing the status
     ///    of the request from rejected to accepted.
     async fn validate<C>(&self, ctx: &C, req_ctx: &ReqContext) -> Result<(), Error>
@@ -1175,19 +1166,7 @@ impl AsContractCall for RejectWithdrawalV1 {
             }
         }
 
-        // 5. Whether the signer bitmap matches the bitmap from our
-        //    records.
-        let signer_votes = ctx
-            .get_storage()
-            .get_withdrawal_request_signer_votes(&self.id, &req_ctx.aggregate_key)
-            .await?;
-        let signer_bitmap = BitArray::<[u8; 16]>::from(signer_votes);
-
-        if signer_bitmap != self.signer_bitmap {
-            return Err(WithdrawalRejectErrorMsg::BitmapMismatch.into_error(req_ctx, self));
-        }
-
-        // 6. Check whether the withdrawal request has expired.
+        // 5. Check whether the withdrawal request has expired.
         let blocks_observed = req_ctx
             .chain_tip
             .block_height
@@ -1198,7 +1177,7 @@ impl AsContractCall for RejectWithdrawalV1 {
             return Err(WithdrawalRejectErrorMsg::RequestNotFinal.into_error(req_ctx, self));
         }
 
-        // 7. Check whether the withdrawal request may be serviced by a
+        // 6. Check whether the withdrawal request may be serviced by a
         //    sweep transaction that may be in the mempool.
         let withdrawal_is_inflight = db
             .is_withdrawal_inflight(&self.id, &req_ctx.chain_tip.block_hash)
@@ -1207,7 +1186,7 @@ impl AsContractCall for RejectWithdrawalV1 {
             return Err(WithdrawalRejectErrorMsg::RequestBeingFulfilled.into_error(req_ctx, self));
         }
 
-        // 8. Check whether the withdrawal request is still active, as in
+        // 7. Check whether the withdrawal request is still active, as in
         //    it could still be fulfilled.
         let withdrawal_is_active = db
             .is_withdrawal_active(&self.id, &req_ctx.chain_tip, WITHDRAWAL_MIN_CONFIRMATIONS)
@@ -1617,7 +1596,7 @@ mod tests {
             },
             outpoint: OutPoint::null(),
             tx_fee: 125,
-            signer_bitmap: BitArray::ZERO,
+            signer_bitmap: 0,
             deployer: StacksAddress::burn_address(false),
             sweep_block_hash: BitcoinBlockHash::from([0; 32]),
             sweep_block_height: 7,
@@ -1636,7 +1615,7 @@ mod tests {
                 txid: StacksTxId::from([0; 32]),
                 block_hash: StacksBlockHash::from([0; 32]),
             },
-            signer_bitmap: BitArray::new([1; 16]),
+            signer_bitmap: 0,
             deployer: StacksAddress::burn_address(false),
         };
 

--- a/signer/src/stacks/contracts.rs
+++ b/signer/src/stacks/contracts.rs
@@ -715,7 +715,7 @@ impl AsContractCall for AcceptWithdrawalV1 {
     where
         C: Context + Send + Sync,
     {
-        // 11. Check whether the withdrawal request is already completed.
+        // 10. Check whether the withdrawal request is already completed.
         let withdrawal_completed = ctx
             .get_stacks_client()
             .is_withdrawal_completed(&req_ctx.deployer, self.id.request_id)
@@ -1172,7 +1172,6 @@ impl AsContractCall for RejectWithdrawalV1 {
             .block_height
             .saturating_sub(report.bitcoin_block_height);
 
-        // 4. The request is expired.
         if blocks_observed <= WITHDRAWAL_BLOCKS_EXPIRY {
             return Err(WithdrawalRejectErrorMsg::RequestNotFinal.into_error(req_ctx, self));
         }

--- a/signer/src/testing/dummy.rs
+++ b/signer/src/testing/dummy.rs
@@ -714,7 +714,7 @@ impl fake::Dummy<fake::Faker> for AcceptWithdrawalV1 {
                 vout: rng.next_u32(),
             },
             tx_fee: config.fake_with_rng(rng),
-            signer_bitmap: BitArray::new(config.fake_with_rng(rng)),
+            signer_bitmap: 0,
             deployer: address,
             sweep_block_hash: config.fake_with_rng(rng),
             sweep_block_height: config.fake_with_rng(rng),
@@ -730,7 +730,7 @@ impl fake::Dummy<fake::Faker> for RejectWithdrawalV1 {
 
         RejectWithdrawalV1 {
             id: config.fake_with_rng(rng),
-            signer_bitmap: BitArray::new(config.fake_with_rng(rng)),
+            signer_bitmap: 0,
             deployer: address,
         }
     }

--- a/signer/src/testing/message.rs
+++ b/signer/src/testing/message.rs
@@ -1,6 +1,5 @@
 //! Test utilities for signer message
 
-use bitvec::array::BitArray;
 use fake::Fake;
 use rand::seq::SliceRandom;
 use stacks_common::types::chainstate::StacksAddress;
@@ -83,7 +82,7 @@ impl fake::Dummy<fake::Faker> for message::StacksTransactionSignRequest {
         Self {
             contract_tx: ContractCall::RejectWithdrawalV1(RejectWithdrawalV1 {
                 id: config.fake_with_rng(rng),
-                signer_bitmap: BitArray::ZERO,
+                signer_bitmap: 0,
                 deployer: StacksAddress::burn_address(false),
             })
             .into(),

--- a/signer/src/testing/transaction_coordinator.rs
+++ b/signer/src/testing/transaction_coordinator.rs
@@ -42,8 +42,6 @@ use crate::transaction_coordinator::coordinator_public_key;
 use crate::transaction_coordinator::TxCoordinatorEventLoop;
 use bitcoin::hashes::Hash as _;
 
-use bitvec::array::BitArray;
-use bitvec::field::BitField as _;
 use blockstack_lib::chainstate::stacks::TransactionContractCall;
 use blockstack_lib::chainstate::stacks::TransactionPayload;
 use blockstack_lib::net::api::getcontractsrc::ContractSrcResponse;
@@ -768,8 +766,6 @@ where
             .await
             .expect("Failed to construct withdrawal accept stacks sign request");
 
-        // We are not storing the decisions in the db, so we will get all zeros
-        let signer_bitmap: BitArray<[u8; 16]> = BitArray::ZERO;
         let outpoint = withdrawal_req.withdrawal_outpoint();
         assert_eq!(sign_request.tx_fee, 123000);
         assert_eq!(sign_request.aggregate_key, bitcoin_aggregate_key);
@@ -781,6 +777,7 @@ where
             assert_eq!(call.tx_fee, withdrawal_fee);
             assert_eq!(call.id.request_id, withdrawal_req.request_id);
             assert_eq!(call.outpoint, outpoint);
+            assert_eq!(call.signer_bitmap, 0);
             assert_eq!(call.sweep_block_hash, withdrawal_req.sweep_block_hash);
             assert_eq!(call.sweep_block_height, withdrawal_req.sweep_block_height);
         } else {
@@ -804,7 +801,7 @@ where
                     Value::Sequence(SequenceData::Buffer(BuffData {
                         data: outpoint.txid.to_le_bytes().to_vec()
                     })),
-                    Value::UInt(signer_bitmap.load_le()),
+                    Value::UInt(0),
                     Value::UInt(outpoint.vout as u128),
                     Value::UInt(withdrawal_fee as u128),
                     Value::Sequence(SequenceData::Buffer(BuffData {
@@ -873,8 +870,6 @@ where
             .await
             .expect("Failed to construct withdrawal reject stacks sign request");
 
-        // We are not storing the decisions in the db, so we will get all zeros
-        let signer_bitmap: BitArray<[u8; 16]> = BitArray::ZERO;
         assert_eq!(sign_request.tx_fee, 123000);
         assert_eq!(sign_request.aggregate_key, bitcoin_aggregate_key);
         assert_eq!(sign_request.txid, multi_tx.tx().txid());
@@ -887,6 +882,7 @@ where
         };
 
         assert_eq!(call.id, withdrawal_req.qualified_id());
+        assert_eq!(call.signer_bitmap, 0);
 
         let TransactionPayload::ContractCall(TransactionContractCall {
             address,
@@ -905,7 +901,7 @@ where
             *function_args,
             vec![
                 Value::UInt(withdrawal_req.request_id as u128),
-                Value::UInt(signer_bitmap.load_le()),
+                Value::UInt(0),
             ]
         );
     }

--- a/signer/src/testing/transaction_coordinator.rs
+++ b/signer/src/testing/transaction_coordinator.rs
@@ -781,7 +781,6 @@ where
             assert_eq!(call.tx_fee, withdrawal_fee);
             assert_eq!(call.id.request_id, withdrawal_req.request_id);
             assert_eq!(call.outpoint, outpoint);
-            assert_eq!(call.signer_bitmap, signer_bitmap);
             assert_eq!(call.sweep_block_hash, withdrawal_req.sweep_block_hash);
             assert_eq!(call.sweep_block_height, withdrawal_req.sweep_block_height);
         } else {
@@ -888,7 +887,6 @@ where
         };
 
         assert_eq!(call.id, withdrawal_req.qualified_id());
-        assert_eq!(call.signer_bitmap, signer_bitmap);
 
         let TransactionPayload::ContractCall(TransactionContractCall {
             address,

--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -1286,17 +1286,11 @@ where
             .assess_output_fee(outpoint.vout as usize)
             .ok_or_else(|| Error::VoutMissing(outpoint.txid, outpoint.vout))?;
 
-        let votes = self
-            .context
-            .get_storage()
-            .get_withdrawal_request_signer_votes(&qualified_id, bitcoin_aggregate_key)
-            .await?;
-
         let contract_call = ContractCall::AcceptWithdrawalV1(AcceptWithdrawalV1 {
             id: qualified_id,
             outpoint,
             tx_fee: assessed_bitcoin_fee.to_sat(),
-            signer_bitmap: votes.into(),
+            signer_bitmap: 0,
             deployer: self.context.config().signer.deployer,
             sweep_block_hash: req.sweep_block_hash,
             sweep_block_height: req.sweep_block_height,
@@ -1331,15 +1325,9 @@ where
         bitcoin_aggregate_key: &PublicKey,
         wallet: &SignerWallet,
     ) -> Result<(StacksTransactionSignRequest, MultisigTx), Error> {
-        let votes = self
-            .context
-            .get_storage()
-            .get_withdrawal_request_signer_votes(&req.qualified_id(), bitcoin_aggregate_key)
-            .await?;
-
         let contract_call = ContractCall::RejectWithdrawalV1(RejectWithdrawalV1 {
             id: req.qualified_id(),
-            signer_bitmap: votes.into(),
+            signer_bitmap: 0,
             deployer: self.context.config().signer.deployer,
         });
 

--- a/signer/tests/integration/contracts.rs
+++ b/signer/tests/integration/contracts.rs
@@ -3,7 +3,6 @@ use std::sync::OnceLock;
 use std::time::Duration;
 
 use bitcoincore_rpc::RpcApi as _;
-use bitvec::array::BitArray;
 use blockstack_lib::chainstate::stacks::StacksTransaction;
 use blockstack_lib::clarity::vm::types::PrincipalData;
 use blockstack_lib::types::chainstate::StacksAddress;
@@ -172,7 +171,7 @@ pub async fn deploy_smart_contracts() -> &'static SignerStxState {
     },
     outpoint: bitcoin::OutPoint::null(),
     tx_fee: 2500,
-    signer_bitmap: BitArray::ZERO,
+    signer_bitmap: 0,
     deployer: *testing::wallet::WALLET.0.address(),
     sweep_block_hash: BitcoinBlockHash::from([0; 32]),
     sweep_block_height: 7,
@@ -189,7 +188,7 @@ pub async fn deploy_smart_contracts() -> &'static SignerStxState {
 	    txid: StacksTxId::from([0; 32]),
 	    block_hash: StacksBlockHash::from([0; 32]),
     },
-    signer_bitmap: BitArray::ZERO,
+    signer_bitmap: 0,
     deployer: *testing::wallet::WALLET.0.address(),
 }); "reject-withdrawal")]
 #[test_case(ContractCallWrapper(RotateKeysV1::new(
@@ -381,7 +380,7 @@ async fn is_withdrawal_completed_rejection_works() {
             block_hash: StacksBlockHash::from([0; 32]),
             txid: StacksTxId::from([0; 32]),
         },
-        signer_bitmap: BitArray::ZERO,
+        signer_bitmap: 0,
         deployer: *testing::wallet::WALLET.0.address(),
     });
 

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -5,7 +5,6 @@ use std::ops::Deref;
 use std::time::Duration;
 
 use bitcoin::hashes::Hash as _;
-use bitvec::array::BitArray;
 use blockstack_lib::chainstate::nakamoto::NakamotoBlock;
 use blockstack_lib::clarity::vm::types::PrincipalData;
 use blockstack_lib::clarity::vm::Value as ClarityValue;
@@ -182,7 +181,7 @@ impl AsContractCall for InitiateWithdrawalRequest {
     },
     outpoint: bitcoin::OutPoint::null(),
     tx_fee: 3500,
-    signer_bitmap: BitArray::ZERO,
+    signer_bitmap: 0,
     deployer: *testing::wallet::WALLET.0.address(),
     sweep_block_hash: BitcoinBlockHash::from([0; 32]),
     sweep_block_height: 7,
@@ -193,7 +192,7 @@ impl AsContractCall for InitiateWithdrawalRequest {
 	txid: StacksTxId::from([0; 32]),
 	block_hash: StacksBlockHash::from([0; 32]),
     },
-    signer_bitmap: BitArray::ZERO,
+    signer_bitmap: 0,
     deployer: *testing::wallet::WALLET.0.address(),
 }); "reject-withdrawal")]
 #[test_case(ContractCallWrapper(RotateKeysV1::new(


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/1505

## Changes

* Change the bitmap field from the internal structs to be `u128`s.
* Remove the validation checks for the bitmap from within the `AcceptWithdrawalV1::validate` and `RejectWithdrawalV1::validate` functions.
* Remove the integration tests that checked the bitmaps.

## Testing Information

This is mainly a refactor that fixes a potential vulnerability. So if tests pass, then everything is fine.

## Checklist:

- [x] I have performed a self-review of my code
