### PR TITLE
feat: emily rolling withdrawal limits

### DIFF
--- a/.generated-sources/emily/client/rust/private/docs/AccountLimits.md
+++ b/.generated-sources/emily/client/rust/private/docs/AccountLimits.md
@@ -8,6 +8,8 @@ Name | Type | Description | Notes
 **per_deposit_cap** | Option<**u64**> | Per deposit cap. If none then the cap is the same as the global per deposit cap. | [optional]
 **per_deposit_minimum** | Option<**u64**> | Per deposit minimum. If none then there is no minimum. | [optional]
 **per_withdrawal_cap** | Option<**u64**> | Per withdrawal cap. If none then the cap is the same as the global per withdrawal cap. | [optional]
+**rolling_withdrawal_blocks** | Option<**u64**> | The number of blocks over which the rolling_withdrawal_cap is applied. | [optional]
+**rolling_withdrawal_cap** | Option<**u64**> | Maximum amount of sBTC that can be withdrawn in the rolling_withdrawal_blocks window. | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/.generated-sources/emily/client/rust/private/docs/Limits.md
+++ b/.generated-sources/emily/client/rust/private/docs/Limits.md
@@ -9,6 +9,8 @@ Name | Type | Description | Notes
 **per_deposit_cap** | Option<**u64**> | Per deposit cap. If none then there is no cap. | [optional]
 **per_deposit_minimum** | Option<**u64**> | Per deposit minimum. If none then there is no minimum. | [optional]
 **per_withdrawal_cap** | Option<**u64**> | Per withdrawal cap. If none then there is no cap. | [optional]
+**rolling_withdrawal_blocks** | Option<**u64**> | The number of blocks over which the rolling_withdrawal_cap is applied. | [optional]
+**rolling_withdrawal_cap** | Option<**u64**> | Maximum amount of sBTC that can be withdrawn in the rolling_withdrawal_blocks window. | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/.generated-sources/emily/client/rust/private/src/models/account_limits.rs
+++ b/.generated-sources/emily/client/rust/private/src/models/account_limits.rs
@@ -46,6 +46,22 @@ pub struct AccountLimits {
         skip_serializing_if = "Option::is_none"
     )]
     pub per_withdrawal_cap: Option<Option<u64>>,
+    /// The number of blocks over which the rolling_withdrawal_cap is applied.
+    #[serde(
+        rename = "rollingWithdrawalBlocks",
+        default,
+        with = "::serde_with::rust::double_option",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub rolling_withdrawal_blocks: Option<Option<u64>>,
+    /// Maximum amount of sBTC that can be withdrawn in the rolling_withdrawal_blocks window.
+    #[serde(
+        rename = "rollingWithdrawalCap",
+        default,
+        with = "::serde_with::rust::double_option",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub rolling_withdrawal_cap: Option<Option<u64>>,
 }
 
 impl AccountLimits {
@@ -56,6 +72,8 @@ impl AccountLimits {
             per_deposit_cap: None,
             per_deposit_minimum: None,
             per_withdrawal_cap: None,
+            rolling_withdrawal_blocks: None,
+            rolling_withdrawal_cap: None,
         }
     }
 }

--- a/.generated-sources/emily/client/rust/private/src/models/limits.rs
+++ b/.generated-sources/emily/client/rust/private/src/models/limits.rs
@@ -49,6 +49,22 @@ pub struct Limits {
         skip_serializing_if = "Option::is_none"
     )]
     pub per_withdrawal_cap: Option<Option<u64>>,
+    /// The number of blocks over which the rolling_withdrawal_cap is applied.
+    #[serde(
+        rename = "rollingWithdrawalBlocks",
+        default,
+        with = "::serde_with::rust::double_option",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub rolling_withdrawal_blocks: Option<Option<u64>>,
+    /// Maximum amount of sBTC that can be withdrawn in the rolling_withdrawal_blocks window.
+    #[serde(
+        rename = "rollingWithdrawalCap",
+        default,
+        with = "::serde_with::rust::double_option",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub rolling_withdrawal_cap: Option<Option<u64>>,
 }
 
 impl Limits {
@@ -60,6 +76,8 @@ impl Limits {
             per_deposit_cap: None,
             per_deposit_minimum: None,
             per_withdrawal_cap: None,
+            rolling_withdrawal_blocks: None,
+            rolling_withdrawal_cap: None,
         }
     }
 }

