### PR TITLE
feat: validation checks withdrawal amounts against rolling cap

### DIFF
--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -671,12 +671,26 @@ pub enum Error {
     PreSignInvalidFeeRate(f64),
 
     /// Error when deposit requests would exceed sBTC supply cap
-    #[error("Total deposit amount ({total_amount} sats) would exceed sBTC supply cap (current max mintable is {max_mintable} sats)")]
+    #[error("total deposit amount ({total_amount} sats) would exceed sBTC supply cap (current max mintable is {max_mintable} sats)")]
     ExceedsSbtcSupplyCap {
         /// Total deposit amount in sats
         total_amount: u64,
         /// Maximum sBTC mintable
         max_mintable: u64,
+    },
+
+    /// Error when withdrawal requests would exceed sBTC's rolling withdrawal caps
+    #[error("total withdrawal amounts ({withdrawal_amounts}) exceeds rolling caps ({withdrawal_cap} over
+            {withdrawal_cap_blocks}) with the currently withdrawn total {withdrawn_total})")]
+    ExceedsSbtcWithdrawalCap {
+        /// Total deposit amount in sats
+        withdrawal_amounts: u64,
+        /// The rolling withdrawal maximum
+        withdrawal_cap: u64,
+        /// The number of bitcoin blocks that are used in the rolling withdrawal cap
+        withdrawal_cap_blocks: u64,
+        /// The currently withdrawal total over the last N bitcoin blocks.
+        withdrawn_total: u64,
     },
 
     /// An error which can be used in test code instead of `unimplemented!()` or

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -3,6 +3,7 @@ use std::borrow::Cow;
 
 use blockstack_lib::types::chainstate::StacksBlockId;
 
+use crate::bitcoin::validation::WithdrawalCapContext;
 use crate::blocklist_client::BlocklistClientError;
 use crate::codec;
 use crate::dkg;
@@ -680,18 +681,10 @@ pub enum Error {
     },
 
     /// Error when withdrawal requests would exceed sBTC's rolling withdrawal caps
-    #[error("total withdrawal amounts ({withdrawal_amounts}) exceeds rolling caps ({withdrawal_cap} over
-            {withdrawal_cap_blocks}) with the currently withdrawn total {withdrawn_total})")]
-    ExceedsSbtcWithdrawalCap {
-        /// Total deposit amount in sats
-        withdrawal_amounts: u64,
-        /// The rolling withdrawal maximum
-        withdrawal_cap: u64,
-        /// The number of bitcoin blocks that are used in the rolling withdrawal cap
-        withdrawal_cap_blocks: u64,
-        /// The currently withdrawal total over the last N bitcoin blocks.
-        withdrawn_total: u64,
-    },
+    #[error("total withdrawal amounts ({amounts}) exceeds rolling caps ({cap} over
+            {cap_blocks}) with the currently withdrawn total {withdrawn_total})", 
+            amounts = .0.amounts, cap = .0.cap, cap_blocks = .0.cap_blocks, withdrawn_total = .0.withdrawn_total)]
+    ExceedsWithdrawalCap(WithdrawalCapContext),
 
     /// An error which can be used in test code instead of `unimplemented!()` or
     /// other alternatives, so that an an actual error is returned instead of

--- a/signer/src/storage/in_memory.rs
+++ b/signer/src/storage/in_memory.rs
@@ -832,6 +832,14 @@ impl super::DbRead for SharedStore {
         unimplemented!()
     }
 
+    async fn compute_withdrawn_total(
+        &self,
+        _: &model::BitcoinBlockHash,
+        _: u16,
+    ) -> Result<u64, Error> {
+        unimplemented!()
+    }
+
     async fn get_bitcoin_tx(
         &self,
         txid: &model::BitcoinTxId,

--- a/signer/src/storage/mod.rs
+++ b/signer/src/storage/mod.rs
@@ -241,6 +241,15 @@ pub trait DbRead {
         signer_public_key: &PublicKey,
     ) -> impl Future<Output = Result<Option<WithdrawalRequestReport>, Error>> + Send;
 
+    /// This function returns the total amount of BTC (in sats) that has
+    /// been swept out and confirmed on the bitcoin blockchain identified
+    /// by the given chain tip and context window.
+    fn compute_withdrawn_total(
+        &self,
+        bitcoin_chain_tip: &model::BitcoinBlockHash,
+        context_window: u16,
+    ) -> impl Future<Output = Result<u64, Error>> + Send;
+
     /// Get bitcoin blocks that include a particular transaction
     fn get_bitcoin_blocks_with_transaction(
         &self,

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -1788,6 +1788,33 @@ impl super::DbRead for PgStore {
         }))
     }
 
