### PR TITLE
fix `test_conservative_initial_sbtc_limits` test

### DIFF
--- a/signer/tests/integration/transaction_coordinator.rs
+++ b/signer/tests/integration/transaction_coordinator.rs
@@ -3213,6 +3213,13 @@ async fn test_conservative_initial_sbtc_limits() {
                 ))))
             });
 
+            // We don't care about this
+            client.expect_accept_withdrawals().returning(|_| {
+                Box::pin(std::future::ready(Err(Error::InvalidStacksResponse(
+                    "dummy",
+                ))))
+            });
+
             let enable_emily_limits = enable_emily_limits.clone();
             let i = i;
             client.expect_get_limits().times(1..).returning(move || {


### PR DESCRIPTION
## Description

There's a swallowed panic in the `transaction_coordinator::test_conservative_initial_sbtc_limits` test's sub-tasks due to a missing `EmilyInteract` mock expectation for `accept_withdrawals()`. This adds an expectation, copying what's done for deposits and fixing the panic.

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