--- a/.generated-sources/emily/client/rust/public/docs/AccountLimits.md
+++ b/.generated-sources/emily/client/rust/public/docs/AccountLimits.md
@@ -8,6 +8,8 @@ Name | Type | Description | Notes
 **per_deposit_cap** | Option<**u64**> | Per deposit cap. If none then the cap is the same as the global per deposit cap. | [optional]
 **per_deposit_minimum** | Option<**u64**> | Per deposit minimum. If none then there is no minimum. | [optional]
 **per_withdrawal_cap** | Option<**u64**> | Per withdrawal cap. If none then the cap is the same as the global per withdrawal cap. | [optional]
+**rolling_withdrawal_blocks** | Option<**u64**> | The number of blocks over which the rolling_withdrawal_cap is applied. | [optional]
+**rolling_withdrawal_cap** | Option<**u64**> | Maximum amount of sBTC that can be withdrawn in the rolling_withdrawal_blocks window. | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/.generated-sources/emily/client/rust/public/docs/Limits.md
+++ b/.generated-sources/emily/client/rust/public/docs/Limits.md
@@ -9,6 +9,8 @@ Name | Type | Description | Notes
 **per_deposit_cap** | Option<**u64**> | Per deposit cap. If none then there is no cap. | [optional]
 **per_deposit_minimum** | Option<**u64**> | Per deposit minimum. If none then there is no minimum. | [optional]
 **per_withdrawal_cap** | Option<**u64**> | Per withdrawal cap. If none then there is no cap. | [optional]
+**rolling_withdrawal_blocks** | Option<**u64**> | The number of blocks over which the rolling_withdrawal_cap is applied. | [optional]
+**rolling_withdrawal_cap** | Option<**u64**> | Maximum amount of sBTC that can be withdrawn in the rolling_withdrawal_blocks window. | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/.generated-sources/emily/client/rust/public/src/models/account_limits.rs
+++ b/.generated-sources/emily/client/rust/public/src/models/account_limits.rs
@@ -46,6 +46,22 @@ pub struct AccountLimits {
         skip_serializing_if = "Option::is_none"
     )]
     pub per_withdrawal_cap: Option<Option<u64>>,
+    /// The number of blocks over which the rolling_withdrawal_cap is applied.
+    #[serde(
+        rename = "rollingWithdrawalBlocks",
+        default,
+        with = "::serde_with::rust::double_option",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub rolling_withdrawal_blocks: Option<Option<u64>>,
+    /// Maximum amount of sBTC that can be withdrawn in the rolling_withdrawal_blocks window.
+    #[serde(
+        rename = "rollingWithdrawalCap",
+        default,
+        with = "::serde_with::rust::double_option",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub rolling_withdrawal_cap: Option<Option<u64>>,
 }
 
 impl AccountLimits {
@@ -56,6 +72,8 @@ impl AccountLimits {
             per_deposit_cap: None,
             per_deposit_minimum: None,
             per_withdrawal_cap: None,
+            rolling_withdrawal_blocks: None,
+            rolling_withdrawal_cap: None,
         }
     }
 }

--- a/.generated-sources/emily/client/rust/public/src/models/limits.rs
+++ b/.generated-sources/emily/client/rust/public/src/models/limits.rs
@@ -49,6 +49,22 @@ pub struct Limits {
         skip_serializing_if = "Option::is_none"
     )]
     pub per_withdrawal_cap: Option<Option<u64>>,
+    /// The number of blocks over which the rolling_withdrawal_cap is applied.
+    #[serde(
+        rename = "rollingWithdrawalBlocks",
+        default,
+        with = "::serde_with::rust::double_option",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub rolling_withdrawal_blocks: Option<Option<u64>>,
+    /// Maximum amount of sBTC that can be withdrawn in the rolling_withdrawal_blocks window.
+    #[serde(
+        rename = "rollingWithdrawalCap",
+        default,
+        with = "::serde_with::rust::double_option",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub rolling_withdrawal_cap: Option<Option<u64>>,
 }
 
 impl Limits {
@@ -60,6 +76,8 @@ impl Limits {
             per_deposit_cap: None,
             per_deposit_minimum: None,
             per_withdrawal_cap: None,
+            rolling_withdrawal_blocks: None,
+            rolling_withdrawal_cap: None,
         }
     }
 }

