### PR TITLE
feat: signer get rolling withdrawals limits from Emily

### DIFF
--- a/signer/src/bitcoin/utxo.rs
+++ b/signer/src/bitcoin/utxo.rs
@@ -1637,6 +1637,8 @@ mod tests {
             Some(Amount::from_sat(per_deposit_minimum)),
             Some(Amount::from_sat(per_deposit_cap)),
             None,
+            None,
+            None,
             Some(Amount::from_sat(max_mintable_cap)),
         )
     }

--- a/signer/src/bitcoin/validation.rs
+++ b/signer/src/bitcoin/validation.rs
@@ -2019,6 +2019,8 @@ mod tests {
             None,
             None,
             None,
+            None,
+            None,
             Some(total_cap - sbtc_supply),
         ));
         // Create cache with test data

--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -574,6 +574,8 @@ impl<C: Context, B> BlockObserver<C, B> {
             Some(limits.per_deposit_minimum()),
             Some(limits.per_deposit_cap()),
             Some(limits.per_withdrawal_cap()),
+            Some(limits.rolling_withdrawal_blocks()),
+            Some(limits.rolling_withdrawal_cap()),
             Some(max_mintable),
         );
 

--- a/signer/src/context/signer_state.rs
+++ b/signer/src/context/signer_state.rs
@@ -137,6 +137,10 @@ pub struct SbtcLimits {
     per_withdrawal_cap: Option<Amount>,
     /// Represents the maximum amount of sBTC that can currently be minted.
     max_mintable_cap: Option<Amount>,
+    /// Represents the number of blocks over which the rolling withdrawal cap is applied.
+    rolling_withdrawal_blocks: Option<u64>,
+    /// Represents the maximum amount of sBTC that can be withdrawn in the rolling withdrawal blocks window.
+    rolling_withdrawal_cap: Option<Amount>,
 }
 
 impl std::fmt::Display for SbtcLimits {
@@ -156,6 +160,8 @@ impl SbtcLimits {
         per_deposit_minimum: Option<Amount>,
         per_deposit_cap: Option<Amount>,
         per_withdrawal_cap: Option<Amount>,
+        rolling_withdrawal_blocks: Option<u64>,
+        rolling_withdrawal_cap: Option<Amount>,
         max_mintable_cap: Option<Amount>,
     ) -> Self {
         Self {
@@ -163,6 +169,8 @@ impl SbtcLimits {
             per_deposit_minimum,
             per_deposit_cap,
             per_withdrawal_cap,
+            rolling_withdrawal_blocks,
+            rolling_withdrawal_cap,
             max_mintable_cap,
         }
     }
@@ -173,6 +181,8 @@ impl SbtcLimits {
             Some(Amount::ZERO),
             Some(Amount::MAX_MONEY),
             Some(Amount::ZERO),
+            Some(Amount::ZERO),
+            Some(u64::MAX),
             Some(Amount::ZERO),
             Some(Amount::ZERO),
         )
@@ -207,6 +217,16 @@ impl SbtcLimits {
     pub fn max_mintable_cap(&self) -> Amount {
         self.max_mintable_cap.unwrap_or(Amount::MAX_MONEY)
     }
+
+    /// Get the number of blocks over which the rolling withdrawal cap is applied.
+    pub fn rolling_withdrawal_blocks(&self) -> u64 {
+        self.rolling_withdrawal_blocks.unwrap_or(0)
+    }
+
+    /// Get the maximum amount of sBTC that can be withdrawn in the rolling withdrawal blocks window.
+    pub fn rolling_withdrawal_cap(&self) -> Amount {
+        self.rolling_withdrawal_cap.unwrap_or(Amount::MAX_MONEY)
+    }
 }
 
 #[cfg(any(test, feature = "testing"))]
@@ -218,6 +238,8 @@ impl SbtcLimits {
             per_deposit_minimum: Some(Amount::ZERO),
             per_deposit_cap: Some(Amount::MAX_MONEY),
             per_withdrawal_cap: Some(Amount::MAX_MONEY),
+            rolling_withdrawal_blocks: Some(0),
+            rolling_withdrawal_cap: Some(Amount::MAX_MONEY),
             max_mintable_cap: Some(Amount::MAX_MONEY),
         }
     }
@@ -230,6 +252,8 @@ impl SbtcLimits {
             per_deposit_minimum: Some(Amount::from_sat(min)),
             per_deposit_cap: Some(Amount::from_sat(max)),
             per_withdrawal_cap: None,
+            rolling_withdrawal_blocks: None,
+            rolling_withdrawal_cap: None,
             max_mintable_cap: None,
         }
     }
@@ -241,6 +265,8 @@ impl SbtcLimits {
             per_deposit_minimum: None,
             per_deposit_cap: None,
             per_withdrawal_cap: Some(Amount::from_sat(max)),
+            rolling_withdrawal_blocks: None,
+            rolling_withdrawal_cap: None,
             max_mintable_cap: None,
         }
     }