+    async fn compute_withdrawn_total(
+        &self,
+        bitcoin_chain_tip: &model::BitcoinBlockHash,
+        context_window: u16,
+    ) -> Result<u64, Error> {
+        let total_amount = sqlx::query_scalar::<_, i64>(
+            r#"
+            SELECT SUM(bto.amount)
+            FROM sbtc_signer.bitcoin_tx_outputs AS bto
+            JOIN sbtc_signer.bitcoin_transactions AS bt
+              ON bt.txid = bto.txid
+            JOIN bitcoin_blockchain_of($1, $2) AS bbo
+              ON bbo.block_hash = bt.block_hash
+            WHERE bto.output_type = 'withdrawal'
+            "#,
+        )
+        .bind(bitcoin_chain_tip)
+        .bind(i32::from(context_window))
+        .fetch_one(&self.0)
+        .await
+        .map_err(Error::SqlxQuery)?;
+
+        // Amounts are always positive in the database, so this conversion
+        // is always fine.
+        u64::try_from(total_amount).map_err(|_| Error::TypeConversion)
+    }
+
     async fn get_bitcoin_blocks_with_transaction(
         &self,
         txid: &model::BitcoinTxId,

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -5975,7 +5975,7 @@ async fn compute_withdrawn_total_gets_all_amounts_in_chain() {
 }
 
 /// Check that the query in `compute_withdrawn_total` returns the total
-/// amount of withdrawal amounts in the window.
+/// amount of withdrawal amounts on the identified blockchain.
 #[tokio::test]
 async fn compute_withdrawn_total_ignores_withdrawals_not_identified_blockchain() {
     let mut db = testing::storage::new_test_database().await;
@@ -6050,7 +6050,8 @@ async fn compute_withdrawn_total_ignores_withdrawals_not_identified_blockchain()
     db.write_tx_output(&output2).await.unwrap();
 
     // The blockchain with a context window of zero is just the chain_tip,
-    // same thing as a context window of 1.
+    // same thing as a context window of 1. So this checks the "regular"
+    // chain tip.
     let current_total = db
         .compute_withdrawn_total(&bitcoin_chain_tip.block_hash, 0)
         .await
@@ -6058,6 +6059,7 @@ async fn compute_withdrawn_total_ignores_withdrawals_not_identified_blockchain()
 
     assert_eq!(current_total, amount1);
 
+    // Let's check for the withdrawal output on that other blockchain.
     let current_total = db
         .compute_withdrawn_total(&another_block.block_hash, 0)
         .await

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -5881,6 +5881,197 @@ async fn is_withdrawal_active_for_considered_withdrawal() {
     signer::testing::storage::drop_db(db).await;
 }
 
+/// Check that the query in `compute_withdrawn_total` returns the total
+/// amount of withdrawal amounts in the window.
+#[tokio::test]
+async fn compute_withdrawn_total_gets_all_amounts_in_chain() {
+    let mut db = testing::storage::new_test_database().await;
+    let mut rng = rand::rngs::StdRng::seed_from_u64(4);
+
+    let test_model_params = testing::storage::model::Params {
+        num_bitcoin_blocks: 30,
+        num_stacks_blocks_per_bitcoin_block: 1,
+        num_deposit_requests_per_block: 0,
+        num_withdraw_requests_per_block: 0,
+        num_signers_per_request: 0,
+        consecutive_blocks: true,
+    };
+    // The number of signers does not matter
+    let num_signers = 1;
+    let signer_set = testing::wsts::generate_signer_set_public_keys(&mut rng, num_signers);
+    let test_data = TestData::generate(&mut rng, &signer_set, &test_model_params);
+    test_data.write_to(&mut db).await;
+
+    let context_window = 10;
+    let bitcoin_chain_tip = db
+        .get_bitcoin_canonical_chain_tip_ref()
+        .await
+        .unwrap()
+        .unwrap();
+    let current_total = db
+        .compute_withdrawn_total(&bitcoin_chain_tip.block_hash, context_window)
+        .await
+        .unwrap();
+    assert_eq!(current_total, 0);
+
+    let mut block = db
+        .get_bitcoin_block(&bitcoin_chain_tip.block_hash)
+        .await
+        .unwrap()
+        .unwrap();
+    let amount = 123_456;
+
+    // Let's add a bunch of withdrawal outputs into our blockchain. Later
+    // we will make sure that the query fetches only the ones that it is
+    // supposed to.
+    for _ in 0..context_window {
+        let output = model::TxOutput {
+            amount,
+            output_type: model::TxOutputType::Withdrawal,
+            ..Faker.fake_with_rng(&mut rng)
+        };
+
+        let tx = model::Transaction {
+            txid: output.txid.into_bytes(),
+            tx: Vec::new(),
+            tx_type: model::TransactionType::SbtcTransaction,
+            block_hash: block.block_hash.into_bytes(),
+        };
+        db.write_bitcoin_transactions(vec![tx]).await.unwrap();
+        db.write_tx_output(&output).await.unwrap();
+
+        block = db
+            .get_bitcoin_block(&block.parent_hash)
+            .await
+            .unwrap()
+            .unwrap();
+    }
+
+    // The blockchain with a context window of zero is just the chain_tip,
+    // same thing as a context window of 1.
+    let current_total = db
+        .compute_withdrawn_total(&bitcoin_chain_tip.block_hash, 0)
+        .await
+        .unwrap();
+
+    assert_eq!(current_total, amount);
+
+    // Now let's check that we keep getting more and more outputs as we
+    // increase the context window.
+    for window in 1..context_window {
+        let current_total = db
+            .compute_withdrawn_total(&bitcoin_chain_tip.block_hash, window)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            current_total,
+            amount * window as u64,
+            "Broke at context_window {window}"
+        );
+    }
+
+    signer::testing::storage::drop_db(db).await;
+}
+
+/// Check that the query in `compute_withdrawn_total` returns the total
+/// amount of withdrawal amounts in the window.
+#[tokio::test]
+async fn compute_withdrawn_total_ignores_withdrawals_not_identified_blockchain() {
+    let mut db = testing::storage::new_test_database().await;
+    let mut rng = rand::rngs::StdRng::seed_from_u64(4);
+
+    let test_model_params = testing::storage::model::Params {
+        num_bitcoin_blocks: 30,
+        num_stacks_blocks_per_bitcoin_block: 1,
+        num_deposit_requests_per_block: 0,
+        num_withdraw_requests_per_block: 0,
+        num_signers_per_request: 0,
+        consecutive_blocks: true,
+    };
+    // The number of signers does not matter
+    let num_signers = 1;
+    let signer_set = testing::wsts::generate_signer_set_public_keys(&mut rng, num_signers);
+    let test_data = TestData::generate(&mut rng, &signer_set, &test_model_params);
+    test_data.write_to(&mut db).await;
+
+    let context_window = 10;
+    let bitcoin_chain_tip = db
+        .get_bitcoin_canonical_chain_tip_ref()
+        .await
+        .unwrap()
+        .unwrap();
+    let current_total = db
+        .compute_withdrawn_total(&bitcoin_chain_tip.block_hash, context_window)
+        .await
+        .unwrap();
+    assert_eq!(current_total, 0);
+
+    // Let's add one withdrawal output into the chain tip of our blockchain
+    // and another output on a block at the same height that is not on our
+    // blockchain.
+    let amount1 = 123_456;
+    let output1 = model::TxOutput {
+        amount: amount1,
+        output_type: model::TxOutputType::Withdrawal,
+        ..Faker.fake_with_rng(&mut rng)
+    };
+
+    let tx = model::Transaction {
+        txid: output1.txid.into_bytes(),
+        tx: Vec::new(),
+        tx_type: model::TransactionType::SbtcTransaction,
+        block_hash: bitcoin_chain_tip.block_hash.into_bytes(),
+    };
+    db.write_bitcoin_transactions(vec![tx]).await.unwrap();
+    db.write_tx_output(&output1).await.unwrap();
+
+    // Okay, and another output on another blockchain
+    let amount2 = 789_101;
+    let another_block = model::BitcoinBlock {
+        block_height: bitcoin_chain_tip.block_height,
+        ..Faker.fake_with_rng(&mut rng)
+    };
+
+    let output2 = model::TxOutput {
+        amount: amount2,
+        output_type: model::TxOutputType::Withdrawal,
+        ..Faker.fake_with_rng(&mut rng)
+    };
+
+    let tx = model::Transaction {
+        txid: output2.txid.into_bytes(),
+        tx: Vec::new(),
+        tx_type: model::TransactionType::SbtcTransaction,
+        block_hash: another_block.block_hash.into_bytes(),
+    };
+    db.write_bitcoin_block(&another_block).await.unwrap();
+    db.write_bitcoin_transactions(vec![tx]).await.unwrap();
+    db.write_tx_output(&output2).await.unwrap();
+
+    // The blockchain with a context window of zero is just the chain_tip,
+    // same thing as a context window of 1.
+    let current_total = db
+        .compute_withdrawn_total(&bitcoin_chain_tip.block_hash, 0)
+        .await
+        .unwrap();
+
+    assert_eq!(current_total, amount1);
+
+    let current_total = db
+        .compute_withdrawn_total(&another_block.block_hash, 0)
+        .await
+        .unwrap();
+
+    assert_eq!(current_total, amount2);
+
+    // Sanity check that the test isn't totally busted. It still might be
+    // regular busted for some other reason though.
+    assert_ne!(amount1, amount2);
+
+    signer::testing::storage::drop_db(db).await;
+}
+
 /// Module containing a test suite and helpers specific to
 /// `DbRead::get_pending_accepted_withdrawal_requests`.
 mod get_pending_accepted_withdrawal_requests {


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/1500.

This PR needs to be updated once https://github.com/stacks-network/sbtc/pull/1513 gets merged. Right now some things are hardcoded or just using the wrong variables when checking the rolling withdrawal limits.

## Changes

* Make sure that the withdrawal limits get checked as part of the bitcoin validation logic.


## Testing Information

This could probably benefit from a few more test cases, but I'll do that once #1513 is merged.

## Checklist:

- [x] I have performed a self-review of my code