--- a/.generated-sources/emily/client/rust/testing/docs/AccountLimits.md
+++ b/.generated-sources/emily/client/rust/testing/docs/AccountLimits.md
@@ -8,6 +8,8 @@ Name | Type | Description | Notes
 **per_deposit_cap** | Option<**u64**> | Per deposit cap. If none then the cap is the same as the global per deposit cap. | [optional]
 **per_deposit_minimum** | Option<**u64**> | Per deposit minimum. If none then there is no minimum. | [optional]
 **per_withdrawal_cap** | Option<**u64**> | Per withdrawal cap. If none then the cap is the same as the global per withdrawal cap. | [optional]
+**rolling_withdrawal_blocks** | Option<**u64**> | The number of blocks over which the rolling_withdrawal_cap is applied. | [optional]
+**rolling_withdrawal_cap** | Option<**u64**> | Maximum amount of sBTC that can be withdrawn in the rolling_withdrawal_blocks window. | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/.generated-sources/emily/client/rust/testing/docs/Limits.md
+++ b/.generated-sources/emily/client/rust/testing/docs/Limits.md
@@ -9,6 +9,8 @@ Name | Type | Description | Notes
 **per_deposit_cap** | Option<**u64**> | Per deposit cap. If none then there is no cap. | [optional]
 **per_deposit_minimum** | Option<**u64**> | Per deposit minimum. If none then there is no minimum. | [optional]
 **per_withdrawal_cap** | Option<**u64**> | Per withdrawal cap. If none then there is no cap. | [optional]
+**rolling_withdrawal_blocks** | Option<**u64**> | The number of blocks over which the rolling_withdrawal_cap is applied. | [optional]
+**rolling_withdrawal_cap** | Option<**u64**> | Maximum amount of sBTC that can be withdrawn in the rolling_withdrawal_blocks window. | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/.generated-sources/emily/client/rust/testing/src/models/account_limits.rs
+++ b/.generated-sources/emily/client/rust/testing/src/models/account_limits.rs
@@ -46,6 +46,22 @@ pub struct AccountLimits {
         skip_serializing_if = "Option::is_none"
     )]
     pub per_withdrawal_cap: Option<Option<u64>>,
+    /// The number of blocks over which the rolling_withdrawal_cap is applied.
+    #[serde(
+        rename = "rollingWithdrawalBlocks",
+        default,
+        with = "::serde_with::rust::double_option",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub rolling_withdrawal_blocks: Option<Option<u64>>,
+    /// Maximum amount of sBTC that can be withdrawn in the rolling_withdrawal_blocks window.
+    #[serde(
+        rename = "rollingWithdrawalCap",
+        default,
+        with = "::serde_with::rust::double_option",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub rolling_withdrawal_cap: Option<Option<u64>>,
 }
 
 impl AccountLimits {
@@ -56,6 +72,8 @@ impl AccountLimits {
             per_deposit_cap: None,
             per_deposit_minimum: None,
             per_withdrawal_cap: None,
+            rolling_withdrawal_blocks: None,
+            rolling_withdrawal_cap: None,
         }
     }
 }

--- a/.generated-sources/emily/client/rust/testing/src/models/limits.rs
+++ b/.generated-sources/emily/client/rust/testing/src/models/limits.rs
@@ -49,6 +49,22 @@ pub struct Limits {
         skip_serializing_if = "Option::is_none"
     )]
     pub per_withdrawal_cap: Option<Option<u64>>,
+    /// The number of blocks over which the rolling_withdrawal_cap is applied.
+    #[serde(
+        rename = "rollingWithdrawalBlocks",
+        default,
+        with = "::serde_with::rust::double_option",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub rolling_withdrawal_blocks: Option<Option<u64>>,
+    /// Maximum amount of sBTC that can be withdrawn in the rolling_withdrawal_blocks window.
+    #[serde(
+        rename = "rollingWithdrawalCap",
+        default,
+        with = "::serde_with::rust::double_option",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub rolling_withdrawal_cap: Option<Option<u64>>,
 }
 
 impl Limits {
@@ -60,6 +76,8 @@ impl Limits {
             per_deposit_cap: None,
             per_deposit_minimum: None,
             per_withdrawal_cap: None,
+            rolling_withdrawal_blocks: None,
+            rolling_withdrawal_cap: None,
         }
     }
 }

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -128,6 +128,8 @@ services:
       - DEFAULT_PEG_CAP=100000000000
       - DEFAULT_PER_DEPOSIT_CAP=100000000
       - DEFAULT_PER_WITHDRAWAL_CAP=100000000
