### PR TITLE
fix: stop logging the trusted api key on deployment

### DIFF
--- a/emily/handler/src/context.rs
+++ b/emily/handler/src/context.rs
@@ -56,12 +56,27 @@ pub struct EmilyContext {
 /// Implement debug print for the context struct.
 impl fmt::Debug for EmilyContext {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{}",
-            serde_json::to_string_pretty(self)
-                .expect("Failed to serialize Emily Context in debug print.")
-        )
+        f.debug_struct("Settings")
+            .field("is_local", &self.settings.is_local)
+            .field("deposit_table_name", &self.settings.deposit_table_name)
+            .field(
+                "withdrawal_table_name",
+                &self.settings.withdrawal_table_name,
+            )
+            .field(
+                "chainstate_table_name",
+                &self.settings.chainstate_table_name,
+            )
+            .field("limit_table_name", &self.settings.limit_table_name)
+            .field("default_limits", &self.settings.default_limits)
+            .field("is_mainnet", &self.settings.is_mainnet)
+            .field("version", &self.settings.version)
+            .field(
+                "deployer_address",
+                &self.settings.deployer_address.to_string(),
+            )
+            .field("api_key", &"[REDACTED]")
+            .finish()
     }
 }
 

--- a/emily/handler/src/context.rs
+++ b/emily/handler/src/context.rs
@@ -75,7 +75,7 @@ impl fmt::Debug for EmilyContext {
                 "deployer_address",
                 &self.settings.deployer_address.to_string(),
             )
-            .field("api_key", &"[REDACTED]")
+            .field("trusted_reorg_api_key", &"[REDACTED]")
             .finish()
     }
 }


### PR DESCRIPTION
## Description

On deployment, the we are logging the settings of the lambda.

https://github.com/stacks-network/sbtc/blob/394dc72e5bc31db2e51d88f3f7445a724072fa56/emily/handler/src/bin/emily-lambda.rs#L21

This PR modifies the Debug implementation of the EmilyContext to not display the api key.


## Changes
- modify Debug implementation of EmilyContext to write each field one by one, but explicitly redacting the trusted api key.


## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
