### PR TITLE
fix: stop coordinator activities when tenure finishes

### DIFF
--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -618,6 +618,18 @@ impl<C: Context, B> BlockObserver<C, B> {
         Ok(())
     }
 
+    /// Update the `SignerState` object with current bitcoin chain tip.
+    async fn update_bitcoin_chain_tip(&self) -> Result<(), Error> {
+        let db = self.context.get_storage();
+        let chain_tip = db
+            .get_bitcoin_canonical_chain_tip_ref()
+            .await?
+            .ok_or(Error::NoChainTip)?;
+
+        self.context.state().set_bitcoin_chain_tip(chain_tip);
+        Ok(())
+    }
+
     /// Update the `SignerState` object with data that is unlikely to
     /// change until the arrival of the next bitcoin block.
     ///
@@ -627,12 +639,16 @@ impl<C: Context, B> BlockObserver<C, B> {
     /// * sBTC limits from Emily.
     /// * The current signer set.
     /// * The current aggregate key.
+    /// * The current bitcoin chain tip.
     async fn update_signer_state(&self, chain_tip: BlockHash) -> Result<(), Error> {
         tracing::info!("loading sbtc limits from Emily");
         self.update_sbtc_limits().await?;
 
         tracing::info!("updating the signer state with the current signer set");
-        self.set_signer_set_and_aggregate_key(chain_tip).await
+        self.set_signer_set_and_aggregate_key(chain_tip).await?;
+
+        tracing::info!("updating the signer state with the current bitcoin chain tip");
+        self.update_bitcoin_chain_tip().await
     }
 
     /// Checks if the latest dkg share is pending and is no longer valid

--- a/signer/src/context/signer_state.rs
+++ b/signer/src/context/signer_state.rs
@@ -11,6 +11,8 @@ use hashbrown::HashSet;
 use libp2p::PeerId;
 
 use crate::keys::PublicKey;
+use crate::storage::model::BitcoinBlockHash;
+use crate::storage::model::BitcoinBlockRef;
 
 /// A struct for holding internal signer state. This struct is served by
 /// the [`SignerContext`] and can be used to cache global state instead of
@@ -23,6 +25,9 @@ pub struct SignerState {
     sbtc_contracts_deployed: AtomicBool,
     sbtc_bitcoin_start_height: AtomicU64,
     is_sbtc_bitcoin_start_height_set: AtomicBool,
+    // The current bitcoin chain tip. This gets updated at the end of the
+    // block observer's duties when it observes a new bitcoin block.
+    bitcoin_chain_tip: RwLock<BitcoinBlockRef>,
 }
 
 impl SignerState {
@@ -61,6 +66,24 @@ impl SignerState {
             .write()
             .expect("BUG: Failed to acquire write lock")
             .replace(aggregate_key);
+    }
+
+    /// Get the current bitcoin chain tip.
+    pub fn bitcoin_chain_tip(&self) -> BitcoinBlockRef {
+        self.bitcoin_chain_tip
+            .read()
+            .expect("BUG: Failed to acquire read lock")
+            .clone()
+    }
+
+    /// Set the current bitcoin chain tip.
+    pub fn set_bitcoin_chain_tip(&self, chain_tip: BitcoinBlockRef) {
+        let mut block = self
+            .bitcoin_chain_tip
+            .write()
+            .expect("BUG: Failed to acquire write lock");
+
+        *block = chain_tip;
     }
 
     /// Get the current sBTC limits.
@@ -120,6 +143,10 @@ impl Default for SignerState {
             sbtc_contracts_deployed: Default::default(),
             sbtc_bitcoin_start_height: Default::default(),
             is_sbtc_bitcoin_start_height_set: Default::default(),
+            bitcoin_chain_tip: RwLock::new(BitcoinBlockRef {
+                block_height: 0,
+                block_hash: BitcoinBlockHash::from([0; 32]),
+            }),
         }
     }
 }

--- a/signer/src/context/signer_state.rs
+++ b/signer/src/context/signer_state.rs
@@ -73,7 +73,7 @@ impl SignerState {
         self.bitcoin_chain_tip
             .read()
             .expect("BUG: Failed to acquire read lock")
-            .clone()
+            .to_owned()
     }
 
     /// Set the current bitcoin chain tip.

--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -795,10 +795,10 @@ where
             )
             .increment(1);
 
-        if &self.context.state().bitcoin_chain_tip() != chain_tip {
-            tracing::info!("new bitcoin chain tip, stoping coordinator activities");
-            return Ok(());
-        }
+            if &self.context.state().bitcoin_chain_tip() != chain_tip {
+                tracing::info!("new bitcoin chain tip, stoping coordinator activities");
+                return Ok(());
+            }
         }
 
         Ok(())

--- a/signer/tests/integration/transaction_coordinator.rs
+++ b/signer/tests/integration/transaction_coordinator.rs
@@ -3972,15 +3972,16 @@ async fn process_rejected_withdrawal(is_completed: bool, is_in_mempool: bool) {
     // When the signer binary starts up in main(), it sets the current
     // signer set public keys in the context state using the values in the
     // bootstrap_signing_set configuration parameter. Later, the aggregate
-    // key gets set in the block observer. We're not running a block
-    // observer in this test, nor are we going through main, so we manually
-    // update the state here.
+    // key and bitcoin chain tip get set in the block observer. We're not
+    // running a block observer in this test, nor are we going through
+    // main, so we manually update the state here.
     let signer_set_public_keys = testing_signer_set.signer_keys().into_iter().collect();
+    let (bitcoin_chain_tip, stacks_chain_tip) = db.get_chain_tips().await;
     let state = context.state();
     state.update_current_signer_set(signer_set_public_keys);
     state.set_current_aggregate_key(aggregate_key);
+    state.set_bitcoin_chain_tip(bitcoin_chain_tip);
 
-    let (bitcoin_chain_tip, stacks_chain_tip) = db.get_chain_tips().await;
     assert_eq!(stacks_chain_tip, genesis_block.block_hash);
 
     // Now we create a withdrawal request (without voting for it)


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-network/sbtc/issues/1516.

I thought about adding just the bitcoin chain tip block height to the signer state, since that is all that is needed for this PR; plus an atomic integer is nicer. But a `BitcoinBlockRef` is probably be more useful, generally speaking, so here we are.

## Changes

* Add the bitcoin chain tip into the signer state object. Set it in the block observer when a new block is observed.
* End the coordinator's tenure when creating deposit and withdrawal stacks transactions if the current chain tip doesn't match the one that was used at the start of the coordinator's tenure.

## Testing Information

I tested that this solves the problem described in https://github.com/stacks-network/sbtc/issues/1516 in devenv, and it works as it's supposed to.

## Checklist:

- [x] I have performed a self-review of my code