+      - DEFAULT_ROLLING_WITHDRAWAL_BLOCKS=144
+      - DEFAULT_ROLLING_WITHDRAWAL_CAP=100000000000
       - DEPLOYER_ADDRESS=SN3R84XZYA63QS28932XQF3G1J8R9PC3W76P9CSQS
     ports:
       - "3031:3031"
@@ -676,7 +678,7 @@ services:
     restart: always
     ports:
       - 9598
-    volumes: 
+    volumes:
       - ./observability/vector.toml:/etc/vector/vector.toml:ro
       # This is needed for vector to read logs from other containers
       - /var/run/docker.sock:/var/run/docker.sock

--- a/emily/handler/src/api/handlers/limits.rs
+++ b/emily/handler/src/api/handlers/limits.rs
@@ -73,6 +73,8 @@ pub async fn set_limits(context: EmilyContext, limits: Limits) -> impl warp::rep
                     per_deposit_minimum: limits.per_deposit_minimum,
                     per_deposit_cap: limits.per_deposit_cap,
                     per_withdrawal_cap: limits.per_withdrawal_cap,
+                    rolling_withdrawal_blocks: limits.rolling_withdrawal_blocks,
+                    rolling_withdrawal_cap: limits.rolling_withdrawal_cap,
                 },
             ),
         )

--- a/emily/handler/src/api/models/limits.rs
+++ b/emily/handler/src/api/models/limits.rs
@@ -17,6 +17,10 @@ pub struct Limits {
     pub per_deposit_cap: Option<u64>,
     /// Per withdrawal cap. If none then there is no cap.
     pub per_withdrawal_cap: Option<u64>,
+    /// The number of blocks over which the rolling_withdrawal_cap is applied.
+    pub rolling_withdrawal_blocks: Option<u64>,
+    /// Maximum amount of sBTC that can be withdrawn in the rolling_withdrawal_blocks window.
+    pub rolling_withdrawal_cap: Option<u64>,
     /// Represents the individual limits for requests coming from different accounts.
     pub account_caps: HashMap<String, AccountLimits>,
 }
@@ -46,4 +50,8 @@ pub struct AccountLimits {
     pub per_deposit_cap: Option<u64>,
     /// Per withdrawal cap. If none then the cap is the same as the global per withdrawal cap.
     pub per_withdrawal_cap: Option<u64>,
+    /// The number of blocks over which the rolling_withdrawal_cap is applied.
+    pub rolling_withdrawal_blocks: Option<u64>,
+    /// Maximum amount of sBTC that can be withdrawn in the rolling_withdrawal_blocks window.
+    pub rolling_withdrawal_cap: Option<u64>,
 }

--- a/emily/handler/src/context.rs
+++ b/emily/handler/src/context.rs
@@ -98,6 +98,14 @@ impl Settings {
                     .ok()
                     .map(|v| v.parse())
                     .transpose()?,
+                rolling_withdrawal_blocks: env::var("DEFAULT_ROLLING_WITHDRAWAL_BLOCKS")
+                    .ok()
+                    .map(|v| v.parse())
+                    .transpose()?,
+                rolling_withdrawal_cap: env::var("DEFAULT_ROLLING_WITHDRAWAL_CAP")
+                    .ok()
+                    .map(|v| v.parse())
+                    .transpose()?,
             },
             trusted_reorg_api_key: env::var("TRUSTED_REORG_API_KEY")?,
             is_mainnet: env::var("IS_MAINNET")?.to_lowercase() == "true",