--- a/signer/src/context/signer_state.rs
+++ b/signer/src/context/signer_state.rs
@@ -135,20 +135,20 @@ pub struct SbtcLimits {
     per_deposit_cap: Option<Amount>,
     /// Represents the maximum amount of sBTC allowed to be pegged-out per transaction.
     per_withdrawal_cap: Option<Amount>,
-    /// Represents the maximum amount of sBTC that can currently be minted.
-    max_mintable_cap: Option<Amount>,
     /// Represents the number of blocks over which the rolling withdrawal cap is applied.
     rolling_withdrawal_blocks: Option<u64>,
     /// Represents the maximum amount of sBTC that can be withdrawn in the rolling withdrawal blocks window.
     rolling_withdrawal_cap: Option<Amount>,
+    /// Represents the maximum amount of sBTC that can currently be minted.
+    max_mintable_cap: Option<Amount>,
 }
 
 impl std::fmt::Display for SbtcLimits {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "[total cap: {:?}, per-deposit min: {:?}, per-deposit cap: {:?}, per-withdrawal cap: {:?}, max-mintable cap: {:?}]",
-            self.total_cap, self.per_deposit_minimum, self.per_deposit_cap, self.per_withdrawal_cap, self.max_mintable_cap
+            "[total cap: {:?}, per-deposit min: {:?}, per-deposit cap: {:?}, per-withdrawal cap: {:?}, max-mintable cap: {:?}, rolling-withdrawal blocks: {:?}, rolling-withdrawal cap: {:?}]",
+            self.total_cap, self.per_deposit_minimum, self.per_deposit_cap, self.per_withdrawal_cap, self.max_mintable_cap, self.rolling_withdrawal_blocks, self.rolling_withdrawal_cap
         )
     }
 }

--- a/signer/src/emily_client.rs
+++ b/signer/src/emily_client.rs
@@ -380,12 +380,20 @@ impl EmilyInteract for EmilyClient {
         let per_withdrawal_cap = limits
             .per_withdrawal_cap
             .and_then(|cap| cap.map(Amount::from_sat));
+        let rolling_withdrawal_blocks = limits
+            .rolling_withdrawal_blocks
+            .and_then(|blocks| blocks.map(|b| b as u64));
+        let rolling_withdrawal_cap = limits
+            .rolling_withdrawal_cap
+            .and_then(|cap| cap.map(Amount::from_sat));
 
         Ok(SbtcLimits::new(
             total_cap,
             per_deposit_minimum,
             per_deposit_cap,
             per_withdrawal_cap,
+            rolling_withdrawal_blocks,
+            rolling_withdrawal_cap,
             None,
         ))
     }

--- a/signer/src/emily_client.rs
+++ b/signer/src/emily_client.rs
@@ -370,22 +370,15 @@ impl EmilyInteract for EmilyClient {
             .map_err(EmilyClientError::GetLimits)
             .map_err(Error::EmilyApi)?;
 
-        let total_cap = limits.peg_cap.and_then(|cap| cap.map(Amount::from_sat));
-        let per_deposit_minimum: Option<Amount> = limits
-            .per_deposit_minimum
-            .and_then(|min| min.map(Amount::from_sat));
-        let per_deposit_cap = limits
-            .per_deposit_cap
-            .and_then(|cap| cap.map(Amount::from_sat));
-        let per_withdrawal_cap = limits
-            .per_withdrawal_cap
-            .and_then(|cap| cap.map(Amount::from_sat));
-        let rolling_withdrawal_blocks = limits
-            .rolling_withdrawal_blocks
-            .and_then(|blocks| blocks.map(|b| b as u64));
+        let total_cap = limits.peg_cap.flatten().map(Amount::from_sat);
+        let per_deposit_minimum = limits.per_deposit_minimum.flatten().map(Amount::from_sat);
+        let per_deposit_cap = limits.per_deposit_cap.flatten().map(Amount::from_sat);
+        let per_withdrawal_cap = limits.per_withdrawal_cap.flatten().map(Amount::from_sat);
+        let rolling_withdrawal_blocks = limits.rolling_withdrawal_blocks.flatten();
         let rolling_withdrawal_cap = limits
             .rolling_withdrawal_cap
-            .and_then(|cap| cap.map(Amount::from_sat));
+            .flatten()
+            .map(Amount::from_sat);
 
         Ok(SbtcLimits::new(
             total_cap,

--- a/signer/tests/integration/block_observer.rs
+++ b/signer/tests/integration/block_observer.rs
@@ -625,9 +625,9 @@ async fn block_observer_stores_donation_and_sbtc_utxos() {
 }
 
 #[test_case::test_case(false, SbtcLimits::unlimited(); "no contracts, default limits")]
-#[test_case::test_case(false, SbtcLimits::new(Some(bitcoin::Amount::from_sat(1_000)), None, None, None, None); "no contracts, total cap limit")]
+#[test_case::test_case(false, SbtcLimits::new(Some(bitcoin::Amount::from_sat(1_000)), None, None, None, None, None, None); "no contracts, total cap limit")]
 #[test_case::test_case(true, SbtcLimits::unlimited(); "deployed contracts, default limits")]
-#[test_case::test_case(true, SbtcLimits::new(Some(bitcoin::Amount::from_sat(1_000)), None, None, None, None); "deployed contracts, total cap limit")]
+#[test_case::test_case(true, SbtcLimits::new(Some(bitcoin::Amount::from_sat(1_000)), None, None, None, None, None, None); "deployed contracts, total cap limit")]
 #[tokio::test]
 async fn block_observer_handles_update_limits(deployed: bool, sbtc_limits: SbtcLimits) {
     // We start with the typical setup with a fresh database and context


### PR DESCRIPTION
## Description

Closes: #1504

Modified the signer's `Limits` struct to integrate the new withdrawal rolling cap parameters.

## Changes
- Add `rolling_withdrawal_blocks` to Limits
- Add `rolling_withdrawal_cap` to Limits

## Testing Information
- updated the tests 

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