--- a/emily/handler/src/database/accessors.rs
+++ b/emily/handler/src/database/accessors.rs
@@ -720,6 +720,8 @@ pub async fn get_limits(context: &EmilyContext) -> Result<Limits, Error> {
         per_deposit_minimum: default_global_cap.per_deposit_minimum,
         per_deposit_cap: default_global_cap.per_deposit_cap,
         per_withdrawal_cap: default_global_cap.per_withdrawal_cap,
+        rolling_withdrawal_blocks: default_global_cap.rolling_withdrawal_blocks,
+        rolling_withdrawal_cap: default_global_cap.rolling_withdrawal_cap,
     };
     // Aggregate all the latest entries by account.
     let mut limit_by_account: HashMap<String, LimitEntry> = HashMap::new();
@@ -757,6 +759,8 @@ pub async fn get_limits(context: &EmilyContext) -> Result<Limits, Error> {
         per_deposit_minimum: global_cap.per_deposit_minimum,
         per_deposit_cap: global_cap.per_deposit_cap,
         per_withdrawal_cap: global_cap.per_withdrawal_cap,
+        rolling_withdrawal_blocks: global_cap.rolling_withdrawal_blocks,
+        rolling_withdrawal_cap: global_cap.rolling_withdrawal_cap,
         account_caps,
     })
 }

--- a/emily/handler/src/database/entries/limits.rs
+++ b/emily/handler/src/database/entries/limits.rs
@@ -38,6 +38,10 @@ pub struct LimitEntry {
     pub per_deposit_cap: Option<u64>,
     /// Per withdrawal cap. If none then the cap is the same as the global per withdrawal cap.
     pub per_withdrawal_cap: Option<u64>,
+    /// The number of blocks over which the rolling_withdrawal_cap is applied.
+    pub rolling_withdrawal_blocks: Option<u64>,
+    /// Maximum amount of sBTC that can be withdrawn in the rolling_withdrawal_blocks window.
+    pub rolling_withdrawal_cap: Option<u64>,
 }
 
 /// Convert from entry to its corresponding limit.
@@ -48,6 +52,8 @@ impl From<LimitEntry> for AccountLimits {
             per_deposit_minimum: limit_entry.per_deposit_minimum,
             per_deposit_cap: limit_entry.per_deposit_cap,
             per_withdrawal_cap: limit_entry.per_withdrawal_cap,
+            rolling_withdrawal_blocks: limit_entry.rolling_withdrawal_blocks,
+            rolling_withdrawal_cap: limit_entry.rolling_withdrawal_cap,
         }
     }
 }
@@ -72,6 +78,8 @@ impl LimitEntry {
             per_deposit_minimum: account_limit.per_deposit_minimum,
             per_deposit_cap: account_limit.per_deposit_cap,
             per_withdrawal_cap: account_limit.per_withdrawal_cap,
+            rolling_withdrawal_blocks: account_limit.rolling_withdrawal_blocks,
+            rolling_withdrawal_cap: account_limit.rolling_withdrawal_cap,
         }
     }
     /// Returns true if the limit entry has no limits set.

--- a/emily/handler/tests/integration/limits.rs
+++ b/emily/handler/tests/integration/limits.rs
@@ -16,6 +16,8 @@ async fn empty_default_is_as_expected() {
         per_deposit_minimum: Some(None),
         per_deposit_cap: Some(None),
         per_withdrawal_cap: Some(None),
+        rolling_withdrawal_blocks: Some(None),
+        rolling_withdrawal_cap: Some(None),
         account_caps: HashMap::new(),
     };
 
@@ -40,6 +42,8 @@ async fn adding_and_then_updating_single_accout_limit_works() {
                 per_deposit_minimum: Some(Some(100)),
                 per_deposit_cap: Some(Some(100)),
                 per_withdrawal_cap: Some(Some(100)),
+                rolling_withdrawal_blocks: Some(Some(100)),
+                rolling_withdrawal_cap: Some(Some(100)),
             },
         ),
         (
@@ -49,6 +53,8 @@ async fn adding_and_then_updating_single_accout_limit_works() {
                 per_deposit_minimum: Some(Some(1200)),
                 per_deposit_cap: Some(Some(1200)),
                 per_withdrawal_cap: Some(Some(1200)),
+                rolling_withdrawal_blocks: Some(Some(1200)),
+                rolling_withdrawal_cap: Some(Some(1200)),
             },
         ),
         (
@@ -58,6 +64,8 @@ async fn adding_and_then_updating_single_accout_limit_works() {
                 per_deposit_minimum: Some(Some(200)),
                 per_deposit_cap: Some(Some(300)),
                 per_withdrawal_cap: Some(Some(500)),
+                rolling_withdrawal_blocks: Some(Some(600)),
+                rolling_withdrawal_cap: Some(Some(700)),
             },
         ),
         (
@@ -67,6 +75,8 @@ async fn adding_and_then_updating_single_accout_limit_works() {
                 per_deposit_minimum: Some(Some(200)),
                 per_deposit_cap: Some(Some(200)),
                 per_withdrawal_cap: Some(Some(200)),
+                rolling_withdrawal_blocks: Some(Some(200)),
+                rolling_withdrawal_cap: Some(Some(200)),
             },
         ),
         (
@@ -76,6 +86,8 @@ async fn adding_and_then_updating_single_accout_limit_works() {
                 per_deposit_minimum: Some(Some(300)),
                 per_deposit_cap: Some(Some(300)),
                 per_withdrawal_cap: Some(Some(300)),
+                rolling_withdrawal_blocks: Some(Some(300)),
+                rolling_withdrawal_cap: Some(Some(300)),
             },
         ),
     ];
@@ -90,6 +102,8 @@ async fn adding_and_then_updating_single_accout_limit_works() {
                 per_deposit_minimum: Some(Some(200)),
                 per_deposit_cap: Some(Some(200)),
                 per_withdrawal_cap: Some(Some(200)),
+                rolling_withdrawal_blocks: Some(Some(200)),
+                rolling_withdrawal_cap: Some(Some(200)),
             },
         ),
         (
@@ -99,6 +113,8 @@ async fn adding_and_then_updating_single_accout_limit_works() {
                 per_deposit_minimum: Some(Some(300)),
                 per_deposit_cap: Some(Some(300)),
                 per_withdrawal_cap: Some(Some(300)),
+                rolling_withdrawal_blocks: Some(Some(300)),
+                rolling_withdrawal_cap: Some(Some(300)),
             },
         ),
     ]
@@ -112,6 +128,8 @@ async fn adding_and_then_updating_single_accout_limit_works() {
         per_deposit_minimum: Some(None),
         per_deposit_cap: Some(None),
         per_withdrawal_cap: Some(None),
+        rolling_withdrawal_blocks: Some(None),
+        rolling_withdrawal_cap: Some(None),
         account_caps: expected_account_caps.clone(),
     };
 
@@ -164,6 +182,8 @@ async fn test_updating_account_limits_via_global_limit_works() {
                 per_deposit_minimum: Some(Some(100)),
                 per_deposit_cap: Some(Some(100)),
                 per_withdrawal_cap: Some(Some(100)),
+                rolling_withdrawal_blocks: Some(Some(100)),
+                rolling_withdrawal_cap: Some(Some(100)),
             },
         ),
         (
@@ -173,6 +193,8 @@ async fn test_updating_account_limits_via_global_limit_works() {
                 per_deposit_minimum: Some(Some(150)),
                 per_deposit_cap: Some(Some(150)),
                 per_withdrawal_cap: Some(Some(150)),
+                rolling_withdrawal_blocks: Some(Some(150)),
+                rolling_withdrawal_cap: Some(Some(150)),
             },
         ),
         (
@@ -182,6 +204,8 @@ async fn test_updating_account_limits_via_global_limit_works() {
                 per_deposit_minimum: Some(Some(150)),
                 per_deposit_cap: Some(Some(150)),
                 per_withdrawal_cap: Some(Some(150)),
+                rolling_withdrawal_blocks: Some(Some(150)),
+                rolling_withdrawal_cap: Some(Some(150)),
             },
         ),
     ];
@@ -196,6 +220,8 @@ async fn test_updating_account_limits_via_global_limit_works() {
                 per_deposit_minimum: Some(Some(200)),
                 per_deposit_cap: Some(Some(200)),
                 per_withdrawal_cap: Some(Some(200)),
+                rolling_withdrawal_blocks: Some(Some(200)),
+                rolling_withdrawal_cap: Some(Some(200)),
             },
         ),
         (
@@ -205,6 +231,8 @@ async fn test_updating_account_limits_via_global_limit_works() {
                 per_deposit_minimum: Some(Some(300)),
                 per_deposit_cap: Some(Some(300)),
                 per_withdrawal_cap: Some(Some(300)),
+                rolling_withdrawal_blocks: Some(Some(300)),
+                rolling_withdrawal_cap: Some(Some(300)),
             },
         ),
         // Set all the values to none so this account should no longer show up
@@ -216,6 +244,8 @@ async fn test_updating_account_limits_via_global_limit_works() {
                 per_deposit_minimum: Some(None),
                 per_deposit_cap: Some(None),
                 per_withdrawal_cap: Some(None),
+                rolling_withdrawal_blocks: Some(None),
+                rolling_withdrawal_cap: Some(None),
             },
         ),
     ]
@@ -227,6 +257,8 @@ async fn test_updating_account_limits_via_global_limit_works() {
         per_deposit_minimum: Some(Some(654)),
         per_deposit_cap: Some(Some(456)),
         per_withdrawal_cap: Some(Some(789)),
+        rolling_withdrawal_blocks: Some(Some(101)),
+        rolling_withdrawal_cap: Some(Some(112)),
         account_caps: account_limits_to_set_globally.clone(),
     };
 
@@ -240,6 +272,8 @@ async fn test_updating_account_limits_via_global_limit_works() {
                 per_deposit_minimum: Some(Some(100)),
                 per_deposit_cap: Some(Some(100)),
                 per_withdrawal_cap: Some(Some(100)),
+                rolling_withdrawal_blocks: Some(Some(100)),
+                rolling_withdrawal_cap: Some(Some(100)),
             },
         ),
         (
@@ -249,6 +283,8 @@ async fn test_updating_account_limits_via_global_limit_works() {
                 per_deposit_minimum: Some(Some(200)),
                 per_deposit_cap: Some(Some(200)),
                 per_withdrawal_cap: Some(Some(200)),
+                rolling_withdrawal_blocks: Some(Some(200)),
+                rolling_withdrawal_cap: Some(Some(200)),
             },
         ),
         (
@@ -258,6 +294,8 @@ async fn test_updating_account_limits_via_global_limit_works() {
                 per_deposit_minimum: Some(Some(300)),
                 per_deposit_cap: Some(Some(300)),
                 per_withdrawal_cap: Some(Some(300)),
+                rolling_withdrawal_blocks: Some(Some(300)),
+                rolling_withdrawal_cap: Some(Some(300)),
             },
         ),
     ]
@@ -269,6 +307,8 @@ async fn test_updating_account_limits_via_global_limit_works() {
         per_deposit_minimum: Some(Some(654)),
         per_deposit_cap: Some(Some(456)),
         per_withdrawal_cap: Some(Some(789)),
+        rolling_withdrawal_blocks: Some(Some(101)),
+        rolling_withdrawal_cap: Some(Some(112)),
         account_caps: expected_global_account_limits.clone(),
     };
 

--- a/emily/openapi-gen/generated-specs/private-emily-openapi-spec.json
+++ b/emily/openapi-gen/generated-specs/private-emily-openapi-spec.json
@@ -2229,6 +2229,20 @@
             "description": "Per withdrawal cap. If none then the cap is the same as the global per withdrawal cap.",
             "nullable": true,
             "minimum": 0
+          },
+          "rollingWithdrawalBlocks": {
+            "type": "integer",
+            "format": "int64",
+            "description": "The number of blocks over which the rolling_withdrawal_cap is applied.",
+            "nullable": true,
+            "minimum": 0
+          },
+          "rollingWithdrawalCap": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Maximum amount of sBTC that can be withdrawn in the rolling_withdrawal_blocks window.",
+            "nullable": true,
+            "minimum": 0
           }
         }
       },
@@ -2710,6 +2724,20 @@
             "type": "integer",
             "format": "int64",
             "description": "Per withdrawal cap. If none then there is no cap.",
+            "nullable": true,
+            "minimum": 0
+          },
+          "rollingWithdrawalBlocks": {
+            "type": "integer",
+            "format": "int64",
+            "description": "The number of blocks over which the rolling_withdrawal_cap is applied.",
+            "nullable": true,
+            "minimum": 0
+          },
+          "rollingWithdrawalCap": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Maximum amount of sBTC that can be withdrawn in the rolling_withdrawal_blocks window.",
             "nullable": true,
             "minimum": 0
           }

--- a/emily/openapi-gen/generated-specs/public-emily-openapi-spec.json
+++ b/emily/openapi-gen/generated-specs/public-emily-openapi-spec.json
@@ -1848,6 +1848,20 @@
             "description": "Per withdrawal cap. If none then the cap is the same as the global per withdrawal cap.",
             "nullable": true,
             "minimum": 0
+          },
+          "rollingWithdrawalBlocks": {
+            "type": "integer",
+            "format": "int64",
+            "description": "The number of blocks over which the rolling_withdrawal_cap is applied.",
+            "nullable": true,
+            "minimum": 0
+          },
+          "rollingWithdrawalCap": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Maximum amount of sBTC that can be withdrawn in the rolling_withdrawal_blocks window.",
+            "nullable": true,
+            "minimum": 0
           }
         }
       },
@@ -2281,6 +2295,20 @@
             "type": "integer",
             "format": "int64",
             "description": "Per withdrawal cap. If none then there is no cap.",
+            "nullable": true,
+            "minimum": 0
+          },
+          "rollingWithdrawalBlocks": {
+            "type": "integer",
+            "format": "int64",
+            "description": "The number of blocks over which the rolling_withdrawal_cap is applied.",
+            "nullable": true,
+            "minimum": 0
+          },
+          "rollingWithdrawalCap": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Maximum amount of sBTC that can be withdrawn in the rolling_withdrawal_blocks window.",
             "nullable": true,
             "minimum": 0
           }

--- a/emily/openapi-gen/generated-specs/testing-emily-openapi-spec.json
+++ b/emily/openapi-gen/generated-specs/testing-emily-openapi-spec.json
@@ -2410,6 +2410,20 @@
             "description": "Per withdrawal cap. If none then the cap is the same as the global per withdrawal cap.",
             "nullable": true,
             "minimum": 0
+          },
+          "rollingWithdrawalBlocks": {
+            "type": "integer",
+            "format": "int64",
+            "description": "The number of blocks over which the rolling_withdrawal_cap is applied.",
+            "nullable": true,
+            "minimum": 0
+          },
+          "rollingWithdrawalCap": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Maximum amount of sBTC that can be withdrawn in the rolling_withdrawal_blocks window.",
+            "nullable": true,
+            "minimum": 0
           }
         }
       },
@@ -2891,6 +2905,20 @@
             "type": "integer",
             "format": "int64",
             "description": "Per withdrawal cap. If none then there is no cap.",
+            "nullable": true,
+            "minimum": 0
+          },
+          "rollingWithdrawalBlocks": {
+            "type": "integer",
+            "format": "int64",
+            "description": "The number of blocks over which the rolling_withdrawal_cap is applied.",
+            "nullable": true,
+            "minimum": 0
+          },
+          "rollingWithdrawalCap": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Maximum amount of sBTC that can be withdrawn in the rolling_withdrawal_blocks window.",
             "nullable": true,
             "minimum": 0
           }


### PR DESCRIPTION
## Description

First step of #1504 

This PR adds support for rolling withdrawal limits in Emily. Specifically, it introduces two new fields:

- `rolling_withdrawal_cap`: The maximum amount of sBTC that can be withdrawn over a specified number of blocks.
- `rolling_withdrawal_blocks`: The number of blocks over which the cap is applied.

These new limits are now stored in the database, exposed via the `GET /limits` endpoint, and configurable via the `POST /limits` endpoint. 


## Changes
- Updated the limits table and related models to store `rolling_withdrawal_cap` and `rolling_withdrawal_blocks`.
- Modified the `POST /limits` endpoint to accept the new fields.
- Updated the `GET /limits` endpoint to return the new fields.
- Updated the `docker-compose.yml` file to include default values for the new limits.
- Adjusted the `EmilyContext` settings to load `DEFAULT_ROLLING_WITHDRAWAL_BLOCKS` and `DEFAULT_ROLLING_WITHDRAWAL_CAP` from environment variables.
- Updated integration tests to validate the new fields.

## Testing Information
- Updated integration tests to validate the new fields.

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
